### PR TITLE
Add table lookup entry point to SqlToSubstrait

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -56,15 +56,17 @@ import org.apache.calcite.sql2rel.StandardConvertletTable;
 /** Take a SQL statement and a set of table definitions and return a substrait plan. */
 public class SqlToSubstrait {
 
+  private final CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
+  private final RelDataTypeFactory factory = new JavaTypeFactoryImpl();
+  private final CalciteConnectionConfig config =
+      CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
+  private final CalciteCatalogReader catalogReader =
+      new CalciteCatalogReader(rootSchema, List.of(), factory, config);
+  private final SqlValidator validator =
+      Validator.create(factory, catalogReader, SqlValidator.Config.DEFAULT);
+
   public Plan execute(String sql, Function<List<String>, Map<String, Type>> tableLookup)
       throws SqlParseException {
-    CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
-    RelDataTypeFactory factory = new JavaTypeFactoryImpl();
-    CalciteConnectionConfig config =
-        CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
-    CalciteCatalogReader catalogReader =
-        new CalciteCatalogReader(rootSchema, List.of(), factory, config);
-    SqlValidator validator = Validator.create(factory, catalogReader, SqlValidator.Config.DEFAULT);
     SqlParser parser = SqlParser.create(sql, SqlParser.Config.DEFAULT);
     var parsed = parser.parseQuery();
     Set<SqlIdentifier> ids = new HashSet<>();
@@ -95,17 +97,10 @@ public class SqlToSubstrait {
       rootSchema.add(dt.getName(), dt);
     }
 
-    return executeInner(parsed, validator, factory, catalogReader);
+    return executeInner(parsed);
   }
 
   public Plan execute(String sql, List<String> tables) throws SqlParseException {
-    CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
-    RelDataTypeFactory factory = new JavaTypeFactoryImpl();
-    CalciteConnectionConfig config =
-        CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
-    CalciteCatalogReader catalogReader =
-        new CalciteCatalogReader(rootSchema, List.of(), factory, config);
-    SqlValidator validator = Validator.create(factory, catalogReader, SqlValidator.Config.DEFAULT);
     if (tables != null) {
       for (String tableDef : tables) {
         List<DefinedTable> tList = parseCreateTable(factory, validator, tableDef);
@@ -117,17 +112,12 @@ public class SqlToSubstrait {
 
     SqlParser parser = SqlParser.create(sql, SqlParser.Config.DEFAULT);
     var parsed = parser.parseQuery();
-    return executeInner(parsed, validator, factory, catalogReader);
+    return executeInner(parsed);
   }
 
-  private Plan executeInner(
-      SqlNode parsed,
-      SqlValidator validator,
-      RelDataTypeFactory factory,
-      CalciteCatalogReader catalogReader) {
+  private Plan executeInner(SqlNode parsed) {
     SqlToRelConverter.Config converterConfig =
         SqlToRelConverter.config().withTrimUnusedFields(true).withExpand(false);
-    validator.validate(parsed);
 
     VolcanoPlanner planner = new VolcanoPlanner(RelOptCostImpl.FACTORY, Contexts.of("hello"));
     RelOptCluster cluster = RelOptCluster.create(planner, new RexBuilder(factory));

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -62,12 +61,10 @@ public class SqlToSubstrait {
           if (table == null) {
             return null;
           }
-          List<RelDataType> types =
-              table.struct().fields().stream()
-                  .map(f -> TypeConverter.convert(factory, f))
-                  .collect(Collectors.toList());
           return new DefinedTable(
-              id.get(id.size() - 1), factory, factory.createStructType(types, table.names()));
+              id.get(id.size() - 1),
+              factory,
+              TypeConverter.convert(factory, table.struct(), table.names()));
         };
 
     CalciteSchema rootSchema = LookupCalciteSchema.createRootSchema(lookup);

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -56,7 +56,6 @@ import org.apache.calcite.sql2rel.StandardConvertletTable;
 /** Take a SQL statement and a set of table definitions and return a substrait plan. */
 public class SqlToSubstrait {
 
-
   public Plan execute(String sql, Function<List<String>, Map<String, Type>> tableLookup)
       throws SqlParseException {
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
@@ -65,8 +64,7 @@ public class SqlToSubstrait {
         CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
     CalciteCatalogReader catalogReader =
         new CalciteCatalogReader(rootSchema, List.of(), factory, config);
-    SqlValidator validator =
-        Validator.create(factory, catalogReader, SqlValidator.Config.DEFAULT);
+    SqlValidator validator = Validator.create(factory, catalogReader, SqlValidator.Config.DEFAULT);
     SqlParser parser = SqlParser.create(sql, SqlParser.Config.DEFAULT);
     var parsed = parser.parseQuery();
     Set<SqlIdentifier> ids = new HashSet<>();
@@ -107,8 +105,7 @@ public class SqlToSubstrait {
         CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
     CalciteCatalogReader catalogReader =
         new CalciteCatalogReader(rootSchema, List.of(), factory, config);
-    SqlValidator validator =
-        Validator.create(factory, catalogReader, SqlValidator.Config.DEFAULT);
+    SqlValidator validator = Validator.create(factory, catalogReader, SqlValidator.Config.DEFAULT);
     if (tables != null) {
       for (String tableDef : tables) {
         List<DefinedTable> tList = parseCreateTable(factory, validator, tableDef);
@@ -123,7 +120,11 @@ public class SqlToSubstrait {
     return executeInner(parsed, validator, factory, catalogReader);
   }
 
-  private Plan executeInner(SqlNode parsed, SqlValidator validator, RelDataTypeFactory factory, CalciteCatalogReader catalogReader) {
+  private Plan executeInner(
+      SqlNode parsed,
+      SqlValidator validator,
+      RelDataTypeFactory factory,
+      CalciteCatalogReader catalogReader) {
     SqlToRelConverter.Config converterConfig =
         SqlToRelConverter.config().withTrimUnusedFields(true).withExpand(false);
     validator.validate(parsed);

--- a/isthmus/src/main/java/org/apache/calcite/jdbc/LookupCalciteSchema.java
+++ b/isthmus/src/main/java/org/apache/calcite/jdbc/LookupCalciteSchema.java
@@ -1,0 +1,48 @@
+package org.apache.calcite.jdbc;
+
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class LookupCalciteSchema extends SimpleCalciteSchema {
+  private final Function<List<String>, Table> lookup;
+  private final Map<List<String>, Table> cache = Maps.newHashMap();
+
+  LookupCalciteSchema(
+      @Nullable CalciteSchema parent,
+      Schema schema,
+      String name,
+      Function<List<String>, Table> lookup) {
+    super(parent, schema, name);
+    this.lookup = lookup;
+  }
+
+  @Override
+  protected @Nullable CalciteSchema getImplicitSubSchema(String schemaName, boolean caseSensitive) {
+    if (cache.computeIfAbsent(path(schemaName), lookup) != null) {
+      return null;
+    }
+    plus().add(schemaName, AbstractSchema.Factory.INSTANCE.create(null, null, null));
+    return super.getSubSchema(schemaName, caseSensitive);
+  }
+
+  @Override
+  protected @Nullable TableEntry getImplicitTable(String tableName, boolean caseSensitive) {
+    Table table = cache.computeIfAbsent(path(tableName), lookup);
+    if (table == null) {
+      return null;
+    }
+    add(tableName, table);
+    return getTable(tableName, caseSensitive);
+  }
+
+  public static CalciteSchema createRootSchema(Function<List<String>, Table> lookup) {
+    Schema rootSchema = new CalciteConnectionImpl.RootSchema();
+    return new LookupCalciteSchema(null, rootSchema, "", lookup);
+  }
+}

--- a/isthmus/src/main/java/org/apache/calcite/jdbc/LookupCalciteSchema.java
+++ b/isthmus/src/main/java/org/apache/calcite/jdbc/LookupCalciteSchema.java
@@ -23,6 +23,13 @@ public class LookupCalciteSchema extends SimpleCalciteSchema {
   }
 
   @Override
+  public CalciteSchema add(String name, Schema schema) {
+    final CalciteSchema calciteSchema = new LookupCalciteSchema(this, schema, name, lookup);
+    subSchemaMap.put(name, calciteSchema);
+    return calciteSchema;
+  }
+
+  @Override
   protected @Nullable CalciteSchema getImplicitSubSchema(String schemaName, boolean caseSensitive) {
     if (cache.computeIfAbsent(path(schemaName), lookup) != null) {
       return null;

--- a/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
@@ -1,6 +1,8 @@
 package io.substrait.isthmus;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.io.IOException;
@@ -35,6 +37,14 @@ public class TableLookupTest extends PlanTestBase {
 
   @Test
   void compareProto() throws SqlParseException, IOException {
+    var names = Lists.<String>newArrayList();
+    var types = Lists.<Type>newArrayList();
+    lineitem.forEach(
+        (k, v) -> {
+          names.add(k);
+          types.add(v);
+        });
+    var struct = NamedStruct.of(names, Type.Struct.builder().fields(types).nullable(true).build());
     SqlToSubstrait s2s1 = new SqlToSubstrait();
     SqlToSubstrait s2s2 = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
@@ -46,7 +56,7 @@ public class TableLookupTest extends PlanTestBase {
             query,
             (tn) -> {
               if (tn.size() == 1 && Objects.equals(tn.get(0), "LINEITEM")) {
-                return lineitem;
+                return struct;
               }
               return null;
             });

--- a/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
@@ -2,6 +2,8 @@ package io.substrait.isthmus;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -44,7 +46,7 @@ public class TableLookupTest extends PlanTestBase {
           names.add(k);
           types.add(v);
         });
-    var struct = NamedStruct.of(names, Type.Struct.builder().fields(types).nullable(true).build());
+    var struct = NamedStruct.of(names, Type.Struct.builder().fields(types).nullable(false).build());
     SqlToSubstrait s2s1 = new SqlToSubstrait();
     SqlToSubstrait s2s2 = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
@@ -60,6 +62,52 @@ public class TableLookupTest extends PlanTestBase {
               }
               return null;
             });
+    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(plan1));
+    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(plan2));
     Assertions.assertEquals(plan1, plan2);
+  }
+
+  @Test
+  void testNamespaced() throws SqlParseException, InvalidProtocolBufferException {
+    var names = Lists.<String>newArrayList();
+    var types = Lists.<Type>newArrayList();
+    lineitem.forEach(
+        (k, v) -> {
+          names.add(k);
+          types.add(v);
+        });
+    var struct = NamedStruct.of(names, Type.Struct.builder().fields(types).nullable(false).build());
+    SqlToSubstrait s = new SqlToSubstrait();
+    var plan =
+        s.execute(
+            "SELECT * from foobar.tpch.lineitem",
+            (tn) -> {
+              if (tn.size() == 3 && Objects.equals(tn.get(2), "LINEITEM")) {
+                return struct;
+              }
+              return null;
+            });
+    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(plan));
+  }
+
+  @Test
+  void testNestedStruct() throws SqlParseException, InvalidProtocolBufferException {
+    var names = Lists.newArrayList("a", "b", "c", "d");
+    var types =
+        Lists.newArrayList(
+            TypeCreator.NULLABLE.I64,
+            TypeCreator.NULLABLE.struct(TypeCreator.NULLABLE.I64, TypeCreator.NULLABLE.FP64));
+    var struct = NamedStruct.of(names, Type.Struct.builder().fields(types).nullable(false).build());
+    SqlToSubstrait s = new SqlToSubstrait();
+    var plan =
+        s.execute(
+            "SELECT * from lineitem",
+            (tn) -> {
+              if (tn.size() == 1 && Objects.equals(tn.get(0), "LINEITEM")) {
+                return struct;
+              }
+              return null;
+            });
+    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(plan));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
@@ -1,0 +1,55 @@
+package io.substrait.isthmus;
+
+import com.google.common.collect.ImmutableMap;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TableLookupTest extends PlanTestBase {
+
+  private static Map<String, Type> lineitem =
+      ImmutableMap.<String, Type>builder()
+          .put("L_ORDERKEY", TypeCreator.REQUIRED.I64)
+          .put("L_PARTKEY", TypeCreator.REQUIRED.I64)
+          .put("L_SUPPKEY", TypeCreator.REQUIRED.I64)
+          .put("L_LINENUMBER", TypeCreator.NULLABLE.I32)
+          .put("L_QUANTITY", TypeCreator.NULLABLE.decimal(38, 0))
+          .put("L_EXTENDEDPRICE", TypeCreator.NULLABLE.decimal(38, 0))
+          .put("L_DISCOUNT", TypeCreator.NULLABLE.decimal(38, 0))
+          .put("L_TAX", TypeCreator.NULLABLE.decimal(38, 0))
+          .put("L_RETURNFLAG", TypeCreator.NULLABLE.fixedChar(1))
+          .put("L_LINESTATUS", TypeCreator.NULLABLE.fixedChar(1))
+          .put("L_SHIPDATE", TypeCreator.NULLABLE.DATE)
+          .put("L_COMMITDATE", TypeCreator.NULLABLE.DATE)
+          .put("L_RECEIPTDATE", TypeCreator.NULLABLE.DATE)
+          .put("L_SHIPINSTRUCT", TypeCreator.NULLABLE.fixedChar(25))
+          .put("L_SHIPMODE", TypeCreator.NULLABLE.fixedChar(10))
+          .put("L_COMMENT", TypeCreator.NULLABLE.varChar(44))
+          .build();
+
+  @Test
+  void compareProto() throws SqlParseException, IOException {
+    SqlToSubstrait s2s1 = new SqlToSubstrait();
+    SqlToSubstrait s2s2 = new SqlToSubstrait();
+    String[] values = asString("tpch/schema.sql").split(";");
+    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    String query = asString("tpch/queries/01.sql");
+    var plan1 = s2s1.execute(query, creates);
+    var plan2 =
+        s2s2.execute(
+            query,
+            (tn) -> {
+              if (tn.size() == 1 && Objects.equals(tn.get(0), "LINEITEM")) {
+                return lineitem;
+              }
+              return null;
+            });
+    Assertions.assertEquals(plan1, plan2);
+  }
+}


### PR DESCRIPTION
This uses a function to look up a table schema without a create table statement. I've intentionally kept the interface free from calcite objects so as to not export them as part of the isthmus public API.

I am not an expert at calcite so I am not sure if this is the best way to do it. Also, note, my fix adds state to the converter. Happy to adjust based on input.