### PR TITLE
Build: Use spotless to format Java files with Google Code formatter / spotlessApply

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+## Style guide
+
+Changes must adhere to the style guide and this will be verified by the continuous integration build.
+
+* Java code style is [Google style](https://google.github.io/styleguide/javaguide.html).
+
+Java code style is checked by [Spotless](https://github.com/diffplug/spotless)
+with [google-java-format](https://github.com/google/google-java-format) during the build.
+
+### Automatically fixing code style issues
+
+Java code style issues can be fixed from the command line using
+`./gradlew spotlessApply`.
+
+### Configuring the Code Formatter for Intellij IDEA and Eclipse
+
+Follow the instructions for [Eclipse](https://github.com/google/google-java-format#eclipse) or
+[IntelliJ](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides),
+note the required manual actions for IntelliJ.
+
+### Gradle & JDK 17
+
+Given that the project currently uses JDK 17 features, it requires to run Gradle itself with JDK 17, which in turn requires the below settings in `~/.gradle/gradle.properties`.
+Without those settings you might see issues when running `./gradlew spotlessApply`.
+
+```
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,10 +21,18 @@ dependencies {
   compileOnly("org.immutables:value-annotations:2.8.8")
 }
 
+val submodulesUpdate by
+  tasks.creating(Exec::class) {
+    group = "Build Setup"
+    description = "Updates (and inits) substrait git submodule"
+    commandLine = listOf("git", "submodule", "update", "--init", "--recursive")
+  }
+
 allprojects {
   repositories { mavenCentral() }
 
   tasks.configureEach<Test> { useJUnitPlatform() }
+  tasks.withType<JavaCompile> { dependsOn(submodulesUpdate) }
 
   tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("--enable-preview") }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,52 +1,49 @@
+import com.diffplug.gradle.spotless.SpotlessExtension
+import com.diffplug.gradle.spotless.SpotlessPlugin
 import com.github.vlsi.gradle.dsl.configureEach
 
 plugins {
-    id("java")
-    id("idea")
-    id("com.github.vlsi.gradle-extensions")  version "1.74"
+  id("java")
+  id("idea")
+  id("com.github.vlsi.gradle-extensions") version "1.74"
+  id("com.diffplug.spotless") version "6.5.1"
 }
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    implementation("org.slf4j:slf4j-jdk14:1.7.30")
-    annotationProcessor("org.immutables:value:2.8.8")
-    compileOnly("org.immutables:value-annotations:2.8.8")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  implementation("org.slf4j:slf4j-jdk14:1.7.30")
+  annotationProcessor("org.immutables:value:2.8.8")
+  compileOnly("org.immutables:value-annotations:2.8.8")
 }
 
 allprojects {
-    repositories {
-        mavenCentral()
+  repositories { mavenCentral() }
+
+  tasks.configureEach<Test> { useJUnitPlatform() }
+
+  tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("--enable-preview") }
+
+  tasks.withType<Test>().configureEach { jvmArgs("--enable-preview") }
+
+  group = "io.substrait"
+  version = "1.0-SNAPSHOT"
+
+  plugins.withType<SpotlessPlugin>().configureEach {
+    configure<SpotlessExtension> {
+      kotlinGradle { ktfmt().googleStyle() }
+      java {
+        googleJavaFormat()
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        targetExclude(
+          "**/build*/**",
+        )
+      }
     }
-
-    tasks.configureEach<Test> {
-        useJUnitPlatform()
-    }
-
-
-    tasks.withType<JavaCompile>().configureEach {
-        options.compilerArgs.add("--enable-preview")
-    }
-
-    tasks.withType<Test>().configureEach {
-        jvmArgs("--enable-preview")
-    }
-
-    group = "io.substrait"
-    version = "1.0-SNAPSHOT"
-
-
-
-
+  }
 }
-

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,10 +3,11 @@ import com.google.protobuf.gradle.protoc
 import org.gradle.plugins.ide.idea.model.IdeaModel
 
 plugins {
-    id("java")
-    id("idea")
-    id("antlr")
-    id("com.google.protobuf") version "0.8.17"
+  id("java")
+  id("idea")
+  id("antlr")
+  id("com.google.protobuf") version "0.8.17"
+  id("com.diffplug.spotless") version "6.5.1"
 }
 
 dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,67 +11,57 @@ plugins {
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    implementation("com.google.protobuf:protobuf-java:3.17.3")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.4")
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.4")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4")
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
+  testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.0")
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  implementation("com.google.protobuf:protobuf-java:3.17.3")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.12.4")
+  implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.4")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4")
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4")
+  implementation("com.google.code.findbugs:jsr305:3.0.2")
 
-
-    antlr("org.antlr:antlr4:4.9.2")
-    implementation("org.slf4j:slf4j-jdk14:1.7.30")
-    implementation("org.antlr:antlr4:4.9.2")
-    annotationProcessor("org.immutables:value:2.8.8")
-    compileOnly("org.immutables:value-annotations:2.8.8")
-
+  antlr("org.antlr:antlr4:4.9.2")
+  implementation("org.slf4j:slf4j-jdk14:1.7.30")
+  implementation("org.antlr:antlr4:4.9.2")
+  annotationProcessor("org.immutables:value:2.8.8")
+  compileOnly("org.immutables:value-annotations:2.8.8")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 sourceSets {
-    main {
-        proto.srcDir("../substrait/proto")
-        resources.srcDir("../substrait/extensions")
-        java.srcDir(file("build/generated/sources/antlr/main/java/"))
-    }
+  main {
+    proto.srcDir("../substrait/proto")
+    resources.srcDir("../substrait/extensions")
+    java.srcDir(file("build/generated/sources/antlr/main/java/"))
+  }
 }
 
 project.configure<IdeaModel> {
-    module {
-        resourceDirs.addAll(listOf(
-            file("../substrait/text"),
-            file("../substrait/extensions"),
-            file("../substrait/proto")
-        ))
-        generatedSourceDirs.addAll(listOf(
-            file("build/generated/sources/antlr/main"),
-            file("build/generated/source/proto/main/java")
-        ))
-    }
+  module {
+    resourceDirs.addAll(
+      listOf(file("../substrait/text"), file("../substrait/extensions"), file("../substrait/proto"))
+    )
+    generatedSourceDirs.addAll(
+      listOf(
+        file("build/generated/sources/antlr/main"),
+        file("build/generated/source/proto/main/java")
+      )
+    )
+  }
 }
 
 tasks.named<AntlrTask>("generateGrammarSource") {
-    arguments.add("-package")
-    arguments.add("io.substrait.type")
-    arguments.add("-visitor")
-    arguments.add("-long-messages")
-    arguments.add("-Xlog")
-    arguments.add("-Werror")
-    arguments.add("-Xexact-output-dir")
-    setSource(fileTree("src/main/antlr/SubstraitType.g4"))
-    outputDirectory = File(buildDir, "generated/sources/antlr/main/java/io/substrait/type")
+  arguments.add("-package")
+  arguments.add("io.substrait.type")
+  arguments.add("-visitor")
+  arguments.add("-long-messages")
+  arguments.add("-Xlog")
+  arguments.add("-Werror")
+  arguments.add("-Xexact-output-dir")
+  setSource(fileTree("src/main/antlr/SubstraitType.g4"))
+  outputDirectory = File(buildDir, "generated/sources/antlr/main/java/io/substrait/type")
 }
 
-protobuf {
-    protoc {
-        artifact = "com.google.protobuf:protoc:3.17.3"
-    }
-}
+protobuf { protoc { artifact = "com.google.protobuf:protoc:3.17.3" } }

--- a/core/src/main/java/io/substrait/expression/AggregateFunctionInvocation.java
+++ b/core/src/main/java/io/substrait/expression/AggregateFunctionInvocation.java
@@ -2,9 +2,8 @@ package io.substrait.expression;
 
 import io.substrait.function.SimpleExtension;
 import io.substrait.type.Type;
-import org.immutables.value.Value;
-
 import java.util.List;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class AggregateFunctionInvocation {
@@ -25,5 +24,4 @@ public abstract class AggregateFunctionInvocation {
   public static ImmutableAggregateFunctionInvocation.Builder builder() {
     return ImmutableAggregateFunctionInvocation.builder();
   }
-
 }

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -3,12 +3,11 @@ package io.substrait.expression;
 import com.google.protobuf.ByteString;
 import io.substrait.function.SimpleExtension;
 import io.substrait.type.Type;
-import org.immutables.value.Value;
-
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.immutables.value.Value;
 
 @Value.Enclosing
 public interface Expression {
@@ -24,10 +23,13 @@ public interface Expression {
 
   <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E;
 
-  @Value.Immutable static abstract class NullLiteral implements Literal {
+  @Value.Immutable
+  abstract static class NullLiteral implements Literal {
     public abstract Type type();
 
-    public Type getType() {return type();}
+    public Type getType() {
+      return type();
+    }
 
     public static ImmutableExpression.NullLiteral.Builder builder() {
       return ImmutableExpression.NullLiteral.builder();
@@ -38,10 +40,13 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class BoolLiteral implements Literal {
+  @Value.Immutable
+  abstract static class BoolLiteral implements Literal {
     public abstract Boolean value();
 
-    public Type getType() {return Type.withNullability(nullable()).BOOLEAN;}
+    public Type getType() {
+      return Type.withNullability(nullable()).BOOLEAN;
+    }
 
     public static ImmutableExpression.BoolLiteral.Builder builder() {
       return ImmutableExpression.BoolLiteral.builder();
@@ -50,13 +55,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class I8Literal implements Literal {
+  @Value.Immutable
+  abstract static class I8Literal implements Literal {
     public abstract int value();
 
-    public Type getType() {return Type.withNullability(nullable()).I8;}
+    public Type getType() {
+      return Type.withNullability(nullable()).I8;
+    }
 
     public static ImmutableExpression.I8Literal.Builder builder() {
       return ImmutableExpression.I8Literal.builder();
@@ -65,13 +72,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class I16Literal implements Literal {
+  @Value.Immutable
+  abstract static class I16Literal implements Literal {
     public abstract int value();
 
-    public Type getType() {return Type.withNullability(nullable()).I16;}
+    public Type getType() {
+      return Type.withNullability(nullable()).I16;
+    }
 
     public static ImmutableExpression.I16Literal.Builder builder() {
       return ImmutableExpression.I16Literal.builder();
@@ -80,13 +89,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class I32Literal implements Literal {
+  @Value.Immutable
+  abstract static class I32Literal implements Literal {
     public abstract int value();
 
-    public Type getType() {return Type.withNullability(nullable()).I32;}
+    public Type getType() {
+      return Type.withNullability(nullable()).I32;
+    }
 
     public static ImmutableExpression.I32Literal.Builder builder() {
       return ImmutableExpression.I32Literal.builder();
@@ -95,13 +106,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class I64Literal implements Literal {
+  @Value.Immutable
+  abstract static class I64Literal implements Literal {
     public abstract long value();
 
-    public Type getType() {return Type.withNullability(nullable()).I64;}
+    public Type getType() {
+      return Type.withNullability(nullable()).I64;
+    }
 
     public static ImmutableExpression.I64Literal.Builder builder() {
       return ImmutableExpression.I64Literal.builder();
@@ -110,13 +123,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class FP32Literal implements Literal {
+  @Value.Immutable
+  abstract static class FP32Literal implements Literal {
     public abstract float value();
 
-    public Type getType() {return Type.withNullability(nullable()).FP32;}
+    public Type getType() {
+      return Type.withNullability(nullable()).FP32;
+    }
 
     public static ImmutableExpression.FP32Literal.Builder builder() {
       return ImmutableExpression.FP32Literal.builder();
@@ -125,13 +140,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class FP64Literal implements Literal {
+  @Value.Immutable
+  abstract static class FP64Literal implements Literal {
     public abstract double value();
 
-    public Type getType() {return Type.withNullability(nullable()).FP64;}
+    public Type getType() {
+      return Type.withNullability(nullable()).FP64;
+    }
 
     public static ImmutableExpression.FP64Literal.Builder builder() {
       return ImmutableExpression.FP64Literal.builder();
@@ -140,13 +157,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class StrLiteral implements Literal {
+  @Value.Immutable
+  abstract static class StrLiteral implements Literal {
     public abstract String value();
 
-    public Type getType() {return Type.withNullability(nullable()).STRING;}
+    public Type getType() {
+      return Type.withNullability(nullable()).STRING;
+    }
 
     public static ImmutableExpression.StrLiteral.Builder builder() {
       return ImmutableExpression.StrLiteral.builder();
@@ -155,13 +174,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class BinaryLiteral implements Literal {
+  @Value.Immutable
+  abstract static class BinaryLiteral implements Literal {
     public abstract ByteString value();
 
-    public Type getType() {return Type.withNullability(nullable()).BINARY;}
+    public Type getType() {
+      return Type.withNullability(nullable()).BINARY;
+    }
 
     public static ImmutableExpression.BinaryLiteral.Builder builder() {
       return ImmutableExpression.BinaryLiteral.builder();
@@ -170,10 +191,10 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class TimestampLiteral implements Literal {
+  @Value.Immutable
+  abstract static class TimestampLiteral implements Literal {
     public abstract long value();
 
     public Type getType() {
@@ -187,10 +208,10 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class TimeLiteral implements Literal {
+  @Value.Immutable
+  abstract static class TimeLiteral implements Literal {
     public abstract long value();
 
     public Type getType() {
@@ -204,10 +225,10 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class DateLiteral implements Literal {
+  @Value.Immutable
+  abstract static class DateLiteral implements Literal {
     public abstract int value();
 
     public Type getType() {
@@ -221,10 +242,10 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class TimestampTZLiteral implements Literal {
+  @Value.Immutable
+  abstract static class TimestampTZLiteral implements Literal {
     public abstract long value();
 
     public Type getType() {
@@ -238,10 +259,10 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class IntervalYearLiteral implements Literal {
+  @Value.Immutable
+  abstract static class IntervalYearLiteral implements Literal {
     public abstract int years();
 
     public abstract int months();
@@ -257,10 +278,10 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class IntervalDayLiteral implements Literal {
+  @Value.Immutable
+  abstract static class IntervalDayLiteral implements Literal {
     public abstract int days();
 
     public abstract int seconds();
@@ -276,13 +297,15 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class UUIDLiteral implements Literal {
+  @Value.Immutable
+  abstract static class UUIDLiteral implements Literal {
     public abstract UUID value();
 
-    public Type getType() {return Type.withNullability(nullable()).UUID;}
+    public Type getType() {
+      return Type.withNullability(nullable()).UUID;
+    }
 
     public static ImmutableExpression.UUIDLiteral.Builder builder() {
       return ImmutableExpression.UUIDLiteral.builder();
@@ -301,12 +324,12 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class FixedCharLiteral implements Literal {
+  @Value.Immutable
+  abstract static class FixedCharLiteral implements Literal {
     public abstract String value();
 
     public Type getType() {
-      return Type.withNullability(nullable())
-          .fixedChar(value().length());
+      return Type.withNullability(nullable()).fixedChar(value().length());
     }
 
     public static ImmutableExpression.FixedCharLiteral.Builder builder() {
@@ -316,17 +339,16 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class VarCharLiteral implements Literal {
+  @Value.Immutable
+  abstract static class VarCharLiteral implements Literal {
     public abstract String value();
 
     public abstract int length();
 
     public Type getType() {
-      return Type.withNullability(nullable())
-          .varChar(length());
+      return Type.withNullability(nullable()).varChar(length());
     }
 
     public static ImmutableExpression.VarCharLiteral.Builder builder() {
@@ -336,15 +358,14 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class FixedBinaryLiteral implements Literal {
+  @Value.Immutable
+  abstract static class FixedBinaryLiteral implements Literal {
     public abstract ByteString value();
 
     public Type getType() {
-      return Type.withNullability(nullable())
-          .fixedBinary(value().size());
+      return Type.withNullability(nullable()).fixedBinary(value().size());
     }
 
     public static ImmutableExpression.FixedBinaryLiteral.Builder builder() {
@@ -354,10 +375,10 @@ public interface Expression {
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
     }
-
   }
 
-  @Value.Immutable static abstract class DecimalLiteral implements Literal {
+  @Value.Immutable
+  abstract static class DecimalLiteral implements Literal {
     public abstract ByteString value();
 
     public abstract int precision();
@@ -365,8 +386,7 @@ public interface Expression {
     public abstract int scale();
 
     public Type getType() {
-      return Type.withNullability(nullable())
-          .decimal(precision(), scale());
+      return Type.withNullability(nullable()).decimal(precision(), scale());
     }
 
     public static ImmutableExpression.DecimalLiteral.Builder builder() {
@@ -378,7 +398,8 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class MapLiteral implements Literal {
+  @Value.Immutable
+  abstract static class MapLiteral implements Literal {
     public abstract Map<Literal, Literal> values();
 
     public Type getType() {
@@ -397,7 +418,8 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class ListLiteral implements Literal {
+  @Value.Immutable
+  abstract static class ListLiteral implements Literal {
     public abstract List<Literal> values();
 
     public Type getType() {
@@ -413,7 +435,8 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class StructLiteral implements Literal {
+  @Value.Immutable
+  abstract static class StructLiteral implements Literal {
     public abstract List<Literal> fields();
 
     public Type getType() {
@@ -430,8 +453,10 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class Switch implements Expression {
+  @Value.Immutable
+  abstract static class Switch implements Expression {
     public abstract List<SwitchClause> switchClauses();
+
     public abstract Expression defaultClause();
 
     public Type getType() {
@@ -447,18 +472,21 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class SwitchClause {
+  @Value.Immutable
+  abstract static class SwitchClause {
     public abstract Literal condition();
+
     public abstract Expression then();
 
     public static ImmutableExpression.SwitchClause.Builder builder() {
       return ImmutableExpression.SwitchClause.builder();
     }
-
   }
 
-  @Value.Immutable static abstract class IfThen implements Expression {
+  @Value.Immutable
+  abstract static class IfThen implements Expression {
     public abstract List<IfClause> ifClauses();
+
     public abstract Expression elseClause();
 
     public Type getType() {
@@ -474,21 +502,26 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class IfClause {
+  @Value.Immutable
+  abstract static class IfClause {
     public abstract Expression condition();
+
     public abstract Expression then();
 
     public static ImmutableExpression.IfClause.Builder builder() {
       return ImmutableExpression.IfClause.builder();
     }
-
   }
 
-  @Value.Immutable static abstract class Cast implements Expression {
+  @Value.Immutable
+  abstract static class Cast implements Expression {
     public abstract Type type();
+
     public abstract Expression input();
 
-    public Type getType() {return type();}
+    public Type getType() {
+      return type();
+    }
 
     public static ImmutableExpression.Cast.Builder builder() {
       return ImmutableExpression.Cast.builder();
@@ -499,7 +532,8 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class ScalarFunctionInvocation implements Expression {
+  @Value.Immutable
+  abstract static class ScalarFunctionInvocation implements Expression {
     public abstract SimpleExtension.ScalarFunctionVariant declaration();
 
     public abstract List<Expression> arguments();
@@ -519,8 +553,10 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class SingleOrList implements Expression {
+  @Value.Immutable
+  abstract static class SingleOrList implements Expression {
     public abstract Expression condition();
+
     public abstract List<Expression> options();
 
     public Type getType() {
@@ -536,8 +572,10 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class MultiOrList implements Expression {
+  @Value.Immutable
+  abstract static class MultiOrList implements Expression {
     public abstract List<Expression> conditions();
+
     public abstract List<MultiOrListRecord> optionCombinations();
 
     public Type getType() {
@@ -553,17 +591,17 @@ public interface Expression {
     }
   }
 
-  @Value.Immutable static abstract class MultiOrListRecord {
+  @Value.Immutable
+  abstract static class MultiOrListRecord {
     public abstract List<Expression> values();
 
     public static ImmutableExpression.MultiOrListRecord.Builder builder() {
       return ImmutableExpression.MultiOrListRecord.builder();
     }
-
   }
 
-
-  @Value.Immutable static abstract class SortField {
+  @Value.Immutable
+  abstract static class SortField {
     public abstract Expression expr();
 
     public abstract SortDirection direction();
@@ -574,10 +612,13 @@ public interface Expression {
   }
 
   enum AggregationPhase {
-    INITIAL_TO_INTERMEDIATE(io.substrait.proto.AggregationPhase.AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE),
-    INTERMEDIATE_TO_INTERMEDIATE(io.substrait.proto.AggregationPhase.AGGREGATION_PHASE_INTERMEDIATE_TO_INTERMEDIATE),
+    INITIAL_TO_INTERMEDIATE(
+        io.substrait.proto.AggregationPhase.AGGREGATION_PHASE_INITIAL_TO_INTERMEDIATE),
+    INTERMEDIATE_TO_INTERMEDIATE(
+        io.substrait.proto.AggregationPhase.AGGREGATION_PHASE_INTERMEDIATE_TO_INTERMEDIATE),
     INITIAL_TO_RESULT(io.substrait.proto.AggregationPhase.AGGREGATION_PHASE_INITIAL_TO_RESULT),
-    INTERMEDIATE_TO_RESULT(io.substrait.proto.AggregationPhase.AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT);
+    INTERMEDIATE_TO_RESULT(
+        io.substrait.proto.AggregationPhase.AGGREGATION_PHASE_INTERMEDIATE_TO_RESULT);
 
     private final io.substrait.proto.AggregationPhase proto;
 
@@ -590,8 +631,8 @@ public interface Expression {
     }
 
     public static AggregationPhase fromProto(io.substrait.proto.AggregationPhase proto) {
-      for(var v : values()) {
-        if(v.proto == proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
           return v;
         }
       }
@@ -618,8 +659,8 @@ public interface Expression {
     }
 
     public static SortDirection fromProto(io.substrait.proto.SortField.SortDirection proto) {
-      for(var v : values()) {
-        if(v.proto == proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
           return v;
         }
       }
@@ -627,5 +668,4 @@ public interface Expression {
       throw new IllegalArgumentException("Unknown type: " + proto);
     }
   }
-
 }

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -3,7 +3,6 @@ package io.substrait.expression;
 import com.google.protobuf.ByteString;
 import io.substrait.function.SimpleExtension;
 import io.substrait.type.Type;
-
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -14,8 +13,7 @@ import java.util.concurrent.TimeUnit;
 public class ExpressionCreator {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExpressionCreator.class);
 
-  private ExpressionCreator() {
-  }
+  private ExpressionCreator() {}
 
   public static Expression.NullLiteral typedNull(Type t) {
     return Expression.NullLiteral.builder().type(t).build();
@@ -58,7 +56,10 @@ public class ExpressionCreator {
   }
 
   public static Expression.BinaryLiteral binary(boolean nullable, byte[] value) {
-    return Expression.BinaryLiteral.builder().nullable(nullable).value(ByteString.copyFrom(value)).build();
+    return Expression.BinaryLiteral.builder()
+        .nullable(nullable)
+        .value(ByteString.copyFrom(value))
+        .build();
   }
 
   public static Expression.DateLiteral date(boolean nullable, int value) {
@@ -74,13 +75,23 @@ public class ExpressionCreator {
   }
 
   public static Expression.TimestampLiteral timestamp(boolean nullable, LocalDateTime value) {
-    var epochMicro = TimeUnit.SECONDS.toMicros(value.toEpochSecond(ZoneOffset.UTC)) +
-        TimeUnit.NANOSECONDS.toMicros(value.toLocalTime().getNano());
+    var epochMicro =
+        TimeUnit.SECONDS.toMicros(value.toEpochSecond(ZoneOffset.UTC))
+            + TimeUnit.NANOSECONDS.toMicros(value.toLocalTime().getNano());
     return timestamp(nullable, epochMicro);
   }
 
-  public static Expression.TimestampLiteral timestamp(boolean nullable, int year, int month, int dayOfMonth, int hour, int minute, int second, int micros) {
-    return timestamp(nullable,
+  public static Expression.TimestampLiteral timestamp(
+      boolean nullable,
+      int year,
+      int month,
+      int dayOfMonth,
+      int hour,
+      int minute,
+      int second,
+      int micros) {
+    return timestamp(
+        nullable,
         LocalDateTime.of(year, month, dayOfMonth, hour, minute, second)
             .withNano((int) TimeUnit.MICROSECONDS.toNanos(micros)));
   }
@@ -90,21 +101,35 @@ public class ExpressionCreator {
   }
 
   public static Expression.TimestampTZLiteral timestampTZ(boolean nullable, Instant value) {
-    var epochMicro = TimeUnit.SECONDS.toMicros(value.getEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(value.getNano());
+    var epochMicro =
+        TimeUnit.SECONDS.toMicros(value.getEpochSecond())
+            + TimeUnit.NANOSECONDS.toMicros(value.getNano());
     return timestampTZ(nullable, epochMicro);
   }
 
-  public static Expression.IntervalYearLiteral intervalYear(boolean nullable, int years, int months) {
-    return Expression.IntervalYearLiteral.builder().nullable(nullable).years(years).months(months).build();
+  public static Expression.IntervalYearLiteral intervalYear(
+      boolean nullable, int years, int months) {
+    return Expression.IntervalYearLiteral.builder()
+        .nullable(nullable)
+        .years(years)
+        .months(months)
+        .build();
   }
 
   public static Expression.IntervalDayLiteral intervalDay(boolean nullable, int days, int seconds) {
-    return Expression.IntervalDayLiteral.builder().nullable(nullable).days(days).seconds(seconds).build();
+    return Expression.IntervalDayLiteral.builder()
+        .nullable(nullable)
+        .days(days)
+        .seconds(seconds)
+        .build();
   }
 
   public static Expression.UUIDLiteral uuid(boolean nullable, ByteString uuid) {
     var bb = uuid.asReadOnlyByteBuffer();
-    return Expression.UUIDLiteral.builder().nullable(nullable).value(new UUID(bb.getLong(), bb.getLong())).build();
+    return Expression.UUIDLiteral.builder()
+        .nullable(nullable)
+        .value(new UUID(bb.getLong(), bb.getLong()))
+        .build();
   }
 
   public static Expression.UUIDLiteral uuid(boolean nullable, UUID uuid) {
@@ -124,19 +149,37 @@ public class ExpressionCreator {
   }
 
   public static Expression.FixedBinaryLiteral fixedBinary(boolean nullable, byte[] bytes) {
-    return Expression.FixedBinaryLiteral.builder().nullable(nullable).value(ByteString.copyFrom(bytes)).build();
+    return Expression.FixedBinaryLiteral.builder()
+        .nullable(nullable)
+        .value(ByteString.copyFrom(bytes))
+        .build();
   }
 
-  public static Expression.DecimalLiteral decimal(boolean nullable, ByteString value, int precision, int scale) {
-    return Expression.DecimalLiteral.builder().nullable(nullable).value(value).precision(precision).scale(scale).build();
+  public static Expression.DecimalLiteral decimal(
+      boolean nullable, ByteString value, int precision, int scale) {
+    return Expression.DecimalLiteral.builder()
+        .nullable(nullable)
+        .value(value)
+        .precision(precision)
+        .scale(scale)
+        .build();
   }
 
-  public static Expression.DecimalLiteral decimal(boolean nullable, BigDecimal value, int precision, int scale) {
-    var twosComplement = padLeftIfNeeded(value.multiply(BigDecimal.valueOf(scale * 10L)).toBigInteger().toByteArray(), 38);
-    return Expression.DecimalLiteral.builder().nullable(nullable).value(twosComplement).precision(precision).scale(scale).build();
+  public static Expression.DecimalLiteral decimal(
+      boolean nullable, BigDecimal value, int precision, int scale) {
+    var twosComplement =
+        padLeftIfNeeded(
+            value.multiply(BigDecimal.valueOf(scale * 10L)).toBigInteger().toByteArray(), 38);
+    return Expression.DecimalLiteral.builder()
+        .nullable(nullable)
+        .value(twosComplement)
+        .precision(precision)
+        .scale(scale)
+        .build();
   }
 
-  public static Expression.MapLiteral map(boolean nullable, Map<Expression.Literal, Expression.Literal> values) {
+  public static Expression.MapLiteral map(
+      boolean nullable, Map<Expression.Literal, Expression.Literal> values) {
     return Expression.MapLiteral.builder().nullable(nullable).putAllValues(values).build();
   }
 
@@ -144,7 +187,8 @@ public class ExpressionCreator {
     return Expression.ListLiteral.builder().nullable(nullable).addValues(values).build();
   }
 
-  public static Expression.ListLiteral list(boolean nullable, Iterable<? extends Expression.Literal> values) {
+  public static Expression.ListLiteral list(
+      boolean nullable, Iterable<? extends Expression.Literal> values) {
     return Expression.ListLiteral.builder().nullable(nullable).addAllValues(values).build();
   }
 
@@ -152,40 +196,77 @@ public class ExpressionCreator {
     return Expression.StructLiteral.builder().nullable(nullable).addFields(values).build();
   }
 
-  public static Expression.StructLiteral struct(boolean nullable, Iterable<? extends Expression.Literal> values) {
+  public static Expression.StructLiteral struct(
+      boolean nullable, Iterable<? extends Expression.Literal> values) {
     return Expression.StructLiteral.builder().nullable(nullable).addAllFields(values).build();
   }
 
-  public static Expression.Switch switchStatement(Expression defaultExpression, Expression.SwitchClause... conditionClauses) {
-    return Expression.Switch.builder().defaultClause(defaultExpression).addSwitchClauses(conditionClauses).build();
+  public static Expression.Switch switchStatement(
+      Expression defaultExpression, Expression.SwitchClause... conditionClauses) {
+    return Expression.Switch.builder()
+        .defaultClause(defaultExpression)
+        .addSwitchClauses(conditionClauses)
+        .build();
   }
 
-  public static Expression.Switch switchStatement(Expression defaultExpression, Iterable<? extends Expression.SwitchClause> conditionClauses) {
-    return Expression.Switch.builder().defaultClause(defaultExpression).addAllSwitchClauses(conditionClauses).build();
+  public static Expression.Switch switchStatement(
+      Expression defaultExpression, Iterable<? extends Expression.SwitchClause> conditionClauses) {
+    return Expression.Switch.builder()
+        .defaultClause(defaultExpression)
+        .addAllSwitchClauses(conditionClauses)
+        .build();
   }
 
-  public static Expression.SwitchClause switchClause(Expression.Literal expectedValue, Expression resultExpression) {
-    return Expression.SwitchClause.builder().condition(expectedValue).then(resultExpression).build();
+  public static Expression.SwitchClause switchClause(
+      Expression.Literal expectedValue, Expression resultExpression) {
+    return Expression.SwitchClause.builder()
+        .condition(expectedValue)
+        .then(resultExpression)
+        .build();
   }
 
-  public static Expression.IfThen ifThenStatement(Expression elseExpression, Expression.IfClause... conditionClauses) {
-    return Expression.IfThen.builder().elseClause(elseExpression).addIfClauses(conditionClauses).build();
+  public static Expression.IfThen ifThenStatement(
+      Expression elseExpression, Expression.IfClause... conditionClauses) {
+    return Expression.IfThen.builder()
+        .elseClause(elseExpression)
+        .addIfClauses(conditionClauses)
+        .build();
   }
 
-  public static Expression.IfThen ifThenStatement(Expression elseExpression, Iterable<? extends Expression.IfClause> conditionClauses) {
-    return Expression.IfThen.builder().elseClause(elseExpression).addAllIfClauses(conditionClauses).build();
+  public static Expression.IfThen ifThenStatement(
+      Expression elseExpression, Iterable<? extends Expression.IfClause> conditionClauses) {
+    return Expression.IfThen.builder()
+        .elseClause(elseExpression)
+        .addAllIfClauses(conditionClauses)
+        .build();
   }
 
-  public static Expression.IfClause ifThenClause(Expression conditionExpression, Expression resultExpression) {
-    return Expression.IfClause.builder().condition(conditionExpression).then(resultExpression).build();
+  public static Expression.IfClause ifThenClause(
+      Expression conditionExpression, Expression resultExpression) {
+    return Expression.IfClause.builder()
+        .condition(conditionExpression)
+        .then(resultExpression)
+        .build();
   }
 
-  public static Expression.ScalarFunctionInvocation scalarFunction(SimpleExtension.ScalarFunctionVariant declaration, Type outputType, Expression...arguments) {
-    return Expression.ScalarFunctionInvocation.builder().declaration(declaration).outputType(outputType).addArguments(arguments).build();
+  public static Expression.ScalarFunctionInvocation scalarFunction(
+      SimpleExtension.ScalarFunctionVariant declaration, Type outputType, Expression... arguments) {
+    return Expression.ScalarFunctionInvocation.builder()
+        .declaration(declaration)
+        .outputType(outputType)
+        .addArguments(arguments)
+        .build();
   }
 
-  public static Expression.ScalarFunctionInvocation scalarFunction(SimpleExtension.ScalarFunctionVariant declaration, Type outputType, Iterable<? extends Expression> arguments) {
-    return Expression.ScalarFunctionInvocation.builder().declaration(declaration).outputType(outputType).addAllArguments(arguments).build();
+  public static Expression.ScalarFunctionInvocation scalarFunction(
+      SimpleExtension.ScalarFunctionVariant declaration,
+      Type outputType,
+      Iterable<? extends Expression> arguments) {
+    return Expression.ScalarFunctionInvocation.builder()
+        .declaration(declaration)
+        .outputType(outputType)
+        .addAllArguments(arguments)
+        .build();
   }
 
   public static AggregateFunctionInvocation aggregateFunction(
@@ -225,10 +306,11 @@ public class ExpressionCreator {
   private static ByteString padLeftIfNeeded(byte[] value, int length) {
 
     if (length < value.length) {
-      throw new IllegalArgumentException("Byte values should either be at or below the expected length.");
+      throw new IllegalArgumentException(
+          "Byte values should either be at or below the expected length.");
     }
 
-    if(length == value.length) {
+    if (length == value.length) {
       return ByteString.copyFrom(value);
     }
 
@@ -236,7 +318,4 @@ public class ExpressionCreator {
     System.arraycopy(value, 0, newArray, length - value.length, value.length);
     return ByteString.copyFrom(newArray);
   }
-
-
-
 }

--- a/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
@@ -4,35 +4,64 @@ public interface ExpressionVisitor<R, E extends Throwable> {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExpressionVisitor.class);
 
   R visit(Expression.NullLiteral expr) throws E;
-  R visit(Expression.BoolLiteral expr) throws E;
-  R visit(Expression.I8Literal expr) throws E;
-  R visit(Expression.I16Literal expr) throws E;
-  R visit(Expression.I32Literal expr) throws E;
-  R visit(Expression.I64Literal expr) throws E;
-  R visit(Expression.FP32Literal expr) throws E;
-  R visit(Expression.FP64Literal expr) throws E;
-  R visit(Expression.StrLiteral expr) throws E;
-  R visit(Expression.BinaryLiteral expr) throws E;
-  R visit(Expression.TimeLiteral expr) throws E;
-  R visit(Expression.DateLiteral expr) throws E;
-  R visit(Expression.TimestampLiteral expr) throws E;
-  R visit(Expression.TimestampTZLiteral expr) throws E;
-  R visit(Expression.IntervalYearLiteral expr) throws E;
-  R visit(Expression.IntervalDayLiteral expr) throws E;
-  R visit(Expression.UUIDLiteral expr) throws E;
-  R visit(Expression.FixedCharLiteral expr) throws E;
-  R visit(Expression.VarCharLiteral expr) throws E;
-  R visit(Expression.FixedBinaryLiteral expr) throws E;
-  R visit(Expression.DecimalLiteral expr) throws E;
-  R visit(Expression.MapLiteral expr) throws E;
-  R visit(Expression.ListLiteral expr) throws E;
-  R visit(Expression.StructLiteral expr) throws E;
-  R visit(Expression.Switch expr) throws E;
-  R visit(Expression.IfThen expr) throws E;
-  R visit(Expression.ScalarFunctionInvocation expr) throws E;
-  R visit(Expression.Cast expr) throws E;
-  R visit(Expression.SingleOrList expr) throws E;
-  R visit(Expression.MultiOrList expr) throws E;
-  R visit(FieldReference expr) throws E;
 
+  R visit(Expression.BoolLiteral expr) throws E;
+
+  R visit(Expression.I8Literal expr) throws E;
+
+  R visit(Expression.I16Literal expr) throws E;
+
+  R visit(Expression.I32Literal expr) throws E;
+
+  R visit(Expression.I64Literal expr) throws E;
+
+  R visit(Expression.FP32Literal expr) throws E;
+
+  R visit(Expression.FP64Literal expr) throws E;
+
+  R visit(Expression.StrLiteral expr) throws E;
+
+  R visit(Expression.BinaryLiteral expr) throws E;
+
+  R visit(Expression.TimeLiteral expr) throws E;
+
+  R visit(Expression.DateLiteral expr) throws E;
+
+  R visit(Expression.TimestampLiteral expr) throws E;
+
+  R visit(Expression.TimestampTZLiteral expr) throws E;
+
+  R visit(Expression.IntervalYearLiteral expr) throws E;
+
+  R visit(Expression.IntervalDayLiteral expr) throws E;
+
+  R visit(Expression.UUIDLiteral expr) throws E;
+
+  R visit(Expression.FixedCharLiteral expr) throws E;
+
+  R visit(Expression.VarCharLiteral expr) throws E;
+
+  R visit(Expression.FixedBinaryLiteral expr) throws E;
+
+  R visit(Expression.DecimalLiteral expr) throws E;
+
+  R visit(Expression.MapLiteral expr) throws E;
+
+  R visit(Expression.ListLiteral expr) throws E;
+
+  R visit(Expression.StructLiteral expr) throws E;
+
+  R visit(Expression.Switch expr) throws E;
+
+  R visit(Expression.IfThen expr) throws E;
+
+  R visit(Expression.ScalarFunctionInvocation expr) throws E;
+
+  R visit(Expression.Cast expr) throws E;
+
+  R visit(Expression.SingleOrList expr) throws E;
+
+  R visit(Expression.MultiOrList expr) throws E;
+
+  R visit(FieldReference expr) throws E;
 }

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -1,17 +1,15 @@
 package io.substrait.expression.proto;
 
-import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.ExpressionVisitor;
 import io.substrait.expression.FieldReference;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.proto.Expression;
 import io.substrait.type.proto.TypeProtoConverter;
-
 import java.util.List;
 import java.util.function.Consumer;
 
 public class ExpressionProtoConverter implements ExpressionVisitor<Expression, RuntimeException> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ExpressionProtoConverter.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(ExpressionProtoConverter.class);
 
   private final FunctionLookup lookup;
 
@@ -97,14 +95,24 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
 
   @Override
   public Expression visit(io.substrait.expression.Expression.IntervalYearLiteral expr) {
-    return lit(bldr -> bldr.setNullable(expr.nullable()).setIntervalYearToMonth(
-        Expression.Literal.IntervalYearToMonth.newBuilder().setYears(expr.years()).setMonths(expr.months())));
+    return lit(
+        bldr ->
+            bldr.setNullable(expr.nullable())
+                .setIntervalYearToMonth(
+                    Expression.Literal.IntervalYearToMonth.newBuilder()
+                        .setYears(expr.years())
+                        .setMonths(expr.months())));
   }
 
   @Override
   public Expression visit(io.substrait.expression.Expression.IntervalDayLiteral expr) {
-    return lit(bldr -> bldr.setNullable(expr.nullable()).setIntervalDayToSecond(
-        Expression.Literal.IntervalDayToSecond.newBuilder().setDays(expr.days()).setSeconds(expr.seconds())));
+    return lit(
+        bldr ->
+            bldr.setNullable(expr.nullable())
+                .setIntervalDayToSecond(
+                    Expression.Literal.IntervalDayToSecond.newBuilder()
+                        .setDays(expr.days())
+                        .setSeconds(expr.seconds())));
   }
 
   @Override
@@ -119,7 +127,13 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
 
   @Override
   public Expression visit(io.substrait.expression.Expression.VarCharLiteral expr) {
-    return lit(bldr -> bldr.setNullable(expr.nullable()).setVarChar(Expression.Literal.VarChar.newBuilder().setValue(expr.value()).setLength(expr.length())));
+    return lit(
+        bldr ->
+            bldr.setNullable(expr.nullable())
+                .setVarChar(
+                    Expression.Literal.VarChar.newBuilder()
+                        .setValue(expr.value())
+                        .setLength(expr.length())));
   }
 
   @Override
@@ -129,39 +143,55 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
 
   @Override
   public Expression visit(io.substrait.expression.Expression.DecimalLiteral expr) {
-    return lit(bldr -> bldr.setNullable(expr.nullable()).setDecimal(
-        Expression.Literal.Decimal.newBuilder()
-            .setValue(expr.value())
-            .setPrecision(expr.precision())
-            .setScale(expr.scale())));
+    return lit(
+        bldr ->
+            bldr.setNullable(expr.nullable())
+                .setDecimal(
+                    Expression.Literal.Decimal.newBuilder()
+                        .setValue(expr.value())
+                        .setPrecision(expr.precision())
+                        .setScale(expr.scale())));
   }
 
   @Override
   public Expression visit(io.substrait.expression.Expression.MapLiteral expr) {
-    return lit(bldr -> {
-      var keyValues = expr.values().entrySet().stream().map(e -> {
-        var key = toLiteral(e.getKey());
-        var value = toLiteral(e.getValue());
-        return Expression.Literal.Map.KeyValue.newBuilder().setKey(key).setValue(value).build();
-      }).toList();
-      bldr.setNullable(expr.nullable()).setMap(Expression.Literal.Map.newBuilder().addAllKeyValues(keyValues));
-    });
+    return lit(
+        bldr -> {
+          var keyValues =
+              expr.values().entrySet().stream()
+                  .map(
+                      e -> {
+                        var key = toLiteral(e.getKey());
+                        var value = toLiteral(e.getValue());
+                        return Expression.Literal.Map.KeyValue.newBuilder()
+                            .setKey(key)
+                            .setValue(value)
+                            .build();
+                      })
+                  .toList();
+          bldr.setNullable(expr.nullable())
+              .setMap(Expression.Literal.Map.newBuilder().addAllKeyValues(keyValues));
+        });
   }
 
   @Override
   public Expression visit(io.substrait.expression.Expression.ListLiteral expr) {
-    return lit(bldr -> {
-      var values = expr.values().stream().map(this::toLiteral).toList();
-      bldr.setNullable(expr.nullable()).setList(Expression.Literal.List.newBuilder().addAllValues(values));
-    });
+    return lit(
+        bldr -> {
+          var values = expr.values().stream().map(this::toLiteral).toList();
+          bldr.setNullable(expr.nullable())
+              .setList(Expression.Literal.List.newBuilder().addAllValues(values));
+        });
   }
 
   @Override
   public Expression visit(io.substrait.expression.Expression.StructLiteral expr) {
-    return lit(bldr -> {
-      var values = expr.fields().stream().map(this::toLiteral).toList();
-      bldr.setNullable(expr.nullable()).setStruct(Expression.Literal.Struct.newBuilder().addAllFields(values));
-    });
+    return lit(
+        bldr -> {
+          var values = expr.fields().stream().map(this::toLiteral).toList();
+          bldr.setNullable(expr.nullable())
+              .setStruct(Expression.Literal.Struct.newBuilder().addAllFields(values));
+        });
   }
 
   private Expression.Literal toLiteral(io.substrait.expression.Expression expression) {
@@ -172,40 +202,60 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
 
   @Override
   public Expression visit(io.substrait.expression.Expression.Switch expr) {
-    var clauses = expr.switchClauses().stream().map(
-        s -> Expression.SwitchExpression.IfValue.newBuilder().setIf(toLiteral(s.condition())).setThen(s.then().accept(this)).build()).toList();
-    return Expression.newBuilder().setSwitchExpression(Expression.SwitchExpression.newBuilder().addAllIfs(clauses)
-            .setElse(expr.defaultClause().accept(this))
-        ).build();
+    var clauses =
+        expr.switchClauses().stream()
+            .map(
+                s ->
+                    Expression.SwitchExpression.IfValue.newBuilder()
+                        .setIf(toLiteral(s.condition()))
+                        .setThen(s.then().accept(this))
+                        .build())
+            .toList();
+    return Expression.newBuilder()
+        .setSwitchExpression(
+            Expression.SwitchExpression.newBuilder()
+                .addAllIfs(clauses)
+                .setElse(expr.defaultClause().accept(this)))
+        .build();
   }
 
   @Override
   public Expression visit(io.substrait.expression.Expression.IfThen expr) {
-    var clauses = expr.ifClauses().stream().map(
-        s -> Expression.IfThen.IfClause.newBuilder()
-            .setIf(s.condition().accept(this))
-            .setThen(s.then().accept(this)).build())
-        .toList();
-    return Expression.newBuilder().setIfThen(Expression.IfThen.newBuilder().addAllIfs(clauses)
-        .setElse(expr.elseClause().accept(this))
-    ).build();
+    var clauses =
+        expr.ifClauses().stream()
+            .map(
+                s ->
+                    Expression.IfThen.IfClause.newBuilder()
+                        .setIf(s.condition().accept(this))
+                        .setThen(s.then().accept(this))
+                        .build())
+            .toList();
+    return Expression.newBuilder()
+        .setIfThen(
+            Expression.IfThen.newBuilder()
+                .addAllIfs(clauses)
+                .setElse(expr.elseClause().accept(this)))
+        .build();
   }
 
   @Override
   public Expression visit(io.substrait.expression.Expression.ScalarFunctionInvocation expr) {
-    return Expression.newBuilder().setScalarFunction(Expression.ScalarFunction.newBuilder()
-        .setOutputType(expr.getType().accept(TypeProtoConverter.INSTANCE))
-        .setFunctionReference(lookup.getFunctionReference(expr.declaration()))
-        .addAllArgs(expr.arguments().stream().map(a -> a.accept(this)).toList())
-    ).build();
+    return Expression.newBuilder()
+        .setScalarFunction(
+            Expression.ScalarFunction.newBuilder()
+                .setOutputType(expr.getType().accept(TypeProtoConverter.INSTANCE))
+                .setFunctionReference(lookup.getFunctionReference(expr.declaration()))
+                .addAllArgs(expr.arguments().stream().map(a -> a.accept(this)).toList()))
+        .build();
   }
 
   @Override
   public Expression visit(io.substrait.expression.Expression.Cast expr) {
     return Expression.newBuilder()
-        .setCast(Expression.Cast.newBuilder()
-            .setInput(expr.input().accept(this))
-            .setType(expr.getType().accept(TypeProtoConverter.INSTANCE)))
+        .setCast(
+            Expression.Cast.newBuilder()
+                .setInput(expr.input().accept(this))
+                .setType(expr.getType().accept(TypeProtoConverter.INSTANCE)))
         .build();
   }
 
@@ -218,7 +268,8 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
   }
 
   @Override
-  public Expression visit(io.substrait.expression.Expression.SingleOrList expr) throws RuntimeException {
+  public Expression visit(io.substrait.expression.Expression.SingleOrList expr)
+      throws RuntimeException {
     return Expression.newBuilder()
         .setSingularOrList(
             Expression.SingularOrList.newBuilder()
@@ -228,15 +279,20 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
   }
 
   @Override
-  public Expression visit(io.substrait.expression.Expression.MultiOrList expr) throws RuntimeException {
+  public Expression visit(io.substrait.expression.Expression.MultiOrList expr)
+      throws RuntimeException {
     return Expression.newBuilder()
         .setMultiOrList(
             Expression.MultiOrList.newBuilder()
                 .addAllValue(from(expr.conditions()))
-                .addAllOptions(expr.optionCombinations()
-                    .stream()
-                    .map(r -> Expression.MultiOrList.Record.newBuilder().addAllFields(from(r.values())).build()).toList())
-        )
+                .addAllOptions(
+                    expr.optionCombinations().stream()
+                        .map(
+                            r ->
+                                Expression.MultiOrList.Record.newBuilder()
+                                    .addAllFields(from(r.values()))
+                                    .build())
+                        .toList()))
         .build();
   }
 
@@ -245,32 +301,34 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
     Expression.ReferenceSegment top = null;
     Expression.ReferenceSegment seg = null;
     for (var segment : expr.segments()) {
-      var protoSegment = switch (segment) {
-        case FieldReference.StructField f -> {
-          var bldr = Expression.ReferenceSegment.StructField.newBuilder().setField(f.offset());
-          if (seg != null) {
-            bldr.setChild(seg);
-          }
-          yield Expression.ReferenceSegment.newBuilder().setStructField(bldr);
-        }
-        case FieldReference.ListElement f -> {
-          var bldr = Expression.ReferenceSegment.ListElement.newBuilder().setOffset(f.offset());
-          if (seg != null) {
-            bldr.setChild(seg);
-          }
-          yield Expression.ReferenceSegment.newBuilder().setListElement(bldr);
-        }
-        case FieldReference.MapKey f -> {
-          var bldr = Expression.ReferenceSegment.MapKey.newBuilder().setMapKey(toLiteral(f.key()));
-          if (seg != null) {
-            bldr.setChild(seg);
-          }
-          yield Expression.ReferenceSegment.newBuilder().setMapKey(bldr);
-        }
-        default -> throw new IllegalArgumentException("Unhandled type: " + segment);
-      };
+      var protoSegment =
+          switch (segment) {
+            case FieldReference.StructField f -> {
+              var bldr = Expression.ReferenceSegment.StructField.newBuilder().setField(f.offset());
+              if (seg != null) {
+                bldr.setChild(seg);
+              }
+              yield Expression.ReferenceSegment.newBuilder().setStructField(bldr);
+            }
+            case FieldReference.ListElement f -> {
+              var bldr = Expression.ReferenceSegment.ListElement.newBuilder().setOffset(f.offset());
+              if (seg != null) {
+                bldr.setChild(seg);
+              }
+              yield Expression.ReferenceSegment.newBuilder().setListElement(bldr);
+            }
+            case FieldReference.MapKey f -> {
+              var bldr =
+                  Expression.ReferenceSegment.MapKey.newBuilder().setMapKey(toLiteral(f.key()));
+              if (seg != null) {
+                bldr.setChild(seg);
+              }
+              yield Expression.ReferenceSegment.newBuilder().setMapKey(bldr);
+            }
+            default -> throw new IllegalArgumentException("Unhandled type: " + segment);
+          };
       var builtSegment = protoSegment.build();
-      if(top == null) {
+      if (top == null) {
         top = builtSegment;
       }
       seg = builtSegment;
@@ -278,13 +336,11 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
 
     var out = Expression.FieldReference.newBuilder().setDirectReference(top);
     if (expr.inputExpression().isPresent()) {
-     out.setExpression(from(expr.inputExpression().get()));
+      out.setExpression(from(expr.inputExpression().get()));
     } else {
       out.setRootReference(Expression.FieldReference.RootReference.getDefaultInstance());
     }
 
     return Expression.newBuilder().setSelection(out).build();
   }
-
-
 }

--- a/core/src/main/java/io/substrait/expression/proto/FunctionLookup.java
+++ b/core/src/main/java/io/substrait/expression/proto/FunctionLookup.java
@@ -1,16 +1,15 @@
 package io.substrait.expression.proto;
 
 import io.substrait.function.SimpleExtension;
-import io.substrait.proto.Capabilities;
 import io.substrait.proto.Plan;
 import io.substrait.proto.SimpleExtensionDeclaration;
 import io.substrait.proto.SimpleExtensionURI;
-
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Maintains a mapping between function anchors and function references. Generates references for new anchors.
+ * Maintains a mapping between function anchors and function references. Generates references for
+ * new anchors.
  */
 public class FunctionLookup {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FunctionLookup.class);
@@ -30,19 +29,23 @@ public class FunctionLookup {
     return counter;
   }
 
-  public SimpleExtension.ScalarFunctionVariant getScalarFunction(int reference, SimpleExtension.ExtensionCollection extensions) {
+  public SimpleExtension.ScalarFunctionVariant getScalarFunction(
+      int reference, SimpleExtension.ExtensionCollection extensions) {
     var anchor = map.get(reference);
     if (anchor == null) {
-      throw new IllegalArgumentException("Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
+      throw new IllegalArgumentException(
+          "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
     }
 
     return extensions.getScalarFunction(anchor);
   }
 
-  public SimpleExtension.AggregateFunctionVariant getAggregateFunction(int reference, SimpleExtension.ExtensionCollection extensions) {
+  public SimpleExtension.AggregateFunctionVariant getAggregateFunction(
+      int reference, SimpleExtension.ExtensionCollection extensions) {
     var anchor = map.get(reference);
     if (anchor == null) {
-      throw new IllegalArgumentException("Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
+      throw new IllegalArgumentException(
+          "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
     }
 
     return extensions.getAggregateFunction(anchor);
@@ -53,15 +56,23 @@ public class FunctionLookup {
     var uris = new HashMap<String, SimpleExtensionURI>();
 
     var extensionList = new ArrayList<SimpleExtensionDeclaration>();
-    for(var e : map.forwardMap.entrySet()) {
-      SimpleExtensionURI uri = uris.computeIfAbsent(e.getValue().namespace(),
-          k -> SimpleExtensionURI.newBuilder().setExtensionUriAnchor(uriPos.getAndIncrement()).setUri(k).build());
-      var decl = SimpleExtensionDeclaration.newBuilder().setExtensionFunction(
-          SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
-              .setFunctionAnchor(e.getKey())
-              .setName(e.getValue().key())
-              .setExtensionUriReference(uri.getExtensionUriAnchor()))
-          .build();
+    for (var e : map.forwardMap.entrySet()) {
+      SimpleExtensionURI uri =
+          uris.computeIfAbsent(
+              e.getValue().namespace(),
+              k ->
+                  SimpleExtensionURI.newBuilder()
+                      .setExtensionUriAnchor(uriPos.getAndIncrement())
+                      .setUri(k)
+                      .build());
+      var decl =
+          SimpleExtensionDeclaration.newBuilder()
+              .setExtensionFunction(
+                  SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+                      .setFunctionAnchor(e.getKey())
+                      .setName(e.getValue().key())
+                      .setExtensionUriReference(uri.getExtensionUriAnchor()))
+              .build();
       extensionList.add(decl);
     }
 
@@ -69,9 +80,7 @@ public class FunctionLookup {
     builder.addAllExtensions(extensionList);
   }
 
-  /**
-   * We don't depend on guava...
-   */
+  /** We don't depend on guava... */
   private static class BidiMap<T1, T2> {
 
     private final Map<T1, T2> forwardMap = new HashMap<>();

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -7,18 +7,19 @@ import io.substrait.expression.ImmutableExpression;
 import io.substrait.function.SimpleExtension;
 import io.substrait.type.Type;
 import io.substrait.type.proto.FromProto;
-
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 public class ProtoExpressionConverter {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProtoExpressionConverter.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(ProtoExpressionConverter.class);
 
   private final FunctionLookup lookup;
   private final SimpleExtension.ExtensionCollection extensions;
   private final Type rootType;
 
-  public ProtoExpressionConverter(FunctionLookup lookup, SimpleExtension.ExtensionCollection extensions, Type rootType) {
+  public ProtoExpressionConverter(
+      FunctionLookup lookup, SimpleExtension.ExtensionCollection extensions, Type rootType) {
     this.lookup = lookup;
     this.extensions = extensions;
     this.rootType = rootType;
@@ -31,43 +32,50 @@ public class ProtoExpressionConverter {
 
         var segments = new ArrayList<FieldReference.ReferenceSegment>();
         while (segment != null) {
-          segments.add(switch (segment.getReferenceTypeCase()) {
-            case MAP_KEY -> {
-              var mapKey = segment.getMapKey();
-              segment = mapKey.getChild();
-              yield FieldReference.MapKey.of(from(mapKey.getMapKey()));
-            }
-            case STRUCT_FIELD -> {
-              var structField = segment.getStructField();
-              segment = structField.getChild();
-              yield FieldReference.StructField.of(structField.getField());
-            }
-            case LIST_ELEMENT -> {
-              var listElement = segment.getListElement();
-              segment = listElement.getChild();
-              yield FieldReference.ListElement.of(listElement.getOffset());
-            }
-            case REFERENCETYPE_NOT_SET -> throw new IllegalArgumentException("Unhandled type: " + segment.getReferenceTypeCase());
-          });
+          segments.add(
+              switch (segment.getReferenceTypeCase()) {
+                case MAP_KEY -> {
+                  var mapKey = segment.getMapKey();
+                  segment = mapKey.getChild();
+                  yield FieldReference.MapKey.of(from(mapKey.getMapKey()));
+                }
+                case STRUCT_FIELD -> {
+                  var structField = segment.getStructField();
+                  segment = structField.getChild();
+                  yield FieldReference.StructField.of(structField.getField());
+                }
+                case LIST_ELEMENT -> {
+                  var listElement = segment.getListElement();
+                  segment = listElement.getChild();
+                  yield FieldReference.ListElement.of(listElement.getOffset());
+                }
+                case REFERENCETYPE_NOT_SET -> throw new IllegalArgumentException(
+                    "Unhandled type: " + segment.getReferenceTypeCase());
+              });
+        }
 
-
-          }
-
-        var fieldReference = switch (reference.getRootTypeCase()) {
-          case EXPRESSION -> FieldReference.ofExpression(from(reference.getExpression()), segments);
-          case ROOT_REFERENCE -> FieldReference.ofRoot(rootType, segments);
-          case OUTER_REFERENCE -> throw new IllegalArgumentException("Subqueries not yet handled.");
-          case ROOTTYPE_NOT_SET -> throw new IllegalArgumentException("Unhandled type: " + reference.getRootTypeCase());
-        };
+        var fieldReference =
+            switch (reference.getRootTypeCase()) {
+              case EXPRESSION -> FieldReference.ofExpression(
+                  from(reference.getExpression()), segments);
+              case ROOT_REFERENCE -> FieldReference.ofRoot(rootType, segments);
+              case OUTER_REFERENCE -> throw new IllegalArgumentException(
+                  "Subqueries not yet handled.");
+              case ROOTTYPE_NOT_SET -> throw new IllegalArgumentException(
+                  "Unhandled type: " + reference.getRootTypeCase());
+            };
 
         return fieldReference;
       }
-      case MASKED_REFERENCE, default -> throw new IllegalArgumentException("Unhandled type: " + reference.getReferenceTypeCase());
+      case MASKED_REFERENCE -> throw new IllegalArgumentException(
+          "Unsupported type: " + reference.getReferenceTypeCase());
+      default -> throw new IllegalArgumentException(
+          "Unhandled type: " + reference.getReferenceTypeCase());
     }
   }
 
   public Expression from(io.substrait.proto.Expression expr) {
-    return switch(expr.getRexTypeCase()) {
+    return switch (expr.getRexTypeCase()) {
       case LITERAL -> from(expr.getLiteral());
       case SELECTION -> from(expr.getSelection());
       case SCALAR_FUNCTION -> {
@@ -83,35 +91,50 @@ public class ProtoExpressionConverter {
       }
       case IF_THEN -> {
         var ifThen = expr.getIfThen();
-        var clauses = ifThen.getIfsList().stream().map(t -> ExpressionCreator.ifThenClause(from(t.getIf()), from(t.getThen()))).toList();
+        var clauses =
+            ifThen.getIfsList().stream()
+                .map(t -> ExpressionCreator.ifThenClause(from(t.getIf()), from(t.getThen())))
+                .toList();
         yield ExpressionCreator.ifThenStatement(from(ifThen.getElse()), clauses);
       }
       case SWITCH_EXPRESSION -> {
         var switchExpr = expr.getSwitchExpression();
-        var clauses = switchExpr.getIfsList().stream().map(t -> ExpressionCreator.switchClause(from(t.getIf()), from(t.getThen()))).toList();
+        var clauses =
+            switchExpr.getIfsList().stream()
+                .map(t -> ExpressionCreator.switchClause(from(t.getIf()), from(t.getThen())))
+                .toList();
         yield ExpressionCreator.switchStatement(from(switchExpr.getElse()), clauses);
       }
       case SINGULAR_OR_LIST -> {
         var orList = expr.getSingularOrList();
         var values = orList.getOptionsList().stream().map(this::from).toList();
-        yield ImmutableExpression.SingleOrList.builder().condition(from(orList.getValue())).addAllOptions(values).build();
+        yield ImmutableExpression.SingleOrList.builder()
+            .condition(from(orList.getValue()))
+            .addAllOptions(values)
+            .build();
       }
       case MULTI_OR_LIST -> {
         var multiOrList = expr.getMultiOrList();
-        var values = multiOrList.getOptionsList()
-            .stream()
-            .map(t -> ImmutableExpression.MultiOrListRecord.builder()
-                .addAllValues(t.getFieldsList().stream().map(this::from).toList()).build())
-            .toList();
+        var values =
+            multiOrList.getOptionsList().stream()
+                .map(
+                    t ->
+                        ImmutableExpression.MultiOrListRecord.builder()
+                            .addAllValues(t.getFieldsList().stream().map(this::from).toList())
+                            .build())
+                .toList();
         yield ImmutableExpression.MultiOrList.builder()
             .addAllOptionCombinations(values)
             .addAllConditions(multiOrList.getValueList().stream().map(this::from).toList())
             .build();
       }
-      case CAST -> ExpressionCreator.cast(FromProto.from(expr.getCast().getType()), from(expr.getCast().getInput()));
+      case CAST -> ExpressionCreator.cast(
+          FromProto.from(expr.getCast().getType()), from(expr.getCast().getInput()));
 
-      //TODO window, enum.
-      case WINDOW_FUNCTION, ENUM, default -> throw new IllegalArgumentException("Unknown type: " + expr.getRexTypeCase());
+        // TODO window, enum.
+      case WINDOW_FUNCTION, ENUM -> throw new IllegalArgumentException(
+          "Unsupported type: " + expr.getRexTypeCase());
+      default -> throw new IllegalArgumentException("Unknown type: " + expr.getRexTypeCase());
     };
   }
 
@@ -120,7 +143,7 @@ public class ProtoExpressionConverter {
   }
 
   private static Expression.Literal from(io.substrait.proto.Expression.Literal literal) {
-    return switch(literal.getLiteralTypeCase()) {
+    return switch (literal.getLiteralTypeCase()) {
       case BOOLEAN -> ExpressionCreator.bool(literal.getNullable(), literal.getBoolean());
       case I8 -> ExpressionCreator.i8(literal.getNullable(), literal.getI8());
       case I16 -> ExpressionCreator.i16(literal.getNullable(), literal.getI16());
@@ -133,19 +156,42 @@ public class ProtoExpressionConverter {
       case TIMESTAMP -> ExpressionCreator.timestamp(literal.getNullable(), literal.getTimestamp());
       case DATE -> ExpressionCreator.date(literal.getNullable(), literal.getDate());
       case TIME -> ExpressionCreator.time(literal.getNullable(), literal.getTime());
-      case INTERVAL_YEAR_TO_MONTH -> ExpressionCreator.intervalYear(literal.getNullable(), literal.getIntervalYearToMonth().getYears(), literal.getIntervalYearToMonth().getMonths());
-      case INTERVAL_DAY_TO_SECOND -> ExpressionCreator.intervalDay(literal.getNullable(), literal.getIntervalDayToSecond().getDays(), literal.getIntervalDayToSecond().getSeconds());
+      case INTERVAL_YEAR_TO_MONTH -> ExpressionCreator.intervalYear(
+          literal.getNullable(),
+          literal.getIntervalYearToMonth().getYears(),
+          literal.getIntervalYearToMonth().getMonths());
+      case INTERVAL_DAY_TO_SECOND -> ExpressionCreator.intervalDay(
+          literal.getNullable(),
+          literal.getIntervalDayToSecond().getDays(),
+          literal.getIntervalDayToSecond().getSeconds());
       case FIXED_CHAR -> ExpressionCreator.fixedChar(literal.getNullable(), literal.getFixedChar());
-      case VAR_CHAR -> ExpressionCreator.varChar(literal.getNullable(), literal.getVarChar().getValue(), literal.getVarChar().getLength());
-      case FIXED_BINARY -> ExpressionCreator.fixedBinary(literal.getNullable(), literal.getFixedBinary());
-      case DECIMAL -> ExpressionCreator.decimal(literal.getNullable(), literal.getDecimal().getValue(), literal.getDecimal().getPrecision(), literal.getDecimal().getScale());
-      case STRUCT -> ExpressionCreator.struct(literal.getNullable(), literal.getStruct().getFieldsList().stream().map(ProtoExpressionConverter::from).toList());
-      case MAP -> ExpressionCreator.map(literal.getNullable(), literal.getMap().getKeyValuesList().stream().collect(Collectors.toMap(kv -> from(kv.getKey()), kv -> from(kv.getValue()))));
-      case TIMESTAMP_TZ -> ExpressionCreator.timestampTZ(literal.getNullable(), literal.getTimestampTz());
+      case VAR_CHAR -> ExpressionCreator.varChar(
+          literal.getNullable(), literal.getVarChar().getValue(), literal.getVarChar().getLength());
+      case FIXED_BINARY -> ExpressionCreator.fixedBinary(
+          literal.getNullable(), literal.getFixedBinary());
+      case DECIMAL -> ExpressionCreator.decimal(
+          literal.getNullable(),
+          literal.getDecimal().getValue(),
+          literal.getDecimal().getPrecision(),
+          literal.getDecimal().getScale());
+      case STRUCT -> ExpressionCreator.struct(
+          literal.getNullable(),
+          literal.getStruct().getFieldsList().stream()
+              .map(ProtoExpressionConverter::from)
+              .toList());
+      case MAP -> ExpressionCreator.map(
+          literal.getNullable(),
+          literal.getMap().getKeyValuesList().stream()
+              .collect(Collectors.toMap(kv -> from(kv.getKey()), kv -> from(kv.getValue()))));
+      case TIMESTAMP_TZ -> ExpressionCreator.timestampTZ(
+          literal.getNullable(), literal.getTimestampTz());
       case UUID -> ExpressionCreator.uuid(literal.getNullable(), literal.getUuid());
       case NULL -> ExpressionCreator.typedNull(from(literal.getNull()));
-      case LIST -> ExpressionCreator.list(literal.getNullable(), literal.getList().getValuesList().stream().map(ProtoExpressionConverter::from).toList());
-      default -> throw new IllegalStateException("Unexpected value: " + literal.getLiteralTypeCase());
+      case LIST -> ExpressionCreator.list(
+          literal.getNullable(),
+          literal.getList().getValuesList().stream().map(ProtoExpressionConverter::from).toList());
+      default -> throw new IllegalStateException(
+          "Unexpected value: " + literal.getLiteralTypeCase());
     };
   }
 }

--- a/core/src/main/java/io/substrait/function/ExtendedTypeCreator.java
+++ b/core/src/main/java/io/substrait/function/ExtendedTypeCreator.java
@@ -1,15 +1,19 @@
 package io.substrait.function;
 
-import io.substrait.type.Type;
-
 public interface ExtendedTypeCreator<T, I> {
   T fixedCharE(I len);
+
   T varCharE(I len);
+
   T fixedBinaryE(I len);
+
   T decimalE(I precision, I scale);
-  
+
   T structE(T... types);
+
   T structE(Iterable<? extends T> types);
+
   T listE(T type);
+
   T mapE(T key, T value);
 }

--- a/core/src/main/java/io/substrait/function/ParameterizedType.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedType.java
@@ -1,9 +1,8 @@
 package io.substrait.function;
 
 import io.substrait.type.TypeVisitor;
-import org.immutables.value.Value;
-
 import java.util.Locale;
+import org.immutables.value.Value;
 
 /**
  * Types used in function argument declarations. Can utilize strings for integer or type parameters.
@@ -21,7 +20,6 @@ public interface ParameterizedType extends TypeExpression {
 
   <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E;
 
-
   public static ParameterizedTypeCreator withNullability(boolean nullable) {
     return nullable ? ParameterizedTypeCreator.NULLABLE : ParameterizedTypeCreator.REQUIRED;
   }
@@ -34,18 +32,20 @@ public interface ParameterizedType extends TypeExpression {
     return false;
   }
 
-  static abstract class BaseParameterizedType implements ParameterizedType {
+  abstract static class BaseParameterizedType implements ParameterizedType {
     public final <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
       if (typeVisitor instanceof ParameterizedTypeVisitor) {
         return accept((ParameterizedTypeVisitor<R, E>) typeVisitor);
       }
       throw new RequiredParameterizedVisitorException();
     }
-    abstract <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E;
+
+    abstract <R, E extends Throwable> R accept(
+        final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E;
   }
 
   @Value.Immutable
-  static abstract class FixedChar extends BaseParameterizedType implements NullableType {
+  abstract static class FixedChar extends BaseParameterizedType implements NullableType {
     public abstract StringLiteral length();
 
     public static ImmutableParameterizedType.FixedChar.Builder builder() {
@@ -53,13 +53,14 @@ public interface ParameterizedType extends TypeExpression {
     }
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
   }
 
   @Value.Immutable
-  static abstract class VarChar extends BaseParameterizedType implements NullableType {
+  abstract static class VarChar extends BaseParameterizedType implements NullableType {
     public abstract StringLiteral length();
 
     public static ImmutableParameterizedType.VarChar.Builder builder() {
@@ -67,13 +68,14 @@ public interface ParameterizedType extends TypeExpression {
     }
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
   }
 
   @Value.Immutable
-  static abstract class FixedBinary extends BaseParameterizedType implements NullableType {
+  abstract static class FixedBinary extends BaseParameterizedType implements NullableType {
     public abstract StringLiteral length();
 
     public static ImmutableParameterizedType.FixedBinary.Builder builder() {
@@ -81,28 +83,31 @@ public interface ParameterizedType extends TypeExpression {
     }
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
   }
 
   @Value.Immutable
-  static abstract class Decimal extends BaseParameterizedType implements NullableType {
+  abstract static class Decimal extends BaseParameterizedType implements NullableType {
     public abstract StringLiteral scale();
 
     public abstract StringLiteral precision();
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
+
     public static ImmutableParameterizedType.Decimal.Builder builder() {
       return ImmutableParameterizedType.Decimal.builder();
     }
   }
 
   @Value.Immutable
-  static abstract class Struct extends BaseParameterizedType implements NullableType {
+  abstract static class Struct extends BaseParameterizedType implements NullableType {
     public abstract java.util.List<ParameterizedType> fields();
 
     public static ImmutableParameterizedType.Struct.Builder builder() {
@@ -110,13 +115,14 @@ public interface ParameterizedType extends TypeExpression {
     }
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
   }
 
   @Value.Immutable
-  static abstract class ListType extends BaseParameterizedType implements NullableType {
+  abstract static class ListType extends BaseParameterizedType implements NullableType {
     public abstract ParameterizedType name();
 
     public static ImmutableParameterizedType.ListType.Builder builder() {
@@ -124,13 +130,14 @@ public interface ParameterizedType extends TypeExpression {
     }
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
   }
 
   @Value.Immutable
-  static abstract class Map extends BaseParameterizedType implements NullableType {
+  abstract static class Map extends BaseParameterizedType implements NullableType {
     public abstract ParameterizedType key();
 
     public abstract ParameterizedType value();
@@ -140,13 +147,14 @@ public interface ParameterizedType extends TypeExpression {
     }
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
   }
 
   @Value.Immutable
-  static abstract class StringLiteral extends BaseParameterizedType {
+  abstract static class StringLiteral extends BaseParameterizedType {
     public abstract String value();
 
     public static ImmutableParameterizedType.StringLiteral.Builder builder() {
@@ -159,9 +167,9 @@ public interface ParameterizedType extends TypeExpression {
     }
 
     @Override
-    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor) throws E {
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
       return parameterizedTypeVisitor.visit(this);
     }
   }
-
 }

--- a/core/src/main/java/io/substrait/function/ParameterizedTypeCreator.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedTypeCreator.java
@@ -2,7 +2,8 @@ package io.substrait.function;
 
 import io.substrait.type.TypeCreator;
 
-public class ParameterizedTypeCreator extends TypeCreator implements ExtendedTypeCreator<ParameterizedType, String> {
+public class ParameterizedTypeCreator extends TypeCreator
+    implements ExtendedTypeCreator<ParameterizedType, String> {
 
   public static final ParameterizedTypeCreator REQUIRED = new ParameterizedTypeCreator(false);
   public static final ParameterizedTypeCreator NULLABLE = new ParameterizedTypeCreator(true);
@@ -24,11 +25,18 @@ public class ParameterizedTypeCreator extends TypeCreator implements ExtendedTyp
   }
 
   public ParameterizedType fixedBinaryE(String len) {
-    return ParameterizedType.FixedBinary.builder().nullable(nullable).length(parameter(len)).build();
+    return ParameterizedType.FixedBinary.builder()
+        .nullable(nullable)
+        .length(parameter(len))
+        .build();
   }
 
   public ParameterizedType decimalE(String precision, String scale) {
-    return ParameterizedType.Decimal.builder().nullable(nullable).precision(parameter(precision)).scale(parameter(scale)).build();
+    return ParameterizedType.Decimal.builder()
+        .nullable(nullable)
+        .precision(parameter(precision))
+        .scale(parameter(scale))
+        .build();
   }
 
   public ParameterizedType structE(ParameterizedType... types) {

--- a/core/src/main/java/io/substrait/function/ParameterizedTypeVisitor.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedTypeVisitor.java
@@ -19,7 +19,8 @@ public interface ParameterizedTypeVisitor<R, E extends Throwable> extends TypeVi
 
   R visit(ParameterizedType.StringLiteral stringLiteral) throws E;
 
-  public static abstract class ParameterizedTypeThrowsVisitor<R, E extends Throwable> extends TypeVisitor.TypeThrowsVisitor<R, E> implements ParameterizedTypeVisitor<R, E> {
+  public abstract static class ParameterizedTypeThrowsVisitor<R, E extends Throwable>
+      extends TypeVisitor.TypeThrowsVisitor<R, E> implements ParameterizedTypeVisitor<R, E> {
 
     protected ParameterizedTypeThrowsVisitor(String unsupportedMessage) {
       super(unsupportedMessage);

--- a/core/src/main/java/io/substrait/function/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/function/SimpleExtension.java
@@ -14,41 +14,58 @@ import io.substrait.type.Deserializers;
 import io.substrait.type.Type;
 import io.substrait.type.TypeExpressionEvaluator;
 import io.substrait.util.Util;
-import org.immutables.value.Value;
-
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
 
 /**
- * Classes used to deserialize YAML extension files. Currently, constrained to Function deserialization.
+ * Classes used to deserialize YAML extension files. Currently, constrained to Function
+ * deserialization.
  */
 @Value.Enclosing
 public class SimpleExtension {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SimpleExtension.class);
 
-  private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory())
-      .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-      .registerModule(new Jdk8Module())
-      .registerModule(Deserializers.MODULE);
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper(new YAMLFactory())
+          .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+          .registerModule(new Jdk8Module())
+          .registerModule(Deserializers.MODULE);
 
-  enum Nullability {MIRROR, DECLARED_OUTPUT, DISCRETE}
-  enum Decomposability {NONE, ONE, MANY}
+  enum Nullability {
+    MIRROR,
+    DECLARED_OUTPUT,
+    DISCRETE
+  }
 
-  private SimpleExtension(){}
+  enum Decomposability {
+    NONE,
+    ONE,
+    MANY
+  }
+
+  private SimpleExtension() {}
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-  @JsonSubTypes({@JsonSubTypes.Type(ValueArgument.class), @JsonSubTypes.Type(TypeArgument.class), @JsonSubTypes.Type(EnumArgument.class)})
+  @JsonSubTypes({
+    @JsonSubTypes.Type(ValueArgument.class),
+    @JsonSubTypes.Type(TypeArgument.class),
+    @JsonSubTypes.Type(EnumArgument.class)
+  })
   public interface Argument {
     String toTypeString();
-    boolean required();
 
+    boolean required();
   }
-  public record ValueArgument(@JsonProperty(required = true) ParameterizedType value, String name, boolean constant) implements Argument {
+
+  public record ValueArgument(
+      @JsonProperty(required = true) ParameterizedType value, String name, boolean constant)
+      implements Argument {
     public String toTypeString() {
       return value.accept(ToTypeString.INSTANCE);
     }
@@ -57,6 +74,7 @@ public class SimpleExtension {
       return true;
     }
   }
+
   public record TypeArgument(ParameterizedType type, String name) implements Argument {
     public String toTypeString() {
       return "type";
@@ -65,10 +83,10 @@ public class SimpleExtension {
     public boolean required() {
       return true;
     }
-
   }
 
-  public record EnumArgument(List<String> options, String name, boolean required) implements Argument {
+  public record EnumArgument(List<String> options, String name, boolean required)
+      implements Argument {
     public String toTypeString() {
       return required ? "req" : "opt";
     }
@@ -77,10 +95,14 @@ public class SimpleExtension {
   @Value.Immutable
   public interface FunctionAnchor {
     String namespace();
+
     String key();
 
     static FunctionAnchor of(String namespace, String key) {
-      return ImmutableSimpleExtension.FunctionAnchor.builder().namespace(namespace).key(key).build();
+      return ImmutableSimpleExtension.FunctionAnchor.builder()
+          .namespace(namespace)
+          .key(key)
+          .build();
     }
   }
 
@@ -89,15 +111,20 @@ public class SimpleExtension {
   @Value.Immutable
   public interface VariadicBehavior {
     int getMin();
+
     OptionalInt getMax();
-    enum ParameterConsistency {CONSISTENT, INCONSISTENT}
+
+    enum ParameterConsistency {
+      CONSISTENT,
+      INCONSISTENT
+    }
 
     default ParameterConsistency parameterConsistency() {
       return ParameterConsistency.CONSISTENT;
     }
   }
 
-  public static abstract class Function {
+  public abstract static class Function {
     @Value.Default
     public String name() {
       // we can't use null detection here since we initially construct this with a parent name.
@@ -106,14 +133,16 @@ public class SimpleExtension {
 
     @Value.Default
     public String uri() {
-      // we can't use null detection here since we initially construct this without a uri, then resolve later.
+      // we can't use null detection here since we initially construct this without a uri, then
+      // resolve later.
       return "";
     }
 
     public abstract Optional<VariadicBehavior> variadic();
 
     @Value.Default
-    @Nullable public String description() {
+    @Nullable
+    public String description() {
       return "";
     }
 
@@ -140,28 +169,36 @@ public class SimpleExtension {
     @JsonProperty(value = "return")
     public abstract TypeExpression returnType();
 
-    private final Supplier<FunctionAnchor> anchorSupplier = Util.memoize(() -> FunctionAnchor.of(uri(), key()));
+    private final Supplier<FunctionAnchor> anchorSupplier =
+        Util.memoize(() -> FunctionAnchor.of(uri(), key()));
     private final Supplier<String> keySupplier = Util.memoize(() -> constructKey(name(), args()));
-    private final Supplier<List<Argument>> requiredArgsSupplier = Util.memoize(() -> {
-      return args().stream().filter(Argument::required).toList();
-    });
+    private final Supplier<List<Argument>> requiredArgsSupplier =
+        Util.memoize(
+            () -> {
+              return args().stream().filter(Argument::required).toList();
+            });
 
     public static String constructKeyFromTypes(String name, List<Type> arguments) {
       try {
-        return name + ":" + arguments.stream()
-            .map(t -> t.accept(ToTypeString.INSTANCE))
-            .collect(Collectors.joining("_"));
+        return name
+            + ":"
+            + arguments.stream()
+                .map(t -> t.accept(ToTypeString.INSTANCE))
+                .collect(Collectors.joining("_"));
       } catch (UnsupportedOperationException ex) {
-        throw new UnsupportedOperationException(String.format("Failure converting types of function %s.", name), ex);
+        throw new UnsupportedOperationException(
+            String.format("Failure converting types of function %s.", name), ex);
       }
     }
+
     public static String constructKey(String name, List<Argument> arguments) {
       try {
-        return name + ":" + arguments.stream()
-            .map(Argument::toTypeString)
-            .collect(Collectors.joining("_"));
+        return name
+            + ":"
+            + arguments.stream().map(Argument::toTypeString).collect(Collectors.joining("_"));
       } catch (UnsupportedOperationException ex) {
-        throw new UnsupportedOperationException(String.format("Failure converting types of function %s.", name), ex);
+        throw new UnsupportedOperationException(
+            String.format("Failure converting types of function %s.", name), ex);
       }
     }
 
@@ -169,12 +206,17 @@ public class SimpleExtension {
       // end range is exclusive so add one to size.
 
       long optionalCount = args().stream().filter(t -> !t.required()).count();
-      int max = variadic()
-          .map(t -> t.getMax().stream().map(x -> args().size() - 1 + x + 1)
-          .findFirst()
-              .orElse(Integer.MAX_VALUE)).orElse(args().size() + 1);
-      int min = variadic()
-          .map(t -> args().size() - 1 + t.getMin()).orElse(requiredArguments().size());
+      int max =
+          variadic()
+              .map(
+                  t ->
+                      t.getMax().stream()
+                          .map(x -> args().size() - 1 + x + 1)
+                          .findFirst()
+                          .orElse(Integer.MAX_VALUE))
+              .orElse(args().size() + 1);
+      int min =
+          variadic().map(t -> args().size() - 1 + t.getMin()).orElse(requiredArguments().size());
       return Util.IntRange.of(min, max);
     }
 
@@ -182,12 +224,15 @@ public class SimpleExtension {
       // TODO: support advanced output type validation using return expressions, parameters, etc.
       // The code below was too restrictive in the case of nullability conversion.
       return;
-//      boolean makeNullable = nullability() == Nullability.MIRROR &&
-//          argumentExpressions.stream().filter(e -> e.getType().nullable()).findFirst().isPresent();
-//      if (returnType() instanceof Type && !outputType.equals(returnType())) {
-//
-//        throw new IllegalArgumentException(String.format("Output type of %s doesn't match expected output type of %s for %s.", outputType, returnType(), this.key()));
-//      }
+      //      boolean makeNullable = nullability() == Nullability.MIRROR &&
+      //          argumentExpressions.stream().filter(e ->
+      // e.getType().nullable()).findFirst().isPresent();
+      //      if (returnType() instanceof Type && !outputType.equals(returnType())) {
+      //
+      //        throw new IllegalArgumentException(String.format("Output type of %s doesn't match
+      // expected output
+      // type of %s for %s.", outputType, returnType(), this.key()));
+      //      }
     }
 
     public String key() {
@@ -197,15 +242,17 @@ public class SimpleExtension {
     public Type resolveType(List<Type> argumentTypes) {
       return TypeExpressionEvaluator.evaluateExpression(returnType(), args(), argumentTypes);
     }
-
   }
 
   @JsonDeserialize(as = ImmutableSimpleExtension.ScalarFunction.class)
   @JsonSerialize(as = ImmutableSimpleExtension.ScalarFunction.class)
   @Value.Immutable
-  public static abstract class ScalarFunction {
+  public abstract static class ScalarFunction {
     public abstract String name();
-    @Nullable public abstract String description();
+
+    @Nullable
+    public abstract String description();
+
     public abstract List<ScalarFunctionVariant> impls();
 
     Stream<ScalarFunctionVariant> resolve(String uri) {
@@ -216,7 +263,7 @@ public class SimpleExtension {
   @JsonDeserialize(as = ImmutableSimpleExtension.ScalarFunctionVariant.class)
   @JsonSerialize(as = ImmutableSimpleExtension.ScalarFunctionVariant.class)
   @Value.Immutable
-  public static abstract class ScalarFunctionVariant extends Function {
+  public abstract static class ScalarFunctionVariant extends Function {
     public ScalarFunctionVariant resolve(String uri, String name, String description) {
       return ImmutableSimpleExtension.ScalarFunctionVariant.builder()
           .uri(uri)
@@ -228,16 +275,18 @@ public class SimpleExtension {
           .returnType(returnType())
           .build();
     }
-
   }
 
   @JsonDeserialize(as = ImmutableSimpleExtension.AggregateFunction.class)
   @JsonSerialize(as = ImmutableSimpleExtension.AggregateFunction.class)
   @Value.Immutable
-  public static abstract class AggregateFunction {
-    @Nullable public abstract String name();
+  public abstract static class AggregateFunction {
+    @Nullable
+    public abstract String name();
 
-    @Nullable public abstract String description();
+    @Nullable
+    public abstract String description();
+
     public abstract List<AggregateFunctionVariant> impls();
 
     public Stream<AggregateFunctionVariant> resolve(String uri) {
@@ -248,7 +297,7 @@ public class SimpleExtension {
   @JsonDeserialize(as = ImmutableSimpleExtension.AggregateFunctionVariant.class)
   @JsonSerialize(as = ImmutableSimpleExtension.AggregateFunctionVariant.class)
   @Value.Immutable
-  public static abstract class AggregateFunctionVariant extends Function {
+  public abstract static class AggregateFunctionVariant extends Function {
     @Value.Default
     @JsonProperty("decomposable")
     public Decomposability decomposability() {
@@ -280,49 +329,68 @@ public class SimpleExtension {
   @JsonDeserialize(as = ImmutableSimpleExtension.FunctionSignatures.class)
   @JsonSerialize(as = ImmutableSimpleExtension.FunctionSignatures.class)
   @Value.Immutable
-  public static abstract class FunctionSignatures {
-    @JsonProperty("scalar_functions") public abstract List<ScalarFunction> scalars();
-    @JsonProperty("aggregate_functions") public abstract List<AggregateFunction> aggregates();
+  public abstract static class FunctionSignatures {
+    @JsonProperty("scalar_functions")
+    public abstract List<ScalarFunction> scalars();
+
+    @JsonProperty("aggregate_functions")
+    public abstract List<AggregateFunction> aggregates();
 
     public int size() {
-      return (scalars() == null ? 0 : scalars().size()) +
-          (aggregates() == null ? 0 : aggregates().size());
+      return (scalars() == null ? 0 : scalars().size())
+          + (aggregates() == null ? 0 : aggregates().size());
     }
 
     public Stream<SimpleExtension.Function> resolve(String uri) {
       return Stream.concat(
           scalars() == null ? Stream.of() : scalars().stream().flatMap(f -> f.resolve(uri)),
-          aggregates() == null ? Stream.of() : aggregates().stream().flatMap(f -> f.resolve(uri))
-          );
+          aggregates() == null ? Stream.of() : aggregates().stream().flatMap(f -> f.resolve(uri)));
     }
-
   }
 
   @Value.Immutable
   public abstract static class ExtensionCollection {
     public abstract List<ScalarFunctionVariant> scalarFunctions();
+
     public abstract List<AggregateFunctionVariant> aggregateFunctions();
 
-    private final Supplier<Set<String>> namespaceSupplier = Util.memoize(() -> {
-      return Stream.concat(scalarFunctions().stream().map(Function::uri),
-          aggregateFunctions().stream().map(Function::uri)).collect(Collectors.toSet());
-    });
-    private final Supplier<Map<FunctionAnchor, ScalarFunctionVariant>> scalarFunctionsLookup = Util.memoize(() -> {
-      return scalarFunctions().stream().collect(Collectors.toMap(Function::getAnchor, java.util.function.Function.identity()));
-    });
+    private final Supplier<Set<String>> namespaceSupplier =
+        Util.memoize(
+            () -> {
+              return Stream.concat(
+                      scalarFunctions().stream().map(Function::uri),
+                      aggregateFunctions().stream().map(Function::uri))
+                  .collect(Collectors.toSet());
+            });
+    private final Supplier<Map<FunctionAnchor, ScalarFunctionVariant>> scalarFunctionsLookup =
+        Util.memoize(
+            () -> {
+              return scalarFunctions().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Function::getAnchor, java.util.function.Function.identity()));
+            });
 
-    private final Supplier<Map<FunctionAnchor, AggregateFunctionVariant>> aggregateFunctionsLookup = Util.memoize(() -> {
-      return aggregateFunctions().stream().collect(Collectors.toMap(Function::getAnchor, java.util.function.Function.identity()));
-    });
+    private final Supplier<Map<FunctionAnchor, AggregateFunctionVariant>> aggregateFunctionsLookup =
+        Util.memoize(
+            () -> {
+              return aggregateFunctions().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Function::getAnchor, java.util.function.Function.identity()));
+            });
 
     public ScalarFunctionVariant getScalarFunction(FunctionAnchor anchor) {
-       ScalarFunctionVariant variant = scalarFunctionsLookup.get().get(anchor);
-       if (variant != null) {
-         return variant;
-       }
+      ScalarFunctionVariant variant = scalarFunctionsLookup.get().get(anchor);
+      if (variant != null) {
+        return variant;
+      }
       checkNamespace(anchor.namespace());
-      throw new IllegalArgumentException(String.format("Unexpected scalar function with key %s. The namespace %s is loaded " +
-          "but no scalar function with this key found.", anchor.key(), anchor.namespace()));
+      throw new IllegalArgumentException(
+          String.format(
+              "Unexpected scalar function with key %s. The namespace %s is loaded "
+                  + "but no scalar function with this key found.",
+              anchor.key(), anchor.namespace()));
     }
 
     private void checkNamespace(String name) {
@@ -330,8 +398,11 @@ public class SimpleExtension {
         return;
       }
 
-      throw new IllegalArgumentException(String.format("Received a reference for extension %s " +
-          "but that extension is not currently loaded.", name));
+      throw new IllegalArgumentException(
+          String.format(
+              "Received a reference for extension %s "
+                  + "but that extension is not currently loaded.",
+              name));
     }
 
     public AggregateFunctionVariant getAggregateFunction(FunctionAnchor anchor) {
@@ -341,22 +412,36 @@ public class SimpleExtension {
       }
 
       checkNamespace(anchor.namespace());
-      throw new IllegalArgumentException(String.format("Unexpected aggregate function with key %s. The namespace %s is loaded " +
-          "but no aggregate function with this key was found.", anchor.key(), anchor.namespace()));
+      throw new IllegalArgumentException(
+          String.format(
+              "Unexpected aggregate function with key %s. The namespace %s is loaded "
+                  + "but no aggregate function with this key was found.",
+              anchor.key(), anchor.namespace()));
     }
 
     public ExtensionCollection merge(ExtensionCollection extensionCollection) {
       return ImmutableSimpleExtension.ExtensionCollection.builder()
-          .addAllAggregateFunctions(aggregateFunctions()).addAllAggregateFunctions(extensionCollection.aggregateFunctions())
-          .addAllScalarFunctions(scalarFunctions()).addAllScalarFunctions(extensionCollection.scalarFunctions())
+          .addAllAggregateFunctions(aggregateFunctions())
+          .addAllAggregateFunctions(extensionCollection.aggregateFunctions())
+          .addAllScalarFunctions(scalarFunctions())
+          .addAllScalarFunctions(extensionCollection.scalarFunctions())
           .build();
     }
   }
 
   public static ExtensionCollection loadDefaults() throws IOException {
-    var defaultFiles = Arrays.asList(
-        "boolean", "aggregate_generic", "arithmetic_decimal", "arithmetic", "comparison", "datetime", "string"
-    ).stream().map(c -> String.format("/functions_%s.yaml", c)).toList();
+    var defaultFiles =
+        Arrays.asList(
+                "boolean",
+                "aggregate_generic",
+                "arithmetic_decimal",
+                "arithmetic",
+                "comparison",
+                "datetime",
+                "string")
+            .stream()
+            .map(c -> String.format("/functions_%s.yaml", c))
+            .toList();
 
     return load(defaultFiles);
   }
@@ -366,13 +451,17 @@ public class SimpleExtension {
       throw new IllegalArgumentException("Require at least one resource path.");
     }
 
-    var extensions = resourcePaths.stream().map(path -> {
-      try(var stream = ExtensionCollection.class.getResourceAsStream(path)) {
-        return load(path, stream);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }).toList();
+    var extensions =
+        resourcePaths.stream()
+            .map(
+                path -> {
+                  try (var stream = ExtensionCollection.class.getResourceAsStream(path)) {
+                    return load(path, stream);
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .toList();
     ExtensionCollection complete = extensions.get(0);
     for (int i = 1; i < extensions.size(); i++) {
       complete = complete.merge(extensions.get(i));
@@ -383,11 +472,18 @@ public class SimpleExtension {
   private static ExtensionCollection load(String namespace, InputStream stream) {
     try {
       var doc = MAPPER.readValue(stream, SimpleExtension.FunctionSignatures.class);
-      var collection = ImmutableSimpleExtension.ExtensionCollection.builder()
-          .addAllAggregateFunctions(doc.aggregates().stream().flatMap(t -> t.resolve(namespace)).toList())
-          .addAllScalarFunctions(doc.scalars().stream().flatMap(t -> t.resolve(namespace)).toList())
-          .build();
-      logger.debug("Loaded {} aggregate functions and {} scalar functions from {}.", collection.aggregateFunctions().size(), collection.scalarFunctions().size(), namespace);
+      var collection =
+          ImmutableSimpleExtension.ExtensionCollection.builder()
+              .addAllAggregateFunctions(
+                  doc.aggregates().stream().flatMap(t -> t.resolve(namespace)).toList())
+              .addAllScalarFunctions(
+                  doc.scalars().stream().flatMap(t -> t.resolve(namespace)).toList())
+              .build();
+      logger.debug(
+          "Loaded {} aggregate functions and {} scalar functions from {}.",
+          collection.aggregateFunctions().size(),
+          collection.scalarFunctions().size(),
+          namespace);
       return collection;
     } catch (RuntimeException ex) {
       throw ex;

--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -2,7 +2,8 @@ package io.substrait.function;
 
 import io.substrait.type.Type;
 
-public class ToTypeString extends ParameterizedTypeVisitor.ParameterizedTypeThrowsVisitor<String, RuntimeException> {
+public class ToTypeString
+    extends ParameterizedTypeVisitor.ParameterizedTypeThrowsVisitor<String, RuntimeException> {
 
   public static ToTypeString INSTANCE = new ToTypeString();
 
@@ -168,5 +169,4 @@ public class ToTypeString extends ParameterizedTypeVisitor.ParameterizedTypeThro
       return super.visit(expr);
     }
   }
-
 }

--- a/core/src/main/java/io/substrait/function/TypeExpression.java
+++ b/core/src/main/java/io/substrait/function/TypeExpression.java
@@ -1,14 +1,12 @@
 package io.substrait.function;
 
-import io.substrait.type.Type;
 import io.substrait.type.TypeVisitor;
 import org.immutables.value.Value;
 
 @Value.Enclosing
 public interface TypeExpression {
 
-  static class RequiredTypeExpressionVisitorException extends RuntimeException {
-  }
+  static class RequiredTypeExpressionVisitorException extends RuntimeException {}
 
   <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E;
 
@@ -16,7 +14,7 @@ public interface TypeExpression {
     return nullable ? TypeExpressionCreator.NULLABLE : TypeExpressionCreator.REQUIRED;
   }
 
-  static abstract class BaseTypeExpression implements TypeExpression {
+  abstract static class BaseTypeExpression implements TypeExpression {
     public final <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
       if (typeVisitor instanceof TypeExpressionVisitor) {
         return acceptE((TypeExpressionVisitor<R, E>) typeVisitor);
@@ -24,11 +22,12 @@ public interface TypeExpression {
       throw new RequiredTypeExpressionVisitorException();
     }
 
-    abstract <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> parameterizedTypeVisitor) throws E;
+    abstract <R, E extends Throwable> R acceptE(
+        final TypeExpressionVisitor<R, E> parameterizedTypeVisitor) throws E;
   }
 
   @Value.Immutable
-  static abstract class FixedChar extends BaseTypeExpression implements NullableType {
+  abstract static class FixedChar extends BaseTypeExpression implements NullableType {
     public abstract TypeExpression length();
 
     public static ImmutableTypeExpression.FixedChar.Builder builder() {
@@ -42,7 +41,7 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
-  static abstract class VarChar extends BaseTypeExpression implements NullableType {
+  abstract static class VarChar extends BaseTypeExpression implements NullableType {
     public abstract TypeExpression length();
 
     public static ImmutableTypeExpression.VarChar.Builder builder() {
@@ -56,7 +55,7 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
-  static abstract class FixedBinary extends BaseTypeExpression implements NullableType {
+  abstract static class FixedBinary extends BaseTypeExpression implements NullableType {
     public abstract TypeExpression length();
 
     public static ImmutableTypeExpression.FixedBinary.Builder builder() {
@@ -70,7 +69,7 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
-  static abstract class Decimal extends BaseTypeExpression implements NullableType {
+  abstract static class Decimal extends BaseTypeExpression implements NullableType {
     public abstract TypeExpression scale();
 
     public abstract TypeExpression precision();
@@ -86,7 +85,7 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
-  static abstract class Struct extends BaseTypeExpression implements NullableType {
+  abstract static class Struct extends BaseTypeExpression implements NullableType {
     public abstract java.util.List<TypeExpression> fields();
 
     public static ImmutableTypeExpression.Struct.Builder builder() {
@@ -100,7 +99,7 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
-  static abstract class ListType extends BaseTypeExpression implements NullableType {
+  abstract static class ListType extends BaseTypeExpression implements NullableType {
     public abstract TypeExpression elementType();
 
     public static ImmutableTypeExpression.ListType.Builder builder() {
@@ -114,7 +113,7 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
-  static abstract class Map extends BaseTypeExpression implements NullableType {
+  abstract static class Map extends BaseTypeExpression implements NullableType {
     public abstract TypeExpression key();
 
     public abstract TypeExpression value();
@@ -129,54 +128,112 @@ public interface TypeExpression {
     }
   }
 
-  @Value.Immutable static abstract class BinaryOperation extends BaseTypeExpression {
-    public enum OpType {ADD, SUBTRACT, MULTIPLY, DIVIDE, MIN, MAX, LT, GT, LTE, GTE, AND, OR, EQ, NOT_EQ, COVERS}
-
-    public abstract OpType opType();
-    public abstract TypeExpression left();
-    public abstract TypeExpression right();
-    public static ImmutableTypeExpression.BinaryOperation.Builder builder() {return ImmutableTypeExpression.BinaryOperation.builder();}
-    @Override <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {return visitor.visit(this);}
-
-  }
-
-  @Value.Immutable static abstract class NotOperation extends BaseTypeExpression {
-    public abstract TypeExpression inner();
-    public static ImmutableTypeExpression.NotOperation.Builder builder() {return ImmutableTypeExpression.NotOperation.builder();}
-    @Override <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {return visitor.visit(this);}
-  }
-
-  @Value.Immutable static abstract class IfOperation extends BaseTypeExpression {
-    public abstract TypeExpression ifCondition();
-    public abstract TypeExpression thenExpr();
-    public abstract TypeExpression elseExpr();
-    public static ImmutableTypeExpression.IfOperation.Builder builder() {return ImmutableTypeExpression.IfOperation.builder();}
-    @Override <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {return visitor.visit(this);}
-
-  }
-
-  @Value.Immutable static abstract class IntegerLiteral extends BaseTypeExpression {
-    public abstract int value();
-    public static ImmutableTypeExpression.IntegerLiteral.Builder builder() {return ImmutableTypeExpression.IntegerLiteral.builder();}
-    @Override <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {return visitor.visit(this);}
-
-  }
-
-  @Value.Immutable static abstract class ReturnProgram extends BaseTypeExpression {
-    public abstract java.util.List<Assignment> assignments();
-    public abstract TypeExpression finalExpression();
-
-    @Value.Immutable public static abstract class Assignment {
-      public abstract java.lang.String name();
-      public abstract TypeExpression expr();
-
-      public static ImmutableTypeExpression.Assignment.Builder builder() {return ImmutableTypeExpression.Assignment.builder();}
+  @Value.Immutable
+  abstract static class BinaryOperation extends BaseTypeExpression {
+    public enum OpType {
+      ADD,
+      SUBTRACT,
+      MULTIPLY,
+      DIVIDE,
+      MIN,
+      MAX,
+      LT,
+      GT,
+      LTE,
+      GTE,
+      AND,
+      OR,
+      EQ,
+      NOT_EQ,
+      COVERS
     }
 
-    public static ImmutableTypeExpression.ReturnProgram.Builder builder() {return ImmutableTypeExpression.ReturnProgram.builder();}
-    @Override <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {return visitor.visit(this);}
+    public abstract OpType opType();
 
+    public abstract TypeExpression left();
+
+    public abstract TypeExpression right();
+
+    public static ImmutableTypeExpression.BinaryOperation.Builder builder() {
+      return ImmutableTypeExpression.BinaryOperation.builder();
+    }
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
   }
 
+  @Value.Immutable
+  abstract static class NotOperation extends BaseTypeExpression {
+    public abstract TypeExpression inner();
 
+    public static ImmutableTypeExpression.NotOperation.Builder builder() {
+      return ImmutableTypeExpression.NotOperation.builder();
+    }
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract static class IfOperation extends BaseTypeExpression {
+    public abstract TypeExpression ifCondition();
+
+    public abstract TypeExpression thenExpr();
+
+    public abstract TypeExpression elseExpr();
+
+    public static ImmutableTypeExpression.IfOperation.Builder builder() {
+      return ImmutableTypeExpression.IfOperation.builder();
+    }
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract static class IntegerLiteral extends BaseTypeExpression {
+    public abstract int value();
+
+    public static ImmutableTypeExpression.IntegerLiteral.Builder builder() {
+      return ImmutableTypeExpression.IntegerLiteral.builder();
+    }
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract static class ReturnProgram extends BaseTypeExpression {
+    public abstract java.util.List<Assignment> assignments();
+
+    public abstract TypeExpression finalExpression();
+
+    @Value.Immutable
+    public abstract static class Assignment {
+      public abstract java.lang.String name();
+
+      public abstract TypeExpression expr();
+
+      public static ImmutableTypeExpression.Assignment.Builder builder() {
+        return ImmutableTypeExpression.Assignment.builder();
+      }
+    }
+
+    public static ImmutableTypeExpression.ReturnProgram.Builder builder() {
+      return ImmutableTypeExpression.ReturnProgram.builder();
+    }
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+  }
 }

--- a/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
@@ -1,11 +1,12 @@
 package io.substrait.function;
 
 import io.substrait.type.TypeCreator;
-
 import java.util.Arrays;
 
-public class TypeExpressionCreator extends TypeCreator implements ExtendedTypeCreator<TypeExpression, TypeExpression> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TypeExpressionCreator.class);
+public class TypeExpressionCreator extends TypeCreator
+    implements ExtendedTypeCreator<TypeExpression, TypeExpression> {
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(TypeExpressionCreator.class);
 
   public static final TypeExpressionCreator REQUIRED = new TypeExpressionCreator(false);
   public static final TypeExpressionCreator NULLABLE = new TypeExpressionCreator(true);
@@ -27,7 +28,11 @@ public class TypeExpressionCreator extends TypeCreator implements ExtendedTypeCr
   }
 
   public TypeExpression decimalE(TypeExpression precision, TypeExpression scale) {
-    return TypeExpression.Decimal.builder().nullable(nullable).scale(scale).precision(precision).build();
+    return TypeExpression.Decimal.builder()
+        .nullable(nullable)
+        .scale(scale)
+        .precision(precision)
+        .build();
   }
 
   public TypeExpression structE(TypeExpression... types) {
@@ -46,14 +51,22 @@ public class TypeExpressionCreator extends TypeCreator implements ExtendedTypeCr
     return TypeExpression.Map.builder().nullable(nullable).key(key).value(value).build();
   }
 
-  public record Assign(String name, TypeExpression expr) {};
+  public record Assign(String name, TypeExpression expr) {}
+  ;
 
   public static TypeExpression program(TypeExpression finalExpr, Assign... assignments) {
     return TypeExpression.ReturnProgram.builder()
         .finalExpression(finalExpr)
-        .addAllAssignments(Arrays.stream(assignments)
-            .map(a -> TypeExpression.ReturnProgram.Assignment.builder().name(a.name()).expr(a.expr()).build())
-            .toList()).build();
+        .addAllAssignments(
+            Arrays.stream(assignments)
+                .map(
+                    a ->
+                        TypeExpression.ReturnProgram.Assignment.builder()
+                            .name(a.name())
+                            .expr(a.expr())
+                            .build())
+                .toList())
+        .build();
   }
 
   public static TypeExpression plus(TypeExpression left, TypeExpression right) {
@@ -64,7 +77,8 @@ public class TypeExpressionCreator extends TypeCreator implements ExtendedTypeCr
     return binary(TypeExpression.BinaryOperation.OpType.SUBTRACT, left, right);
   }
 
-  public static TypeExpression binary(TypeExpression.BinaryOperation.OpType op, TypeExpression left, TypeExpression right) {
+  public static TypeExpression binary(
+      TypeExpression.BinaryOperation.OpType op, TypeExpression left, TypeExpression right) {
     return TypeExpression.BinaryOperation.builder().opType(op).left(left).right(right).build();
   }
 

--- a/core/src/main/java/io/substrait/function/TypeExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionVisitor.java
@@ -1,6 +1,7 @@
 package io.substrait.function;
 
-public interface TypeExpressionVisitor<R, E extends Throwable> extends ParameterizedTypeVisitor<R, E> {
+public interface TypeExpressionVisitor<R, E extends Throwable>
+    extends ParameterizedTypeVisitor<R, E> {
   R visit(TypeExpression.FixedChar expr) throws E;
 
   R visit(TypeExpression.VarChar expr) throws E;
@@ -25,7 +26,9 @@ public interface TypeExpressionVisitor<R, E extends Throwable> extends Parameter
 
   R visit(TypeExpression.ReturnProgram expr) throws E;
 
-  public static abstract class TypeExpressionThrowsVisitor<R, E extends Throwable> extends ParameterizedTypeVisitor.ParameterizedTypeThrowsVisitor<R, E> implements TypeExpressionVisitor<R, E> {
+  public abstract static class TypeExpressionThrowsVisitor<R, E extends Throwable>
+      extends ParameterizedTypeVisitor.ParameterizedTypeThrowsVisitor<R, E>
+      implements TypeExpressionVisitor<R, E> {
 
     protected TypeExpressionThrowsVisitor(String unsupportedMessage) {
       super(unsupportedMessage);
@@ -90,6 +93,5 @@ public interface TypeExpressionVisitor<R, E extends Throwable> extends Parameter
     public R visit(TypeExpression.ReturnProgram expr) throws E {
       throw t();
     }
-
   }
 }

--- a/core/src/main/java/io/substrait/relation/AbstractReadRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractReadRel.java
@@ -4,7 +4,6 @@ import io.substrait.expression.Expression;
 import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
-
 import java.util.Optional;
 
 public abstract class AbstractReadRel extends ZeroInputRel {
@@ -13,8 +12,8 @@ public abstract class AbstractReadRel extends ZeroInputRel {
 
   public abstract Optional<Expression> getFilter();
 
-  //TODO:
-  //public abstract Optional<MaskExpression>
+  // TODO:
+  // public abstract Optional<MaskExpression>
 
   public abstract Optional<AdvancedExtension> getGeneralExtension();
 

--- a/core/src/main/java/io/substrait/relation/AbstractRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRel.java
@@ -2,15 +2,16 @@ package io.substrait.relation;
 
 import io.substrait.type.Type;
 import io.substrait.util.Util;
-
 import java.util.function.Supplier;
 
 public abstract class AbstractRel implements Rel {
 
-  private Supplier<Type.Struct> recordType = Util.memoize(() -> {
-    Type.Struct s = deriveRecordType();
-    return getRemap().map(r -> r.remap(s)).orElse(s);
-  });
+  private Supplier<Type.Struct> recordType =
+      Util.memoize(
+          () -> {
+            Type.Struct s = deriveRecordType();
+            return getRemap().map(r -> r.remap(s)).orElse(s);
+          });
 
   protected abstract Type.Struct deriveRecordType();
 
@@ -18,5 +19,4 @@ public abstract class AbstractRel implements Rel {
   public final Type.Struct getRecordType() {
     return recordType.get();
   }
-
 }

--- a/core/src/main/java/io/substrait/relation/Aggregate.java
+++ b/core/src/main/java/io/substrait/relation/Aggregate.java
@@ -4,13 +4,12 @@ import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
-import org.immutables.value.Value;
-
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class Aggregate extends SingleInputRel {
@@ -23,16 +22,16 @@ public abstract class Aggregate extends SingleInputRel {
   @Override
   protected Type.Struct deriveRecordType() {
     return TypeCreator.REQUIRED.struct(
-      Stream.concat(
-          // unique grouping expressions
-          getGroupings().stream()
-              .flatMap(g -> g.getExpressions().stream())
-              .collect(Collectors.toCollection(LinkedHashSet::new))
-              .stream().map(Expression::getType),
+        Stream.concat(
+            // unique grouping expressions
+            getGroupings().stream()
+                .flatMap(g -> g.getExpressions().stream())
+                .collect(Collectors.toCollection(LinkedHashSet::new))
+                .stream()
+                .map(Expression::getType),
 
-          // measures
-          getMeasures().stream().map(t -> t.getFunction().getType())
-          ));
+            // measures
+            getMeasures().stream().map(t -> t.getFunction().getType())));
   }
 
   @Override
@@ -41,7 +40,7 @@ public abstract class Aggregate extends SingleInputRel {
   }
 
   @Value.Immutable
-  public static abstract class Grouping {
+  public abstract static class Grouping {
     public abstract List<Expression> getExpressions();
 
     public static ImmutableGrouping.Builder builder() {
@@ -50,8 +49,9 @@ public abstract class Aggregate extends SingleInputRel {
   }
 
   @Value.Immutable
-  public static abstract class Measure {
+  public abstract static class Measure {
     public abstract AggregateFunctionInvocation getFunction();
+
     public abstract Optional<Expression> getPreMeasureFilter();
 
     public static ImmutableMeasure.Builder builder() {

--- a/core/src/main/java/io/substrait/relation/BiRel.java
+++ b/core/src/main/java/io/substrait/relation/BiRel.java
@@ -7,6 +7,7 @@ public abstract class BiRel extends AbstractRel {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BiRel.class);
 
   public abstract Rel getLeft();
+
   public abstract Rel getRight();
 
   @Override

--- a/core/src/main/java/io/substrait/relation/Fetch.java
+++ b/core/src/main/java/io/substrait/relation/Fetch.java
@@ -1,18 +1,15 @@
 package io.substrait.relation;
 
-import io.substrait.expression.Expression;
 import io.substrait.type.Type;
-import org.immutables.value.Value;
-
-import java.util.List;
-import java.util.Optional;
 import java.util.OptionalLong;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class Fetch extends SingleInputRel {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Fetch.class);
 
   public abstract long getOffset();
+
   public abstract OptionalLong getCount();
 
   @Override

--- a/core/src/main/java/io/substrait/relation/Filter.java
+++ b/core/src/main/java/io/substrait/relation/Filter.java
@@ -2,11 +2,7 @@ package io.substrait.relation;
 
 import io.substrait.expression.Expression;
 import io.substrait.type.Type;
-import io.substrait.type.TypeCreator;
 import org.immutables.value.Value;
-
-import java.util.List;
-import java.util.stream.Stream;
 
 @Value.Immutable
 public abstract class Filter extends SingleInputRel {

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -4,10 +4,9 @@ import io.substrait.expression.Expression;
 import io.substrait.proto.JoinRel;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
-import org.immutables.value.Value;
-
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class Join extends BiRel {
@@ -40,10 +39,10 @@ public abstract class Join extends BiRel {
 
   @Override
   protected Type.Struct deriveRecordType() {
-    return TypeCreator.REQUIRED.struct(Stream.concat(
-        getLeft().getRecordType().fields().stream(),
-        getRight().getRecordType().fields().stream()
-    ));
+    return TypeCreator.REQUIRED.struct(
+        Stream.concat(
+            getLeft().getRecordType().fields().stream(),
+            getRight().getRecordType().fields().stream()));
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/NamedScan.java
+++ b/core/src/main/java/io/substrait/relation/NamedScan.java
@@ -1,10 +1,9 @@
 package io.substrait.relation;
 
 import io.substrait.io.substrait.extension.AdvancedExtension;
-import org.immutables.value.Value;
-
 import java.util.List;
 import java.util.Optional;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class NamedScan extends AbstractReadRel {

--- a/core/src/main/java/io/substrait/relation/Project.java
+++ b/core/src/main/java/io/substrait/relation/Project.java
@@ -3,10 +3,9 @@ package io.substrait.relation;
 import io.substrait.expression.Expression;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
-import org.immutables.value.Value;
-
 import java.util.List;
 import java.util.stream.Stream;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class Project extends SingleInputRel {
@@ -19,10 +18,8 @@ public abstract class Project extends SingleInputRel {
     Type.Struct initial = getInput().getRecordType();
     return TypeCreator.of(initial.nullable())
         .struct(
-        Stream.concat(
-            initial.fields().stream(),
-            getExpressions().stream().map(Expression::getType)));
-
+            Stream.concat(
+                initial.fields().stream(), getExpressions().stream().map(Expression::getType)));
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -2,25 +2,25 @@ package io.substrait.relation;
 
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
-import org.immutables.value.Value;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
+import org.immutables.value.Value;
 
 public interface Rel {
   Optional<Remap> getRemap();
+
   Type.Struct getRecordType();
+
   List<Rel> getInputs();
 
   @Value.Immutable
-  public static abstract class Remap {
+  public abstract static class Remap {
     public abstract List<Integer> indices();
 
     public Type.Struct remap(Type.Struct initial) {
       List<Type> types = initial.fields();
-      return TypeCreator.of(initial.nullable())
-          .struct(indices().stream().map(i -> types.get(i)));
+      return TypeCreator.of(initial.nullable()).struct(indices().stream().map(i -> types.get(i)));
     }
 
     public static Remap of(Iterable<Integer> fields) {

--- a/core/src/main/java/io/substrait/relation/RelConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelConverter.java
@@ -3,10 +3,9 @@ package io.substrait.relation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.proto.ExpressionProtoConverter;
 import io.substrait.expression.proto.FunctionLookup;
-import io.substrait.proto.Rel;
 import io.substrait.proto.*;
+import io.substrait.proto.Rel;
 import io.substrait.type.proto.TypeProtoConverter;
-
 import java.util.Collection;
 import java.util.List;
 
@@ -38,62 +37,69 @@ public class RelConverter implements RelVisitor<Rel, RuntimeException> {
 
   private List<SortField> toProtoS(Collection<Expression.SortField> sorts) {
     return sorts.stream()
-        .map(s -> {
-          return SortField.newBuilder().setDirection(s.direction().toProto())
-              .setExpr(toProto(s.expr()))
-              .build();
-        })
+        .map(
+            s -> {
+              return SortField.newBuilder()
+                  .setDirection(s.direction().toProto())
+                  .setExpr(toProto(s.expr()))
+                  .build();
+            })
         .toList();
   }
 
   @Override
   public Rel visit(Aggregate aggregate) throws RuntimeException {
-    var builder = AggregateRel.newBuilder()
-        .setInput(toProto(aggregate.getInput()))
-        .setCommon(common(aggregate))
-        .addAllGroupings(aggregate.getGroupings().stream().map(this::toProto).toList())
-        .addAllMeasures(aggregate.getMeasures().stream().map(this::toProto).toList())
-        ;
+    var builder =
+        AggregateRel.newBuilder()
+            .setInput(toProto(aggregate.getInput()))
+            .setCommon(common(aggregate))
+            .addAllGroupings(aggregate.getGroupings().stream().map(this::toProto).toList())
+            .addAllMeasures(aggregate.getMeasures().stream().map(this::toProto).toList());
 
     return Rel.newBuilder().setAggregate(builder).build();
   }
 
   private AggregateRel.Measure toProto(Aggregate.Measure measure) {
-    var func = AggregateFunction.newBuilder()
-        .setPhase(measure.getFunction().aggregationPhase().toProto())
-        .setOutputType(toProto(measure.getFunction().getType()))
-        .addAllArgs(toProto(measure.getFunction().arguments()))
-        .addAllSorts(toProtoS(measure.getFunction().sort()))
-        .setFunctionReference(functionLookup.getFunctionReference(measure.getFunction().declaration()));
+    var func =
+        AggregateFunction.newBuilder()
+            .setPhase(measure.getFunction().aggregationPhase().toProto())
+            .setOutputType(toProto(measure.getFunction().getType()))
+            .addAllArgs(toProto(measure.getFunction().arguments()))
+            .addAllSorts(toProtoS(measure.getFunction().sort()))
+            .setFunctionReference(
+                functionLookup.getFunctionReference(measure.getFunction().declaration()));
 
-    var builder = AggregateRel.Measure.newBuilder()
-        .setMeasure(func);
+    var builder = AggregateRel.Measure.newBuilder().setMeasure(func);
 
     measure.getPreMeasureFilter().ifPresent(f -> builder.setFilter(toProto(f)));
     return builder.build();
   }
 
   private AggregateRel.Grouping toProto(Aggregate.Grouping grouping) {
-    return AggregateRel.Grouping.newBuilder().addAllGroupingExpressions(toProto(grouping.getExpressions())).build();
+    return AggregateRel.Grouping.newBuilder()
+        .addAllGroupingExpressions(toProto(grouping.getExpressions()))
+        .build();
   }
-
 
   @Override
   public Rel visit(EmptyScan emptyScan) throws RuntimeException {
-    return Rel.newBuilder().setRead(ReadRel.newBuilder()
-            .setCommon(common(emptyScan))
-            .setVirtualTable(ReadRel.VirtualTable.newBuilder().build())
-            .setBaseSchema(emptyScan.getInitialSchema().toProto())
-            .build())
+    return Rel.newBuilder()
+        .setRead(
+            ReadRel.newBuilder()
+                .setCommon(common(emptyScan))
+                .setVirtualTable(ReadRel.VirtualTable.newBuilder().build())
+                .setBaseSchema(emptyScan.getInitialSchema().toProto())
+                .build())
         .build();
   }
 
   @Override
   public Rel visit(Fetch fetch) throws RuntimeException {
-    var builder = FetchRel.newBuilder()
-        .setCommon(common(fetch))
-        .setInput(toProto(fetch.getInput()))
-        .setOffset(fetch.getOffset());
+    var builder =
+        FetchRel.newBuilder()
+            .setCommon(common(fetch))
+            .setInput(toProto(fetch.getInput()))
+            .setOffset(fetch.getOffset());
 
     fetch.getCount().ifPresent(f -> builder.setCount(f));
     return Rel.newBuilder().setFetch(builder).build();
@@ -101,21 +107,23 @@ public class RelConverter implements RelVisitor<Rel, RuntimeException> {
 
   @Override
   public Rel visit(Filter filter) throws RuntimeException {
-    var builder = FilterRel.newBuilder()
-        .setCommon(common(filter))
-        .setInput(toProto(filter.getInput()))
-        .setCondition(filter.getCondition().accept(protoConverter));
+    var builder =
+        FilterRel.newBuilder()
+            .setCommon(common(filter))
+            .setInput(toProto(filter.getInput()))
+            .setCondition(filter.getCondition().accept(protoConverter));
 
     return Rel.newBuilder().setFilter(builder).build();
   }
 
   @Override
   public Rel visit(Join join) throws RuntimeException {
-    var builder = JoinRel.newBuilder()
-        .setCommon(common(join))
-        .setLeft(toProto(join.getLeft()))
-        .setRight(toProto(join.getRight()))
-        .setType(join.getJoinType().toProto());
+    var builder =
+        JoinRel.newBuilder()
+            .setCommon(common(join))
+            .setLeft(toProto(join.getLeft()))
+            .setRight(toProto(join.getRight()))
+            .setType(join.getJoinType().toProto());
 
     join.getCondition().ifPresent(t -> builder.setExpression(toProto(t)));
 
@@ -124,52 +132,62 @@ public class RelConverter implements RelVisitor<Rel, RuntimeException> {
 
   @Override
   public Rel visit(NamedScan namedScan) throws RuntimeException {
-    return Rel.newBuilder().setRead(ReadRel.newBuilder()
-            .setCommon(common(namedScan))
-            .setNamedTable(ReadRel.NamedTable.newBuilder().addAllNames(namedScan.getNames()))
-            .setBaseSchema(namedScan.getInitialSchema().toProto())
-            .build())
+    return Rel.newBuilder()
+        .setRead(
+            ReadRel.newBuilder()
+                .setCommon(common(namedScan))
+                .setNamedTable(ReadRel.NamedTable.newBuilder().addAllNames(namedScan.getNames()))
+                .setBaseSchema(namedScan.getInitialSchema().toProto())
+                .build())
         .build();
   }
 
   @Override
   public Rel visit(Project project) throws RuntimeException {
-    var builder = ProjectRel.newBuilder()
-        .setCommon(common(project))
-        .setInput(toProto(project.getInput()))
-        .addAllExpressions(project.getExpressions().stream().map(this::toProto).toList());
+    var builder =
+        ProjectRel.newBuilder()
+            .setCommon(common(project))
+            .setInput(toProto(project.getInput()))
+            .addAllExpressions(project.getExpressions().stream().map(this::toProto).toList());
 
     return Rel.newBuilder().setProject(builder).build();
   }
 
   @Override
   public Rel visit(Sort sort) throws RuntimeException {
-    var builder = SortRel.newBuilder()
-        .setCommon(common(sort))
-        .setInput(toProto(sort.getInput()))
-        .addAllSorts(toProtoS(sort.getSortFields()));
+    var builder =
+        SortRel.newBuilder()
+            .setCommon(common(sort))
+            .setInput(toProto(sort.getInput()))
+            .addAllSorts(toProtoS(sort.getSortFields()));
     return Rel.newBuilder().setSort(builder).build();
   }
 
-
   @Override
   public Rel visit(VirtualTableScan virtualTableScan) throws RuntimeException {
-    return Rel.newBuilder().setRead(ReadRel.newBuilder()
-            .setCommon(common(virtualTableScan))
-            .setVirtualTable(ReadRel.VirtualTable.newBuilder()
-                .addAllValues(virtualTableScan.getRows().stream().map(this::toProto).map(t -> t.getLiteral().getStruct()).toList())
+    return Rel.newBuilder()
+        .setRead(
+            ReadRel.newBuilder()
+                .setCommon(common(virtualTableScan))
+                .setVirtualTable(
+                    ReadRel.VirtualTable.newBuilder()
+                        .addAllValues(
+                            virtualTableScan.getRows().stream()
+                                .map(this::toProto)
+                                .map(t -> t.getLiteral().getStruct())
+                                .toList())
+                        .build())
+                .setBaseSchema(virtualTableScan.getInitialSchema().toProto())
                 .build())
-            .setBaseSchema(virtualTableScan.getInitialSchema().toProto())
-            .build())
         .build();
   }
 
   private RelCommon common(io.substrait.relation.Rel rel) {
     var builder = RelCommon.newBuilder();
-    rel.getRemap().ifPresentOrElse(
-        r -> builder.setEmit(RelCommon.Emit.newBuilder().addAllOutputMapping(r.indices())),
-        () -> builder.setDirect(RelCommon.Direct.getDefaultInstance())
-    );
+    rel.getRemap()
+        .ifPresentOrElse(
+            r -> builder.setEmit(RelCommon.Emit.newBuilder().addAllOutputMapping(r.indices())),
+            () -> builder.setDirect(RelCommon.Direct.getDefaultInstance()));
     return builder.build();
   }
 }

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -2,12 +2,20 @@ package io.substrait.relation;
 
 public interface RelVisitor<OUTPUT, EXCEPTION extends Exception> {
   OUTPUT visit(Aggregate aggregate) throws EXCEPTION;
+
   OUTPUT visit(EmptyScan emptyScan) throws EXCEPTION;
+
   OUTPUT visit(Fetch fetch) throws EXCEPTION;
+
   OUTPUT visit(Filter filter) throws EXCEPTION;
+
   OUTPUT visit(Join join) throws EXCEPTION;
+
   OUTPUT visit(NamedScan namedScan) throws EXCEPTION;
+
   OUTPUT visit(Project project) throws EXCEPTION;
+
   OUTPUT visit(Sort sort) throws EXCEPTION;
+
   OUTPUT visit(VirtualTableScan virtualTableScan) throws EXCEPTION;
 }

--- a/core/src/main/java/io/substrait/relation/SingleInputRel.java
+++ b/core/src/main/java/io/substrait/relation/SingleInputRel.java
@@ -11,5 +11,4 @@ public abstract class SingleInputRel extends AbstractRel {
   public final List<Rel> getInputs() {
     return Collections.singletonList(getInput());
   }
-
 }

--- a/core/src/main/java/io/substrait/relation/Sort.java
+++ b/core/src/main/java/io/substrait/relation/Sort.java
@@ -2,9 +2,8 @@ package io.substrait.relation;
 
 import io.substrait.expression.Expression;
 import io.substrait.type.Type;
-import org.immutables.value.Value;
-
 import java.util.List;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class Sort extends SingleInputRel {

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -4,20 +4,19 @@ import io.substrait.expression.Expression;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
-import org.immutables.value.Value;
-
 import java.util.List;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class VirtualTableScan extends AbstractReadRel {
 
   public abstract List<String> getDfsNames();
+
   public abstract List<Expression.StructLiteral> getRows();
 
   @Override
   public final NamedStruct getInitialSchema() {
-    Type.Struct struct = TypeCreator.REQUIRED.struct(
-        getRows().stream().map(Expression::getType));
+    Type.Struct struct = TypeCreator.REQUIRED.struct(getRows().stream().map(Expression::getType));
 
     return NamedStruct.of(getDfsNames(), struct);
   }

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -6,12 +6,10 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
 import io.substrait.type.parser.ParseToPojo;
 import io.substrait.type.parser.TypeStringParser;
-
 import java.io.IOException;
 import java.util.function.Function;
 
@@ -25,14 +23,17 @@ public class Deserializers {
   public static final StdDeserializer<TypeExpression> DERIVATION_EXPRESSION =
       new ParseDeserializer<>(TypeExpression.class, ParseToPojo::typeExpression);
 
-  public static final SimpleModule MODULE = new SimpleModule()
-      .addDeserializer(ParameterizedType.class, PARAMETERIZED_TYPE)
-      .addDeserializer(TypeExpression.class, DERIVATION_EXPRESSION);
+  public static final SimpleModule MODULE =
+      new SimpleModule()
+          .addDeserializer(ParameterizedType.class, PARAMETERIZED_TYPE)
+          .addDeserializer(TypeExpression.class, DERIVATION_EXPRESSION);
 
   public static class ParseDeserializer<T> extends StdDeserializer<T> {
 
     private final Function<SubstraitTypeParser.StartContext, T> converter;
-    public ParseDeserializer(Class<T> clazz, Function<SubstraitTypeParser.StartContext, T> converter) {
+
+    public ParseDeserializer(
+        Class<T> clazz, Function<SubstraitTypeParser.StartContext, T> converter) {
       super(clazz);
       this.converter = converter;
     }
@@ -44,9 +45,9 @@ public class Deserializers {
       try {
         return TypeStringParser.parse(typeString, converter);
       } catch (Exception ex) {
-        throw JsonMappingException.from(p, "Unable to parse string " + typeString.replace("\n", " \\n"), ex);
+        throw JsonMappingException.from(
+            p, "Unable to parse string " + typeString.replace("\n", " \\n"), ex);
       }
     }
   }
-
 }

--- a/core/src/main/java/io/substrait/type/NamedStruct.java
+++ b/core/src/main/java/io/substrait/type/NamedStruct.java
@@ -1,14 +1,13 @@
 package io.substrait.type;
 
-
 import io.substrait.type.proto.TypeProtoConverter;
-import org.immutables.value.Value;
-
 import java.util.List;
+import org.immutables.value.Value;
 
 @Value.Immutable
 public interface NamedStruct {
   Type.Struct struct();
+
   List<String> names();
 
   public static NamedStruct of(List<String> names, Type.Struct type) {

--- a/core/src/main/java/io/substrait/type/StringTypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/StringTypeVisitor.java
@@ -111,7 +111,9 @@ public class StringTypeVisitor implements TypeVisitor<String, RuntimeException> 
 
   @Override
   public String visit(Type.Struct type) throws RuntimeException {
-    return String.format("struct<%s>%s", type.fields().stream().map(t -> t.accept(this)).collect(Collectors.joining(", ")), n(type));
+    return String.format(
+        "struct<%s>%s",
+        type.fields().stream().map(t -> t.accept(this)).collect(Collectors.joining(", ")), n(type));
   }
 
   @Override
@@ -121,6 +123,7 @@ public class StringTypeVisitor implements TypeVisitor<String, RuntimeException> 
 
   @Override
   public String visit(Type.Map type) throws RuntimeException {
-    return String.format("map<%s,%s>%s", type.key().accept(this), type.value().accept(this), n(type));
+    return String.format(
+        "map<%s,%s>%s", type.key().accept(this), type.value().accept(this), n(type));
   }
 }

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -1,6 +1,5 @@
 package io.substrait.type;
 
-
 import io.substrait.function.NullableType;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
@@ -20,206 +19,296 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType {
   <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E;
 
   @Value.Immutable
-  static abstract class Bool implements Type {
-    public static ImmutableType.Bool.Builder builder() {return ImmutableType.Bool.builder();}
+  abstract static class Bool implements Type {
+    public static ImmutableType.Bool.Builder builder() {
+      return ImmutableType.Bool.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class I8 implements Type {
-    public static ImmutableType.I8.Builder builder() {return ImmutableType.I8.builder();}
+  abstract static class I8 implements Type {
+    public static ImmutableType.I8.Builder builder() {
+      return ImmutableType.I8.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class I16 implements Type {
-    public static ImmutableType.I16.Builder builder() {return ImmutableType.I16.builder();}
+  abstract static class I16 implements Type {
+    public static ImmutableType.I16.Builder builder() {
+      return ImmutableType.I16.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class I32 implements Type {
-    public static ImmutableType.I32.Builder builder() {return ImmutableType.I32.builder();}
+  abstract static class I32 implements Type {
+    public static ImmutableType.I32.Builder builder() {
+      return ImmutableType.I32.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class I64 implements Type {
-    public static ImmutableType.I64.Builder builder() {return ImmutableType.I64.builder();}
+  abstract static class I64 implements Type {
+    public static ImmutableType.I64.Builder builder() {
+      return ImmutableType.I64.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class FP32 implements Type {
-    public static ImmutableType.FP32.Builder builder() {return ImmutableType.FP32.builder();}
+  abstract static class FP32 implements Type {
+    public static ImmutableType.FP32.Builder builder() {
+      return ImmutableType.FP32.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class FP64 implements Type {
-    public static ImmutableType.FP64.Builder builder() {return ImmutableType.FP64.builder();}
+  abstract static class FP64 implements Type {
+    public static ImmutableType.FP64.Builder builder() {
+      return ImmutableType.FP64.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Str implements Type {
-    public static ImmutableType.Str.Builder builder() {return ImmutableType.Str.builder();}
+  abstract static class Str implements Type {
+    public static ImmutableType.Str.Builder builder() {
+      return ImmutableType.Str.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Binary implements Type {
-    public static ImmutableType.Binary.Builder builder() {return ImmutableType.Binary.builder();}
+  abstract static class Binary implements Type {
+    public static ImmutableType.Binary.Builder builder() {
+      return ImmutableType.Binary.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Date implements Type {
-    public static ImmutableType.Date.Builder builder() {return ImmutableType.Date.builder();}
+  abstract static class Date implements Type {
+    public static ImmutableType.Date.Builder builder() {
+      return ImmutableType.Date.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Time implements Type {
-    public static ImmutableType.Time.Builder builder() {return ImmutableType.Time.builder();}
+  abstract static class Time implements Type {
+    public static ImmutableType.Time.Builder builder() {
+      return ImmutableType.Time.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class TimestampTZ implements Type {
-    public static ImmutableType.TimestampTZ.Builder builder() {return ImmutableType.TimestampTZ.builder();}
+  abstract static class TimestampTZ implements Type {
+    public static ImmutableType.TimestampTZ.Builder builder() {
+      return ImmutableType.TimestampTZ.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Timestamp implements Type {
-    public static ImmutableType.Timestamp.Builder builder() {return ImmutableType.Timestamp.builder();}
+  abstract static class Timestamp implements Type {
+    public static ImmutableType.Timestamp.Builder builder() {
+      return ImmutableType.Timestamp.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class IntervalYear implements Type {
-    public static ImmutableType.IntervalYear.Builder builder() {return ImmutableType.IntervalYear.builder();}
+  abstract static class IntervalYear implements Type {
+    public static ImmutableType.IntervalYear.Builder builder() {
+      return ImmutableType.IntervalYear.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class IntervalDay implements Type {
-    public static ImmutableType.IntervalDay.Builder builder() {return ImmutableType.IntervalDay.builder();}
+  abstract static class IntervalDay implements Type {
+    public static ImmutableType.IntervalDay.Builder builder() {
+      return ImmutableType.IntervalDay.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class UUID implements Type {
-    public static ImmutableType.UUID.Builder builder() {return ImmutableType.UUID.builder();}
+  abstract static class UUID implements Type {
+    public static ImmutableType.UUID.Builder builder() {
+      return ImmutableType.UUID.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class FixedChar implements Type {
+  abstract static class FixedChar implements Type {
     public abstract int length();
 
-    public static ImmutableType.FixedChar.Builder builder() {return ImmutableType.FixedChar.builder();}
+    public static ImmutableType.FixedChar.Builder builder() {
+      return ImmutableType.FixedChar.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class VarChar implements Type {
+  abstract static class VarChar implements Type {
     public abstract int length();
 
-    public static ImmutableType.VarChar.Builder builder() {return ImmutableType.VarChar.builder();}
+    public static ImmutableType.VarChar.Builder builder() {
+      return ImmutableType.VarChar.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class FixedBinary implements Type {
+  abstract static class FixedBinary implements Type {
     public abstract int length();
 
-    public static ImmutableType.FixedBinary.Builder builder() {return ImmutableType.FixedBinary.builder();}
+    public static ImmutableType.FixedBinary.Builder builder() {
+      return ImmutableType.FixedBinary.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Decimal implements Type {
+  abstract static class Decimal implements Type {
     public abstract int scale();
 
     public abstract int precision();
 
-    public static ImmutableType.Decimal.Builder builder() {return ImmutableType.Decimal.builder();}
+    public static ImmutableType.Decimal.Builder builder() {
+      return ImmutableType.Decimal.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Struct implements Type {
+  abstract static class Struct implements Type {
     public abstract java.util.List<Type> fields();
 
-    public static ImmutableType.Struct.Builder builder() {return ImmutableType.Struct.builder();}
+    public static ImmutableType.Struct.Builder builder() {
+      return ImmutableType.Struct.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class ListType implements Type {
+  abstract static class ListType implements Type {
     public abstract Type elementType();
 
-    public static ImmutableType.ListType.Builder builder() {return ImmutableType.ListType.builder();}
+    public static ImmutableType.ListType.Builder builder() {
+      return ImmutableType.ListType.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
 
   @Value.Immutable
-  static abstract class Map implements Type {
+  abstract static class Map implements Type {
     public abstract Type key();
 
     public abstract Type value();
 
-    public static ImmutableType.Map.Builder builder() {return ImmutableType.Map.builder();}
+    public static ImmutableType.Map.Builder builder() {
+      return ImmutableType.Map.builder();
+    }
 
-    @Override public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor)
-        throws E {return typeVisitor.visit(this);}
-
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
   }
-
 }

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -71,7 +71,10 @@ public class TypeCreator {
   }
 
   public Type.Struct struct(Stream<? extends Type> types) {
-    return Type.Struct.builder().nullable(nullable).addAllFields(types.collect(Collectors.toList())).build();
+    return Type.Struct.builder()
+        .nullable(nullable)
+        .addAllFields(types.collect(Collectors.toList()))
+        .build();
   }
 
   public Type list(Type type) {

--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -2,12 +2,11 @@ package io.substrait.type;
 
 import io.substrait.function.SimpleExtension;
 import io.substrait.function.TypeExpression;
-
 import java.util.List;
 
 public class TypeExpressionEvaluator {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(
-      TypeExpressionEvaluator.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(TypeExpressionEvaluator.class);
 
   public static Type evaluateExpression(
       TypeExpression returnExpression,

--- a/core/src/main/java/io/substrait/type/TypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/TypeVisitor.java
@@ -47,8 +47,8 @@ public interface TypeVisitor<R, E extends Throwable> {
 
   R visit(Type.Map type) throws E;
 
-
-  public static abstract class TypeThrowsVisitor<R, E extends Throwable> implements TypeVisitor<R, E> {
+  public abstract static class TypeThrowsVisitor<R, E extends Throwable>
+      implements TypeVisitor<R, E> {
 
     private final String unsupportedMessage;
 
@@ -59,7 +59,7 @@ public interface TypeVisitor<R, E extends Throwable> {
     protected final UnsupportedOperationException t() {
       throw new UnsupportedOperationException(unsupportedMessage);
     }
-    
+
     @Override
     public R visit(Type.Bool type) throws E {
       throw t();

--- a/core/src/main/java/io/substrait/type/YamlRead.java
+++ b/core/src/main/java/io/substrait/type/YamlRead.java
@@ -3,9 +3,7 @@ package io.substrait.type;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
 import io.substrait.function.SimpleExtension;
-
 import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -14,40 +12,53 @@ import java.util.stream.Stream;
 public class YamlRead {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(YamlRead.class);
 
-  private final static List<String> FUNCTIONS = Collections.unmodifiableList(Arrays.asList(
-     "boolean", "aggregate_generic", "arithmetic_decimal", "arithmetic", "comparison", "datetime", "string"
-  ));
+  private static final List<String> FUNCTIONS =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              "boolean",
+              "aggregate_generic",
+              "arithmetic_decimal",
+              "arithmetic",
+              "comparison",
+              "datetime",
+              "string"));
+
   public static void main(String[] args) throws Exception {
     try {
       System.out.println("Read: " + YamlRead.class.getResource("/functions_boolean.yaml"));
       List<SimpleExtension.Function> signatures = loadFunctions();
 
       signatures.forEach(f -> System.out.println(f.key()));
-    } catch (Exception ex){
+    } catch (Exception ex) {
       throw ex;
     }
   }
 
   public static List<SimpleExtension.Function> loadFunctions() {
-    return loadFunctions(FUNCTIONS.stream().map(c -> String.format("/src/substrait/extensions/functions_%s.yaml", c)).toList());
+    return loadFunctions(
+        FUNCTIONS.stream()
+            .map(c -> String.format("/src/substrait/extensions/functions_%s.yaml", c))
+            .toList());
   }
 
   public static List<SimpleExtension.Function> loadFunctions(List<String> files) {
-     return files.stream().flatMap(YamlRead::parse)
-         .collect(Collectors.toList());
+    return files.stream().flatMap(YamlRead::parse).collect(Collectors.toList());
   }
 
   private static Stream<SimpleExtension.Function> parse(String name) {
 
     try {
-      ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
-          .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-          .registerModule(Deserializers.MODULE);
+      ObjectMapper mapper =
+          new ObjectMapper(new YAMLFactory())
+              .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+              .registerModule(Deserializers.MODULE);
       var doc = mapper.readValue(new File(name), SimpleExtension.FunctionSignatures.class);
 
-      logger.debug("Parsed {} functions in file {}.",
-          Optional.ofNullable(doc.scalars()).map(List::size).orElse(0) +
-              Optional.ofNullable(doc.aggregates()).map(List::size).orElse(0), name);
+      logger.debug(
+          "Parsed {} functions in file {}.",
+          Optional.ofNullable(doc.scalars()).map(List::size).orElse(0)
+              + Optional.ofNullable(doc.aggregates()).map(List::size).orElse(0),
+          name);
 
       return doc.resolve(name);
     } catch (RuntimeException ex) {
@@ -56,5 +67,4 @@ public class YamlRead {
       throw new RuntimeException("Failure while parsing file " + name, ex);
     }
   }
-
 }

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -1,21 +1,20 @@
 package io.substrait.type.parser;
 
-import io.substrait.type.SubstraitTypeParser;
-import io.substrait.type.SubstraitTypeVisitor;
-import io.substrait.type.Type;
-import io.substrait.type.TypeCreator;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.ParameterizedTypeCreator;
 import io.substrait.function.TypeExpression;
 import io.substrait.function.TypeExpressionCreator;
+import io.substrait.type.SubstraitTypeParser;
+import io.substrait.type.SubstraitTypeVisitor;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.RuleNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
-
-import java.util.Locale;
-import java.util.function.Function;
-import java.util.function.IntFunction;
 
 public class ParseToPojo {
 
@@ -30,9 +29,11 @@ public class ParseToPojo {
   public static TypeExpression typeExpression(SubstraitTypeParser.StartContext ctx) {
     return ctx.accept(Visitor.EXPRESSION);
   }
-  
+
   public static enum Visitor implements SubstraitTypeVisitor<TypeExpression> {
-    SIMPLE, PARAMETERIZED, EXPRESSION;
+    SIMPLE,
+    PARAMETERIZED,
+    EXPRESSION;
 
     private void checkParameterizedOrExpression() {
       if (this != EXPRESSION && this != PARAMETERIZED) {
@@ -48,88 +49,110 @@ public class ParseToPojo {
       }
     }
 
-    @Override public TypeExpression visitStart(final SubstraitTypeParser.StartContext ctx) {
+    @Override
+    public TypeExpression visitStart(final SubstraitTypeParser.StartContext ctx) {
       return ctx.expr().accept(this);
     }
 
-    @Override public Type visitBoolean(final SubstraitTypeParser.BooleanContext ctx) {
+    @Override
+    public Type visitBoolean(final SubstraitTypeParser.BooleanContext ctx) {
       return withNull(ctx).BOOLEAN;
     }
 
-    @Override public Type visitI8(final SubstraitTypeParser.I8Context ctx) {
+    @Override
+    public Type visitI8(final SubstraitTypeParser.I8Context ctx) {
       return withNull(ctx).I8;
     }
 
-    @Override public Type visitI16(final SubstraitTypeParser.I16Context ctx) {
+    @Override
+    public Type visitI16(final SubstraitTypeParser.I16Context ctx) {
       return withNull(ctx).I16;
     }
 
-    @Override public Type visitI32(final SubstraitTypeParser.I32Context ctx) {
+    @Override
+    public Type visitI32(final SubstraitTypeParser.I32Context ctx) {
       return withNull(ctx).I32;
     }
 
-    @Override public Type visitI64(final SubstraitTypeParser.I64Context ctx) {
+    @Override
+    public Type visitI64(final SubstraitTypeParser.I64Context ctx) {
       return withNull(ctx).I64;
     }
 
-    @Override public TypeExpression visitTypeLiteral(final SubstraitTypeParser.TypeLiteralContext ctx) {
+    @Override
+    public TypeExpression visitTypeLiteral(final SubstraitTypeParser.TypeLiteralContext ctx) {
       return ctx.type().accept(this);
     }
 
-    @Override public Type visitFp32(final SubstraitTypeParser.Fp32Context ctx) {
+    @Override
+    public Type visitFp32(final SubstraitTypeParser.Fp32Context ctx) {
       return withNull(ctx).FP32;
     }
 
-    @Override public Type visitFp64(final SubstraitTypeParser.Fp64Context ctx) {
+    @Override
+    public Type visitFp64(final SubstraitTypeParser.Fp64Context ctx) {
       return withNull(ctx).FP64;
     }
 
-    @Override public Type visitString(final SubstraitTypeParser.StringContext ctx) {
+    @Override
+    public Type visitString(final SubstraitTypeParser.StringContext ctx) {
       return withNull(ctx).STRING;
     }
 
-    @Override public Type visitBinary(final SubstraitTypeParser.BinaryContext ctx) {
+    @Override
+    public Type visitBinary(final SubstraitTypeParser.BinaryContext ctx) {
       return withNull(ctx).BINARY;
     }
 
-    @Override public Type visitTimestamp(
-        final SubstraitTypeParser.TimestampContext ctx) {
+    @Override
+    public Type visitTimestamp(final SubstraitTypeParser.TimestampContext ctx) {
       return withNull(ctx).TIMESTAMP;
     }
 
-    @Override public Type visitTimestampTz(final SubstraitTypeParser.TimestampTzContext ctx) {
+    @Override
+    public Type visitTimestampTz(final SubstraitTypeParser.TimestampTzContext ctx) {
       return withNull(ctx).TIMESTAMP_TZ;
     }
 
-    @Override public Type visitDate(final SubstraitTypeParser.DateContext ctx) {
+    @Override
+    public Type visitDate(final SubstraitTypeParser.DateContext ctx) {
       return withNull(ctx).DATE;
     }
 
-    @Override public Type visitTime(final SubstraitTypeParser.TimeContext ctx) {
+    @Override
+    public Type visitTime(final SubstraitTypeParser.TimeContext ctx) {
       return withNull(ctx).TIME;
     }
 
-    @Override public Type visitIntervalDay(final SubstraitTypeParser.IntervalDayContext ctx) {
+    @Override
+    public Type visitIntervalDay(final SubstraitTypeParser.IntervalDayContext ctx) {
       return withNull(ctx).INTERVAL_DAY;
     }
 
-    @Override public Type visitIntervalYear(final SubstraitTypeParser.IntervalYearContext ctx) {
+    @Override
+    public Type visitIntervalYear(final SubstraitTypeParser.IntervalYearContext ctx) {
       return withNull(ctx).INTERVAL_YEAR;
     }
 
-    @Override public Type visitUuid(final SubstraitTypeParser.UuidContext ctx) {
+    @Override
+    public Type visitUuid(final SubstraitTypeParser.UuidContext ctx) {
       return withNull(ctx).UUID;
     }
 
-    @Override public TypeExpression visitFixedChar(final SubstraitTypeParser.FixedCharContext ctx) {
-      return of(ctx.len,
+    @Override
+    public TypeExpression visitFixedChar(final SubstraitTypeParser.FixedCharContext ctx) {
+      return of(
+          ctx.len,
           withNull(ctx)::fixedChar,
           withNullP(ctx)::fixedCharE,
-          withNullE(ctx)::fixedCharE
-      );
+          withNullE(ctx)::fixedCharE);
     }
 
-    private TypeExpression of(SubstraitTypeParser.NumericParameterContext ctx, IntFunction<TypeExpression> intFunc, Function<String, TypeExpression> strFunc, Function<TypeExpression, TypeExpression> exprFunc) {
+    private TypeExpression of(
+        SubstraitTypeParser.NumericParameterContext ctx,
+        IntFunction<TypeExpression> intFunc,
+        Function<String, TypeExpression> strFunc,
+        Function<TypeExpression, TypeExpression> exprFunc) {
       TypeExpression type = ctx.accept(this);
       if (type instanceof TypeExpression.IntegerLiteral) {
         return intFunc.apply(((TypeExpression.IntegerLiteral) type).value());
@@ -142,24 +165,23 @@ public class ParseToPojo {
       return exprFunc.apply(type);
     }
 
-    @Override public TypeExpression visitVarChar(final SubstraitTypeParser.VarCharContext ctx) {
-      return of(ctx.len,
-          withNull(ctx)::varChar,
-          withNullP(ctx)::varCharE,
-          withNullE(ctx)::varCharE
-      );
+    @Override
+    public TypeExpression visitVarChar(final SubstraitTypeParser.VarCharContext ctx) {
+      return of(
+          ctx.len, withNull(ctx)::varChar, withNullP(ctx)::varCharE, withNullE(ctx)::varCharE);
     }
 
-    @Override public TypeExpression visitFixedBinary(
-        final SubstraitTypeParser.FixedBinaryContext ctx) {
-      return of(ctx.len,
+    @Override
+    public TypeExpression visitFixedBinary(final SubstraitTypeParser.FixedBinaryContext ctx) {
+      return of(
+          ctx.len,
           withNull(ctx)::fixedBinary,
           withNullP(ctx)::fixedBinaryE,
-          withNullE(ctx)::fixedBinaryE
-      );
+          withNullE(ctx)::fixedBinaryE);
     }
 
-    @Override public TypeExpression visitDecimal(final SubstraitTypeParser.DecimalContext ctx) {
+    @Override
+    public TypeExpression visitDecimal(final SubstraitTypeParser.DecimalContext ctx) {
       Object precision = i(ctx.precision);
       Object scale = i(ctx.scale);
 
@@ -174,7 +196,6 @@ public class ParseToPojo {
 
       checkExpression();
       return withNullE(ctx).decimalE(ctx.precision.accept(this), ctx.scale.accept(this));
-
     }
 
     private Object i(SubstraitTypeParser.NumericParameterContext ctx) {
@@ -190,7 +211,8 @@ public class ParseToPojo {
       }
     }
 
-    @Override public TypeExpression visitStruct(final SubstraitTypeParser.StructContext ctx) {
+    @Override
+    public TypeExpression visitStruct(final SubstraitTypeParser.StructContext ctx) {
       var types = ctx.expr().stream().map(t -> t.accept(this)).toList();
       if (types.stream().allMatch(t -> t instanceof Type)) {
         return withNull(ctx).struct(types.stream().map(t -> ((Type) t)).toList());
@@ -205,11 +227,13 @@ public class ParseToPojo {
       return withNullE(ctx).structE(types);
     }
 
-    @Override public TypeExpression visitNStruct(final SubstraitTypeParser.NStructContext ctx) {
+    @Override
+    public TypeExpression visitNStruct(final SubstraitTypeParser.NStructContext ctx) {
       throw new UnsupportedOperationException();
     }
 
-    @Override public TypeExpression visitList(final SubstraitTypeParser.ListContext ctx) {
+    @Override
+    public TypeExpression visitList(final SubstraitTypeParser.ListContext ctx) {
       TypeExpression element = ctx.expr().accept(this);
       if (element instanceof Type) {
         return withNull(ctx).list((Type) element);
@@ -224,7 +248,8 @@ public class ParseToPojo {
       return withNullE(ctx).listE(element);
     }
 
-    @Override public TypeExpression visitMap(final SubstraitTypeParser.MapContext ctx) {
+    @Override
+    public TypeExpression visitMap(final SubstraitTypeParser.MapContext ctx) {
       TypeExpression key = ctx.key.accept(this);
       TypeExpression value = ctx.value.accept(this);
       if (key instanceof Type && value instanceof Type) {
@@ -240,32 +265,39 @@ public class ParseToPojo {
     }
 
     private TypeCreator withNull(SubstraitTypeParser.RequiredTypeContext required) {
-      return Type.withNullability(((SubstraitTypeParser.TypeContext) required.parent).isnull != null);
+      return Type.withNullability(
+          ((SubstraitTypeParser.TypeContext) required.parent).isnull != null);
     }
 
     private TypeExpressionCreator withNullE(SubstraitTypeParser.RequiredTypeContext required) {
-      return TypeExpression.withNullability(((SubstraitTypeParser.TypeContext) required.parent).isnull != null);
+      return TypeExpression.withNullability(
+          ((SubstraitTypeParser.TypeContext) required.parent).isnull != null);
     }
 
     private ParameterizedTypeCreator withNullP(SubstraitTypeParser.RequiredTypeContext required) {
-      return ParameterizedType.withNullability(((SubstraitTypeParser.TypeContext) required.parent).isnull != null);
+      return ParameterizedType.withNullability(
+          ((SubstraitTypeParser.TypeContext) required.parent).isnull != null);
     }
 
-    @Override public TypeExpression visitType(final SubstraitTypeParser.TypeContext ctx) {
+    @Override
+    public TypeExpression visitType(final SubstraitTypeParser.TypeContext ctx) {
       return ctx.requiredType().accept(this);
     }
 
-    @Override public TypeExpression visitTypeParam(final SubstraitTypeParser.TypeParamContext ctx) {
+    @Override
+    public TypeExpression visitTypeParam(final SubstraitTypeParser.TypeParamContext ctx) {
       checkParameterizedOrExpression();
       return ParameterizedType.StringLiteral.builder().value(ctx.getText()).build();
     }
 
-    @Override public TypeExpression visitParenExpression(
+    @Override
+    public TypeExpression visitParenExpression(
         final SubstraitTypeParser.ParenExpressionContext ctx) {
       return ctx.expr().accept(this);
     }
 
-    @Override public TypeExpression visitIfExpr(final SubstraitTypeParser.IfExprContext ctx) {
+    @Override
+    public TypeExpression visitIfExpr(final SubstraitTypeParser.IfExprContext ctx) {
       checkExpression();
       return TypeExpression.IfOperation.builder()
           .ifCondition(ctx.ifExpr.accept(this))
@@ -274,7 +306,8 @@ public class ParseToPojo {
           .build();
     }
 
-    @Override public TypeExpression visitTernary(final SubstraitTypeParser.TernaryContext ctx) {
+    @Override
+    public TypeExpression visitTernary(final SubstraitTypeParser.TernaryContext ctx) {
       checkExpression();
       return TypeExpression.IfOperation.builder()
           .ifCondition(ctx.ifExpr.accept(this))
@@ -283,7 +316,8 @@ public class ParseToPojo {
           .build();
     }
 
-    @Override public TypeExpression visitMultilineDefinition(
+    @Override
+    public TypeExpression visitMultilineDefinition(
         final SubstraitTypeParser.MultilineDefinitionContext ctx) {
       checkExpression();
       var exprs = ctx.expr().stream().map(t -> t.accept(this)).toList();
@@ -292,80 +326,87 @@ public class ParseToPojo {
 
       var bldr = TypeExpression.ReturnProgram.builder();
       for (int i = 0; i < exprs.size(); i++) {
-        bldr.addAssignments(TypeExpression.ReturnProgram.Assignment.builder()
-            .expr(exprs.get(i))
-            .name(identifiers.get(i))
-            .build()
-        );
+        bldr.addAssignments(
+            TypeExpression.ReturnProgram.Assignment.builder()
+                .expr(exprs.get(i))
+                .name(identifiers.get(i))
+                .build());
       }
 
       bldr.finalExpression(finalExpr);
       return bldr.build();
     }
 
-    @Override public TypeExpression visitBinaryExpr(final SubstraitTypeParser.BinaryExprContext ctx) {
+    @Override
+    public TypeExpression visitBinaryExpr(final SubstraitTypeParser.BinaryExprContext ctx) {
       checkExpression();
-      TypeExpression.BinaryOperation.OpType type = switch (ctx.op.getText()
-          .toUpperCase(Locale.ROOT)) {
-        case "+" -> TypeExpression.BinaryOperation.OpType.ADD;
-        case "-" -> TypeExpression.BinaryOperation.OpType.SUBTRACT;
-        case "*" -> TypeExpression.BinaryOperation.OpType.MULTIPLY;
-        case "/" -> TypeExpression.BinaryOperation.OpType.DIVIDE;
-        case ">" -> TypeExpression.BinaryOperation.OpType.GT;
-        case "<" -> TypeExpression.BinaryOperation.OpType.LT;
-        case "AND" -> TypeExpression.BinaryOperation.OpType.AND;
-        case "OR" -> TypeExpression.BinaryOperation.OpType.OR;
-        case "=" -> TypeExpression.BinaryOperation.OpType.EQ;
-        case ":=" -> TypeExpression.BinaryOperation.OpType.COVERS;
-        default -> throw new IllegalStateException();
-      };
-      return TypeExpression.BinaryOperation.builder().opType(type)
+      TypeExpression.BinaryOperation.OpType type =
+          switch (ctx.op.getText().toUpperCase(Locale.ROOT)) {
+            case "+" -> TypeExpression.BinaryOperation.OpType.ADD;
+            case "-" -> TypeExpression.BinaryOperation.OpType.SUBTRACT;
+            case "*" -> TypeExpression.BinaryOperation.OpType.MULTIPLY;
+            case "/" -> TypeExpression.BinaryOperation.OpType.DIVIDE;
+            case ">" -> TypeExpression.BinaryOperation.OpType.GT;
+            case "<" -> TypeExpression.BinaryOperation.OpType.LT;
+            case "AND" -> TypeExpression.BinaryOperation.OpType.AND;
+            case "OR" -> TypeExpression.BinaryOperation.OpType.OR;
+            case "=" -> TypeExpression.BinaryOperation.OpType.EQ;
+            case ":=" -> TypeExpression.BinaryOperation.OpType.COVERS;
+            default -> throw new IllegalStateException();
+          };
+      return TypeExpression.BinaryOperation.builder()
+          .opType(type)
           .left(ctx.left.accept(this))
           .right(ctx.right.accept(this))
           .build();
-
     }
 
-    @Override public TypeExpression visitNumericLiteral(
-        final SubstraitTypeParser.NumericLiteralContext ctx) {
+    @Override
+    public TypeExpression visitNumericLiteral(final SubstraitTypeParser.NumericLiteralContext ctx) {
       return TypeExpression.IntegerLiteral.builder().value(Integer.parseInt(ctx.getText())).build();
     }
 
-    @Override public TypeExpression visitNumericParameterName(
+    @Override
+    public TypeExpression visitNumericParameterName(
         final SubstraitTypeParser.NumericParameterNameContext ctx) {
       checkParameterizedOrExpression();
       return ParameterizedType.StringLiteral.builder().value(ctx.getText()).build();
     }
 
-    @Override public TypeExpression visitNumericExpression(
+    @Override
+    public TypeExpression visitNumericExpression(
         final SubstraitTypeParser.NumericExpressionContext ctx) {
       return ctx.expr().accept(this);
     }
 
-    @Override public TypeExpression visitFunctionCall(
-        final SubstraitTypeParser.FunctionCallContext ctx) {
+    @Override
+    public TypeExpression visitFunctionCall(final SubstraitTypeParser.FunctionCallContext ctx) {
       checkExpression();
       if (ctx.expr().size() != 2) {
         throw new IllegalStateException("Only two argument functions exist for type expressions.");
       }
       var name = ctx.Identifier().getSymbol().getText().toUpperCase(Locale.ROOT);
-      TypeExpression.BinaryOperation.OpType type = switch (name) {
-        case "MIN" -> TypeExpression.BinaryOperation.OpType.MIN;
-        case "MAX" -> TypeExpression.BinaryOperation.OpType.MAX;
-        default -> throw new IllegalStateException("The following operation was unrecognized: " + name);
-      };
-      return TypeExpression.BinaryOperation.builder().opType(type)
+      TypeExpression.BinaryOperation.OpType type =
+          switch (name) {
+            case "MIN" -> TypeExpression.BinaryOperation.OpType.MIN;
+            case "MAX" -> TypeExpression.BinaryOperation.OpType.MAX;
+            default -> throw new IllegalStateException(
+                "The following operation was unrecognized: " + name);
+          };
+      return TypeExpression.BinaryOperation.builder()
+          .opType(type)
           .left(ctx.expr(0).accept(this))
           .right(ctx.expr(1).accept(this))
           .build();
     }
 
-    @Override public TypeExpression visitNotExpr(final SubstraitTypeParser.NotExprContext ctx) {
+    @Override
+    public TypeExpression visitNotExpr(final SubstraitTypeParser.NotExprContext ctx) {
       return TypeExpression.NotOperation.builder().inner(ctx.expr().accept(this)).build();
     }
 
-    @Override public TypeExpression visitLiteralNumber(
-        final SubstraitTypeParser.LiteralNumberContext ctx) {
+    @Override
+    public TypeExpression visitLiteralNumber(final SubstraitTypeParser.LiteralNumberContext ctx) {
       return i(Integer.parseInt(ctx.getText()));
     }
 
@@ -373,21 +414,24 @@ public class ParseToPojo {
       return TypeExpression.IntegerLiteral.builder().value(val).build();
     }
 
-    @Override public Type visit(final ParseTree tree) {
+    @Override
+    public Type visit(final ParseTree tree) {
       throw new UnsupportedOperationException();
     }
 
-    @Override public Type visitChildren(final RuleNode node) {
+    @Override
+    public Type visitChildren(final RuleNode node) {
       throw new UnsupportedOperationException();
     }
 
-    @Override public Type visitTerminal(final TerminalNode node) {
+    @Override
+    public Type visitTerminal(final TerminalNode node) {
       throw new UnsupportedOperationException();
     }
 
-    @Override public Type visitErrorNode(final ErrorNode node) {
+    @Override
+    public Type visitErrorNode(final ErrorNode node) {
       throw new UnsupportedOperationException();
     }
   }
 }
-

--- a/core/src/main/java/io/substrait/type/parser/ThrowVisitor.java
+++ b/core/src/main/java/io/substrait/type/parser/ThrowVisitor.java
@@ -6,7 +6,8 @@ import org.antlr.v4.runtime.tree.RuleNode;
 class ThrowVisitor<T> extends SubstraitTypeBaseVisitor<T> {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ThrowVisitor.class);
 
-  @Override public T visitChildren(final RuleNode node) {
+  @Override
+  public T visitChildren(final RuleNode node) {
     throw new UnsupportedOperationException();
   }
 }

--- a/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
+++ b/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
@@ -1,17 +1,16 @@
 package io.substrait.type.parser;
 
 import io.substrait.function.ParameterizedType;
+import io.substrait.function.TypeExpression;
 import io.substrait.type.SubstraitTypeLexer;
 import io.substrait.type.SubstraitTypeParser;
-import io.substrait.function.TypeExpression;
 import io.substrait.type.Type;
+import java.util.function.Function;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-
-import java.util.function.Function;
 
 public class TypeStringParser {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TypeStringParser.class);
@@ -53,19 +52,24 @@ public class TypeStringParser {
 
     public static final TypeErrorListener INSTANCE = new TypeErrorListener();
 
-    @Override public void syntaxError(final Recognizer<?, ?> recognizer, final Object offendingSymbol,
+    @Override
+    public void syntaxError(
+        final Recognizer<?, ?> recognizer,
+        final Object offendingSymbol,
         final int line,
-        final int charPositionInLine, final String msg, final RecognitionException e) {
+        final int charPositionInLine,
+        final String msg,
+        final RecognitionException e) {
       throw new ParseError(msg, e, line, charPositionInLine);
     }
-
   }
 
   public static class ParseError extends RuntimeException {
     private final int line;
     private final int posInLine;
 
-    public ParseError(final String message, final Throwable cause, final int line, final int posInLine) {
+    public ParseError(
+        final String message, final Throwable cause, final int line, final int posInLine) {
       super(message, cause);
       this.line = line;
       this.posInLine = posInLine;

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -1,11 +1,13 @@
 package io.substrait.type.proto;
 
-import io.substrait.type.Type;
 import io.substrait.function.NullableType;
 import io.substrait.function.TypeExpressionVisitor;
+import io.substrait.type.Type;
 
-abstract class BaseProtoConverter<T, I> extends TypeExpressionVisitor.TypeExpressionThrowsVisitor<T, RuntimeException> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseProtoConverter.class);
+abstract class BaseProtoConverter<T, I>
+    extends TypeExpressionVisitor.TypeExpressionThrowsVisitor<T, RuntimeException> {
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(BaseProtoConverter.class);
 
   public abstract BaseProtoTypes<T, I> typeContainer(boolean nullable);
 
@@ -17,96 +19,118 @@ abstract class BaseProtoConverter<T, I> extends TypeExpressionVisitor.TypeExpres
     return typeContainer(literal.nullable());
   }
 
-  @Override public final T visit(final Type.Bool expr) {
+  @Override
+  public final T visit(final Type.Bool expr) {
     return typeContainer(expr).BOOLEAN;
   }
 
-  @Override public final T visit(final Type.I8 expr) {
+  @Override
+  public final T visit(final Type.I8 expr) {
     return typeContainer(expr).I8;
   }
 
-  @Override public final T visit(final Type.I16 expr) {
+  @Override
+  public final T visit(final Type.I16 expr) {
     return typeContainer(expr).I16;
   }
 
-  @Override public final T visit(final Type.I32 expr) {
+  @Override
+  public final T visit(final Type.I32 expr) {
     return typeContainer(expr).I32;
   }
 
-  @Override public final T visit(final Type.I64 expr) {
+  @Override
+  public final T visit(final Type.I64 expr) {
     return typeContainer(expr).I64;
   }
 
-  @Override public final T visit(final Type.FP32 expr) {
+  @Override
+  public final T visit(final Type.FP32 expr) {
     return typeContainer(expr).FP32;
   }
 
-  @Override public final T visit(final Type.FP64 expr) {
+  @Override
+  public final T visit(final Type.FP64 expr) {
     return typeContainer(expr).FP64;
   }
 
-  @Override public final T visit(final Type.Str expr) {
+  @Override
+  public final T visit(final Type.Str expr) {
     return typeContainer(expr).STRING;
   }
 
-  @Override public final T visit(final Type.Binary expr) {
+  @Override
+  public final T visit(final Type.Binary expr) {
     return typeContainer(expr).BINARY;
   }
 
-  @Override public final T visit(final Type.Date expr) {
+  @Override
+  public final T visit(final Type.Date expr) {
     return typeContainer(expr).DATE;
   }
 
-  @Override public final T visit(final Type.Time expr) {
+  @Override
+  public final T visit(final Type.Time expr) {
     return typeContainer(expr).TIME;
   }
 
-  @Override public final T visit(final Type.TimestampTZ expr) {
+  @Override
+  public final T visit(final Type.TimestampTZ expr) {
     return typeContainer(expr).TIMESTAMP_TZ;
   }
 
-  @Override public final T visit(final Type.Timestamp expr) {
+  @Override
+  public final T visit(final Type.Timestamp expr) {
     return typeContainer(expr).TIMESTAMP;
   }
 
-  @Override public final T visit(final Type.IntervalYear expr) {
+  @Override
+  public final T visit(final Type.IntervalYear expr) {
     return typeContainer(expr).INTERVAL_YEAR;
   }
 
-  @Override public final T visit(final Type.IntervalDay expr) {
+  @Override
+  public final T visit(final Type.IntervalDay expr) {
     return typeContainer(expr).INTERVAL_DAY;
   }
 
-  @Override public final T visit(final Type.UUID expr) {
+  @Override
+  public final T visit(final Type.UUID expr) {
     return typeContainer(expr).UUID;
   }
 
-  @Override public final T visit(final Type.FixedChar expr) {
+  @Override
+  public final T visit(final Type.FixedChar expr) {
     return typeContainer(expr).fixedChar(expr.length());
   }
 
-  @Override public final T visit(final Type.VarChar expr) {
+  @Override
+  public final T visit(final Type.VarChar expr) {
     return typeContainer(expr).varChar(expr.length());
   }
 
-  @Override public final T visit(final Type.FixedBinary expr) {
+  @Override
+  public final T visit(final Type.FixedBinary expr) {
     return typeContainer(expr).fixedBinary(expr.length());
   }
 
-  @Override public final T visit(final Type.Decimal expr) {
+  @Override
+  public final T visit(final Type.Decimal expr) {
     return typeContainer(expr).decimal(expr.scale(), expr.precision());
   }
 
-  @Override public final T visit(final Type.Struct expr) {
+  @Override
+  public final T visit(final Type.Struct expr) {
     return typeContainer(expr).struct(expr.fields().stream().map(t -> t.accept(this)).toList());
   }
 
-  @Override public final T visit(final Type.ListType expr) {
+  @Override
+  public final T visit(final Type.ListType expr) {
     return typeContainer(expr).list(expr.elementType().accept(this));
   }
 
-  @Override public final T visit(final Type.Map expr) {
+  @Override
+  public final T visit(final Type.Map expr) {
     return typeContainer(expr).map(expr.key().accept(this), expr.value().accept(this));
   }
-  
 }

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
@@ -1,11 +1,10 @@
 package io.substrait.type.proto;
 
 import io.substrait.proto.Type;
-
 import java.util.Arrays;
 
 abstract class BaseProtoTypes<T, I> {
-  
+
   protected final Type.Nullability nullability;
   public final T BOOLEAN;
   public final T I8;

--- a/core/src/main/java/io/substrait/type/proto/FromProto.java
+++ b/core/src/main/java/io/substrait/type/proto/FromProto.java
@@ -3,11 +3,10 @@ package io.substrait.type.proto;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 
-
 public class FromProto {
 
   public static Type from(io.substrait.proto.Type type) {
-    return switch(type.getKindCase()) {
+    return switch (type.getKindCase()) {
       case BOOL -> n(type.getBool().getNullability()).BOOLEAN;
       case I8 -> n(type.getI8().getNullability()).I8;
       case I16 -> n(type.getI16().getNullability()).I16;
@@ -24,18 +23,25 @@ public class FromProto {
       case INTERVAL_DAY -> n(type.getIntervalDay().getNullability()).INTERVAL_DAY;
       case TIMESTAMP_TZ -> n(type.getTimestampTz().getNullability()).TIMESTAMP_TZ;
       case UUID -> n(type.getUuid().getNullability()).UUID;
-      case FIXED_CHAR -> n(type.getFixedChar().getNullability()).fixedChar(type.getFixedChar().getLength());
+      case FIXED_CHAR -> n(type.getFixedChar().getNullability())
+          .fixedChar(type.getFixedChar().getLength());
       case VARCHAR -> n(type.getVarchar().getNullability()).varChar(type.getVarchar().getLength());
-      case FIXED_BINARY -> n(type.getFixedBinary().getNullability()).fixedBinary(type.getFixedBinary().getLength());
-      case DECIMAL -> n(type.getDecimal().getNullability()).decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
-      case STRUCT -> n(type.getStruct().getNullability()).struct(type.getStruct().getTypesList().stream().map(FromProto::from).toList());
+      case FIXED_BINARY -> n(type.getFixedBinary().getNullability())
+          .fixedBinary(type.getFixedBinary().getLength());
+      case DECIMAL -> n(type.getDecimal().getNullability())
+          .decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
+      case STRUCT -> n(type.getStruct().getNullability())
+          .struct(type.getStruct().getTypesList().stream().map(FromProto::from).toList());
       case LIST -> n(type.getList().getNullability()).list(from(type.getList().getType()));
-      case MAP -> n(type.getMap().getNullability()).map(from(type.getMap().getKey()), from(type.getMap().getValue()));
+      case MAP -> n(type.getMap().getNullability())
+          .map(from(type.getMap().getKey()), from(type.getMap().getValue()));
       case USER_DEFINED_TYPE_REFERENCE, KIND_NOT_SET -> throw new UnsupportedOperationException();
     };
   }
 
   private static TypeCreator n(io.substrait.proto.Type.Nullability n) {
-    return n == io.substrait.proto.Type.Nullability.NULLABILITY_NULLABLE ? TypeCreator.NULLABLE : TypeCreator.REQUIRED;
+    return n == io.substrait.proto.Type.Nullability.NULLABILITY_NULLABLE
+        ? TypeCreator.NULLABLE
+        : TypeCreator.REQUIRED;
   }
 }

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -1,90 +1,111 @@
 package io.substrait.type.proto;
 
-import io.substrait.proto.ParameterizedType;
 import io.substrait.function.TypeExpression;
 import io.substrait.function.TypeExpressionVisitor;
+import io.substrait.proto.ParameterizedType;
 import io.substrait.proto.Type;
 
-public class ParameterizedProtoConverter extends BaseProtoConverter<ParameterizedType, ParameterizedType.IntegerOption> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(
-      ParameterizedProtoConverter.class);
+public class ParameterizedProtoConverter
+    extends BaseProtoConverter<ParameterizedType, ParameterizedType.IntegerOption> {
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(ParameterizedProtoConverter.class);
 
   public ParameterizedProtoConverter() {
     super("Parameterized types cannot include return type expressions.");
   }
 
-  @Override public BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption> typeContainer(
+  @Override
+  public BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption> typeContainer(
       final boolean nullable) {
     return nullable ? PARAMETERIZED_NULLABLE : PARAMETERIZED_REQUIRED;
   }
 
-  private static final BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption> PARAMETERIZED_NULLABLE = new ParameterizedTypes(Type.Nullability.NULLABILITY_NULLABLE);
-  private static final BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption> PARAMETERIZED_REQUIRED = new ParameterizedTypes(Type.Nullability.NULLABILITY_REQUIRED);
+  private static final BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption>
+      PARAMETERIZED_NULLABLE = new ParameterizedTypes(Type.Nullability.NULLABILITY_NULLABLE);
+  private static final BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption>
+      PARAMETERIZED_REQUIRED = new ParameterizedTypes(Type.Nullability.NULLABILITY_REQUIRED);
 
   public ParameterizedType.IntegerOption i(final TypeExpression num) {
     return num.accept(new IntegerVisitor());
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.FixedChar expr) throws RuntimeException {
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.FixedChar expr)
+      throws RuntimeException {
     return typeContainer(expr).fixedChar(expr.length().value());
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.VarChar expr) throws RuntimeException {
-    return  typeContainer(expr).varChar(expr.length().value());
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.VarChar expr)
+      throws RuntimeException {
+    return typeContainer(expr).varChar(expr.length().value());
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.FixedBinary expr) throws RuntimeException {
-    return  typeContainer(expr).fixedBinary(expr.length().value());
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.FixedBinary expr)
+      throws RuntimeException {
+    return typeContainer(expr).fixedBinary(expr.length().value());
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.Decimal expr) throws RuntimeException {
-    return  typeContainer(expr).decimal(i(expr.precision()), i(expr.scale()));
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.Decimal expr)
+      throws RuntimeException {
+    return typeContainer(expr).decimal(i(expr.precision()), i(expr.scale()));
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.Struct expr) throws RuntimeException {
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.Struct expr)
+      throws RuntimeException {
     return typeContainer(expr).struct(expr.fields().stream().map(f -> f.accept(this)).toList());
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.ListType expr) throws RuntimeException {
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.ListType expr)
+      throws RuntimeException {
     return typeContainer(expr).list(expr.name().accept(this));
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.Map expr) throws RuntimeException {
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.Map expr)
+      throws RuntimeException {
     return typeContainer(expr).map(expr.key().accept(this), expr.value().accept(this));
   }
 
   @Override
-  public ParameterizedType visit(io.substrait.function.ParameterizedType.StringLiteral stringLiteral) throws RuntimeException {
-    return ParameterizedType.newBuilder().setTypeParameter(ParameterizedType.TypeParameter.newBuilder().setName(stringLiteral.value())).build();
+  public ParameterizedType visit(
+      io.substrait.function.ParameterizedType.StringLiteral stringLiteral) throws RuntimeException {
+    return ParameterizedType.newBuilder()
+        .setTypeParameter(
+            ParameterizedType.TypeParameter.newBuilder().setName(stringLiteral.value()))
+        .build();
   }
 
-  private static class IntegerVisitor extends TypeExpressionVisitor.TypeExpressionThrowsVisitor<ParameterizedType.IntegerOption, RuntimeException> {
+  private static class IntegerVisitor
+      extends TypeExpressionVisitor.TypeExpressionThrowsVisitor<
+          ParameterizedType.IntegerOption, RuntimeException> {
 
     public IntegerVisitor() {
       super("Parameterized integer locations should only include integer names or literals.");
     }
 
-    @Override public ParameterizedType.IntegerOption visit(final TypeExpression.IntegerLiteral literal) {
+    @Override
+    public ParameterizedType.IntegerOption visit(final TypeExpression.IntegerLiteral literal) {
       return ParameterizedType.IntegerOption.newBuilder().setLiteral(literal.value()).build();
     }
 
     @Override
-    public ParameterizedType.IntegerOption visit(io.substrait.function.ParameterizedType.StringLiteral stringLiteral) throws RuntimeException {
+    public ParameterizedType.IntegerOption visit(
+        io.substrait.function.ParameterizedType.StringLiteral stringLiteral)
+        throws RuntimeException {
       return ParameterizedType.IntegerOption.newBuilder()
-          .setParameter(ParameterizedType.IntegerParameter.newBuilder().setName(stringLiteral.value()))
+          .setParameter(
+              ParameterizedType.IntegerParameter.newBuilder().setName(stringLiteral.value()))
           .build();
     }
-
   }
 
-  public static class ParameterizedTypes  extends BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption> {
+  public static class ParameterizedTypes
+      extends BaseProtoTypes<ParameterizedType, ParameterizedType.IntegerOption> {
 
     public ParameterizedTypes(final Type.Nullability nullability) {
       super(nullability);
@@ -92,16 +113,24 @@ public class ParameterizedProtoConverter extends BaseProtoConverter<Parameterize
 
     public ParameterizedType fixedChar(ParameterizedType.IntegerOption len) {
       return wrap(
-          ParameterizedType.ParameterizedFixedChar.newBuilder().setLength(len).setNullability(nullability).build());
+          ParameterizedType.ParameterizedFixedChar.newBuilder()
+              .setLength(len)
+              .setNullability(nullability)
+              .build());
     }
 
-    @Override public ParameterizedType typeParam(final String name) {
-      return ParameterizedType.newBuilder().setTypeParameter(ParameterizedType.TypeParameter.newBuilder().setName(name)).build();
+    @Override
+    public ParameterizedType typeParam(final String name) {
+      return ParameterizedType.newBuilder()
+          .setTypeParameter(ParameterizedType.TypeParameter.newBuilder().setName(name))
+          .build();
     }
 
-    @Override public ParameterizedType.IntegerOption integerParam(final String name) {
-      return ParameterizedType.IntegerOption.newBuilder().setParameter(
-          ParameterizedType.IntegerParameter.newBuilder().setName(name)).build();
+    @Override
+    public ParameterizedType.IntegerOption integerParam(final String name) {
+      return ParameterizedType.IntegerOption.newBuilder()
+          .setParameter(ParameterizedType.IntegerParameter.newBuilder().setName(name))
+          .build();
     }
 
     protected ParameterizedType.IntegerOption i(int len) {
@@ -109,37 +138,66 @@ public class ParameterizedProtoConverter extends BaseProtoConverter<Parameterize
     }
 
     private static ParameterizedType.IntegerOption i(String param) {
-      return ParameterizedType.IntegerOption.newBuilder().setParameter(
-          ParameterizedType.IntegerParameter.newBuilder().setName(param)).build();
+      return ParameterizedType.IntegerOption.newBuilder()
+          .setParameter(ParameterizedType.IntegerParameter.newBuilder().setName(param))
+          .build();
     }
 
     public ParameterizedType varChar(ParameterizedType.IntegerOption len) {
-      return wrap(ParameterizedType.ParameterizedVarChar.newBuilder().setLength(len).setNullability(nullability).build());
+      return wrap(
+          ParameterizedType.ParameterizedVarChar.newBuilder()
+              .setLength(len)
+              .setNullability(nullability)
+              .build());
     }
 
     public ParameterizedType fixedBinary(ParameterizedType.IntegerOption len) {
-      return wrap(ParameterizedType.ParameterizedFixedBinary.newBuilder().setLength(len).setNullability(nullability).build());
+      return wrap(
+          ParameterizedType.ParameterizedFixedBinary.newBuilder()
+              .setLength(len)
+              .setNullability(nullability)
+              .build());
     }
 
-    public ParameterizedType decimal(ParameterizedType.IntegerOption scale, ParameterizedType.IntegerOption precision) {
-      return wrap(ParameterizedType.ParameterizedDecimal.newBuilder().setScale(scale).setPrecision(precision).setNullability(nullability).build());
+    public ParameterizedType decimal(
+        ParameterizedType.IntegerOption scale, ParameterizedType.IntegerOption precision) {
+      return wrap(
+          ParameterizedType.ParameterizedDecimal.newBuilder()
+              .setScale(scale)
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
     }
 
     public ParameterizedType struct(Iterable<ParameterizedType> types) {
-      return wrap(ParameterizedType.ParameterizedStruct.newBuilder().addAllTypes(types).setNullability(nullability).build());
+      return wrap(
+          ParameterizedType.ParameterizedStruct.newBuilder()
+              .addAllTypes(types)
+              .setNullability(nullability)
+              .build());
     }
 
     public ParameterizedType list(ParameterizedType type) {
-      return wrap(ParameterizedType.ParameterizedList.newBuilder().setType(type).setNullability(Type.Nullability.NULLABILITY_NULLABLE).build());
+      return wrap(
+          ParameterizedType.ParameterizedList.newBuilder()
+              .setType(type)
+              .setNullability(Type.Nullability.NULLABILITY_NULLABLE)
+              .build());
     }
 
     public ParameterizedType map(ParameterizedType key, ParameterizedType value) {
-      return wrap(ParameterizedType.ParameterizedMap.newBuilder().setKey(key).setValue(value).setNullability(Type.Nullability.NULLABILITY_NULLABLE).build());
+      return wrap(
+          ParameterizedType.ParameterizedMap.newBuilder()
+              .setKey(key)
+              .setValue(value)
+              .setNullability(Type.Nullability.NULLABILITY_NULLABLE)
+              .build());
     }
 
-    @Override protected ParameterizedType wrap(final Object o) {
+    @Override
+    protected ParameterizedType wrap(final Object o) {
       var bldr = ParameterizedType.newBuilder();
-      return switch(o) {
+      return switch (o) {
         case Type.Boolean t -> bldr.setBool(t).build();
         case Type.I8 t -> bldr.setI8(t).build();
         case Type.I16 t -> bldr.setI16(t).build();
@@ -163,7 +221,8 @@ public class ParameterizedProtoConverter extends BaseProtoConverter<Parameterize
         case ParameterizedType.ParameterizedList t -> bldr.setList(t).build();
         case ParameterizedType.ParameterizedMap t -> bldr.setMap(t).build();
         case Type.UUID t -> bldr.setUuid(t).build();
-        default -> throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
+        default -> throw new UnsupportedOperationException(
+            "Unable to wrap type of " + o.getClass());
       };
     }
   }

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -1,78 +1,102 @@
 package io.substrait.type.proto;
 
-import io.substrait.proto.DerivationExpression;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
+import io.substrait.proto.DerivationExpression;
 import io.substrait.proto.Type;
 
-public class TypeExpressionProtoVisitor extends BaseProtoConverter<DerivationExpression, DerivationExpression> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(
-      TypeExpressionProtoVisitor.class);
+public class TypeExpressionProtoVisitor
+    extends BaseProtoConverter<DerivationExpression, DerivationExpression> {
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(TypeExpressionProtoVisitor.class);
 
   public TypeExpressionProtoVisitor() {
     super("Unexpected expression type. This shouldn't happen.");
   }
 
-  @Override public BaseProtoTypes<DerivationExpression, DerivationExpression> typeContainer(
+  @Override
+  public BaseProtoTypes<DerivationExpression, DerivationExpression> typeContainer(
       final boolean nullable) {
     return nullable ? DERIVATION_NULLABLE : DERIVATION_REQUIRED;
   }
 
-  private static final DerivationTypes DERIVATION_NULLABLE = new DerivationTypes(Type.Nullability.NULLABILITY_NULLABLE);
-  private static final DerivationTypes DERIVATION_REQUIRED = new DerivationTypes(Type.Nullability.NULLABILITY_REQUIRED);
+  private static final DerivationTypes DERIVATION_NULLABLE =
+      new DerivationTypes(Type.Nullability.NULLABILITY_NULLABLE);
+  private static final DerivationTypes DERIVATION_REQUIRED =
+      new DerivationTypes(Type.Nullability.NULLABILITY_REQUIRED);
 
-  @Override public DerivationExpression visit(final TypeExpression.BinaryOperation expr) {
-    var opType = switch (expr.opType()) {
-      case ADD -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_PLUS;
-      case SUBTRACT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
-      case MIN -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MIN;
-      case MAX -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MAX;
-      case LT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
-      //case LTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
-      case GT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_GREATER_THAN;
-      //case GTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
-      //case NOT_EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQ;
-      case EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQUALS;
-      case COVERS -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_COVERS;
-      default -> throw new IllegalStateException("Unexpected value: " + expr.opType());
-    };
+  @Override
+  public DerivationExpression visit(final TypeExpression.BinaryOperation expr) {
+    var opType =
+        switch (expr.opType()) {
+          case ADD -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_PLUS;
+          case SUBTRACT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
+          case MIN -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MIN;
+          case MAX -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MAX;
+          case LT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
+            // case LTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
+          case GT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_GREATER_THAN;
+            // case GTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
+            // case NOT_EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQ;
+          case EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQUALS;
+          case COVERS -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_COVERS;
+          default -> throw new IllegalStateException("Unexpected value: " + expr.opType());
+        };
     return DerivationExpression.newBuilder()
-        .setBinaryOp(DerivationExpression.BinaryOp.newBuilder()
-            .setArg1(expr.left().accept(this))
-            .setArg2(expr.right().accept(this))
-            .setOpType(opType)
-            .build()).build();
-  }
-
-  @Override public DerivationExpression visit(final TypeExpression.NotOperation expr) {
-    return DerivationExpression.newBuilder().setUnaryOp(
-        DerivationExpression.UnaryOp.newBuilder().setOpType(
-            DerivationExpression.UnaryOp.UnaryOpType.UNARY_OP_TYPE_BOOLEAN_NOT)
-            .setArg(expr.inner().accept(this)))
+        .setBinaryOp(
+            DerivationExpression.BinaryOp.newBuilder()
+                .setArg1(expr.left().accept(this))
+                .setArg2(expr.right().accept(this))
+                .setOpType(opType)
+                .build())
         .build();
   }
 
-  @Override public DerivationExpression visit(final TypeExpression.IfOperation expr) {
-    return DerivationExpression.newBuilder().setIfElse(DerivationExpression.IfElse.newBuilder()
-            .setIfCondition(expr.ifCondition().accept(this))
-            .setIfReturn(expr.thenExpr().accept(this))
-            .setElseReturn(expr.elseExpr().accept(this))
-            .build())
+  @Override
+  public DerivationExpression visit(final TypeExpression.NotOperation expr) {
+    return DerivationExpression.newBuilder()
+        .setUnaryOp(
+            DerivationExpression.UnaryOp.newBuilder()
+                .setOpType(DerivationExpression.UnaryOp.UnaryOpType.UNARY_OP_TYPE_BOOLEAN_NOT)
+                .setArg(expr.inner().accept(this)))
         .build();
   }
 
-  @Override public DerivationExpression visit(final TypeExpression.IntegerLiteral expr) {
+  @Override
+  public DerivationExpression visit(final TypeExpression.IfOperation expr) {
+    return DerivationExpression.newBuilder()
+        .setIfElse(
+            DerivationExpression.IfElse.newBuilder()
+                .setIfCondition(expr.ifCondition().accept(this))
+                .setIfReturn(expr.thenExpr().accept(this))
+                .setElseReturn(expr.elseExpr().accept(this))
+                .build())
+        .build();
+  }
+
+  @Override
+  public DerivationExpression visit(final TypeExpression.IntegerLiteral expr) {
     return DerivationExpression.newBuilder().setIntegerLiteral(expr.value()).build();
   }
 
-  @Override public DerivationExpression visit(final TypeExpression.ReturnProgram expr) {
-    var assignments = expr.assignments().stream().map(a -> DerivationExpression.ReturnProgram.Assignment.newBuilder().setName(a.name()).setExpression(a.expr().accept(this)).build()).toList();
+  @Override
+  public DerivationExpression visit(final TypeExpression.ReturnProgram expr) {
+    var assignments =
+        expr.assignments().stream()
+            .map(
+                a ->
+                    DerivationExpression.ReturnProgram.Assignment.newBuilder()
+                        .setName(a.name())
+                        .setExpression(a.expr().accept(this))
+                        .build())
+            .toList();
     var finalExpr = expr.finalExpression().accept(this);
-    return DerivationExpression.newBuilder().setReturnProgram(
-        DerivationExpression.ReturnProgram.newBuilder()
-            .setFinalExpression(finalExpr)
-            .addAllAssignments(assignments)
-            .build())
+    return DerivationExpression.newBuilder()
+        .setReturnProgram(
+            DerivationExpression.ReturnProgram.newBuilder()
+                .setFinalExpression(finalExpr)
+                .addAllAssignments(assignments)
+                .build())
         .build();
   }
 
@@ -83,17 +107,17 @@ public class TypeExpressionProtoVisitor extends BaseProtoConverter<DerivationExp
 
   @Override
   public DerivationExpression visit(ParameterizedType.VarChar expr) {
-    return  typeContainer(expr).varChar(expr.length().value());
+    return typeContainer(expr).varChar(expr.length().value());
   }
 
   @Override
   public DerivationExpression visit(ParameterizedType.FixedBinary expr) {
-    return  typeContainer(expr).fixedBinary(expr.length().value());
+    return typeContainer(expr).fixedBinary(expr.length().value());
   }
 
   @Override
   public DerivationExpression visit(ParameterizedType.Decimal expr) {
-    return  typeContainer(expr).decimal(expr.precision().accept(this), expr.scale().accept(this));
+    return typeContainer(expr).decimal(expr.precision().accept(this), expr.scale().accept(this));
   }
 
   @Override
@@ -123,17 +147,17 @@ public class TypeExpressionProtoVisitor extends BaseProtoConverter<DerivationExp
 
   @Override
   public DerivationExpression visit(TypeExpression.VarChar expr) {
-    return  typeContainer(expr).varChar(expr.length().accept(this));
+    return typeContainer(expr).varChar(expr.length().accept(this));
   }
 
   @Override
   public DerivationExpression visit(TypeExpression.FixedBinary expr) {
-    return  typeContainer(expr).fixedBinary(expr.length().accept(this));
+    return typeContainer(expr).fixedBinary(expr.length().accept(this));
   }
 
   @Override
   public DerivationExpression visit(TypeExpression.Decimal expr) {
-    return  typeContainer(expr).decimal(expr.precision().accept(this), expr.scale().accept(this));
+    return typeContainer(expr).decimal(expr.precision().accept(this), expr.scale().accept(this));
   }
 
   @Override
@@ -151,8 +175,8 @@ public class TypeExpressionProtoVisitor extends BaseProtoConverter<DerivationExp
     return typeContainer(expr).map(expr.key().accept(this), expr.value().accept(this));
   }
 
-
-  private static class DerivationTypes extends BaseProtoTypes<DerivationExpression, DerivationExpression> {
+  private static class DerivationTypes
+      extends BaseProtoTypes<DerivationExpression, DerivationExpression> {
 
     public DerivationTypes(final Type.Nullability nullability) {
       super(nullability);
@@ -160,31 +184,54 @@ public class TypeExpressionProtoVisitor extends BaseProtoConverter<DerivationExp
 
     public DerivationExpression fixedChar(DerivationExpression len) {
       return wrap(
-          DerivationExpression.ExpressionFixedChar.newBuilder().setLength(len).setNullability(nullability).build());
+          DerivationExpression.ExpressionFixedChar.newBuilder()
+              .setLength(len)
+              .setNullability(nullability)
+              .build());
     }
 
-    @Override public DerivationExpression typeParam(final String name) {
+    @Override
+    public DerivationExpression typeParam(final String name) {
       return DerivationExpression.newBuilder().setTypeParameterName(name).build();
     }
 
-    @Override public DerivationExpression integerParam(final String name) {
+    @Override
+    public DerivationExpression integerParam(final String name) {
       return DerivationExpression.newBuilder().setIntegerParameterName(name).build();
     }
 
     public DerivationExpression varChar(DerivationExpression len) {
-      return wrap(DerivationExpression.ExpressionVarChar.newBuilder().setLength(len).setNullability(nullability).build());
+      return wrap(
+          DerivationExpression.ExpressionVarChar.newBuilder()
+              .setLength(len)
+              .setNullability(nullability)
+              .build());
     }
 
     public DerivationExpression fixedBinary(DerivationExpression len) {
-      return wrap(DerivationExpression.ExpressionFixedBinary.newBuilder().setLength(len).setNullability(nullability).build());
+      return wrap(
+          DerivationExpression.ExpressionFixedBinary.newBuilder()
+              .setLength(len)
+              .setNullability(nullability)
+              .build());
     }
 
-    public DerivationExpression decimal(DerivationExpression scale, DerivationExpression precision) {
-      return wrap(DerivationExpression.ExpressionDecimal.newBuilder().setScale(scale).setPrecision(precision).setNullability(nullability).build());
+    public DerivationExpression decimal(
+        DerivationExpression scale, DerivationExpression precision) {
+      return wrap(
+          DerivationExpression.ExpressionDecimal.newBuilder()
+              .setScale(scale)
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
     }
 
     public DerivationExpression struct(Iterable<DerivationExpression> types) {
-      return wrap(DerivationExpression.ExpressionStruct.newBuilder().addAllTypes(types).setNullability(nullability).build());
+      return wrap(
+          DerivationExpression.ExpressionStruct.newBuilder()
+              .addAllTypes(types)
+              .setNullability(nullability)
+              .build());
     }
 
     public DerivationExpression param(String name) {
@@ -192,16 +239,26 @@ public class TypeExpressionProtoVisitor extends BaseProtoConverter<DerivationExp
     }
 
     public DerivationExpression list(DerivationExpression type) {
-      return wrap(DerivationExpression.ExpressionList.newBuilder().setType(type).setNullability(Type.Nullability.NULLABILITY_NULLABLE).build());
+      return wrap(
+          DerivationExpression.ExpressionList.newBuilder()
+              .setType(type)
+              .setNullability(Type.Nullability.NULLABILITY_NULLABLE)
+              .build());
     }
 
     public DerivationExpression map(DerivationExpression key, DerivationExpression value) {
-      return wrap(DerivationExpression.ExpressionMap.newBuilder().setKey(key).setValue(value).setNullability(Type.Nullability.NULLABILITY_REQUIRED).build());
+      return wrap(
+          DerivationExpression.ExpressionMap.newBuilder()
+              .setKey(key)
+              .setValue(value)
+              .setNullability(Type.Nullability.NULLABILITY_REQUIRED)
+              .build());
     }
 
-    @Override protected DerivationExpression wrap(final Object o) {
+    @Override
+    protected DerivationExpression wrap(final Object o) {
       var bldr = DerivationExpression.newBuilder();
-      return switch(o) {
+      return switch (o) {
         case Type.Boolean t -> bldr.setBool(t).build();
         case Type.I8 t -> bldr.setI8(t).build();
         case Type.I16 t -> bldr.setI16(t).build();
@@ -225,13 +282,14 @@ public class TypeExpressionProtoVisitor extends BaseProtoConverter<DerivationExp
         case DerivationExpression.ExpressionList t -> bldr.setList(t).build();
         case DerivationExpression.ExpressionMap t -> bldr.setMap(t).build();
         case Type.UUID t -> bldr.setUuid(t).build();
-        default -> throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
+        default -> throw new UnsupportedOperationException(
+            "Unable to wrap type of " + o.getClass());
       };
     }
 
-    @Override protected DerivationExpression i(final int integerValue) {
+    @Override
+    protected DerivationExpression i(final int integerValue) {
       return DerivationExpression.newBuilder().setIntegerLiteral(integerValue).build();
     }
-
   }
 }

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -4,7 +4,8 @@ import io.substrait.function.TypeExpressionVisitor;
 import io.substrait.proto.Type;
 
 public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TypeProtoConverter.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(TypeProtoConverter.class);
 
   public static TypeExpressionVisitor<Type, RuntimeException> INSTANCE = new TypeProtoConverter();
 
@@ -12,10 +13,13 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     super("Type literals cannot contain parameters or expressions.");
   }
 
-  private static final BaseProtoTypes<Type, Integer> NULLABLE = new Types(Type.Nullability.NULLABILITY_NULLABLE);
-  private static final BaseProtoTypes<Type, Integer> REQUIRED = new Types(Type.Nullability.NULLABILITY_REQUIRED);
+  private static final BaseProtoTypes<Type, Integer> NULLABLE =
+      new Types(Type.Nullability.NULLABILITY_NULLABLE);
+  private static final BaseProtoTypes<Type, Integer> REQUIRED =
+      new Types(Type.Nullability.NULLABILITY_REQUIRED);
 
-  @Override public BaseProtoTypes<Type, Integer> typeContainer(final boolean nullable) {
+  @Override
+  public BaseProtoTypes<Type, Integer> typeContainer(final boolean nullable) {
     return nullable ? NULLABLE : REQUIRED;
   }
 
@@ -29,12 +33,16 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
       return wrap(Type.FixedChar.newBuilder().setLength(len).setNullability(nullability).build());
     }
 
-    @Override public Type typeParam(final String name) {
-      throw new UnsupportedOperationException("It is not possible to use parameters in basic types.");
+    @Override
+    public Type typeParam(final String name) {
+      throw new UnsupportedOperationException(
+          "It is not possible to use parameters in basic types.");
     }
 
-    @Override public Integer integerParam(final String name) {
-      throw new UnsupportedOperationException("It is not possible to use parameters in basic types.");
+    @Override
+    public Integer integerParam(final String name) {
+      throw new UnsupportedOperationException(
+          "It is not possible to use parameters in basic types.");
     }
 
     public Type varChar(Integer len) {
@@ -46,7 +54,12 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     }
 
     public Type decimal(Integer scale, Integer precision) {
-      return wrap(Type.Decimal.newBuilder().setScale(scale).setPrecision(precision).setNullability(nullability).build());
+      return wrap(
+          Type.Decimal.newBuilder()
+              .setScale(scale)
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
     }
 
     public Type struct(Iterable<Type> types) {
@@ -58,12 +71,14 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     }
 
     public Type map(Type key, Type value) {
-      return wrap(Type.Map.newBuilder().setKey(key).setValue(value).setNullability(nullability).build());
+      return wrap(
+          Type.Map.newBuilder().setKey(key).setValue(value).setNullability(nullability).build());
     }
 
-    @Override protected Type wrap(final Object o) {
+    @Override
+    protected Type wrap(final Object o) {
       var bldr = Type.newBuilder();
-      return switch(o) {
+      return switch (o) {
         case Type.Boolean t -> bldr.setBool(t).build();
         case Type.I8 t -> bldr.setI8(t).build();
         case Type.I16 t -> bldr.setI16(t).build();
@@ -87,13 +102,14 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
         case Type.List t -> bldr.setList(t).build();
         case Type.Map t -> bldr.setMap(t).build();
         case Type.UUID t -> bldr.setUuid(t).build();
-        default -> throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
+        default -> throw new UnsupportedOperationException(
+            "Unable to wrap type of " + o.getClass());
       };
     }
 
-    @Override protected Integer i(final int integerValue) {
+    @Override
+    protected Integer i(final int integerValue) {
       return integerValue;
     }
   }
-
 }

--- a/core/src/main/java/io/substrait/util/Util.java
+++ b/core/src/main/java/io/substrait/util/Util.java
@@ -5,7 +5,6 @@ import java.util.function.Supplier;
 public class Util {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Util.class);
 
-
   public static <T> Supplier<T> memoize(Supplier<T> supplier) {
     return new Memoizer<T>(supplier);
   }
@@ -28,9 +27,7 @@ public class Util {
       }
       return value;
     }
-
   }
-
 
   public static class IntRange {
     private final int startInclusive;

--- a/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
+++ b/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
@@ -1,13 +1,13 @@
 package io.substrait.type.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.substrait.function.ParameterizedTypeCreator;
 import io.substrait.function.TypeExpression;
 import io.substrait.function.TypeExpressionCreator;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTypeParser {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTypeParser.class);
@@ -47,8 +47,14 @@ public class TestTypeParser {
 
   @Test
   public void derivationExpression() {
-    test(ParseToPojo.Visitor.EXPRESSION, eo.fixedCharE(eo.plus(pr.parameter("L1"), pr.parameter("L2"))), "FIXEDCHAR<L1+L2>");
-    test(ParseToPojo.Visitor.EXPRESSION, eo.program(pr.fixedCharE("L1"), new TypeExpressionCreator.Assign("L1", eo.i(1))), "L1=1\nFIXEDCHAR<L1>");
+    test(
+        ParseToPojo.Visitor.EXPRESSION,
+        eo.fixedCharE(eo.plus(pr.parameter("L1"), pr.parameter("L2"))),
+        "FIXEDCHAR<L1+L2>");
+    test(
+        ParseToPojo.Visitor.EXPRESSION,
+        eo.program(pr.fixedCharE("L1"), new TypeExpressionCreator.Assign("L1", eo.i(1))),
+        "L1=1\nFIXEDCHAR<L1>");
   }
 
   private <T> void simpleTests(ParseToPojo.Visitor v) {
@@ -67,5 +73,4 @@ public class TestTypeParser {
   private static void test(ParseToPojo.Visitor visitor, TypeExpression expected, String toParse) {
     assertEquals(expected, TypeStringParser.parse(toParse, visitor));
   }
-
 }

--- a/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
@@ -1,14 +1,13 @@
 package io.substrait.type.proto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import com.google.protobuf.ByteString;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.proto.ExpressionProtoConverter;
 import io.substrait.expression.proto.ProtoExpressionConverter;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -16,130 +15,128 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class GenericRoundtripTest {
-    static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(GenericRoundtripTest.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(GenericRoundtripTest.class);
 
-    static Random rand = new Random(123);
+  static Random rand = new Random(123);
 
-    @ParameterizedTest
-    @MethodSource("generateInvocations")
-    /**
-     * This tests executes a roundtrip for {@link Method} m invoked with a {@link List<Object>} of parameters.
-     * If the param generation has failed the {@link UnsupportedTypeGenerationException} e is populated,
-     * and the test will be ignored (kept here for tracking).
-     */
-    public void roundtripTest(Method m, List<Object> paramInst, UnsupportedTypeGenerationException e)
-            throws InvocationTargetException, IllegalAccessException {
+  @ParameterizedTest
+  @MethodSource("generateInvocations")
+  /**
+   * This tests executes a roundtrip for {@link Method} m invoked with a {@link List<Object>} of
+   * parameters. If the param generation has failed the {@link UnsupportedTypeGenerationException} e
+   * is populated, and the test will be ignored (kept here for tracking).
+   */
+  public void roundtripTest(Method m, List<Object> paramInst, UnsupportedTypeGenerationException e)
+      throws InvocationTargetException, IllegalAccessException {
 
-        // If there is an UncoveredTypeGenerationException we  ignore this test
-        if (e != null) {
-            Assumptions.assumeTrue(false, e.getMessage());
-        }
-
-        // roundtrip to protobuff and back and check equality
-        Expression val = (Expression) m.invoke(null, paramInst.toArray(new Object[0]));
-
-        var to = new ExpressionProtoConverter(null);
-        var from = new ProtoExpressionConverter(null, null, null);
-        assertEquals(val, from.from(val.accept(to)));
+    // If there is an UncoveredTypeGenerationException we  ignore this test
+    if (e != null) {
+      Assumptions.assumeTrue(false, e.getMessage());
     }
 
+    // roundtrip to protobuff and back and check equality
+    Expression val = (Expression) m.invoke(null, paramInst.toArray(new Object[0]));
 
-    //Parametrized case generator
-    private static Collection generateInvocations() {
+    var to = new ExpressionProtoConverter(null);
+    var from = new ProtoExpressionConverter(null, null, null);
+    assertEquals(val, from.from(val.accept(to)));
+  }
 
-        ArrayList<Arguments> invocations = new ArrayList<>();
+  // Parametrized case generator
+  private static Collection generateInvocations() {
 
-        //We list all public and static methods of ExpressionCreator
-        List<Method> methodsToTest = getMethods(ExpressionCreator.class, true, true);
+    ArrayList<Arguments> invocations = new ArrayList<>();
 
+    // We list all public and static methods of ExpressionCreator
+    List<Method> methodsToTest = getMethods(ExpressionCreator.class, true, true);
 
-        // We generate synthetic input params (for a subset of types we support)
-        for (Method m : methodsToTest) {
-            try {
-                invocations.add(arguments(m, instantiateParams(m), null));
-            } catch (UnsupportedTypeGenerationException e) {
-                invocations.add(arguments(m, null, e));
-            }
-        }
-        return invocations;
+    // We generate synthetic input params (for a subset of types we support)
+    for (Method m : methodsToTest) {
+      try {
+        invocations.add(arguments(m, instantiateParams(m), null));
+      } catch (UnsupportedTypeGenerationException e) {
+        invocations.add(arguments(m, null, e));
+      }
+    }
+    return invocations;
+  }
+
+  private static List<Object> instantiateParams(Method m)
+      throws UnsupportedTypeGenerationException {
+    List<Object> l = new ArrayList<>();
+    for (Class param : m.getParameterTypes()) {
+      Object val = valGenerator(param);
+      if (val == null) {
+        throw new UnsupportedTypeGenerationException(
+            "We can't yet handle generation for type: " + param.getName());
+      }
+      l.add(valGenerator(param));
+    }
+    return l;
+  }
+
+  private static List<Method> getMethods(
+      Class c, boolean filterPublicOnly, boolean filterStaticOnly) {
+    Method[] allMethods = c.getMethods();
+    List<Method> selectedMethods = new ArrayList<>();
+    for (Method m : allMethods) {
+      if ((filterPublicOnly && !Modifier.isPublic(m.getModifiers()))
+          || (filterStaticOnly && !Modifier.isStatic(m.getModifiers()))) {
+        continue;
+      }
+      selectedMethods.add(m);
+    }
+    return selectedMethods;
+  }
+
+  private static Object valGenerator(Class<?> type) {
+    // For each "type" generate some random value
+
+    if (type.equals(Boolean.TYPE) || type.equals(Boolean.class)) {
+      return rand.nextBoolean();
+    } else if (type.equals((Integer.TYPE)) || type.equals(Integer.class)) {
+      // we generate always numbers in 1-12 as this is often use for timestamp
+      // construction and need to respect the days/months/years formats.
+      // we would not test all values, but get ok coverage of basics
+      return rand.nextInt(11) + 1;
+    } else if (type.equals(Long.TYPE) || type.equals(Long.class)) {
+      return rand.nextLong();
+    } else if (type.equals(Double.TYPE) || type.equals(Double.class)) {
+      return rand.nextDouble();
+    } else if (type.equals(Float.TYPE) || type.equals(Float.class)) {
+      return rand.nextFloat();
+    } else if (type.equals(String.class)) {
+      return UUID.randomUUID().toString();
+    } else if (type.equals(UUID.class)) {
+      return UUID.randomUUID();
+    } else if (type.equals(LocalDateTime.class)) {
+      return LocalDateTime.now();
+    } else if (type.equals(ByteString.class)) {
+      return ByteString.copyFromUtf8(UUID.randomUUID().toString());
+    } else if (type.equals(BigDecimal.class)) {
+      return BigDecimal.valueOf(rand.nextLong());
+    } else if (type.equals(Instant.class)) {
+      return Instant.now();
     }
 
+    return null;
+  }
 
-    private static List<Object> instantiateParams(Method m) throws UnsupportedTypeGenerationException {
-        List<Object> l = new ArrayList<>();
-        for (Class param : m.getParameterTypes()) {
-            Object val = valGenerator(param);
-            if (val == null) {
-                throw new UnsupportedTypeGenerationException("We can't yet handle generation for type: " +
-                         param.getName());
-            }
-            l.add(valGenerator(param));
-        }
-        return l;
+  // Class used to propagate type generation errors from param generator to test cases
+  private static class UnsupportedTypeGenerationException extends Exception {
+    public UnsupportedTypeGenerationException(String s) {
+      super(s);
     }
-
-    private static List<Method> getMethods(Class c, boolean filterPublicOnly, boolean filterStaticOnly) {
-        Method[] allMethods = c.getMethods();
-        List<Method> selectedMethods = new ArrayList<>();
-        for (Method m : allMethods) {
-            if ((filterPublicOnly && !Modifier.isPublic(m.getModifiers())) ||
-                    (filterStaticOnly && !Modifier.isStatic(m.getModifiers()))) {
-                continue;
-            }
-            selectedMethods.add(m);
-        }
-        return selectedMethods;
-    }
-
-
-    private static Object valGenerator(Class<?> type) {
-        // For each "type" generate some random value
-
-        if (type.equals(Boolean.TYPE) || type.equals(Boolean.class)) {
-            return rand.nextBoolean();
-        } else if (type.equals((Integer.TYPE)) || type.equals(Integer.class)) {
-            // we generate always numbers in 1-12 as this is often use for timestamp
-            // construction and need to respect the days/months/years formats.
-            // we would not test all values, but get ok coverage of basics
-            return rand.nextInt(11)+1;
-        } else if (type.equals(Long.TYPE) || type.equals(Long.class)) {
-            return rand.nextLong();
-        } else if (type.equals(Double.TYPE) || type.equals(Double.class)) {
-            return rand.nextDouble();
-        } else if (type.equals(Float.TYPE) || type.equals(Float.class)) {
-            return rand.nextFloat();
-        } else if (type.equals(String.class)) {
-            return UUID.randomUUID().toString();
-        } else if (type.equals(UUID.class)) {
-            return UUID.randomUUID();
-        } else if (type.equals(LocalDateTime.class)) {
-            return LocalDateTime.now();
-        } else if (type.equals(ByteString.class)) {
-            return ByteString.copyFromUtf8(UUID.randomUUID().toString());
-        } else if (type.equals(BigDecimal.class)) {
-            return BigDecimal.valueOf(rand.nextLong());
-        } else if (type.equals(Instant.class)) {
-            return Instant.now();
-        }
-
-        return null;
-    }
-
-    // Class used to propagate type generation errors from param generator to test cases
-    private static class UnsupportedTypeGenerationException extends Exception {
-        public UnsupportedTypeGenerationException(String s) {
-            super(s);
-        }
-    }
-
+  }
 }

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -1,20 +1,20 @@
 package io.substrait.type.proto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.proto.ExpressionProtoConverter;
 import io.substrait.expression.proto.ProtoExpressionConverter;
+import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class LiteralRoundtripTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LiteralRoundtripTest.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(LiteralRoundtripTest.class);
 
   @Test
   void decimal() {
-    var val = ExpressionCreator.decimal(false, BigDecimal.TEN, 10,2);
+    var val = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
     var to = new ExpressionProtoConverter(null);
     var from = new ProtoExpressionConverter(null, null, null);
     assertEquals(val, from.from(val.accept(to)));

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -1,11 +1,11 @@
 package io.substrait.type.proto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTypeRoundtrip {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTypeRoundtrip.class);
@@ -32,7 +32,7 @@ public class TestTypeRoundtrip {
     t(creator(n).fixedChar(25));
     t(creator(n).varChar(35));
     t(creator(n).fixedBinary(45));
-    t(creator(n).decimal(34,3));
+    t(creator(n).decimal(34, 3));
     t(creator(n).map(creator(n).I8, creator(n).I16));
     t(creator(n).list(creator(n).TIME));
     t(creator(n).struct(creator(n).TIME, creator(n).TIMESTAMP, creator(n).TIMESTAMP_TZ));
@@ -40,6 +40,7 @@ public class TestTypeRoundtrip {
 
   /**
    * Test a type pojo -> proto -> pojo roundtrip.
+   *
    * @param type
    */
   private void t(Type type) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,8 @@
-org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx512m -XX:MaxMetaspaceSize=512m --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -5,44 +5,42 @@ plugins {
   id("com.diffplug.spotless") version "6.5.1"
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 dependencies {
-    implementation(project(":core"))
-    implementation("org.apache.calcite:calcite-core:1.30.0")
-    implementation("org.apache.calcite:calcite-server:1.28.0")
-    implementation("org.junit.jupiter:junit-jupiter:5.7.0")
-    implementation("org.reflections:reflections:0.9.12")
-    implementation("com.google.guava:guava:29.0-jre")
-    implementation("org.graalvm.sdk:graal-sdk:22.0.0.2")
-    implementation("info.picocli:picocli:4.6.1")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.4")
-    implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.4")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4")
-    implementation("com.google.protobuf:protobuf-java-util:3.17.3") {
-        exclude("com.google.guava","guava")
-            .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
-    }
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
-    implementation("com.github.ben-manes.caffeine:caffeine:3.0.4")
-    implementation("org.immutables:value-annotations:2.8.8")
+  implementation(project(":core"))
+  implementation("org.apache.calcite:calcite-core:1.30.0")
+  implementation("org.apache.calcite:calcite-server:1.28.0")
+  implementation("org.junit.jupiter:junit-jupiter:5.7.0")
+  implementation("org.reflections:reflections:0.9.12")
+  implementation("com.google.guava:guava:29.0-jre")
+  implementation("org.graalvm.sdk:graal-sdk:22.0.0.2")
+  implementation("info.picocli:picocli:4.6.1")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.12.4")
+  implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.4")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4")
+  implementation("com.google.protobuf:protobuf-java-util:3.17.3") {
+    exclude("com.google.guava", "guava")
+      .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
+  }
+  implementation("com.google.code.findbugs:jsr305:3.0.2")
+  implementation("com.github.ben-manes.caffeine:caffeine:3.0.4")
+  implementation("org.immutables:value-annotations:2.8.8")
 }
 
 graal {
-    mainClass("io.substrait.isthmus.PlanEntryPoint")
-    outputName("isthmus")
-    graalVersion("22.0.0.2")
-    javaVersion("17")
-    option("--no-fallback")
-    option("--initialize-at-build-time=io.substrait.isthmus.InitializeAtBuildTime,org.slf4j.impl.StaticLoggerBinder,com.google.common.math.IntMath\$1,com.google.common.base.Platform,com.google.common.util.concurrent.AbstractFuture\$UnsafeAtomicHelper,com.google.common.collect.ImmutableSortedMap,com.google.common.math.IntMath,com.google.common.collect.RegularImmutableSortedSet,com.google.common.cache.LocalCache,com.google.common.collect.Range,org.apache.commons.codec.language.Soundex,com.google.common.collect.ImmutableRangeSet,org.slf4j.LoggerFactory,com.google.common.collect.Platform,com.google.common.util.concurrent.SettableFuture,com.google.common.util.concurrent.AbstractFuture,com.google.common.util.concurrent.AbstractFuture,com.google.common.cache.CacheBuilder,com.google.common.base.Preconditions,com.google.common.collect.RegularImmutableMap,org.slf4j.impl.JDK14LoggerAdapter,org.apache.calcite.rel.metadata.RelMdColumnUniqueness,org.apache.calcite.rel.metadata.BuiltInMetadata\$ColumnOrigin,io.substrait.isthmus.metadata.LambdaMetadataSupplier,org.apache.calcite.rel.metadata.BuiltInMetadata\$PopulationSize,org.apache.calcite.rel.metadata.BuiltInMetadata\$Size,org.apache.calcite.rel.metadata.BuiltInMetadata\$UniqueKeys,org.apache.calcite.rel.metadata.RelMdColumnOrigins,org.apache.calcite.rel.metadata.RelMdExplainVisibility,org.apache.calcite.rel.metadata.RelMdMemory,org.apache.calcite.rel.metadata.RelMdExpressionLineage,org.apache.calcite.rel.metadata.RelMdDistinctRowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$RowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$PercentageOriginalRows,org.apache.calcite.util.Pair,org.apache.calcite.rel.metadata.BuiltInMetadata\$ExpressionLineage,org.apache.calcite.rel.metadata.BuiltInMetadata\$MinRowCount,com.google.common.primitives.Primitives,org.apache.calcite.rel.metadata.BuiltInMetadata\$Selectivity,org.apache.calcite.rel.metadata.BuiltInMetadata\$Parallelism,org.apache.calcite.rel.metadata.RelMdUniqueKeys,org.apache.calcite.rel.metadata.RelMdParallelism,org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows,org.apache.calcite.rel.metadata.BuiltInMetadata\$Predicates,org.apache.calcite.rel.metadata.BuiltInMetadata\$Distribution,org.apache.calcite.config.CalciteSystemProperty,org.apache.calcite.rel.metadata.BuiltInMetadata\$NonCumulativeCost,org.apache.calcite.util.Util,org.apache.calcite.rel.metadata.RelMdAllPredicates,io.substrait.isthmus.metadata.LambdaHandlerCache,org.apache.calcite.rel.metadata.BuiltInMetadata\$TableReferences,org.apache.calcite.rel.metadata.RelMdNodeTypes,org.apache.calcite.rel.metadata.RelMdCollation,org.apache.calcite.rel.metadata.RelMdSelectivity,org.apache.calcite.rel.metadata.BuiltInMetadata\$NodeTypes,org.apache.calcite.rel.metadata.RelMdPredicates,org.apache.calcite.rel.metadata.BuiltInMetadata\$DistinctRowCount,org.apache.calcite.rel.metadata.RelMdRowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$MaxRowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$AllPredicates,org.apache.calcite.rel.metadata.RelMdMaxRowCount,org.apache.calcite.rel.metadata.RelMdLowerBoundCost,org.apache.calcite.rel.metadata.BuiltInMetadata\$ExplainVisibility,org.apache.calcite.rel.metadata.BuiltInMetadata\$ColumnUniqueness,org.apache.calcite.rel.metadata.RelMdPopulationSize,org.apache.calcite.rel.metadata.BuiltInMetadata\$Memory,org.apache.calcite.rel.metadata.RelMdMinRowCount,org.apache.calcite.rel.metadata.RelMdSize,org.apache.calcite.rel.metadata.BuiltInMetadata\$LowerBoundCost,org.apache.calcite.rel.metadata.RelMdTableReferences,org.apache.calcite.rel.metadata.RelMdDistribution,io.substrait.isthmus.metadata.LegacyToLambdaGenerator,org.apache.calcite.rel.metadata.BuiltInMetadata\$CumulativeCost,org.apache.calcite.rel.metadata.BuiltInMetadata\$Collation")
-    option("-H:IncludeResources=.*yaml")
-    option("--report-unsupported-elements-at-runtime")
-    option("-H:+ReportExceptionStackTraces")
-    option("-H:DynamicProxyConfigurationFiles=proxies.json")
-    option("--features=io.substrait.isthmus.RegisterAtRuntime")
-    option("-J--enable-preview")
+  mainClass("io.substrait.isthmus.PlanEntryPoint")
+  outputName("isthmus")
+  graalVersion("22.0.0.2")
+  javaVersion("17")
+  option("--no-fallback")
+  option(
+    "--initialize-at-build-time=io.substrait.isthmus.InitializeAtBuildTime,org.slf4j.impl.StaticLoggerBinder,com.google.common.math.IntMath\$1,com.google.common.base.Platform,com.google.common.util.concurrent.AbstractFuture\$UnsafeAtomicHelper,com.google.common.collect.ImmutableSortedMap,com.google.common.math.IntMath,com.google.common.collect.RegularImmutableSortedSet,com.google.common.cache.LocalCache,com.google.common.collect.Range,org.apache.commons.codec.language.Soundex,com.google.common.collect.ImmutableRangeSet,org.slf4j.LoggerFactory,com.google.common.collect.Platform,com.google.common.util.concurrent.SettableFuture,com.google.common.util.concurrent.AbstractFuture,com.google.common.util.concurrent.AbstractFuture,com.google.common.cache.CacheBuilder,com.google.common.base.Preconditions,com.google.common.collect.RegularImmutableMap,org.slf4j.impl.JDK14LoggerAdapter,org.apache.calcite.rel.metadata.RelMdColumnUniqueness,org.apache.calcite.rel.metadata.BuiltInMetadata\$ColumnOrigin,io.substrait.isthmus.metadata.LambdaMetadataSupplier,org.apache.calcite.rel.metadata.BuiltInMetadata\$PopulationSize,org.apache.calcite.rel.metadata.BuiltInMetadata\$Size,org.apache.calcite.rel.metadata.BuiltInMetadata\$UniqueKeys,org.apache.calcite.rel.metadata.RelMdColumnOrigins,org.apache.calcite.rel.metadata.RelMdExplainVisibility,org.apache.calcite.rel.metadata.RelMdMemory,org.apache.calcite.rel.metadata.RelMdExpressionLineage,org.apache.calcite.rel.metadata.RelMdDistinctRowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$RowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$PercentageOriginalRows,org.apache.calcite.util.Pair,org.apache.calcite.rel.metadata.BuiltInMetadata\$ExpressionLineage,org.apache.calcite.rel.metadata.BuiltInMetadata\$MinRowCount,com.google.common.primitives.Primitives,org.apache.calcite.rel.metadata.BuiltInMetadata\$Selectivity,org.apache.calcite.rel.metadata.BuiltInMetadata\$Parallelism,org.apache.calcite.rel.metadata.RelMdUniqueKeys,org.apache.calcite.rel.metadata.RelMdParallelism,org.apache.calcite.rel.metadata.RelMdPercentageOriginalRows,org.apache.calcite.rel.metadata.BuiltInMetadata\$Predicates,org.apache.calcite.rel.metadata.BuiltInMetadata\$Distribution,org.apache.calcite.config.CalciteSystemProperty,org.apache.calcite.rel.metadata.BuiltInMetadata\$NonCumulativeCost,org.apache.calcite.util.Util,org.apache.calcite.rel.metadata.RelMdAllPredicates,io.substrait.isthmus.metadata.LambdaHandlerCache,org.apache.calcite.rel.metadata.BuiltInMetadata\$TableReferences,org.apache.calcite.rel.metadata.RelMdNodeTypes,org.apache.calcite.rel.metadata.RelMdCollation,org.apache.calcite.rel.metadata.RelMdSelectivity,org.apache.calcite.rel.metadata.BuiltInMetadata\$NodeTypes,org.apache.calcite.rel.metadata.RelMdPredicates,org.apache.calcite.rel.metadata.BuiltInMetadata\$DistinctRowCount,org.apache.calcite.rel.metadata.RelMdRowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$MaxRowCount,org.apache.calcite.rel.metadata.BuiltInMetadata\$AllPredicates,org.apache.calcite.rel.metadata.RelMdMaxRowCount,org.apache.calcite.rel.metadata.RelMdLowerBoundCost,org.apache.calcite.rel.metadata.BuiltInMetadata\$ExplainVisibility,org.apache.calcite.rel.metadata.BuiltInMetadata\$ColumnUniqueness,org.apache.calcite.rel.metadata.RelMdPopulationSize,org.apache.calcite.rel.metadata.BuiltInMetadata\$Memory,org.apache.calcite.rel.metadata.RelMdMinRowCount,org.apache.calcite.rel.metadata.RelMdSize,org.apache.calcite.rel.metadata.BuiltInMetadata\$LowerBoundCost,org.apache.calcite.rel.metadata.RelMdTableReferences,org.apache.calcite.rel.metadata.RelMdDistribution,io.substrait.isthmus.metadata.LegacyToLambdaGenerator,org.apache.calcite.rel.metadata.BuiltInMetadata\$CumulativeCost,org.apache.calcite.rel.metadata.BuiltInMetadata\$Collation"
+  )
+  option("-H:IncludeResources=.*yaml")
+  option("--report-unsupported-elements-at-runtime")
+  option("-H:+ReportExceptionStackTraces")
+  option("-H:DynamicProxyConfigurationFiles=proxies.json")
+  option("--features=io.substrait.isthmus.RegisterAtRuntime")
+  option("-J--enable-preview")
 }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
-    id("java")
-    id("idea")
-    id("com.palantir.graal") version "0.10.0"
+  id("java")
+  id("idea")
+  id("com.palantir.graal") version "0.10.0"
+  id("com.diffplug.spotless") version "6.5.1"
 }
 
 java {

--- a/isthmus/src/main/java/io/substrait/isthmus/AttemptTypePromotion.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AttemptTypePromotion.java
@@ -1,7 +1,6 @@
 package io.substrait.isthmus;
 
 public class AttemptTypePromotion {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AttemptTypePromotion.class);
-
-
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(AttemptTypePromotion.class);
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/CallConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/CallConverter.java
@@ -1,11 +1,10 @@
 package io.substrait.isthmus;
 
 import io.substrait.expression.Expression;
-import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexNode;
-
 import java.util.Optional;
 import java.util.function.Function;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
 
 @FunctionalInterface
 public interface CallConverter {

--- a/isthmus/src/main/java/io/substrait/isthmus/InitializeAtBuildTime.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/InitializeAtBuildTime.java
@@ -1,5 +1,3 @@
 package io.substrait.isthmus;
 
-public class InitializeAtBuildTime {
-
-}
+public class InitializeAtBuildTime {}

--- a/isthmus/src/main/java/io/substrait/isthmus/PlanEntryPoint.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/PlanEntryPoint.java
@@ -1,12 +1,12 @@
 package io.substrait.isthmus;
 
+import static picocli.CommandLine.*;
+
 import com.google.protobuf.util.JsonFormat;
 import io.substrait.proto.Plan;
-import picocli.CommandLine;
-
 import java.util.List;
 import java.util.concurrent.Callable;
-import static picocli.CommandLine.*;
+import picocli.CommandLine;
 
 @Command(
     name = "isthmus",
@@ -18,8 +18,10 @@ public class PlanEntryPoint implements Callable<Integer> {
   @Parameters(index = "0", description = "The sql we should parse.")
   private String sql;
 
-  @Option(names = {"-c", "--create"},
-          description = "One or multiple create table statements e.g. CREATE TABLE T1(foo int, bar bigint)")
+  @Option(
+      names = {"-c", "--create"},
+      description =
+          "One or multiple create table statements e.g. CREATE TABLE T1(foo int, bar bigint)")
   private List<String> createStatements;
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/RegisterAtRuntime.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/RegisterAtRuntime.java
@@ -4,6 +4,8 @@ import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.ProtocolMessageEnum;
 import io.substrait.function.SimpleExtension;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import org.apache.calcite.rel.metadata.*;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.runtime.Resources;
@@ -17,10 +19,6 @@ import org.immutables.value.Value;
 import org.reflections.Reflections;
 import org.reflections.scanners.FieldAnnotationsScanner;
 import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
 
 public class RegisterAtRuntime implements Feature {
   public void beforeAnalysis(BeforeAnalysisAccess access) {
@@ -29,7 +27,7 @@ public class RegisterAtRuntime implements Feature {
       // cli picocli
       register(PlanEntryPoint.class);
 
-      //protobuf items
+      // protobuf items
       registerByParent(substrait, GeneratedMessageV3.class);
       registerByParent(substrait, MessageLite.Builder.class);
       registerByParent(substrait, ProtocolMessageEnum.class);
@@ -43,7 +41,9 @@ public class RegisterAtRuntime implements Feature {
       register(SimpleExtension.ValueArgument.class);
 
       // calcite items
-      Reflections calcite = new Reflections("org.apache.calcite", new FieldAnnotationsScanner(), new SubTypesScanner());
+      Reflections calcite =
+          new Reflections(
+              "org.apache.calcite", new FieldAnnotationsScanner(), new SubTypesScanner());
       register(BuiltInMetadata.class);
       register(SqlValidatorException.class);
       register(CalciteContextException.class);
@@ -53,38 +53,41 @@ public class RegisterAtRuntime implements Feature {
       registerByParent(calcite, MetadataHandler.class);
       registerByParent(calcite, Resources.Element.class);
 
-      Arrays.asList(RelMdPercentageOriginalRows.class,
-          RelMdColumnOrigins.class,
-          RelMdExpressionLineage.class,
-          RelMdTableReferences.class,
-          RelMdNodeTypes.class,
-          RelMdRowCount.class,
-          RelMdMaxRowCount.class,
-          RelMdMinRowCount.class,
-          RelMdUniqueKeys.class,
-          RelMdColumnUniqueness.class,
-          RelMdPopulationSize.class,
-          RelMdSize.class,
-          RelMdParallelism.class,
-          RelMdDistribution.class,
-          RelMdLowerBoundCost.class,
-          RelMdMemory.class,
-          RelMdDistinctRowCount.class,
-          RelMdSelectivity.class,
-          RelMdExplainVisibility.class,
-          RelMdPredicates.class,
-          RelMdAllPredicates.class,
-          RelMdCollation.class)
+      Arrays.asList(
+              RelMdPercentageOriginalRows.class,
+              RelMdColumnOrigins.class,
+              RelMdExpressionLineage.class,
+              RelMdTableReferences.class,
+              RelMdNodeTypes.class,
+              RelMdRowCount.class,
+              RelMdMaxRowCount.class,
+              RelMdMinRowCount.class,
+              RelMdUniqueKeys.class,
+              RelMdColumnUniqueness.class,
+              RelMdPopulationSize.class,
+              RelMdSize.class,
+              RelMdParallelism.class,
+              RelMdDistribution.class,
+              RelMdLowerBoundCost.class,
+              RelMdMemory.class,
+              RelMdDistinctRowCount.class,
+              RelMdSelectivity.class,
+              RelMdExplainVisibility.class,
+              RelMdPredicates.class,
+              RelMdAllPredicates.class,
+              RelMdCollation.class)
           .forEach(RegisterAtRuntime::register);
 
       RuntimeReflection.register(Resources.class);
       RuntimeReflection.register(SqlValidatorException.class);
 
-      Arrays.stream(BuiltInMethod.values()).forEach(c -> {
-        if (c.field != null) RuntimeReflection.register(c.field);
-        if (c.constructor != null) RuntimeReflection.register(c.constructor);
-        if (c.method != null) RuntimeReflection.register(c.method);
-      });
+      Arrays.stream(BuiltInMethod.values())
+          .forEach(
+              c -> {
+                if (c.field != null) RuntimeReflection.register(c.field);
+                if (c.constructor != null) RuntimeReflection.register(c.constructor);
+                if (c.method != null) RuntimeReflection.register(c.method);
+              });
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -101,17 +104,17 @@ public class RegisterAtRuntime implements Feature {
   }
 
   private static void registerByAnnotation(Reflections reflections, Class<? extends Annotation> c) {
-    reflections.getTypesAnnotatedWith(c).stream().forEach(inner -> {
-      register(inner);
-      reflections.getSubTypesOf(c).stream().forEach(RegisterAtRuntime::register);
-    });
+    reflections.getTypesAnnotatedWith(c).stream()
+        .forEach(
+            inner -> {
+              register(inner);
+              reflections.getSubTypesOf(c).stream().forEach(RegisterAtRuntime::register);
+            });
   }
 
   private static void registerByParent(Reflections reflections, Class<?> c) {
     register(c);
     reflections.getSubTypesOf(c).stream().forEach(RegisterAtRuntime::register);
   }
-
-
   ;
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/RelNodeVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/RelNodeVisitor.java
@@ -5,106 +5,116 @@ import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.*;
 
-/**
- * A more generic version of RelShuttle that allows an alternative return value.
- */
+/** A more generic version of RelShuttle that allows an alternative return value. */
 public abstract class RelNodeVisitor<OUTPUT, EXCEPTION extends Throwable> {
 
   public OUTPUT visit(TableScan scan) throws EXCEPTION {
     return visitOther(scan);
   }
+
   public OUTPUT visit(TableFunctionScan scan) throws EXCEPTION {
     return visitOther(scan);
   }
+
   public OUTPUT visit(LogicalValues values) throws EXCEPTION {
     return visitOther(values);
   }
+
   public OUTPUT visit(LogicalFilter filter) throws EXCEPTION {
     return visitOther(filter);
   }
+
   public OUTPUT visit(LogicalCalc calc) throws EXCEPTION {
     return visitOther(calc);
   }
+
   public OUTPUT visit(LogicalProject project) throws EXCEPTION {
     return visitOther(project);
   }
+
   public OUTPUT visit(LogicalJoin join) throws EXCEPTION {
     return visitOther(join);
   }
+
   public OUTPUT visit(LogicalCorrelate correlate) throws EXCEPTION {
     return visitOther(correlate);
   }
+
   public OUTPUT visit(LogicalUnion union) throws EXCEPTION {
     return visitOther(union);
   }
+
   public OUTPUT visit(LogicalIntersect intersect) throws EXCEPTION {
     return visitOther(intersect);
   }
+
   public OUTPUT visit(LogicalMinus minus) throws EXCEPTION {
     return visitOther(minus);
   }
+
   public OUTPUT visit(LogicalAggregate aggregate) throws EXCEPTION {
     return visitOther(aggregate);
   }
+
   public OUTPUT visit(LogicalMatch match) throws EXCEPTION {
     return visitOther(match);
   }
+
   public OUTPUT visit(LogicalSort sort) throws EXCEPTION {
     return visitOther(sort);
   }
+
   public OUTPUT visit(LogicalExchange exchange) throws EXCEPTION {
     return visitOther(exchange);
   }
+
   public OUTPUT visit(LogicalTableModify modify) throws EXCEPTION {
     return visitOther(modify);
   }
 
   public abstract OUTPUT visitOther(RelNode other) throws EXCEPTION;
 
-  protected RelNodeVisitor(){}
+  protected RelNodeVisitor() {}
 
   /**
    * The method you call when you would normally call RelNode.accept(visitor). Instead call
    * RelVisitor.reverseAccept(RelNode) due to the lack of ability to extend base classes.
    */
   public final OUTPUT reverseAccept(RelNode node) throws EXCEPTION {
-    if(node instanceof TableScan scan) {
+    if (node instanceof TableScan scan) {
       return this.visit(scan);
-    } else if(node instanceof TableFunctionScan scan) {
+    } else if (node instanceof TableFunctionScan scan) {
       return this.visit(scan);
-    } else if(node instanceof LogicalValues values) {
+    } else if (node instanceof LogicalValues values) {
       return this.visit(values);
-    } else if(node instanceof LogicalFilter filter) {
+    } else if (node instanceof LogicalFilter filter) {
       return this.visit(filter);
-    } else if(node instanceof LogicalCalc calc) {
+    } else if (node instanceof LogicalCalc calc) {
       return this.visit(calc);
-    } else if(node instanceof LogicalProject project) {
+    } else if (node instanceof LogicalProject project) {
       return this.visit(project);
-    } else if(node instanceof LogicalJoin join) {
+    } else if (node instanceof LogicalJoin join) {
       return this.visit(join);
-    } else if(node instanceof LogicalCorrelate correlate) {
+    } else if (node instanceof LogicalCorrelate correlate) {
       return this.visit(correlate);
-    } else if(node instanceof LogicalUnion union) {
+    } else if (node instanceof LogicalUnion union) {
       return this.visit(union);
-    } else if(node instanceof LogicalIntersect intersect) {
+    } else if (node instanceof LogicalIntersect intersect) {
       return this.visit(intersect);
-    } else if(node instanceof LogicalMinus minus) {
+    } else if (node instanceof LogicalMinus minus) {
       return this.visit(minus);
-    } else if(node instanceof LogicalMatch match) {
+    } else if (node instanceof LogicalMatch match) {
       return this.visit(match);
-    } else if(node instanceof LogicalSort sort) {
+    } else if (node instanceof LogicalSort sort) {
       return this.visit(sort);
-    } else if(node instanceof LogicalExchange exchange) {
+    } else if (node instanceof LogicalExchange exchange) {
       return this.visit(exchange);
-    } else if(node instanceof LogicalAggregate aggregate) {
+    } else if (node instanceof LogicalAggregate aggregate) {
       return this.visit(aggregate);
-    } else if(node instanceof LogicalTableModify modify) {
+    } else if (node instanceof LogicalTableModify modify) {
       return this.visit(modify);
     } else {
       return this.visitOther(node);
     }
-
   }
-
 }
-

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -7,6 +7,11 @@ import io.substrait.function.SimpleExtension;
 import io.substrait.isthmus.expression.*;
 import io.substrait.relation.*;
 import io.substrait.type.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
@@ -19,26 +24,23 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexVisitor;
 import org.apache.calcite.util.ImmutableBitSet;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SubstraitRelVisitor.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(SubstraitRelVisitor.class);
 
   private final SimpleExtension.ExtensionCollection extensions;
   private final RexVisitor<Expression> converter;
   private final AggregateFunctionConverter aggregateFunctionConverter;
 
-  public SubstraitRelVisitor(RelDataTypeFactory typeFactory, SimpleExtension.ExtensionCollection extensions) {
+  public SubstraitRelVisitor(
+      RelDataTypeFactory typeFactory, SimpleExtension.ExtensionCollection extensions) {
     this.extensions = extensions;
     var converters = new ArrayList<CallConverter>();
     converters.addAll(CallConverters.DEFAULTS);
     converters.add(new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory));
     this.converter = new RexExpressionConverter(converters);
-    this.aggregateFunctionConverter = new AggregateFunctionConverter(extensions.aggregateFunctions(), typeFactory);
+    this.aggregateFunctionConverter =
+        new AggregateFunctionConverter(extensions.aggregateFunctions(), typeFactory);
   }
 
   private Expression toExpression(RexNode node) {
@@ -48,7 +50,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   @Override
   public Rel visit(TableScan scan) {
     var type = TypeConverter.toNamedStruct(scan.getRowType());
-    return NamedScan.builder().initialSchema(type)
+    return NamedScan.builder()
+        .initialSchema(type)
         .addAllNames(scan.getTable().getQualifiedName())
         .build();
   }
@@ -65,10 +68,17 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
       return EmptyScan.builder().initialSchema(type).build();
     }
 
-    List<Expression.StructLiteral> structs = values.getTuples().stream().map(list -> {
-      var fields =  list.stream().map(l -> LiteralConverter.convert(l)).collect(Collectors.toUnmodifiableList());
-      return ExpressionCreator.struct(false, fields);
-    }).collect(Collectors.toUnmodifiableList());
+    List<Expression.StructLiteral> structs =
+        values.getTuples().stream()
+            .map(
+                list -> {
+                  var fields =
+                      list.stream()
+                          .map(l -> LiteralConverter.convert(l))
+                          .collect(Collectors.toUnmodifiableList());
+                  return ExpressionCreator.struct(false, fields);
+                })
+            .collect(Collectors.toUnmodifiableList());
     return VirtualTableScan.builder().addAllDfsNames(type.names()).addAllRows(structs).build();
   }
 
@@ -89,7 +99,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
     // todo: eliminate excessive projects. This should be done by converting rexinputrefs to remaps.
     return Project.builder()
-        .remap(Rel.Remap.offset(project.getInput().getRowType().getFieldCount(), expressions.size()))
+        .remap(
+            Rel.Remap.offset(project.getInput().getRowType().getFieldCount(), expressions.size()))
         .expressions(expressions)
         .input(apply(project.getInput()))
         .build();
@@ -100,14 +111,15 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     var left = apply(join.getLeft());
     var right = apply(join.getRight());
     var condition = toExpression(join.getCondition());
-    var joinType = switch(join.getJoinType()) {
-      case INNER -> Join.JoinType.INNER;
-      case LEFT -> Join.JoinType.LEFT;
-      case RIGHT -> Join.JoinType.RIGHT;
-      case FULL -> Join.JoinType.OUTER;
-      case SEMI -> Join.JoinType.SEMI;
-      case ANTI -> Join.JoinType.ANTI;
-    };
+    var joinType =
+        switch (join.getJoinType()) {
+          case INNER -> Join.JoinType.INNER;
+          case LEFT -> Join.JoinType.LEFT;
+          case RIGHT -> Join.JoinType.RIGHT;
+          case FULL -> Join.JoinType.OUTER;
+          case SEMI -> Join.JoinType.SEMI;
+          case ANTI -> Join.JoinType.ANTI;
+        };
 
     return Join.builder().condition(condition).joinType(joinType).left(left).right(right).build();
   }
@@ -142,33 +154,38 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
       sets = Stream.of(aggregate.getGroupSet());
     }
 
-    var groupings = sets.filter(s -> s != null)
-        .map(s -> fromGroupSet(s, input))
-        .collect(Collectors.toList());
+    var groupings =
+        sets.filter(s -> s != null).map(s -> fromGroupSet(s, input)).collect(Collectors.toList());
 
-    var aggCalls = aggregate.getAggCallList()
-        .stream()
-        .map(c -> fromAggCall(aggregate.getInput(), input.getRecordType(), c))
-        .collect(Collectors.toList());
+    var aggCalls =
+        aggregate.getAggCallList().stream()
+            .map(c -> fromAggCall(aggregate.getInput(), input.getRecordType(), c))
+            .collect(Collectors.toList());
 
-    return Aggregate.builder().input(input).addAllGroupings(groupings).addAllMeasures(aggCalls).build();
+    return Aggregate.builder()
+        .input(input)
+        .addAllGroupings(groupings)
+        .addAllMeasures(aggCalls)
+        .build();
   }
 
   Aggregate.Grouping fromGroupSet(ImmutableBitSet bitSet, Rel input) {
-    List<Expression> references = bitSet.asList()
-        .stream().map(i -> FieldReference.newInputRelReference(i, input))
-        .collect(Collectors.toList());
+    List<Expression> references =
+        bitSet.asList().stream()
+            .map(i -> FieldReference.newInputRelReference(i, input))
+            .collect(Collectors.toList());
     return Aggregate.Grouping.builder().addAllExpressions(references).build();
   }
 
   Aggregate.Measure fromAggCall(RelNode input, Type.Struct inputType, AggregateCall call) {
-    var invocation = aggregateFunctionConverter.convert(input, inputType, call, t -> t.accept(converter));
-    if(invocation.isEmpty()) {
+    var invocation =
+        aggregateFunctionConverter.convert(input, inputType, call, t -> t.accept(converter));
+    if (invocation.isEmpty()) {
       throw new UnsupportedOperationException("Unable to find binding for call " + call);
     }
     var builder = Aggregate.Measure.builder().function(invocation.get());
     if (call.filterArg != -1) {
-       builder.preMeasureFilter(FieldReference.newRootStructReference(call.filterArg, inputType));
+      builder.preMeasureFilter(FieldReference.newRootStructReference(call.filterArg, inputType));
     }
     return builder.build();
   }
@@ -181,7 +198,10 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   @Override
   public Rel visit(LogicalSort sort) {
     var input = apply(sort.getInput());
-    var fields = sort.getCollation().getFieldCollations().stream().map(t -> toSortField(t, input.getRecordType())).toList();
+    var fields =
+        sort.getCollation().getFieldCollations().stream()
+            .map(t -> toSortField(t, input.getRecordType()))
+            .toList();
     var convertedSort = Sort.builder().addAllSortFields(fields).input(input).build();
     if (sort.fetch == null && sort.offset == null) {
       return convertedSort;
@@ -197,22 +217,32 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
   private long asLong(RexNode rex) {
     var expr = toExpression(rex);
-    return switch(expr) {
+    return switch (expr) {
       case Expression.I64Literal i -> i.value();
       case Expression.I32Literal i -> i.value();
       default -> throw new UnsupportedOperationException("Unknown type: " + rex);
     };
   }
 
-  public static Expression.SortField toSortField(RelFieldCollation collation, Type.Struct inputType) {
-    Expression.SortDirection direction = switch(collation.direction) {
-      case STRICTLY_ASCENDING,ASCENDING -> collation.nullDirection == RelFieldCollation.NullDirection.LAST ? Expression.SortDirection.ASC_NULLS_LAST : Expression.SortDirection.ASC_NULLS_FIRST;
-      case STRICTLY_DESCENDING,DESCENDING -> collation.nullDirection == RelFieldCollation.NullDirection.LAST ? Expression.SortDirection.DESC_NULLS_LAST : Expression.SortDirection.DESC_NULLS_FIRST;
-      case CLUSTERED -> Expression.SortDirection.CLUSTERED;
-    };
+  public static Expression.SortField toSortField(
+      RelFieldCollation collation, Type.Struct inputType) {
+    Expression.SortDirection direction =
+        switch (collation.direction) {
+          case STRICTLY_ASCENDING, ASCENDING -> collation.nullDirection
+                  == RelFieldCollation.NullDirection.LAST
+              ? Expression.SortDirection.ASC_NULLS_LAST
+              : Expression.SortDirection.ASC_NULLS_FIRST;
+          case STRICTLY_DESCENDING, DESCENDING -> collation.nullDirection
+                  == RelFieldCollation.NullDirection.LAST
+              ? Expression.SortDirection.DESC_NULLS_LAST
+              : Expression.SortDirection.DESC_NULLS_FIRST;
+          case CLUSTERED -> Expression.SortDirection.CLUSTERED;
+        };
 
-    return Expression.SortField.builder().expr(FieldReference.newRootStructReference(collation.getFieldIndex(), inputType))
-        .direction(direction).build();
+    return Expression.SortField.builder()
+        .expr(FieldReference.newRootStructReference(collation.getFieldIndex(), inputType))
+        .direction(direction)
+        .build();
   }
 
   @Override
@@ -235,7 +265,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   }
 
   public static Rel convert(RelRoot root, SimpleExtension.ExtensionCollection extensions) {
-    SubstraitRelVisitor visitor = new SubstraitRelVisitor(root.rel.getCluster().getTypeFactory(), extensions);
+    SubstraitRelVisitor visitor =
+        new SubstraitRelVisitor(root.rel.getCluster().getTypeFactory(), extensions);
     return visitor.apply(root.rel);
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -7,15 +7,16 @@ import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(
-      SubstraitTypeSystem.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(SubstraitTypeSystem.class);
 
   public static final RelDataTypeSystem TYPE_SYSTEM = new SubstraitTypeSystem();
 
   private SubstraitTypeSystem() {}
 
-  @Override public int getMaxPrecision(final SqlTypeName typeName) {
-    switch (typeName){
+  @Override
+  public int getMaxPrecision(final SqlTypeName typeName) {
+    switch (typeName) {
       case INTERVAL_DAY:
       case INTERVAL_YEAR:
       case INTERVAL_YEAR_MONTH:
@@ -28,11 +29,13 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
     return super.getMaxPrecision(typeName);
   }
 
-  @Override public int getMaxNumericScale() {
+  @Override
+  public int getMaxNumericScale() {
     return 38;
   }
 
-  @Override public int getMaxNumericPrecision() {
+  @Override
+  public int getMaxNumericPrecision() {
     return 38;
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -1,10 +1,13 @@
 package io.substrait.isthmus;
 
 import io.substrait.function.NullableType;
+import io.substrait.function.TypeExpression;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import io.substrait.type.TypeVisitor;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -13,24 +16,20 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import io.substrait.function.TypeExpression;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class TypeConverter {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TypeConverter.class);
 
-  static final SqlIntervalQualifier INTERVAL_YEAR = new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO);
-  static final SqlIntervalQualifier INTERVAL_DAY = new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO);
+  static final SqlIntervalQualifier INTERVAL_YEAR =
+      new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO);
+  static final SqlIntervalQualifier INTERVAL_DAY =
+      new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO);
 
   public static Type convert(RelDataType type) {
     return convert(type, new ArrayList<>());
   }
 
   public static NamedStruct toNamedStruct(RelDataType type) {
-    if(type.getSqlTypeName() != SqlTypeName.ROW) {
+    if (type.getSqlTypeName() != SqlTypeName.ROW) {
       throw new IllegalArgumentException("Expected type of struct.");
     }
 
@@ -51,7 +50,8 @@ public class TypeConverter {
       case DOUBLE -> creator.FP64;
       case DECIMAL -> {
         if (type.getPrecision() > 38) {
-          throw new UnsupportedOperationException("unsupported decimal precision " + type.getPrecision());
+          throw new UnsupportedOperationException(
+              "unsupported decimal precision " + type.getPrecision());
         }
         yield creator.decimal(type.getPrecision(), type.getScale());
       }
@@ -66,25 +66,36 @@ public class TypeConverter {
       case DATE -> creator.DATE;
       case TIME -> {
         if (type.getPrecision() != 6) {
-          throw new UnsupportedOperationException("unsupported time precision " + type.getPrecision());
+          throw new UnsupportedOperationException(
+              "unsupported time precision " + type.getPrecision());
         }
         yield creator.TIME;
       }
       case TIMESTAMP -> {
         if (type.getPrecision() != 6) {
-          throw new UnsupportedOperationException("unsupported timestamp precision " + type.getPrecision());
+          throw new UnsupportedOperationException(
+              "unsupported timestamp precision " + type.getPrecision());
         }
         yield creator.TIMESTAMP;
       }
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE -> {
         if (type.getPrecision() != 6) {
-          throw new UnsupportedOperationException("unsupported timestamptz precision " + type.getPrecision());
+          throw new UnsupportedOperationException(
+              "unsupported timestamptz precision " + type.getPrecision());
         }
         yield creator.TIMESTAMP_TZ;
       }
       case INTERVAL_YEAR, INTERVAL_YEAR_MONTH, INTERVAL_MONTH -> creator.INTERVAL_YEAR;
-      case INTERVAL_DAY, INTERVAL_DAY_HOUR, INTERVAL_DAY_MINUTE, INTERVAL_DAY_SECOND, INTERVAL_HOUR, INTERVAL_HOUR_MINUTE,
-          INTERVAL_HOUR_SECOND, INTERVAL_MINUTE, INTERVAL_MINUTE_SECOND, INTERVAL_SECOND -> creator.INTERVAL_DAY;
+      case INTERVAL_DAY,
+          INTERVAL_DAY_HOUR,
+          INTERVAL_DAY_MINUTE,
+          INTERVAL_DAY_SECOND,
+          INTERVAL_HOUR,
+          INTERVAL_HOUR_MINUTE,
+          INTERVAL_HOUR_SECOND,
+          INTERVAL_MINUTE,
+          INTERVAL_MINUTE_SECOND,
+          INTERVAL_SECOND -> creator.INTERVAL_DAY;
       case VARBINARY -> creator.BINARY;
       case BINARY -> creator.fixedBinary(type.getPrecision());
       case MAP -> {
@@ -94,13 +105,14 @@ public class TypeConverter {
       case ROW -> {
         var children = new ArrayList<Type>();
         for (var field : type.getFieldList()) {
-            names.add(field.getName());
-            children.add(convert(field.getType(), names));
+          names.add(field.getName());
+          children.add(convert(field.getType(), names));
         }
         yield creator.struct(children);
       }
       case ARRAY -> creator.list(convert(type.getComponentType(), names));
-      default -> throw new UnsupportedOperationException(String.format("Unable to convert the type " + type.toString()));
+      default -> throw new UnsupportedOperationException(
+          String.format("Unable to convert the type " + type.toString()));
     };
   }
 
@@ -108,101 +120,126 @@ public class TypeConverter {
     return convert(type, typeExpression, null);
   }
 
-  public static RelDataType convert(RelDataTypeFactory type, TypeExpression typeExpression, List<String> dfsFieldNames) {
-      return typeExpression.accept(new ToRelDataType(type, dfsFieldNames, 0));
+  public static RelDataType convert(
+      RelDataTypeFactory type, TypeExpression typeExpression, List<String> dfsFieldNames) {
+    return typeExpression.accept(new ToRelDataType(type, dfsFieldNames, 0));
   }
 
-  private static class ToRelDataType extends TypeVisitor.TypeThrowsVisitor<RelDataType, RuntimeException> {
+  private static class ToRelDataType
+      extends TypeVisitor.TypeThrowsVisitor<RelDataType, RuntimeException> {
 
     private final RelDataTypeFactory typeFactory;
     private final List<String> fieldNames;
     private int fieldNamePosition;
     private boolean withinStruct;
 
-    public ToRelDataType(final RelDataTypeFactory type, final List<String> fieldNames, int fieldNamePosition) {
+    public ToRelDataType(
+        final RelDataTypeFactory type, final List<String> fieldNames, int fieldNamePosition) {
       super("Unknown expression type.");
       this.typeFactory = type;
       this.fieldNames = fieldNames;
       this.fieldNamePosition = fieldNamePosition;
     }
 
-    @Override public RelDataType visit(Type.Bool expr) {
+    @Override
+    public RelDataType visit(Type.Bool expr) {
       return t(n(expr), SqlTypeName.BOOLEAN);
     }
 
-    @Override public RelDataType visit(Type.I8 expr) {
+    @Override
+    public RelDataType visit(Type.I8 expr) {
       return t(n(expr), SqlTypeName.TINYINT);
     }
 
-    @Override public RelDataType visit(Type.I16 expr) {
+    @Override
+    public RelDataType visit(Type.I16 expr) {
       return t(n(expr), SqlTypeName.SMALLINT);
     }
 
-    @Override public RelDataType visit(Type.I32 expr) {
+    @Override
+    public RelDataType visit(Type.I32 expr) {
       return t(n(expr), SqlTypeName.INTEGER);
     }
 
-    @Override public RelDataType visit(Type.I64 expr) {
+    @Override
+    public RelDataType visit(Type.I64 expr) {
       return t(n(expr), SqlTypeName.BIGINT);
     }
 
-    @Override public RelDataType visit(Type.FP32 expr) {
+    @Override
+    public RelDataType visit(Type.FP32 expr) {
       return t(n(expr), SqlTypeName.FLOAT);
     }
 
-    @Override public RelDataType visit(Type.FP64 expr) {
+    @Override
+    public RelDataType visit(Type.FP64 expr) {
       return t(n(expr), SqlTypeName.DOUBLE);
     }
 
-    @Override public RelDataType visit(Type.Str expr) {
+    @Override
+    public RelDataType visit(Type.Str expr) {
       return t(n(expr), SqlTypeName.VARCHAR);
     }
 
-    @Override public RelDataType visit(Type.Binary expr) {
+    @Override
+    public RelDataType visit(Type.Binary expr) {
       return t(n(expr), SqlTypeName.VARBINARY);
     }
 
-    @Override public RelDataType visit(Type.Date expr) {
+    @Override
+    public RelDataType visit(Type.Date expr) {
       return t(n(expr), SqlTypeName.DATE);
     }
 
-    @Override public RelDataType visit(Type.Time expr) {
+    @Override
+    public RelDataType visit(Type.Time expr) {
       return t(n(expr), SqlTypeName.TIME, 6);
     }
 
-    @Override public RelDataType visit(Type.TimestampTZ expr) {
+    @Override
+    public RelDataType visit(Type.TimestampTZ expr) {
       return t(n(expr), SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 6);
     }
 
-    @Override public RelDataType visit(Type.Timestamp expr) {
+    @Override
+    public RelDataType visit(Type.Timestamp expr) {
       return t(n(expr), SqlTypeName.TIMESTAMP, 6);
     }
 
-    @Override public RelDataType visit(Type.IntervalYear expr) {
-      return typeFactory.createTypeWithNullability(typeFactory.createSqlIntervalType(INTERVAL_YEAR), n(expr));
+    @Override
+    public RelDataType visit(Type.IntervalYear expr) {
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createSqlIntervalType(INTERVAL_YEAR), n(expr));
     }
 
-    @Override public RelDataType visit(Type.IntervalDay expr) {
-      return typeFactory.createTypeWithNullability(typeFactory.createSqlIntervalType(INTERVAL_DAY), n(expr));
+    @Override
+    public RelDataType visit(Type.IntervalDay expr) {
+      return typeFactory.createTypeWithNullability(
+          typeFactory.createSqlIntervalType(INTERVAL_DAY), n(expr));
     }
 
-    @Override public RelDataType visit(Type.FixedChar expr) {
+    @Override
+    public RelDataType visit(Type.FixedChar expr) {
       return t(n(expr), SqlTypeName.CHAR, expr.length());
     }
 
-    @Override public RelDataType visit(Type.VarChar expr) {
+    @Override
+    public RelDataType visit(Type.VarChar expr) {
       return t(n(expr), SqlTypeName.VARCHAR, expr.length());
     }
 
-    @Override public RelDataType visit(Type.FixedBinary expr) {
+    @Override
+    public RelDataType visit(Type.FixedBinary expr) {
       return t(n(expr), SqlTypeName.BINARY, expr.length());
     }
 
-    @Override public RelDataType visit(Type.Decimal expr) {
+    @Override
+    public RelDataType visit(Type.Decimal expr) {
       return t(n(expr), SqlTypeName.DECIMAL, expr.precision(), expr.scale());
     }
 
-    @Override public RelDataType visit(Type.Struct expr) {
+    @Override
+    public RelDataType visit(Type.Struct expr) {
       if (withinStruct) {
         throw new IllegalStateException("Visitor can't be re-used for nested structs.");
       }
@@ -211,9 +248,11 @@ public class TypeConverter {
         List<RelDataType> fieldTypes = new ArrayList<>();
         List<String> localFieldNames = new ArrayList<>();
         for (TypeExpression field : expr.fields()) {
-          localFieldNames.add(fieldNames == null ? "f" + fieldNamePosition : fieldNames.get(fieldNamePosition));
+          localFieldNames.add(
+              fieldNames == null ? "f" + fieldNamePosition : fieldNames.get(fieldNamePosition));
           fieldNamePosition++;
-          ToRelDataType childVisitor = new ToRelDataType(typeFactory, fieldNames, fieldNamePosition);
+          ToRelDataType childVisitor =
+              new ToRelDataType(typeFactory, fieldNames, fieldNamePosition);
           fieldTypes.add(field.accept(childVisitor));
           fieldNamePosition = childVisitor.fieldNamePosition;
         }
@@ -225,11 +264,13 @@ public class TypeConverter {
       }
     }
 
-    @Override public RelDataType visit(Type.ListType expr) {
+    @Override
+    public RelDataType visit(Type.ListType expr) {
       return n(expr, typeFactory.createArrayType(expr.elementType().accept(this), -1));
     }
 
-    @Override public RelDataType visit(Type.Map expr) {
+    @Override
+    public RelDataType visit(Type.Map expr) {
       return n(expr, typeFactory.createMapType(expr.key().accept(this), expr.value().accept(this)));
     }
 
@@ -238,12 +279,13 @@ public class TypeConverter {
     }
 
     private RelDataType t(boolean nullable, SqlTypeName typeName, Integer... props) {
-      final RelDataType baseType = switch(props.length) {
-        case 0 -> typeFactory.createSqlType(typeName);
-        case 1 -> typeFactory.createSqlType(typeName, props[0]);
-        case 2 -> typeFactory.createSqlType(typeName, props[0], props[1]);
-        default -> throw new IllegalArgumentException();
-      };
+      final RelDataType baseType =
+          switch (props.length) {
+            case 0 -> typeFactory.createSqlType(typeName);
+            case 1 -> typeFactory.createSqlType(typeName, props[0]);
+            case 2 -> typeFactory.createSqlType(typeName, props[0], props[1]);
+            default -> throw new IllegalArgumentException();
+          };
 
       return typeFactory.createTypeWithNullability(baseType, nullable);
     }
@@ -252,5 +294,4 @@ public class TypeConverter {
       return typeFactory.createTypeWithNullability(type, n(substraitType));
     }
   }
-
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
@@ -7,6 +7,11 @@ import io.substrait.expression.ExpressionCreator;
 import io.substrait.function.SimpleExtension;
 import io.substrait.isthmus.SubstraitRelVisitor;
 import io.substrait.type.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
@@ -14,21 +19,19 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
 public class AggregateFunctionConverter
-    extends FunctionConverter<SimpleExtension.AggregateFunctionVariant, AggregateFunctionInvocation, AggregateFunctionConverter.WrappedAggregateCall> {
+    extends FunctionConverter<
+        SimpleExtension.AggregateFunctionVariant,
+        AggregateFunctionInvocation,
+        AggregateFunctionConverter.WrappedAggregateCall> {
 
   @Override
   protected ImmutableList<FunctionMappings.Sig> getSigs() {
     return FunctionMappings.AGGREGATE_SIGS;
   }
 
-  public AggregateFunctionConverter(List<SimpleExtension.AggregateFunctionVariant> functions, RelDataTypeFactory typeFactory) {
+  public AggregateFunctionConverter(
+      List<SimpleExtension.AggregateFunctionVariant> functions, RelDataTypeFactory typeFactory) {
     super(functions, typeFactory);
   }
 
@@ -47,10 +50,14 @@ public class AggregateFunctionConverter
       Type outputType) {
     AggregateCall agg = call.getUnderlying();
 
-    List<Expression.SortField> sorts = agg.getCollation() != null ?
-        agg.getCollation().getFieldCollations().stream().map(r -> SubstraitRelVisitor.toSortField(r, call.inputType)).toList()
-        : Collections.emptyList();
-    return ExpressionCreator.aggregateFunction(function, outputType, Expression.AggregationPhase.INITIAL_TO_RESULT, sorts, arguments);
+    List<Expression.SortField> sorts =
+        agg.getCollation() != null
+            ? agg.getCollation().getFieldCollations().stream()
+                .map(r -> SubstraitRelVisitor.toSortField(r, call.inputType))
+                .toList()
+            : Collections.emptyList();
+    return ExpressionCreator.aggregateFunction(
+        function, outputType, Expression.AggregationPhase.INITIAL_TO_RESULT, sorts, arguments);
   }
 
   public Optional<AggregateFunctionInvocation> convert(
@@ -58,7 +65,6 @@ public class AggregateFunctionConverter
       Type.Struct inputType,
       AggregateCall call,
       Function<RexNode, Expression> topLevelConverter) {
-
 
     FunctionFinder m = signatures.get(call.getAggregation());
     if (m == null) {
@@ -78,7 +84,8 @@ public class AggregateFunctionConverter
     private final RexBuilder rexBuilder;
     private final Type.Struct inputType;
 
-    private WrappedAggregateCall(AggregateCall call, RelNode input, RexBuilder rexBuilder, Type.Struct inputType) {
+    private WrappedAggregateCall(
+        AggregateCall call, RelNode input, RexBuilder rexBuilder, Type.Struct inputType) {
       this.call = call;
       this.input = input;
       this.rexBuilder = rexBuilder;

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -5,74 +5,81 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.ImmutableExpression;
 import io.substrait.isthmus.*;
-import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.SqlKind;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
 
 public class CallConverters {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CallConverters.class);
 
-  public static SimpleCallConverter CAST = (call, visitor) -> {
-    if (call.getKind() != SqlKind.CAST) {
-      return null;
-    }
+  public static SimpleCallConverter CAST =
+      (call, visitor) -> {
+        if (call.getKind() != SqlKind.CAST) {
+          return null;
+        }
 
-    return ExpressionCreator.cast(TypeConverter.convert(call.getType()), visitor.apply(call.getOperands().get(0)));
-  };
+        return ExpressionCreator.cast(
+            TypeConverter.convert(call.getType()), visitor.apply(call.getOperands().get(0)));
+      };
 
-//  public static SimpleCallConverter OrAnd(FunctionConverter c) {
-//      return (call, visitor) -> {
-//        if (call.getKind() != SqlKind.AND && call.getKind() != SqlKind.OR) {
-//          return null;
-//        }
-//
-//
-//        return null;
-//      };
-//  }
-  /**
-   *
-   */
-  public static SimpleCallConverter CASE = (call, visitor) -> {
-    if (call.getKind() != SqlKind.CASE) {
-      return null;
-    }
+  //  public static SimpleCallConverter OrAnd(FunctionConverter c) {
+  //      return (call, visitor) -> {
+  //        if (call.getKind() != SqlKind.AND && call.getKind() != SqlKind.OR) {
+  //          return null;
+  //        }
+  //
+  //
+  //        return null;
+  //      };
+  //  }
+  /** */
+  public static SimpleCallConverter CASE =
+      (call, visitor) -> {
+        if (call.getKind() != SqlKind.CASE) {
+          return null;
+        }
 
-    // number of arguments are always going to be odd (each condition/then combination plus else)
-    assert call.getOperands().size() % 2 == 1;
+        // number of arguments are always going to be odd (each condition/then combination plus
+        // else)
+        assert call.getOperands().size() % 2 == 1;
 
-    var caseArgs = call.getOperands().stream().map(visitor).toList();
+        var caseArgs = call.getOperands().stream().map(visitor).toList();
 
-    var last = caseArgs.size() - 1;
-    // for if/else, process in reverse to maintain query order
-    var caseConditions = new ArrayList<Expression.IfClause>();
-    for (int i = 0; i < last; i += 2) {
-      caseConditions.add(ImmutableExpression.IfClause.builder().condition(caseArgs.get(i)).then(caseArgs.get(i+1)).build());
-    }
+        var last = caseArgs.size() - 1;
+        // for if/else, process in reverse to maintain query order
+        var caseConditions = new ArrayList<Expression.IfClause>();
+        for (int i = 0; i < last; i += 2) {
+          caseConditions.add(
+              ImmutableExpression.IfClause.builder()
+                  .condition(caseArgs.get(i))
+                  .then(caseArgs.get(i + 1))
+                  .build());
+        }
 
-    var defaultResult = caseArgs.get(last);
-    return ExpressionCreator.ifThenStatement(defaultResult, caseConditions);
-  };
+        var defaultResult = caseArgs.get(last);
+        return ExpressionCreator.ifThenStatement(defaultResult, caseConditions);
+      };
 
-  public static final List<CallConverter> DEFAULTS = ImmutableList.of(
-      new FieldSelectionConverter(),
-      CallConverters.CASE,
-      CallConverters.CAST,
-      new LiteralConstructorConverter()
-  );
+  public static final List<CallConverter> DEFAULTS =
+      ImmutableList.of(
+          new FieldSelectionConverter(),
+          CallConverters.CASE,
+          CallConverters.CAST,
+          new LiteralConstructorConverter());
 
   public interface SimpleCallConverter extends CallConverter {
 
-    @Nullable Expression apply(RexCall call, Function<RexNode, Expression> topLevelConverter);
+    @Nullable
+    Expression apply(RexCall call, Function<RexNode, Expression> topLevelConverter);
 
     @Override
-    default Optional<Expression> convert(RexCall call, Function<RexNode, Expression> topLevelConverter) {
+    default Optional<Expression> convert(
+        RexCall call, Function<RexNode, Expression> topLevelConverter) {
       return Optional.ofNullable(apply(call, topLevelConverter));
     }
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
@@ -4,24 +4,23 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FieldReference;
 import io.substrait.isthmus.CallConverter;
+import java.util.Optional;
+import java.util.function.Function;
 import org.apache.calcite.rex.*;
 import org.apache.calcite.sql.SqlKind;
 
-import java.util.Optional;
-import java.util.function.Function;
-
-/**
- * Converts field selections from Calcite representation.
- */
+/** Converts field selections from Calcite representation. */
 public class FieldSelectionConverter implements CallConverter {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FieldSelectionConverter.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(FieldSelectionConverter.class);
 
   public FieldSelectionConverter() {
     super();
   }
 
   @Override
-  public Optional<Expression> convert(RexCall call, Function<RexNode, Expression> topLevelConverter) {
+  public Optional<Expression> convert(
+      RexCall call, Function<RexNode, Expression> topLevelConverter) {
     if (!(call.getKind() == SqlKind.ITEM)) {
       return Optional.empty();
     }
@@ -30,7 +29,10 @@ public class FieldSelectionConverter implements CallConverter {
     var reference = call.getOperands().get(1);
 
     if (reference.getKind() != SqlKind.LITERAL || !(reference instanceof RexLiteral)) {
-      logger.warn("Found item operator without literal kind/type. This isn't handled well. Reference was {} with toString {}.", reference.getKind().name(), reference);
+      logger.warn(
+          "Found item operator without literal kind/type. This isn't handled well. Reference was {} with toString {}.",
+          reference.getKind().name(),
+          reference);
       return Optional.empty();
     }
 
@@ -38,52 +40,54 @@ public class FieldSelectionConverter implements CallConverter {
 
     var input = topLevelConverter.apply(toDereference);
 
-    switch(toDereference.getType().getSqlTypeName()) {
-      case ROW: {
-        var index = toInt(literal);
-        if (index.isEmpty()) {
-          return Optional.empty();
+    switch (toDereference.getType().getSqlTypeName()) {
+      case ROW:
+        {
+          var index = toInt(literal);
+          if (index.isEmpty()) {
+            return Optional.empty();
+          }
+          if (input instanceof FieldReference) {
+            return Optional.of(((FieldReference) input).dereferenceStruct(index.get()));
+          } else {
+            return Optional.of(FieldReference.newStructReference(index.get(), input));
+          }
         }
-        if (input instanceof FieldReference) {
-          return Optional.of(((FieldReference) input).dereferenceStruct(index.get()));
-        } else {
-          return Optional.of(FieldReference.newStructReference(index.get(), input));
-        }
-      }
-      case ARRAY: {
-        var index = toInt(literal);
-        if (index.isEmpty()) {
-          return Optional.empty();
+      case ARRAY:
+        {
+          var index = toInt(literal);
+          if (index.isEmpty()) {
+            return Optional.empty();
+          }
+
+          if (input instanceof FieldReference) {
+            return Optional.of(((FieldReference) input).dereferenceList(index.get()));
+          } else {
+            return Optional.of(FieldReference.newListReference(index.get(), input));
+          }
         }
 
-        if(input instanceof FieldReference) {
-          return Optional.of(((FieldReference) input).dereferenceList(index.get()));
-        } else {
-          return Optional.of(FieldReference.newListReference(index.get(), input));
-        }
+      case MAP:
+        {
+          var mapKey = toString(literal);
+          if (mapKey.isEmpty()) {
+            return Optional.empty();
+          }
 
-      }
-
-      case MAP:  {
-        var mapKey = toString(literal);
-        if(mapKey.isEmpty()) {
-          return Optional.empty();
+          Expression.Literal keyLiteral = ExpressionCreator.string(false, mapKey.get());
+          if (input instanceof FieldReference) {
+            return Optional.of(((FieldReference) input).dereferenceMap(keyLiteral));
+          } else {
+            return Optional.of(FieldReference.newMapReference(keyLiteral, input));
+          }
         }
-
-        Expression.Literal keyLiteral = ExpressionCreator.string(false, mapKey.get());
-        if (input instanceof FieldReference) {
-          return Optional.of(((FieldReference) input).dereferenceMap(keyLiteral));
-        } else {
-          return Optional.of(FieldReference.newMapReference(keyLiteral, input));
-        }
-      }
     }
 
     return Optional.empty();
   }
 
   private Optional<Integer> toInt(Expression.Literal l) {
-    return switch(l) {
+    return switch (l) {
       case Expression.I8Literal i8 -> Optional.of(i8.value());
       case Expression.I16Literal i16 -> Optional.of(i16.value());
       case Expression.I32Literal i32 -> Optional.of(i32.value());
@@ -103,5 +107,4 @@ public class FieldSelectionConverter implements CallConverter {
 
     return Optional.of(((Expression.FixedCharLiteral) l).value());
   }
-
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -3,23 +3,22 @@ package io.substrait.isthmus.expression;
 import com.google.common.collect.*;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
-import io.substrait.function.SimpleExtension;
 import io.substrait.function.ParameterizedType;
+import io.substrait.function.SimpleExtension;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.Type;
 import io.substrait.util.Util;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
 
-
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
-abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extends FunctionConverter.GenericCall> {
+abstract class FunctionConverter<
+    F extends SimpleExtension.Function, T, C extends FunctionConverter.GenericCall> {
 
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FunctionConverter.class);
 
@@ -31,9 +30,13 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
     this(functions, Collections.EMPTY_LIST, typeFactory);
   }
 
-  public FunctionConverter(List<F> functions, List<FunctionMappings.Sig> additionalSignatures, RelDataTypeFactory typeFactory) {
+  public FunctionConverter(
+      List<F> functions,
+      List<FunctionMappings.Sig> additionalSignatures,
+      RelDataTypeFactory typeFactory) {
     rexBuilder = new RexBuilder(typeFactory);
-    var signatures = new ArrayList<FunctionMappings.Sig>(getSigs().size() + additionalSignatures.size());
+    var signatures =
+        new ArrayList<FunctionMappings.Sig>(getSigs().size() + additionalSignatures.size());
     signatures.addAll(additionalSignatures);
     signatures.addAll(getSigs());
     this.typeFactory = typeFactory;
@@ -43,7 +46,11 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
       alm.put(f.name().toLowerCase(Locale.ROOT), f);
     }
 
-    ListMultimap<String, FunctionMappings.Sig> calciteOperators = signatures.stream().collect(Multimaps.toMultimap(FunctionMappings.Sig::name, f->f, () -> ArrayListMultimap.create()));
+    ListMultimap<String, FunctionMappings.Sig> calciteOperators =
+        signatures.stream()
+            .collect(
+                Multimaps.toMultimap(
+                    FunctionMappings.Sig::name, f -> f, () -> ArrayListMultimap.create()));
     var matcherMap = new IdentityHashMap<SqlOperator, FunctionFinder>();
     for (String key : alm.keySet()) {
       var sigs = calciteOperators.get(key);
@@ -52,21 +59,18 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
         continue;
       }
 
-      for(var sig : sigs) {
+      for (var sig : sigs) {
         var implList = alm.get(key);
         if (implList == null || implList.isEmpty()) {
           continue;
         }
 
         matcherMap.put(sig.operator(), new FunctionFinder(key, sig.operator(), implList));
-
       }
     }
 
     this.signatures = matcherMap;
   }
-
-
 
   protected abstract ImmutableList<FunctionMappings.Sig> getSigs();
 
@@ -83,9 +87,10 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
       this.name = name;
       this.operator = operator;
       this.functions = functions;
-      this.argRange = Util.IntRange.of(
-          functions.stream().mapToInt(t -> t.getRange().getStartInclusive()).min().getAsInt(),
-          functions.stream().mapToInt(t -> t.getRange().getEndExclusive()).max().getAsInt());
+      this.argRange =
+          Util.IntRange.of(
+              functions.stream().mapToInt(t -> t.getRange().getStartInclusive()).min().getAsInt(),
+              functions.stream().mapToInt(t -> t.getRange().getEndExclusive()).max().getAsInt());
       this.matcher = getSignatureMatcher(operator, functions);
       this.singularInputType = getSingularInputType(functions);
       var directMap = ImmutableMap.<String, F>builder();
@@ -104,8 +109,7 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
     }
 
     private static <F extends SimpleExtension.Function> SignatureMatcher<F> getSignatureMatcher(
-        SqlOperator operator,
-        List<F> functions) {
+        SqlOperator operator, List<F> functions) {
       // TODO: define up-converting matchers.
       return (a, b) -> Optional.empty();
     }
@@ -114,9 +118,11 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
      * If some of the function variants for this function name have single, repeated argument type,
      * we will attempt to find matches using these patterns and least-restrictive casting.
      *
-     * If this exists, the function finder will attempt to find a least-restrictive match using these.
+     * <p>If this exists, the function finder will attempt to find a least-restrictive match using
+     * these.
      */
-    private static <F extends SimpleExtension.Function> Optional<SingularArgumentMatcher<F>> getSingularInputType(List<F> functions) {
+    private static <F extends SimpleExtension.Function>
+        Optional<SingularArgumentMatcher<F>> getSingularInputType(List<F> functions) {
       List<SingularArgumentMatcher> matchers = new ArrayList<>();
       for (var f : functions) {
 
@@ -147,21 +153,20 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
           }
         }
 
-
         if (firstType != null) {
           matchers.add(singular(f, firstType));
         }
-
       }
 
-      return switch(matchers.size()) {
+      return switch (matchers.size()) {
         case 0 -> Optional.empty();
         case 1 -> Optional.of(matchers.get(0));
         default -> Optional.of(chained(matchers));
       };
     }
 
-    public static <F extends SimpleExtension.Function> SingularArgumentMatcher<F> singular(F function, ParameterizedType type) {
+    public static <F extends SimpleExtension.Function> SingularArgumentMatcher<F> singular(
+        F function, ParameterizedType type) {
       return (inputType, outputType) -> {
         var check = isMatch(inputType, type);
         if (check) {
@@ -199,9 +204,9 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
         return Optional.of(generateBinding(call, variant, operands, outputType));
       }
 
-
       if (singularInputType.isPresent()) {
-        RelDataType leastRestrictive = typeFactory.leastRestrictive(call.getOperands().map(RexNode::getType).toList());
+        RelDataType leastRestrictive =
+            typeFactory.leastRestrictive(call.getOperands().map(RexNode::getType).toList());
         if (leastRestrictive == null) {
           return Optional.empty();
         }
@@ -221,25 +226,30 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
 
   public interface GenericCall {
     Stream<RexNode> getOperands();
+
     RelDataType getType();
   }
 
   /**
-   * Coerced types according to an expected output type. Coercion is only done for type mismatches, not for nullability or parameter mismatches.
+   * Coerced types according to an expected output type. Coercion is only done for type mismatches,
+   * not for nullability or parameter mismatches.
    */
   private List<Expression> coerceArguments(List<Expression> arguments, Type type) {
 
-    return arguments.stream().map(a -> {
-      var typeMatches = isMatch(type, a.getType());
-      if (!typeMatches) {
-        return ExpressionCreator.cast(type, a);
-      }
-      return a;
-    }).toList();
+    return arguments.stream()
+        .map(
+            a -> {
+              var typeMatches = isMatch(type, a.getType());
+              if (!typeMatches) {
+                return ExpressionCreator.cast(type, a);
+              }
+              return a;
+            })
+        .toList();
   }
 
-  protected abstract T generateBinding(C call, F function, List<Expression> arguments, Type outputType);
-
+  protected abstract T generateBinding(
+      C call, F function, List<Expression> arguments, Type outputType);
 
   public interface SingularArgumentMatcher<F> {
     Optional<F> tryMatch(Type type, Type outputType);
@@ -250,7 +260,7 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
   }
 
   private static SignatureMatcher chainedSignature(SignatureMatcher... matchers) {
-    return switch(matchers.length) {
+    return switch (matchers.length) {
       case 0 -> (types, outputType) -> Optional.empty();
       case 1 -> matchers[0];
       default -> (types, outputType) -> {
@@ -266,17 +276,16 @@ abstract class FunctionConverter<F extends SimpleExtension.Function, T, C extend
   }
 
   private static boolean isMatch(Type inputType, ParameterizedType type) {
-    if(type.isWildcard()) {
+    if (type.isWildcard()) {
       return true;
     }
     return inputType.accept(new IgnoreNullableAndParameters(type));
   }
 
   private static boolean isMatch(ParameterizedType inputType, ParameterizedType type) {
-    if(type.isWildcard()) {
+    if (type.isWildcard()) {
       return true;
     }
     return inputType.accept(new IgnoreNullableAndParameters(type));
   }
-
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -1,47 +1,52 @@
 package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Locale;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 
-import java.util.Locale;
-
 public class FunctionMappings {
-  // Static list of signature mapping between Calcite SQL operators and Substrait base function names.
+  // Static list of signature mapping between Calcite SQL operators and Substrait base function
+  // names.
   public static final ImmutableList<Sig> SCALAR_SIGS;
   public static final ImmutableList<Sig> AGGREGATE_SIGS;
 
   static {
-    SCALAR_SIGS = ImmutableList.<Sig>builder().add(
-        s(SqlStdOperatorTable.PLUS, "add"),
-        s(SqlStdOperatorTable.MINUS, "subtract"),
-        s(SqlStdOperatorTable.MULTIPLY, "multiply"),
-        s(SqlStdOperatorTable.DIVIDE, "divide"),
-        s(SqlStdOperatorTable.AND),
-        s(SqlStdOperatorTable.OR),
-        s(SqlStdOperatorTable.NOT),
-        s(SqlStdOperatorTable.LESS_THAN, "lt"),
-        s(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, "lte"),
-        s(SqlStdOperatorTable.GREATER_THAN, "gt"),
-        s(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, "gte"),
-        s(SqlStdOperatorTable.EQUALS, "equal"),
-        s(SqlStdOperatorTable.BIT_XOR, "xor"),
-        s(SqlStdOperatorTable.NOT_EQUALS, "not_equal"),
-        s(SqlStdOperatorTable.MINUS_DATE, "subtract"),
-        s(SqlStdOperatorTable.DATETIME_PLUS, "add"),
-        s(SqlStdOperatorTable.LIKE)
-    ).build();
+    SCALAR_SIGS =
+        ImmutableList.<Sig>builder()
+            .add(
+                s(SqlStdOperatorTable.PLUS, "add"),
+                s(SqlStdOperatorTable.MINUS, "subtract"),
+                s(SqlStdOperatorTable.MULTIPLY, "multiply"),
+                s(SqlStdOperatorTable.DIVIDE, "divide"),
+                s(SqlStdOperatorTable.AND),
+                s(SqlStdOperatorTable.OR),
+                s(SqlStdOperatorTable.NOT),
+                s(SqlStdOperatorTable.LESS_THAN, "lt"),
+                s(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, "lte"),
+                s(SqlStdOperatorTable.GREATER_THAN, "gt"),
+                s(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, "gte"),
+                s(SqlStdOperatorTable.EQUALS, "equal"),
+                s(SqlStdOperatorTable.BIT_XOR, "xor"),
+                s(SqlStdOperatorTable.NOT_EQUALS, "not_equal"),
+                s(SqlStdOperatorTable.MINUS_DATE, "subtract"),
+                s(SqlStdOperatorTable.DATETIME_PLUS, "add"),
+                s(SqlStdOperatorTable.LIKE))
+            .build();
 
-    AGGREGATE_SIGS = ImmutableList.<Sig>builder().add(
-        s(SqlStdOperatorTable.SUM, "sum"),
-        s(SqlStdOperatorTable.COUNT, "count"),
-        s(SqlStdOperatorTable.AVG, "avg")
-    ).build();
+    AGGREGATE_SIGS =
+        ImmutableList.<Sig>builder()
+            .add(
+                s(SqlStdOperatorTable.SUM, "sum"),
+                s(SqlStdOperatorTable.COUNT, "count"),
+                s(SqlStdOperatorTable.AVG, "avg"))
+            .build();
   }
 
   public static void main(String[] args) {
     SCALAR_SIGS.forEach(System.out::println);
   }
+
   public static Sig s(SqlOperator operator, String substraitName) {
     return new Sig(operator, substraitName.toLowerCase(Locale.ROOT));
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMatch.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMatch.java
@@ -8,31 +8,24 @@ public class FunctionMatch {
 
   public static void load() {
 
-    Matcher m = new Matcher() {
+    Matcher m =
+        new Matcher() {
 
-
-      {
-
-
-        m("add",SqlStdOperatorTable.SUM);
-        m("avg",SqlStdOperatorTable.AVG);
-        m("count",SqlStdOperatorTable.COUNT);
-        m("+",SqlStdOperatorTable.PLUS);
-        m("+",SqlStdOperatorTable.DATETIME_PLUS);
-        m("-",SqlStdOperatorTable.MINUS);
-        m("*",SqlStdOperatorTable.MULTIPLY);
-        m("/",SqlStdOperatorTable.DIVIDE);
-      }
-    };
+          {
+            m("add", SqlStdOperatorTable.SUM);
+            m("avg", SqlStdOperatorTable.AVG);
+            m("count", SqlStdOperatorTable.COUNT);
+            m("+", SqlStdOperatorTable.PLUS);
+            m("+", SqlStdOperatorTable.DATETIME_PLUS);
+            m("-", SqlStdOperatorTable.MINUS);
+            m("*", SqlStdOperatorTable.MULTIPLY);
+            m("/", SqlStdOperatorTable.DIVIDE);
+          }
+        };
   }
 
   static class Matcher {
 
-
-
-    void m(String functionName, SqlOperator calciteOperator) {
-
-    }
+    void m(String functionName, SqlOperator calciteOperator) {}
   }
-
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
@@ -4,7 +4,8 @@ import io.substrait.function.ParameterizedType;
 import io.substrait.function.ParameterizedTypeVisitor;
 import io.substrait.type.Type;
 
-public class IgnoreNullableAndParameters implements ParameterizedTypeVisitor<Boolean, RuntimeException> {
+public class IgnoreNullableAndParameters
+    implements ParameterizedTypeVisitor<Boolean, RuntimeException> {
 
   private final ParameterizedType typeToMatch;
 
@@ -94,7 +95,8 @@ public class IgnoreNullableAndParameters implements ParameterizedTypeVisitor<Boo
 
   @Override
   public Boolean visit(Type.FixedChar type) {
-    return typeToMatch instanceof Type.FixedChar || typeToMatch instanceof ParameterizedType.FixedChar;
+    return typeToMatch instanceof Type.FixedChar
+        || typeToMatch instanceof ParameterizedType.FixedChar;
   }
 
   @Override
@@ -104,7 +106,8 @@ public class IgnoreNullableAndParameters implements ParameterizedTypeVisitor<Boo
 
   @Override
   public Boolean visit(Type.FixedBinary type) {
-    return typeToMatch instanceof Type.FixedBinary || typeToMatch instanceof ParameterizedType.FixedBinary;
+    return typeToMatch instanceof Type.FixedBinary
+        || typeToMatch instanceof ParameterizedType.FixedBinary;
   }
 
   @Override
@@ -119,7 +122,8 @@ public class IgnoreNullableAndParameters implements ParameterizedTypeVisitor<Boo
 
   @Override
   public Boolean visit(Type.ListType type) {
-    return typeToMatch instanceof Type.ListType || typeToMatch instanceof ParameterizedType.ListType;
+    return typeToMatch instanceof Type.ListType
+        || typeToMatch instanceof ParameterizedType.ListType;
   }
 
   @Override
@@ -129,7 +133,8 @@ public class IgnoreNullableAndParameters implements ParameterizedTypeVisitor<Boo
 
   @Override
   public Boolean visit(ParameterizedType.FixedChar expr) throws RuntimeException {
-    return typeToMatch instanceof Type.FixedChar || typeToMatch instanceof ParameterizedType.FixedChar;
+    return typeToMatch instanceof Type.FixedChar
+        || typeToMatch instanceof ParameterizedType.FixedChar;
   }
 
   @Override
@@ -139,7 +144,8 @@ public class IgnoreNullableAndParameters implements ParameterizedTypeVisitor<Boo
 
   @Override
   public Boolean visit(ParameterizedType.FixedBinary expr) throws RuntimeException {
-    return typeToMatch instanceof Type.FixedBinary || typeToMatch instanceof ParameterizedType.FixedBinary;
+    return typeToMatch instanceof Type.FixedBinary
+        || typeToMatch instanceof ParameterizedType.FixedBinary;
   }
 
   @Override
@@ -154,7 +160,8 @@ public class IgnoreNullableAndParameters implements ParameterizedTypeVisitor<Boo
 
   @Override
   public Boolean visit(ParameterizedType.ListType expr) throws RuntimeException {
-    return typeToMatch instanceof Type.ListType || typeToMatch instanceof ParameterizedType.ListType;
+    return typeToMatch instanceof Type.ListType
+        || typeToMatch instanceof ParameterizedType.ListType;
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ListSqlOperatorFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ListSqlOperatorFunctions.java
@@ -1,46 +1,48 @@
 package io.substrait.isthmus.expression;
 
-import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.SqlSetOperator;
-import org.apache.calcite.sql.fun.SqlMultisetSetOperator;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSetOperator;
+import org.apache.calcite.sql.fun.SqlMultisetSetOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 
 public class ListSqlOperatorFunctions {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(
-      ListSqlOperatorFunctions.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(ListSqlOperatorFunctions.class);
 
   public static void main(String[] args) {
-    Map<String, SqlOperator> operators = Arrays.stream(SqlStdOperatorTable.class.getFields())
-        .filter(f -> {
-          if(!SqlOperator.class.isAssignableFrom(f.getType())) {
-            return false;
-          }
+    Map<String, SqlOperator> operators =
+        Arrays.stream(SqlStdOperatorTable.class.getFields())
+            .filter(
+                f -> {
+                  if (!SqlOperator.class.isAssignableFrom(f.getType())) {
+                    return false;
+                  }
 
-          if(SqlSetOperator.class.isAssignableFrom(f.getType()) || SqlMultisetSetOperator.class.isAssignableFrom(f.getType())) {
-            return false;
-          }
+                  if (SqlSetOperator.class.isAssignableFrom(f.getType())
+                      || SqlMultisetSetOperator.class.isAssignableFrom(f.getType())) {
+                    return false;
+                  }
 
-          try {
-            SqlOperator op = (SqlOperator) f.get(null);
-            return true;
-          } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-          }
-        })
-        .filter(f -> Modifier.isStatic(f.getModifiers()) && Modifier.isPublic(f.getModifiers()))
-        .collect(Collectors.toMap(Field::getName, ListSqlOperatorFunctions::toOp));
+                  try {
+                    SqlOperator op = (SqlOperator) f.get(null);
+                    return true;
+                  } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                  }
+                })
+            .filter(f -> Modifier.isStatic(f.getModifiers()) && Modifier.isPublic(f.getModifiers()))
+            .collect(Collectors.toMap(Field::getName, ListSqlOperatorFunctions::toOp));
 
     operators.keySet().forEach(System.out::println);
     System.out.println("Operator count: " + operators.size());
   }
 
-  private static SqlOperator toOp(Field f){
+  private static SqlOperator toOp(Field f) {
     try {
       return (SqlOperator) f.get(null);
     } catch (IllegalAccessException e) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
@@ -3,33 +3,39 @@ package io.substrait.isthmus.expression;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.CallConverter;
-import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.fun.SqlArrayValueConstructor;
-import org.apache.calcite.sql.fun.SqlMapValueConstructor;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlArrayValueConstructor;
+import org.apache.calcite.sql.fun.SqlMapValueConstructor;
 
 public class LiteralConstructorConverter implements CallConverter {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LiteralConstructorConverter.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(LiteralConstructorConverter.class);
 
   @Override
-  public Optional<Expression> convert(RexCall call, Function<RexNode, Expression> topLevelConverter) {
-    return switch(call.getOperator()) {
+  public Optional<Expression> convert(
+      RexCall call, Function<RexNode, Expression> topLevelConverter) {
+    return switch (call.getOperator()) {
       case SqlArrayValueConstructor array -> Optional.of(
-          ExpressionCreator.list(false,
-              call.operands.stream().map(t -> ((Expression.Literal) t.accept(new RexExpressionConverter()))).toList()));
-
+          ExpressionCreator.list(
+              false,
+              call.operands.stream()
+                  .map(t -> ((Expression.Literal) t.accept(new RexExpressionConverter())))
+                  .toList()));
 
       case SqlMapValueConstructor map -> {
-        List<Expression.Literal> literals = call.operands.stream().map(t -> ((Expression.Literal) t.accept(new RexExpressionConverter()))).toList();
+        List<Expression.Literal> literals =
+            call.operands.stream()
+                .map(t -> ((Expression.Literal) t.accept(new RexExpressionConverter())))
+                .toList();
         Map<Expression.Literal, Expression.Literal> items = new HashMap<>();
         assert literals.size() % 2 == 0;
-        for (int i = 0; i < literals.size(); i+=2) {
+        for (int i = 0; i < literals.size(); i += 2) {
           items.put(literals.get(i), literals.get(i + 1));
         }
         yield Optional.of(ExpressionCreator.map(false, items));

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -1,16 +1,14 @@
 package io.substrait.isthmus.expression;
 
+import static io.substrait.expression.ExpressionCreator.*;
+import static java.time.temporal.ChronoField.*;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import com.google.protobuf.ByteString;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.Type;
-
-import org.apache.calcite.avatica.util.TimeUnitRange;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.util.*;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.*;
@@ -18,10 +16,10 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import static java.time.temporal.ChronoField.*;
-import static io.substrait.expression.ExpressionCreator.*;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.util.*;
 
 public class LiteralConverter {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LiteralConverter.class);
@@ -29,43 +27,47 @@ public class LiteralConverter {
   private static final long MICROS_IN_DAY = TimeUnit.DAYS.toMicros(1);
 
   static final DateTimeFormatter CALCITE_LOCAL_DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
-  static final DateTimeFormatter CALCITE_LOCAL_TIME_FORMATTER = new DateTimeFormatterBuilder()
-      .appendValue(HOUR_OF_DAY, 2)
-      .appendLiteral(':')
-      .appendValue(MINUTE_OF_HOUR, 2)
-      .appendLiteral(':')
-      .appendValue(SECOND_OF_MINUTE, 2)
-      .optionalStart()
-      .appendFraction(NANO_OF_SECOND, 0, 9, true)
-      .toFormatter();
-  private static final DateTimeFormatter CALCITE_LOCAL_DATETIME_FORMATTER = new DateTimeFormatterBuilder()
-      .parseCaseInsensitive()
-      .append(CALCITE_LOCAL_DATE_FORMATTER)
-      .appendLiteral(' ')
-      .append(CALCITE_LOCAL_TIME_FORMATTER)
-      .toFormatter();
+  static final DateTimeFormatter CALCITE_LOCAL_TIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendValue(HOUR_OF_DAY, 2)
+          .appendLiteral(':')
+          .appendValue(MINUTE_OF_HOUR, 2)
+          .appendLiteral(':')
+          .appendValue(SECOND_OF_MINUTE, 2)
+          .optionalStart()
+          .appendFraction(NANO_OF_SECOND, 0, 9, true)
+          .toFormatter();
+  private static final DateTimeFormatter CALCITE_LOCAL_DATETIME_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .append(CALCITE_LOCAL_DATE_FORMATTER)
+          .appendLiteral(' ')
+          .append(CALCITE_LOCAL_TIME_FORMATTER)
+          .toFormatter();
 
-  private static final DateTimeFormatter CALCITE_TIMESTAMP_WITH_ZONE_FORMATTER = new DateTimeFormatterBuilder()
-      .parseCaseInsensitive()
-      .append(CALCITE_LOCAL_DATE_FORMATTER)
-      .appendLiteral(' ')
-      .append(CALCITE_LOCAL_TIME_FORMATTER)
-      .appendLiteral(' ')
-      .appendZoneId()
-      .toFormatter();
+  private static final DateTimeFormatter CALCITE_TIMESTAMP_WITH_ZONE_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .append(CALCITE_LOCAL_DATE_FORMATTER)
+          .appendLiteral(' ')
+          .append(CALCITE_LOCAL_TIME_FORMATTER)
+          .appendLiteral(' ')
+          .appendZoneId()
+          .toFormatter();
 
-  private static final ZoneOffset SYSTEM_TIMEZONE = OffsetDateTime.now(ZoneId.systemDefault()).getOffset();
+  private static final ZoneOffset SYSTEM_TIMEZONE =
+      OffsetDateTime.now(ZoneId.systemDefault()).getOffset();
 
   private Expression nullOf(RexLiteral literal) {
     return null;
   }
 
-  private static BigDecimal i(RexLiteral literal ) {
+  private static BigDecimal i(RexLiteral literal) {
     return bd(literal).setScale(0, RoundingMode.HALF_UP);
   }
 
   private static String s(RexLiteral literal) {
-    return ((NlsString)literal.getValue()).getValue();
+    return ((NlsString) literal.getValue()).getValue();
   }
 
   private static BigDecimal bd(RexLiteral literal) {
@@ -81,7 +83,7 @@ public class LiteralConverter {
       return typedNull(type);
     }
 
-    return switch(literal.getType().getSqlTypeName()) {
+    return switch (literal.getType().getSqlTypeName()) {
       case TINYINT -> i8(n, i(literal).intValue());
       case SMALLINT -> i16(n, i(literal).intValue());
       case INTEGER -> i32(n, i(literal).intValue());
@@ -89,7 +91,7 @@ public class LiteralConverter {
       case BOOLEAN -> bool(n, (Boolean) literal.getValue());
       case CHAR -> {
         var val = literal.getValue();
-        yield switch(val) {
+        yield switch (val) {
           case NlsString nls -> fixedChar(n, nls.getValue());
           default -> throw new UnsupportedOperationException("Unable to handle char type: " + val);
         };
@@ -97,7 +99,7 @@ public class LiteralConverter {
       case DOUBLE -> fp64(n, bd(literal).doubleValue());
       case FLOAT -> fp32(n, bd(literal).floatValue());
 
-      case DECIMAL ->  {
+      case DECIMAL -> {
         BigDecimal bd = bd(literal);
         yield decimal(n, bd, literal.getType().getPrecision(), literal.getType().getScale());
       }
@@ -107,13 +109,17 @@ public class LiteralConverter {
         }
 
         yield varChar(n, s(literal), literal.getType().getPrecision());
-
       }
-      case BINARY -> fixedBinary(n, ByteString.copyFrom(padRightIfNeeded(literal.getValueAs(org.apache.calcite.avatica.util.ByteString.class), literal.getType().getPrecision())));
+      case BINARY -> fixedBinary(
+          n,
+          ByteString.copyFrom(
+              padRightIfNeeded(
+                  literal.getValueAs(org.apache.calcite.avatica.util.ByteString.class),
+                  literal.getType().getPrecision())));
       case VARBINARY -> binary(n, ByteString.copyFrom(literal.getValueAs(byte[].class)));
       case SYMBOL -> {
         Object value = literal.getValue();
-        yield switch(value) {
+        yield switch (value) {
           case NlsString s -> string(n, s.getValue());
           case TimeUnitRange tur -> string(n, tur.name());
           default -> throw new UnsupportedOperationException("Unable to handle symbol: " + value);
@@ -130,15 +136,16 @@ public class LiteralConverter {
         yield time(n, NANOSECONDS.toMicros(localTime.toNanoOfDay()));
       }
 
-      case TIMESTAMP,TIMESTAMP_WITH_LOCAL_TIME_ZONE -> {
+      case TIMESTAMP, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> {
         TimestampString timestamp = literal.getValueAs(TimestampString.class);
-        LocalDateTime ldt = LocalDateTime.parse(timestamp.toString(), CALCITE_LOCAL_DATETIME_FORMATTER);
+        LocalDateTime ldt =
+            LocalDateTime.parse(timestamp.toString(), CALCITE_LOCAL_DATETIME_FORMATTER);
         yield timestamp(n, ldt);
       }
 
       case INTERVAL_YEAR -> {
         var intervalLength = literal.getValueAs(BigDecimal.class).longValue();
-        var years = intervalLength/12;
+        var years = intervalLength / 12;
         var months = intervalLength - years * 12;
         yield intervalYear(n, (int) years, (int) months);
       }
@@ -155,16 +162,24 @@ public class LiteralConverter {
         // we need to convert to microseconds.
         int precision = literal.getType().getPrecision();
         var intervalLength = literal.getValueAs(BigDecimal.class).longValue();
-        var adjustedLength = precision > 6 ?
-            intervalLength/((int)Math.pow(10,precision - 6))
-            : intervalLength * ((int)Math.pow(10,6 - precision));
-        var days = adjustedLength/MICROS_IN_DAY;
+        var adjustedLength =
+            precision > 6
+                ? intervalLength / ((int) Math.pow(10, precision - 6))
+                : intervalLength * ((int) Math.pow(10, 6 - precision));
+        var days = adjustedLength / MICROS_IN_DAY;
         var microseconds = adjustedLength - days * MICROS_IN_DAY;
         yield intervalDay(n, (int) days, (int) microseconds);
       }
 
-      case INTERVAL_DAY_HOUR, INTERVAL_DAY_MINUTE, INTERVAL_DAY_SECOND, INTERVAL_HOUR, INTERVAL_HOUR_MINUTE,
-      INTERVAL_HOUR_SECOND, INTERVAL_MINUTE, INTERVAL_MINUTE_SECOND, INTERVAL_SECOND -> {
+      case INTERVAL_DAY_HOUR,
+          INTERVAL_DAY_MINUTE,
+          INTERVAL_DAY_SECOND,
+          INTERVAL_HOUR,
+          INTERVAL_HOUR_MINUTE,
+          INTERVAL_HOUR_SECOND,
+          INTERVAL_MINUTE,
+          INTERVAL_MINUTE_SECOND,
+          INTERVAL_SECOND -> {
         throw new UnsupportedOperationException("Need to implement IntervalDay");
       }
 
@@ -178,22 +193,26 @@ public class LiteralConverter {
         yield list(n, literals.stream().map(LiteralConverter::convert).toList());
       }
 
-      default ->
-        throw new UnsupportedOperationException(String.format("Unable to convert the value of %s of type %s to a literal.", literal, literal.getType().getSqlTypeName()));
+      default -> throw new UnsupportedOperationException(
+          String.format(
+              "Unable to convert the value of %s of type %s to a literal.",
+              literal, literal.getType().getSqlTypeName()));
     };
   }
 
-  public static byte[] padRightIfNeeded(org.apache.calcite.avatica.util.ByteString bytes, int length) {
+  public static byte[] padRightIfNeeded(
+      org.apache.calcite.avatica.util.ByteString bytes, int length) {
     return padRightIfNeeded(bytes.getBytes(), length);
   }
 
   public static byte[] padRightIfNeeded(byte[] value, int length) {
 
     if (length < value.length) {
-      throw new IllegalArgumentException("Byte values should either be at or below the expected length.");
+      throw new IllegalArgumentException(
+          "Byte values should either be at or below the expected length.");
     }
 
-    if(length == value.length) {
+    if (length == value.length) {
       return value;
     }
 
@@ -201,6 +220,4 @@ public class LiteralConverter {
     System.arraycopy(value, 0, newArray, 0, value.length);
     return newArray;
   }
-
-
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -5,14 +5,14 @@ import io.substrait.expression.FieldReference;
 import io.substrait.isthmus.CallConverter;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.StringTypeVisitor;
-import org.apache.calcite.rex.*;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.calcite.rex.*;
 
 public class RexExpressionConverter implements RexVisitor<Expression> {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RexExpressionConverter.class);
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(RexExpressionConverter.class);
 
   private final List<CallConverter> callConverters;
 
@@ -30,7 +30,8 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
 
   @Override
   public Expression visitInputRef(RexInputRef inputRef) {
-    return FieldReference.newRootStructReference(inputRef.getIndex(), TypeConverter.convert(inputRef.getType()));
+    return FieldReference.newRootStructReference(
+        inputRef.getIndex(), TypeConverter.convert(inputRef.getType()));
   }
 
   @Override
@@ -42,11 +43,13 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
       }
     }
 
-    String msg = String.format("Unable to convert call %s(%s).", call.getOperator().getName(),
-        call.getOperands()
-            .stream()
-            .map(t -> t.accept(this).getType().accept(new StringTypeVisitor()))
-            .collect(Collectors.joining(", ")));
+    String msg =
+        String.format(
+            "Unable to convert call %s(%s).",
+            call.getOperator().getName(),
+            call.getOperands().stream()
+                .map(t -> t.accept(this).getType().accept(new StringTypeVisitor()))
+                .collect(Collectors.joining(", ")));
     throw new IllegalArgumentException(msg);
   }
 
@@ -99,5 +102,4 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
   public Expression visitPatternFieldRef(RexPatternFieldRef fieldRef) {
     throw new UnsupportedOperationException("RexPatternFieldRef not supported");
   }
-
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -5,25 +5,31 @@ import io.substrait.expression.Expression;
 import io.substrait.function.SimpleExtension;
 import io.substrait.isthmus.CallConverter;
 import io.substrait.type.Type;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
 public class ScalarFunctionConverter
-    extends FunctionConverter<SimpleExtension.ScalarFunctionVariant, Expression, ScalarFunctionConverter.WrappedScalarCall>
+    extends FunctionConverter<
+        SimpleExtension.ScalarFunctionVariant,
+        Expression,
+        ScalarFunctionConverter.WrappedScalarCall>
     implements CallConverter {
 
-  public ScalarFunctionConverter(List<SimpleExtension.ScalarFunctionVariant> functions, RelDataTypeFactory typeFactory) {
+  public ScalarFunctionConverter(
+      List<SimpleExtension.ScalarFunctionVariant> functions, RelDataTypeFactory typeFactory) {
     super(functions, typeFactory);
   }
 
-  public ScalarFunctionConverter(List<SimpleExtension.ScalarFunctionVariant> functions, List<FunctionMappings.Sig> additionalSignatures, RelDataTypeFactory typeFactory) {
+  public ScalarFunctionConverter(
+      List<SimpleExtension.ScalarFunctionVariant> functions,
+      List<FunctionMappings.Sig> additionalSignatures,
+      RelDataTypeFactory typeFactory) {
     super(functions, additionalSignatures, typeFactory);
   }
 
@@ -33,7 +39,8 @@ public class ScalarFunctionConverter
   }
 
   @Override
-  public Optional<Expression> convert(RexCall call, Function<RexNode, Expression> topLevelConverter) {
+  public Optional<Expression> convert(
+      RexCall call, Function<RexNode, Expression> topLevelConverter) {
     FunctionFinder m = signatures.get(call.op);
     if (m == null) {
       return Optional.empty();
@@ -50,7 +57,8 @@ public class ScalarFunctionConverter
   protected Expression generateBinding(
       WrappedScalarCall call,
       SimpleExtension.ScalarFunctionVariant function,
-      List<Expression> arguments, Type outputType) {
+      List<Expression> arguments,
+      Type outputType) {
     return Expression.ScalarFunctionInvocation.builder()
         .outputType(outputType)
         .declaration(function)

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
@@ -1,5 +1,9 @@
 package io.substrait.isthmus;
 
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.function.ImmutableSimpleExtension;
@@ -7,16 +11,11 @@ import io.substrait.function.SimpleExtension;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.type.Type;
+import java.io.IOException;
+import java.util.function.Consumer;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.function.Consumer;
-
-import static org.apache.calcite.sql.fun.SqlStdOperatorTable.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CalciteCallTest extends CalciteObjs {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CalciteCallTest.class);
@@ -27,7 +26,8 @@ public class CalciteCallTest extends CalciteObjs {
   private final RexExpressionConverter converter = new RexExpressionConverter(functionConverter);
 
   static {
-    SimpleExtension.ExtensionCollection defaults = ImmutableSimpleExtension.ExtensionCollection.builder().build();
+    SimpleExtension.ExtensionCollection defaults =
+        ImmutableSimpleExtension.ExtensionCollection.builder().build();
     try {
       defaults = SimpleExtension.loadDefaults();
     } catch (IOException e) {
@@ -39,20 +39,28 @@ public class CalciteCallTest extends CalciteObjs {
 
   @Test
   public void coerceNumericOp() {
-    test("add:opt_i64_i64", rex.makeCall(PLUS, c(4, SqlTypeName.INTEGER), c(4, SqlTypeName.BIGINT)), func -> {
-      // check that there is a cast for the incorrect argument type.
-      assertEquals(ExpressionCreator.cast(Type.REQUIRED.I64, ExpressionCreator.i32(false, 4)), func.arguments().get(0));
-    });
+    test(
+        "add:opt_i64_i64",
+        rex.makeCall(PLUS, c(4, SqlTypeName.INTEGER), c(4, SqlTypeName.BIGINT)),
+        func -> {
+          // check that there is a cast for the incorrect argument type.
+          assertEquals(
+              ExpressionCreator.cast(Type.REQUIRED.I64, ExpressionCreator.i32(false, 4)),
+              func.arguments().get(0));
+        });
   }
 
   @Test
   public void directMatchPlus() {
-    test("add:opt_i64_i64", rex.makeCall(PLUS, c(4, SqlTypeName.BIGINT), c(4, SqlTypeName.BIGINT)), func -> {
+    test(
+        "add:opt_i64_i64",
+        rex.makeCall(PLUS, c(4, SqlTypeName.BIGINT), c(4, SqlTypeName.BIGINT)),
+        func -> {
 
-      // ensure both literals are included directly.
-      assertTrue(func.arguments().get(0) instanceof Expression.I64Literal);
-      assertTrue(func.arguments().get(1) instanceof Expression.I64Literal);
-    });
+          // ensure both literals are included directly.
+          assertTrue(func.arguments().get(0) instanceof Expression.I64Literal);
+          assertTrue(func.arguments().get(1) instanceof Expression.I64Literal);
+        });
   }
 
   @Test
@@ -70,12 +78,12 @@ public class CalciteCallTest extends CalciteObjs {
     test("not:bool", rex.makeCall(NOT, c(false, SqlTypeName.BOOLEAN)));
   }
 
-
   private void test(String expectedName, RexNode call) {
     test(expectedName, call, c -> {});
   }
 
-  private void test(String expectedName, RexNode call, Consumer<Expression.ScalarFunctionInvocation> consumer) {
+  private void test(
+      String expectedName, RexNode call, Consumer<Expression.ScalarFunctionInvocation> consumer) {
     var expression = call.accept(converter);
     assertTrue(expression instanceof Expression.ScalarFunctionInvocation);
     Expression.ScalarFunctionInvocation func = (Expression.ScalarFunctionInvocation) expression;

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteFieldSelectionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteFieldSelectionTest.java
@@ -3,11 +3,9 @@ package io.substrait.isthmus;
 import org.junit.jupiter.api.Test;
 
 public class CalciteFieldSelectionTest {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CalciteFieldSelectionTest.class);
-
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(CalciteFieldSelectionTest.class);
 
   @Test
-  public void simpleSelection() {
-    
-  }
+  public void simpleSelection() {}
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -1,9 +1,17 @@
 package io.substrait.isthmus;
 
+import static io.substrait.expression.ExpressionCreator.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
 import io.substrait.expression.Expression;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.type.Type;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
@@ -12,18 +20,9 @@ import org.apache.calcite.util.TimestampString;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
-
-import static io.substrait.expression.ExpressionCreator.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class CalciteLiteralTest extends CalciteObjs {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CalciteLiteralTest.class);
-
+  static final org.slf4j.Logger logger =
+      org.slf4j.LoggerFactory.getLogger(CalciteLiteralTest.class);
 
   @Test
   void nullLiteral() {
@@ -68,45 +67,48 @@ public class CalciteLiteralTest extends CalciteObjs {
   @Test
   void tBinary() {
     var val = "my test".getBytes(StandardCharsets.UTF_8);
-    test(binary(false, val), c(new org.apache.calcite.avatica.util.ByteString(val), SqlTypeName.VARBINARY));
+    test(
+        binary(false, val),
+        c(new org.apache.calcite.avatica.util.ByteString(val), SqlTypeName.VARBINARY));
   }
 
   @Test
   void tTime() {
-    test(time(false, (14L * 60 * 60 + 22 * 60 + 47) * 1000 * 1000), rex.makeTimeLiteral(new TimeString(14,22,47), 6));
+    test(
+        time(false, (14L * 60 * 60 + 22 * 60 + 47) * 1000 * 1000),
+        rex.makeTimeLiteral(new TimeString(14, 22, 47), 6));
   }
 
   @Test
   void tDate() {
-    test(date(false, (int) LocalDate.of(2002, 2, 14).toEpochDay()), rex.makeDateLiteral(new DateString(2002,2,14)));
+    test(
+        date(false, (int) LocalDate.of(2002, 2, 14).toEpochDay()),
+        rex.makeDateLiteral(new DateString(2002, 2, 14)));
   }
 
   @Test
   void tTimestamp() {
-    var ts = timestamp(false, 2002,2,14,16,20,47, 123);
+    var ts = timestamp(false, 2002, 2, 14, 16, 20, 47, 123);
     var nano = (int) TimeUnit.MICROSECONDS.toNanos(123);
-    var tsx = new TimestampString(2002,2,14, 16, 20, 47).withNanos(nano);
+    var tsx = new TimestampString(2002, 2, 14, 16, 20, 47).withNanos(nano);
     test(ts, rex.makeTimestampLiteral(tsx, 6));
   }
-
 
   @Disabled("Not clear what the right literal mapping is.")
   @Test
   void tTimestampTZ() {
-    // Calcite has TimestampWithTimeZoneString but it doesn't appear to be available as a literal or data type. (Doesn't exist in SqlTypeName.)
+    // Calcite has TimestampWithTimeZoneString but it doesn't appear to be available as a literal or
+    // data type.
+    // (Doesn't exist in SqlTypeName.)
   }
 
   @Disabled("NYI")
   @Test
-  void tIntervalYear() {
-
-  }
+  void tIntervalYear() {}
 
   @Disabled("NYI")
   @Test
-  void tIntervalDay() {
-
-  }
+  void tIntervalDay() {}
 
   @Test
   void tFixedChar() {
@@ -126,31 +128,48 @@ public class CalciteLiteralTest extends CalciteObjs {
 
   @Test
   void tMap() {
-    var ss = ImmutableMap.<Expression.Literal, Expression.Literal>of(string(false, "foo"), i32(false, 4), string(false, "bar"), i32(false, -1));
-    var calcite = rex.makeLiteral(ImmutableMap.of("foo", 4, "bar", -1), type.createMapType(t(SqlTypeName.VARCHAR), t(SqlTypeName.INTEGER)), true, false);
+    var ss =
+        ImmutableMap.<Expression.Literal, Expression.Literal>of(
+            string(false, "foo"), i32(false, 4), string(false, "bar"), i32(false, -1));
+    var calcite =
+        rex.makeLiteral(
+            ImmutableMap.of("foo", 4, "bar", -1),
+            type.createMapType(t(SqlTypeName.VARCHAR), t(SqlTypeName.INTEGER)),
+            true,
+            false);
     test(map(false, ss), calcite);
   }
 
   @Test
   void tList() {
-    test(list(false, i32(false, 4), i32(false, -1)),
-        rex.makeLiteral(Arrays.asList(4, -1), type.createArrayType(t(SqlTypeName.INTEGER), -1), false, false));
+    test(
+        list(false, i32(false, 4), i32(false, -1)),
+        rex.makeLiteral(
+            Arrays.asList(4, -1), type.createArrayType(t(SqlTypeName.INTEGER), -1), false, false));
   }
 
   @Test
   void tStruct() {
-    test(struct(false, i32(false, 4), i32(false, -1)),
-        rex.makeLiteral(Arrays.asList(4, -1), type.createStructType(Arrays.asList(t(SqlTypeName.INTEGER), t(SqlTypeName.INTEGER)), Arrays.asList("c1", "c2")), false, false));
-
+    test(
+        struct(false, i32(false, 4), i32(false, -1)),
+        rex.makeLiteral(
+            Arrays.asList(4, -1),
+            type.createStructType(
+                Arrays.asList(t(SqlTypeName.INTEGER), t(SqlTypeName.INTEGER)),
+                Arrays.asList("c1", "c2")),
+            false,
+            false));
   }
+
   @Test
   void tFixedBinary() {
     var val = "my test".getBytes(StandardCharsets.UTF_8);
-    test(fixedBinary(false, val), c(new org.apache.calcite.avatica.util.ByteString(val), SqlTypeName.BINARY));
+    test(
+        fixedBinary(false, val),
+        c(new org.apache.calcite.avatica.util.ByteString(val), SqlTypeName.BINARY));
   }
 
   public void test(Expression expression, RexNode rex) {
     assertEquals(expression, rex.accept(new RexExpressionConverter()));
   }
-
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteObjs.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteObjs.java
@@ -6,9 +6,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Set of classes/methods that make it easier to work with Calcite.
- */
+/** Set of classes/methods that make it easier to work with Calcite. */
 public abstract class CalciteObjs {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CalciteObjs.class);
 
@@ -16,7 +14,7 @@ public abstract class CalciteObjs {
   final RexBuilder rex = new RexBuilder(type);
 
   RelDataType t(SqlTypeName typeName, int... vals) {
-    return switch(vals.length) {
+    return switch (vals.length) {
       case 0 -> type.createSqlType(typeName);
       case 1 -> type.createSqlType(typeName, vals[0]);
       case 2 -> type.createSqlType(typeName, vals[0], vals[1]);
@@ -28,16 +26,16 @@ public abstract class CalciteObjs {
     return type.createTypeWithNullability(t(typeName, vals), true);
   }
 
-  public RexNode makeCalciteLiteral(boolean nullable, SqlTypeName typeName, Object value, int... vals) {
+  public RexNode makeCalciteLiteral(
+      boolean nullable, SqlTypeName typeName, Object value, int... vals) {
     return rex.makeLiteral(value, nullable ? tN(typeName, vals) : t(typeName, vals), true, false);
   }
 
-  public RexNode c(Object value, SqlTypeName typeName, int...vals) {
+  public RexNode c(Object value, SqlTypeName typeName, int... vals) {
     return makeCalciteLiteral(false, typeName, value, vals);
   }
 
-  public RexNode cN(Object value, SqlTypeName typeName, int...vals) {
+  public RexNode cN(Object value, SqlTypeName typeName, int... vals) {
     return makeCalciteLiteral(true, typeName, value, vals);
   }
-
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -1,17 +1,16 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.substrait.function.TypeExpression;
 import io.substrait.type.Type;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CalciteTypeTest extends CalciteObjs {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CalciteTypeTest.class);
@@ -79,19 +78,29 @@ class CalciteTypeTest extends CalciteObjs {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void timestamptz(boolean nullable) {
-    testType(Type.withNullability(nullable).TIMESTAMP_TZ, SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, nullable, 6);
+    testType(
+        Type.withNullability(nullable).TIMESTAMP_TZ,
+        SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+        nullable,
+        6);
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void intervalYear(boolean nullable) {
-    testType(Type.withNullability(nullable).INTERVAL_YEAR, type.createSqlIntervalType(TypeConverter.INTERVAL_YEAR), nullable);
+    testType(
+        Type.withNullability(nullable).INTERVAL_YEAR,
+        type.createSqlIntervalType(TypeConverter.INTERVAL_YEAR),
+        nullable);
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void intervalDay(boolean nullable) {
-    testType(Type.withNullability(nullable).INTERVAL_DAY, type.createSqlIntervalType(TypeConverter.INTERVAL_DAY), nullable);
+    testType(
+        Type.withNullability(nullable).INTERVAL_DAY,
+        type.createSqlIntervalType(TypeConverter.INTERVAL_DAY),
+        nullable);
   }
 
   @ParameterizedTest
@@ -135,54 +144,55 @@ class CalciteTypeTest extends CalciteObjs {
   void list(boolean nullable) {
     testType(
         Type.withNullability(nullable).list(Type.REQUIRED.I16),
-        type.createArrayType(type.createSqlType(SqlTypeName.SMALLINT), -1), nullable);
+        type.createArrayType(type.createSqlType(SqlTypeName.SMALLINT), -1),
+        nullable);
   }
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void map(boolean nullable) {
-    testType(Type.withNullability(nullable).map(Type.REQUIRED.STRING, Type.REQUIRED.I8),
+    testType(
+        Type.withNullability(nullable).map(Type.REQUIRED.STRING, Type.REQUIRED.I8),
         type.createMapType(
-            type.createSqlType(SqlTypeName.VARCHAR),
-            type.createSqlType(SqlTypeName.TINYINT)),
+            type.createSqlType(SqlTypeName.VARCHAR), type.createSqlType(SqlTypeName.TINYINT)),
         nullable);
   }
 
   @Test
   void struct() {
-    testType(Type.REQUIRED.struct(Type.REQUIRED.STRING, Type.REQUIRED.I8),
+    testType(
+        Type.REQUIRED.struct(Type.REQUIRED.STRING, Type.REQUIRED.I8),
         type.createStructType(
-            Arrays.asList(type.createSqlType(SqlTypeName.VARCHAR),
-                type.createSqlType(SqlTypeName.TINYINT)),
-            Arrays.asList("foo", "bar")
-        ),
+            Arrays.asList(
+                type.createSqlType(SqlTypeName.VARCHAR), type.createSqlType(SqlTypeName.TINYINT)),
+            Arrays.asList("foo", "bar")),
         Arrays.asList("foo", "bar"));
   }
 
   @Test
   void nestedStruct() {
-    testType(Type.REQUIRED.struct(
+    testType(
+        Type.REQUIRED.struct(
             Type.REQUIRED.struct(Type.REQUIRED.STRING, Type.REQUIRED.I8),
             Type.REQUIRED.struct(Type.REQUIRED.STRING, Type.REQUIRED.I8),
             Type.REQUIRED.STRING),
         type.createStructType(
             Arrays.asList(
                 type.createStructType(
-                    Arrays.asList(type.createSqlType(SqlTypeName.VARCHAR),
+                    Arrays.asList(
+                        type.createSqlType(SqlTypeName.VARCHAR),
                         type.createSqlType(SqlTypeName.TINYINT)),
-                    Arrays.asList("inner1", "inner2")
-                ),
+                    Arrays.asList("inner1", "inner2")),
                 type.createStructType(
-                    Arrays.asList(type.createSqlType(SqlTypeName.VARCHAR),
+                    Arrays.asList(
+                        type.createSqlType(SqlTypeName.VARCHAR),
                         type.createSqlType(SqlTypeName.TINYINT)),
-                    Arrays.asList("inner3", "inner4")
-                ),
+                    Arrays.asList("inner3", "inner4")),
                 type.createSqlType(SqlTypeName.VARCHAR)),
-            Arrays.asList("topStruct1", "topStruct2", "topVarChar")
-        ),
-        Arrays.asList("topStruct1", "inner1", "inner2", "topStruct2", "inner3", "inner4", "topVarChar"));
+            Arrays.asList("topStruct1", "topStruct2", "topVarChar")),
+        Arrays.asList(
+            "topStruct1", "inner1", "inner2", "topStruct2", "inner3", "inner4", "topVarChar"));
   }
-
 
   private void testType(TypeExpression expression, SqlTypeName typeName, boolean nullable) {
     testType(expression, type.createTypeWithNullability(type.createSqlType(typeName), nullable));
@@ -192,17 +202,21 @@ class CalciteTypeTest extends CalciteObjs {
     testType(expression, type.createTypeWithNullability(calciteType, nullable));
   }
 
-  private void testType(TypeExpression expression, SqlTypeName typeName, boolean nullable, int prec) {
-    testType(expression, type.createTypeWithNullability(
-        type.createSqlType(typeName, prec), nullable));
+  private void testType(
+      TypeExpression expression, SqlTypeName typeName, boolean nullable, int prec) {
+    testType(
+        expression, type.createTypeWithNullability(type.createSqlType(typeName, prec), nullable));
   }
 
-  private void testType(TypeExpression expression, SqlTypeName typeName, boolean nullable, int prec, int scale) {
-    testType(expression, type.createTypeWithNullability(
-        type.createSqlType(typeName, prec, scale), nullable));
+  private void testType(
+      TypeExpression expression, SqlTypeName typeName, boolean nullable, int prec, int scale) {
+    testType(
+        expression,
+        type.createTypeWithNullability(type.createSqlType(typeName, prec, scale), nullable));
   }
 
-  private void testType(TypeExpression expression, RelDataType calciteType, List<String> dfsFieldNames) {
+  private void testType(
+      TypeExpression expression, RelDataType calciteType, List<String> dfsFieldNames) {
     assertEquals(expression, TypeConverter.convert(calciteType));
     assertEquals(calciteType, TypeConverter.convert(type, expression, dfsFieldNames));
   }
@@ -210,5 +224,4 @@ class CalciteTypeTest extends CalciteObjs {
   private void testType(TypeExpression expression, RelDataType type) {
     testType(expression, type, null);
   }
-
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -2,11 +2,10 @@ package io.substrait.isthmus;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import java.io.IOException;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.tools.RelBuilder;
-
-import java.io.IOException;
 
 public class PlanTestBase {
   protected final RelCreator creator = new RelCreator();
@@ -15,7 +14,6 @@ public class PlanTestBase {
   protected final RelDataTypeFactory type = creator.type();
 
   public static String asString(String resource) throws IOException {
-    return Resources.toString(
-        Resources.getResource(resource), Charsets.UTF_8);
+    return Resources.toString(Resources.getResource(resource), Charsets.UTF_8);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus;
 
+import java.util.Arrays;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -25,8 +26,6 @@ import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.tools.RelBuilder;
 
-import java.util.Arrays;
-
 public class RelCreator {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(RelCreator.class);
 
@@ -36,7 +35,8 @@ public class RelCreator {
   public RelCreator() {
     CalciteSchema schema = CalciteSchema.createRootSchema(false);
     RelDataTypeFactory factory = new JavaTypeFactoryImpl(SubstraitTypeSystem.TYPE_SYSTEM);
-    CalciteConnectionConfig config = CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
+    CalciteConnectionConfig config =
+        CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
     catalog = new CalciteCatalogReader(schema, Arrays.asList(), factory, config);
     VolcanoPlanner planner = new VolcanoPlanner(RelOptCostImpl.FACTORY, Contexts.EMPTY_CONTEXT);
     cluster = RelOptCluster.create(planner, new RexBuilder(factory));
@@ -47,14 +47,18 @@ public class RelCreator {
     try {
       SqlParser parser = SqlParser.create(sql, SqlParser.Config.DEFAULT);
       var parsed = parser.parseQuery();
-      cluster.setMetadataQuerySupplier(() -> new RelMetadataQuery(new ProxyingMetadataHandlerProvider(DefaultRelMetadataProvider.INSTANCE)));
-      SqlValidator validator = new Validator(catalog, cluster.getTypeFactory(), SqlValidator.Config.DEFAULT);
+      cluster.setMetadataQuerySupplier(
+          () ->
+              new RelMetadataQuery(
+                  new ProxyingMetadataHandlerProvider(DefaultRelMetadataProvider.INSTANCE)));
+      SqlValidator validator =
+          new Validator(catalog, cluster.getTypeFactory(), SqlValidator.Config.DEFAULT);
 
-      SqlToRelConverter.Config converterConfig = SqlToRelConverter.config()
-          .withTrimUnusedFields(true)
-          .withExpand(false);
-      SqlToRelConverter converter = new SqlToRelConverter(null, validator, catalog, cluster,
-          StandardConvertletTable.INSTANCE, converterConfig);
+      SqlToRelConverter.Config converterConfig =
+          SqlToRelConverter.config().withTrimUnusedFields(true).withExpand(false);
+      SqlToRelConverter converter =
+          new SqlToRelConverter(
+              null, validator, catalog, cluster, StandardConvertletTable.INSTANCE, converterConfig);
       RelRoot root = converter.convertQuery(parsed, true, true);
       return root;
     } catch (SqlParseException e) {
@@ -76,11 +80,9 @@ public class RelCreator {
 
   private static final class Validator extends SqlValidatorImpl {
 
-    public Validator(SqlValidatorCatalogReader catalogReader, RelDataTypeFactory typeFactory, Config config) {
+    public Validator(
+        SqlValidatorCatalogReader catalogReader, RelDataTypeFactory typeFactory, Config config) {
       super(SqlStdOperatorTable.instance(), catalogReader, typeFactory, config);
     }
-
   }
-
-
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
@@ -4,12 +4,11 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.substrait.proto.Plan;
-import org.apache.calcite.sql.parser.SqlParseException;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Test;
 
 public class SimplePlansTest extends PlanTestBase {
 
@@ -26,8 +25,9 @@ public class SimplePlansTest extends PlanTestBase {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
     var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
-    //creates.forEach(System.out::println);
-    s.execute("select l_partkey, sum(distinct L_ORDERKEY) from lineitem group by l_partkey ", creates);
+    // creates.forEach(System.out::println);
+    s.execute(
+        "select l_partkey, sum(distinct L_ORDERKEY) from lineitem group by l_partkey ", creates);
   }
 
   @Test
@@ -35,15 +35,17 @@ public class SimplePlansTest extends PlanTestBase {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
     var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
-    //creates.forEach(System.out::println);
+    // creates.forEach(System.out::println);
     print(s.execute("select * from lineitem WHERE L_ORDERKEY > 10", creates));
   }
 
   @Test
   public void joinWithMultiDDLInOneString() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
-    List<String>  ddlStmts = Lists.newArrayList(asString("tpch/schema.sql"));
-    print(s.execute("select * from lineitem l, orders o WHERE o.o_orderkey = l.l_orderkey  and L_ORDERKEY > 10",
+    List<String> ddlStmts = Lists.newArrayList(asString("tpch/schema.sql"));
+    print(
+        s.execute(
+            "select * from lineitem l, orders o WHERE o.o_orderkey = l.l_orderkey  and L_ORDERKEY > 10",
             ddlStmts));
   }
 
@@ -54,6 +56,4 @@ public class SimplePlansTest extends PlanTestBase {
       throw new RuntimeException(e);
     }
   }
-
-
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
@@ -1,16 +1,15 @@
 package io.substrait.isthmus;
 
 import com.google.protobuf.util.JsonFormat;
+import java.util.Arrays;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.Arrays;
 
 public class TpchQueryNoValidation extends PlanTestBase {
 
   @ParameterizedTest
-  //@ValueSource(ints = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22})
-  @ValueSource(ints = {1,3,5,6,10,14,19})
+  // @ValueSource(ints = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22})
+  @ValueSource(ints = {1, 3, 5, 6, 10, 14, 19})
   public void tpch(int query) throws Exception {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
@@ -18,5 +17,4 @@ public class TpchQueryNoValidation extends PlanTestBase {
     var plan = s.execute(asString(String.format("tpch/queries/%02d.sql", query)), creates);
     System.out.println(JsonFormat.printer().print(plan));
   }
-
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,19 +1,22 @@
 rootProject.name = "substrait"
+
 include("bom", "core", "isthmus")
 
 pluginManagement {
-    plugins {
-        fun String.v() = extra["$this.version"].toString()
-        fun PluginDependenciesSpec.idv(id: String, key: String = id) = id(id) version key.v()
+  plugins {
+    fun String.v() = extra["$this.version"].toString()
+    fun PluginDependenciesSpec.idv(id: String, key: String = id) = id(id) version key.v()
 
-        idv("com.google.protobuf")
-        idv("org.jetbrains.gradle.plugin.idea-ext")
-        kotlin("jvm") version "kotlin".v()
+    idv("com.google.protobuf")
+    idv("org.jetbrains.gradle.plugin.idea-ext")
+    kotlin("jvm") version "kotlin".v()
+  }
+  if (extra.has("enableMavenLocal") &&
+      extra["enableMavenLocal"].toString().ifBlank { "true" }.toBoolean()
+  ) {
+    repositories {
+      mavenLocal()
+      gradlePluginPortal()
     }
-    if (extra.has("enableMavenLocal") && extra["enableMavenLocal"].toString().ifBlank { "true" }.toBoolean()) {
-        repositories {
-            mavenLocal()
-            gradlePluginPortal()
-        }
-    }
+  }
 }


### PR DESCRIPTION
## Code format & Proposal


The problem with code format is that there is no single format that can satisfy the preferences of everybody. However, from my experience, once people start to use **any** code format that produces consistent results across **Eclipse/IntelliJ/cmd line**, people stop worrying about code format details. 

This is also one of the reasons why the creators of Go decided to have a code formatter built-in (https://go.dev/doc/effective_go#formatting):

> Formatting issues are the most contentious but the least consequential. People can adapt to different formatting styles but it's  better if they don't have to, and less time is devoted to the topic if everyone adheres to the same style. The problem is how to approach this Utopia without a long prescriptive style guide.
> With Go we take an unusual approach and let the machine take care of most formatting issues. The gofmt program (also available as go fmt, which operates at the package level rather than source file level) reads a Go program and emits the source in a standard style of indentation and vertical alignment, retaining and if necessary reformatting comments.

I would like to propose using the **Google Java Format** with Spotless. The reason for this format is essentially that this is a widely-adopted code format that is designed specifically for code reviews (since we're spending more time reviewing code than writing it). 
Additionally, it produces consistent formatting results across **Eclipse/IntelliJ/cmd line**, which I think is another very important factor.

The implications of using this particular format is that it for example starts to wrap lines even if the line length hasn't been reached as @jacques-n already found out when looking over the code. However, keep in mind that this is basically being done so that later changes actually produce diffs that are much easier to read while reviewing code.