### PR TITLE
Converter for proto to pojo rel representation

### DIFF
--- a/core/src/main/java/io/substrait/expression/FunctionLookup.java
+++ b/core/src/main/java/io/substrait/expression/FunctionLookup.java
@@ -1,7 +1,6 @@
 package io.substrait.expression;
 
 import io.substrait.function.SimpleExtension;
-import java.util.*;
 
 public interface FunctionLookup {
   SimpleExtension.ScalarFunctionVariant getScalarFunction(

--- a/core/src/main/java/io/substrait/expression/proto/ImmutableFunctionLookup.java
+++ b/core/src/main/java/io/substrait/expression/proto/ImmutableFunctionLookup.java
@@ -3,7 +3,9 @@ package io.substrait.expression.proto;
 import io.substrait.function.SimpleExtension;
 import io.substrait.proto.Plan;
 import io.substrait.proto.SimpleExtensionDeclaration;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Maintains a mapping between function anchors and function references. Generates references for

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -35,6 +35,16 @@ public abstract class Join extends BiRel {
     public JoinRel.JoinType toProto() {
       return proto;
     }
+
+    public static JoinType fromProto(JoinRel.JoinType proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
+          return v;
+        }
+      }
+
+      throw new IllegalArgumentException("Unknown type: " + proto);
+    }
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -1,0 +1,250 @@
+package io.substrait.relation;
+
+import static io.substrait.expression.proto.ProtoExpressionConverter.EMPTY_TYPE;
+
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionLookup;
+import io.substrait.expression.ImmutableExpression;
+import io.substrait.expression.proto.ProtoExpressionConverter;
+import io.substrait.function.SimpleExtension;
+import io.substrait.proto.AggregateRel;
+import io.substrait.proto.FetchRel;
+import io.substrait.proto.FilterRel;
+import io.substrait.proto.JoinRel;
+import io.substrait.proto.ProjectRel;
+import io.substrait.proto.ReadRel;
+import io.substrait.proto.SortRel;
+import io.substrait.type.ImmutableNamedStruct;
+import io.substrait.type.NamedStruct;
+import io.substrait.type.Type;
+import io.substrait.type.proto.FromProto;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** Converts from proto to pojo rel representation TODO: AdvancedExtension, CrossJoin, Set */
+public class ProtoRelConverter {
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProtoRelConverter.class);
+
+  private final FunctionLookup lookup;
+  private final SimpleExtension.ExtensionCollection extensions;
+
+  public ProtoRelConverter(FunctionLookup lookup, SimpleExtension.ExtensionCollection extensions) {
+    this.lookup = lookup;
+    this.extensions = extensions;
+  }
+
+  public Rel from(io.substrait.proto.Rel rel) {
+    var relType = rel.getRelTypeCase();
+    switch (relType) {
+      case READ -> {
+        return newRead(rel.getRead());
+      }
+      case FILTER -> {
+        return newFilter(rel.getFilter());
+      }
+      case FETCH -> {
+        return newFetch(rel.getFetch());
+      }
+      case AGGREGATE -> {
+        return newAggregate(rel.getAggregate());
+      }
+      case SORT -> {
+        return newSort(rel.getSort());
+      }
+      case JOIN -> {
+        return newJoin(rel.getJoin());
+      }
+      case PROJECT -> {
+        return newProject(rel.getProject());
+      }
+      default -> {
+        // TODO: add support for SET, EXTENSION_SINGLE, EXTENSION_MULTI, EXTENSION_LEAF, CROSS
+        throw new UnsupportedOperationException("Unsupported RelTypeCase of " + relType);
+      }
+    }
+  }
+
+  private Rel newRead(ReadRel rel) {
+    if (rel.hasVirtualTable()) {
+      return newVirtualTable(rel);
+    } else if (rel.hasNamedTable()) {
+      return newNamedScan(rel);
+    } else {
+      return newEmptyScan(rel);
+    }
+  }
+
+  private Filter newFilter(FilterRel rel) {
+    var input = from(rel.getInput());
+    // TODO: For case of subquery, we'll need to pass in ProtoRelConverter to
+    //       ProtoExpressionConverter with nested structure of Rel/Expression.
+    return Filter.builder()
+        .input(input)
+        .condition(
+            new ProtoExpressionConverter(lookup, extensions, input.getRecordType())
+                .from(rel.getCondition()))
+        .remap(optionalRelmap(rel.getCommon()))
+        .build();
+  }
+
+  private NamedStruct newNamedStruct(ReadRel rel) {
+    var namedStruct = rel.getBaseSchema();
+    var struct = namedStruct.getStruct();
+    return ImmutableNamedStruct.builder()
+        .names(namedStruct.getNamesList())
+        .struct(
+            Type.Struct.builder()
+                .fields(struct.getTypesList().stream().map(FromProto::from).toList())
+                .nullable(FromProto.isNullable(struct.getNullability()))
+                .build())
+        .build();
+  }
+
+  private EmptyScan newEmptyScan(ReadRel rel) {
+    var namedStruct = newNamedStruct(rel);
+    return EmptyScan.builder()
+        .initialSchema(namedStruct)
+        .remap(optionalRelmap(rel.getCommon()))
+        .filter(
+            Optional.ofNullable(
+                rel.hasFilter()
+                    ? new ProtoExpressionConverter(lookup, extensions, namedStruct.struct())
+                        .from(rel.getFilter())
+                    : null))
+        .build();
+  }
+
+  private NamedScan newNamedScan(ReadRel rel) {
+    var namedStruct = newNamedStruct(rel);
+    return NamedScan.builder()
+        .initialSchema(namedStruct)
+        .names(rel.getNamedTable().getNamesList())
+        .remap(optionalRelmap(rel.getCommon()))
+        .filter(
+            Optional.ofNullable(
+                rel.hasFilter()
+                    ? new ProtoExpressionConverter(lookup, extensions, namedStruct.struct())
+                        .from(rel.getFilter())
+                    : null))
+        .build();
+  }
+
+  private VirtualTableScan newVirtualTable(ReadRel rel) {
+    var virtualTable = rel.getVirtualTable();
+    List<Expression.StructLiteral> structLiterals = new ArrayList<>(virtualTable.getValuesCount());
+    for (var struct : virtualTable.getValuesList()) {
+      structLiterals.add(
+          ImmutableExpression.StructLiteral.builder()
+              .fields(struct.getFieldsList().stream().map(ProtoExpressionConverter::from).toList())
+              .build());
+    }
+    var converter = new ProtoExpressionConverter(lookup, extensions, EMPTY_TYPE);
+    return VirtualTableScan.builder()
+        .filter(converter.from(rel.getFilter()))
+        .remap(optionalRelmap(rel.getCommon()))
+        .rows(structLiterals)
+        .build();
+  }
+
+  private Fetch newFetch(FetchRel rel) {
+    var input = from(rel.getInput());
+    return Fetch.builder()
+        .input(input)
+        .remap(optionalRelmap(rel.getCommon()))
+        .count(rel.getCount())
+        .offset(rel.getOffset())
+        .build();
+  }
+
+  private Project newProject(ProjectRel rel) {
+    var input = from(rel.getInput());
+    var converter = new ProtoExpressionConverter(lookup, extensions, input.getRecordType());
+    return Project.builder()
+        .input(input)
+        .remap(optionalRelmap(rel.getCommon()))
+        .expressions(rel.getExpressionsList().stream().map(converter::from).toList())
+        .build();
+  }
+
+  private Aggregate newAggregate(AggregateRel rel) {
+    var input = from(rel.getInput());
+    var converter = new ProtoExpressionConverter(lookup, extensions, input.getRecordType());
+    List<Aggregate.Grouping> groupings = new ArrayList<>(rel.getGroupingsCount());
+    for (var grouping : rel.getGroupingsList()) {
+      groupings.add(
+          Aggregate.Grouping.builder()
+              .expressions(
+                  grouping.getGroupingExpressionsList().stream().map(converter::from).toList())
+              .build());
+    }
+    List<Aggregate.Measure> measures = new ArrayList<>(rel.getMeasuresCount());
+    for (var measure : rel.getMeasuresList()) {
+      var func = measure.getMeasure();
+      measures.add(
+          Aggregate.Measure.builder()
+              .function(
+                  AggregateFunctionInvocation.builder()
+                      .arguments(
+                          measure.getMeasure().getArgsList().stream().map(converter::from).toList())
+                      .declaration(
+                          lookup.getAggregateFunction(func.getFunctionReference(), extensions))
+                      .outputType(FromProto.from(func.getOutputType()))
+                      .aggregationPhase(Expression.AggregationPhase.fromProto(func.getPhase()))
+                      .build())
+              .preMeasureFilter(
+                  Optional.ofNullable(
+                      measure.hasFilter() ? converter.from(measure.getFilter()) : null))
+              .build());
+    }
+    return Aggregate.builder()
+        .input(input)
+        .groupings(groupings)
+        .measures(measures)
+        .remap(optionalRelmap(rel.getCommon()))
+        .build();
+  }
+
+  private Sort newSort(SortRel rel) {
+    var input = from(rel.getInput());
+    var converter = new ProtoExpressionConverter(lookup, extensions, input.getRecordType());
+    return Sort.builder()
+        .input(input)
+        .remap(optionalRelmap(rel.getCommon()))
+        .sortFields(
+            rel.getSortsList().stream()
+                .map(
+                    field ->
+                        Expression.SortField.builder()
+                            .direction(Expression.SortDirection.fromProto(field.getDirection()))
+                            .expr(converter.from(field.getExpr()))
+                            .build())
+                .toList())
+        .build();
+  }
+
+  private Join newJoin(JoinRel rel) {
+    Rel left = from(rel.getLeft());
+    Rel right = from(rel.getRight());
+    Type.Struct leftStruct = left.getRecordType();
+    Type.Struct rightStruct = right.getRecordType();
+    Type.Struct unionedStruct = Type.Struct.builder().from(leftStruct).from(rightStruct).build();
+    var converter = new ProtoExpressionConverter(lookup, extensions, unionedStruct);
+    return Join.builder()
+        .condition(converter.from(rel.getExpression()))
+        .joinType(Join.JoinType.fromProto(rel.getType()))
+        .left(left)
+        .right(right)
+        .remap(optionalRelmap(rel.getCommon()))
+        .postJoinFilter(
+            Optional.ofNullable(
+                rel.hasPostJoinFilter() ? converter.from(rel.getPostJoinFilter()) : null))
+        .build();
+  }
+
+  private static Optional<Rel.Remap> optionalRelmap(io.substrait.proto.RelCommon relCommon) {
+    return Optional.ofNullable(
+        relCommon.hasEmit() ? Rel.Remap.of(relCommon.getEmit().getOutputMappingList()) : null);
+  }
+}

--- a/core/src/main/java/io/substrait/relation/RelConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelConverter.java
@@ -3,8 +3,17 @@ package io.substrait.relation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.proto.ExpressionProtoConverter;
 import io.substrait.expression.proto.FunctionCollector;
-import io.substrait.proto.*;
+import io.substrait.proto.AggregateFunction;
+import io.substrait.proto.AggregateRel;
+import io.substrait.proto.FetchRel;
+import io.substrait.proto.FilterRel;
+import io.substrait.proto.JoinRel;
+import io.substrait.proto.ProjectRel;
+import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
+import io.substrait.proto.RelCommon;
+import io.substrait.proto.SortField;
+import io.substrait.proto.SortRel;
 import io.substrait.type.proto.TypeProtoConverter;
 import java.util.Collection;
 import java.util.List;
@@ -27,7 +36,7 @@ public class RelConverter implements RelVisitor<Rel, RuntimeException> {
     return expression.accept(protoConverter);
   }
 
-  private io.substrait.proto.Rel toProto(io.substrait.relation.Rel rel) {
+  public io.substrait.proto.Rel toProto(io.substrait.relation.Rel rel) {
     return rel.accept(this);
   }
 

--- a/core/src/main/java/io/substrait/type/proto/FromProto.java
+++ b/core/src/main/java/io/substrait/type/proto/FromProto.java
@@ -5,6 +5,8 @@ import io.substrait.type.TypeCreator;
 
 public class FromProto {
 
+  private FromProto() {}
+
   public static Type from(io.substrait.proto.Type type) {
     return switch (type.getKindCase()) {
       case BOOL -> n(type.getBool().getNullability()).BOOLEAN;
@@ -37,6 +39,10 @@ public class FromProto {
           .map(from(type.getMap().getKey()), from(type.getMap().getValue()));
       case USER_DEFINED_TYPE_REFERENCE, KIND_NOT_SET -> throw new UnsupportedOperationException();
     };
+  }
+
+  public static boolean isNullable(io.substrait.proto.Type.Nullability nullability) {
+    return io.substrait.proto.Type.Nullability.NULLABILITY_NULLABLE == nullability;
   }
 
   private static TypeCreator n(io.substrait.proto.Type.Nullability n) {

--- a/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
@@ -1,5 +1,6 @@
 package io.substrait.type.proto;
 
+import static io.substrait.expression.proto.ProtoExpressionConverter.EMPTY_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -49,7 +50,7 @@ public class GenericRoundtripTest {
     Expression val = (Expression) m.invoke(null, paramInst.toArray(new Object[0]));
 
     var to = new ExpressionProtoConverter(null, null);
-    var from = new ProtoExpressionConverter(null, null, null);
+    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE);
     assertEquals(val, from.from(val.accept(to)));
   }
 

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -1,5 +1,6 @@
 package io.substrait.type.proto;
 
+import static io.substrait.expression.proto.ProtoExpressionConverter.EMPTY_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.substrait.expression.ExpressionCreator;
@@ -16,7 +17,7 @@ public class LiteralRoundtripTest {
   void decimal() {
     var val = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
     var to = new ExpressionProtoConverter(null, null);
-    var from = new ProtoExpressionConverter(null, null, null);
+    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE);
     assertEquals(val, from.from(val.accept(to)));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoRelConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoRelConverterTest.java
@@ -1,0 +1,76 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.expression.FunctionLookup;
+import io.substrait.expression.proto.FunctionCollector;
+import io.substrait.expression.proto.ImmutableFunctionLookup;
+import io.substrait.function.SimpleExtension;
+import io.substrait.proto.Plan;
+import io.substrait.proto.PlanRel;
+import io.substrait.relation.ProtoRelConverter;
+import io.substrait.relation.Rel;
+import io.substrait.relation.RelConverter;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Test;
+
+public class ProtoRelConverterTest extends PlanTestBase {
+  private void assertProtoRelRoundrip(String query) throws IOException, SqlParseException {
+    SqlToSubstrait s = new SqlToSubstrait();
+    String[] values = asString("tpch/schema.sql").split(";");
+    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    Plan p = s.execute(query, creates);
+    SimpleExtension.ExtensionCollection extensionCollection = SimpleExtension.loadDefaults();
+    FunctionLookup functionLookup = ImmutableFunctionLookup.builder().from(p).build();
+    ProtoRelConverter relConverter = new ProtoRelConverter(functionLookup, extensionCollection);
+    for (PlanRel planRel : p.getRelationsList()) {
+      io.substrait.proto.Rel protoRel1 = planRel.getRoot().getInput();
+      Rel rel = relConverter.from(protoRel1);
+      io.substrait.proto.Rel protoRel2 = new RelConverter(new FunctionCollector()).toProto(rel);
+      assertEquals(protoRel1, protoRel2);
+    }
+  }
+
+  @Test
+  public void aggregate() throws IOException, SqlParseException {
+    assertProtoRelRoundrip("select count(L_ORDERKEY),sum(L_ORDERKEY) from lineitem");
+  }
+
+  @Test
+  public void filter() throws IOException, SqlParseException {
+    assertProtoRelRoundrip("select L_ORDERKEY from lineitem WHERE L_ORDERKEY + 1 > 10");
+  }
+
+  @Test
+  public void joinAggSortLimit() throws IOException, SqlParseException {
+    assertProtoRelRoundrip(
+        "select\n"
+            + "  l.l_orderkey,\n"
+            + "  sum(l.l_extendedprice * (1 - l.l_discount)) as revenue,\n"
+            + "  o.o_orderdate,\n"
+            + "  o.o_shippriority\n"
+            + "\n"
+            + "from\n"
+            + "  \"customer\" c,\n"
+            + "  \"orders\" o,\n"
+            + "  \"lineitem\" l\n"
+            + "\n"
+            + "where\n"
+            + "  c.c_mktsegment = 'HOUSEHOLD'\n"
+            + "  and c.c_custkey = o.o_custkey\n"
+            + "  and l.l_orderkey = o.o_orderkey\n"
+            + "  and o.o_orderdate < date '1995-03-25'\n"
+            + "  and l.l_shipdate > date '1995-03-25'\n"
+            + "\n"
+            + "group by\n"
+            + "  l.l_orderkey,\n"
+            + "  o.o_orderdate,\n"
+            + "  o.o_shippriority\n"
+            + "order by\n"
+            + "  revenue desc,\n"
+            + "  o.o_orderdate\n"
+            + "limit 10");
+  }
+}


### PR DESCRIPTION
Processing on Substrait plans in Java is much more clearly accomplished by working with the POJO representation rather than the serialized proto representation. The ProtoRelConverter class implements this with the help of the existing ProtoExpressionConverter class.