### PR TITLE
Generate extension uris and functions from pojos instead of storing

### DIFF
--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -1,8 +1,6 @@
 package io.substrait.plan;
 
 import io.substrait.proto.AdvancedExtension;
-import io.substrait.proto.SimpleExtensionDeclaration;
-import io.substrait.proto.SimpleExtensionURI;
 import io.substrait.relation.Rel;
 import java.util.List;
 import java.util.Optional;
@@ -15,10 +13,6 @@ public abstract class Plan {
   public abstract List<Root> getRoots();
 
   public abstract List<String> getExpectedTypeUrls();
-
-  public abstract List<SimpleExtensionDeclaration> getExtensionDeclarations();
-
-  public abstract List<SimpleExtensionURI> getExtensionUris();
 
   public abstract Optional<AdvancedExtension> getAdvancedExtension();
 

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -14,8 +14,9 @@ public class PlanProtoConverter {
 
   public Plan toProto(io.substrait.plan.Plan plan) {
     List<PlanRel> planRels = new ArrayList<>();
+    FunctionCollector functionCollector = new FunctionCollector();
     for (io.substrait.plan.Plan.Root root : plan.getRoots()) {
-      Rel input = new RelProtoConverter(new FunctionCollector()).toProto(root.getInput());
+      Rel input = new RelProtoConverter(functionCollector).toProto(root.getInput());
       planRels.add(
           PlanRel.newBuilder()
               .setRoot(
@@ -26,10 +27,9 @@ public class PlanProtoConverter {
     }
     Plan.Builder builder =
         Plan.newBuilder()
-            .addAllExtensionUris(plan.getExtensionUris())
-            .addAllExtensions(plan.getExtensionDeclarations())
-            .addAllExpectedTypeUrls(plan.getExpectedTypeUrls())
-            .addAllRelations(planRels);
+            .addAllRelations(planRels)
+            .addAllExpectedTypeUrls(plan.getExpectedTypeUrls());
+    functionCollector.addFunctionsToPlan(builder);
     if (plan.getAdvancedExtension().isPresent()) {
       builder.setAdvancedExtensions(plan.getAdvancedExtension().get());
     }

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -37,8 +37,6 @@ public class ProtoPlanConverter {
     return ImmutablePlan.builder()
         .roots(roots)
         .expectedTypeUrls(plan.getExpectedTypeUrlsList())
-        .extensionDeclarations(plan.getExtensionsList())
-        .extensionUris(plan.getExtensionUrisList())
         .advancedExtension(
             Optional.ofNullable(plan.hasAdvancedExtensions() ? plan.getAdvancedExtensions() : null))
         .build();


### PR DESCRIPTION
Fix bug in Plan proto conversion caused by storing extension uris and functions in Plan pojo and using when generating proto instead of regenerating.