### PR TITLE
Issue #62: For calcite SqlSearchOperator expand the Sarg Literals into a simple predicates.

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.*;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -56,6 +57,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     var converters = new ArrayList<CallConverter>();
     converters.addAll(CallConverters.DEFAULTS);
     converters.add(new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory));
+    converters.add(CallConverters.CREATE_SEARCH_CONV.apply(new RexBuilder(typeFactory)));
     this.aggregateFunctionConverter =
         new AggregateFunctionConverter(extensions.aggregateFunctions(), typeFactory);
     var windowFunctionConverter =

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
@@ -25,13 +25,13 @@ public class LiteralConstructorConverter implements CallConverter {
           ExpressionCreator.list(
               false,
               call.operands.stream()
-                  .map(t -> ((Expression.Literal) t.accept(new RexExpressionConverter())))
+                  .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
                   .toList()));
 
       case SqlMapValueConstructor map -> {
         List<Expression.Literal> literals =
             call.operands.stream()
-                .map(t -> ((Expression.Literal) t.accept(new RexExpressionConverter())))
+                .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
                 .toList();
         Map<Expression.Literal, Expression.Literal> items = new HashMap<>();
         assert literals.size() % 2 == 0;

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -44,6 +44,9 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
     this.windowFunctionConverter = windowFunctionConverter;
   }
 
+  /**
+   * Only used for testing. Missing `ScalarFunctionConverter`, `CallConverters.CREATE_SEARCH_CONV`
+   */
   public RexExpressionConverter() {
     this.callConverters = CallConverters.DEFAULTS;
     this.relVisitor =

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
@@ -9,7 +9,8 @@ public class TpchQueryNoValidation extends PlanTestBase {
 
   @ParameterizedTest
   // @ValueSource(ints = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22})
-  @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 10, 11, 14, 15, 17, 18, 19, 20, 21})
+  @ValueSource(
+      ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22})
   public void tpch(int query) throws Exception {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");


### PR DESCRIPTION
Invoke `RexUtil.expandSearch` to do the conversion.
