### PR TITLE
Build: Add gradle task to init substrait submodule when building project 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,10 +19,18 @@ dependencies {
   compileOnly("org.immutables:value-annotations:2.8.8")
 }
 
+val submodulesUpdate by
+  tasks.creating(Exec::class) {
+    group = "Build Setup"
+    description = "Updates (and inits) substrait git submodule"
+    commandLine = listOf("git", "submodule", "update", "--init", "--recursive")
+  }
+
 allprojects {
   repositories { mavenCentral() }
 
   tasks.configureEach<Test> { useJUnitPlatform() }
+  tasks.withType<JavaCompile> { dependsOn(submodulesUpdate) }
 
   tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("--enable-preview") }
 


### PR DESCRIPTION
When cloning the repo and running `./gradlew clean jar` the build will currently fail, because it requires a manual step to init the git submodule via `git submodule update --init --recursive`.
    
This commit adds a Gradle task that does that and also includes that task when compiling the project.

This currently depends on https://github.com/substrait-io/substrait-java/pull/7 but will be rebased once it's merged