### PR TITLE
Fix issue #18

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -153,10 +153,12 @@ public class ProtoRelConverter {
               .fields(struct.getFieldsList().stream().map(ProtoExpressionConverter::from).toList())
               .build());
     }
+    var fieldNames = rel.getBaseSchema().getNamesList().stream().toList();
     var converter = new ProtoExpressionConverter(lookup, extensions, EMPTY_TYPE);
     return VirtualTableScan.builder()
         .filter(Optional.ofNullable(rel.hasFilter() ? converter.from(rel.getFilter()) : null))
         .remap(optionalRelmap(rel.getCommon()))
+        .addAllDfsNames(fieldNames)
         .rows(structLiterals)
         .build();
   }

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -3,7 +3,6 @@ package io.substrait.relation;
 import io.substrait.expression.Expression;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
-import io.substrait.type.TypeCreator;
 import java.util.List;
 import org.immutables.value.Value;
 
@@ -14,11 +13,26 @@ public abstract class VirtualTableScan extends AbstractReadRel {
 
   public abstract List<Expression.StructLiteral> getRows();
 
+  /**
+   *
+   * <li>non-empty rowset
+   * <li>non-null field-names
+   * <li>no null rows
+   * <li>row shape must match field-list
+   */
+  @Value.Check
+  protected void check() {
+    var names = getDfsNames();
+    var rows = getRows();
+
+    assert rows.size() > 0
+        && names.stream().noneMatch(s -> s == null)
+        && rows.stream().noneMatch(r -> r == null || r.fields().size() != names.size());
+  }
+
   @Override
   public final NamedStruct getInitialSchema() {
-    Type.Struct struct = TypeCreator.REQUIRED.struct(getRows().stream().map(Expression::getType));
-
-    return NamedStruct.of(getDfsNames(), struct);
+    return NamedStruct.of(getDfsNames(), (Type.Struct) getRows().get(0).getType());
   }
 
   @Override

--- a/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
@@ -49,4 +49,11 @@ public class SimplePlansTest extends PlanTestBase {
         new SqlToSubstrait(
             new SqlToSubstrait.Options(SqlToSubstrait.StatementBatching.MULTI_STATEMENT)));
   }
+
+  @Test
+  public void virtualTable() throws IOException, SqlParseException {
+    assertProtoPlanRoundrip("SELECT  1");
+    assertProtoPlanRoundrip(
+        "SELECT  * FROM    ( " + "        VALUES (1), (3) " + "        ) AS q (col1)");
+  }
 }


### PR DESCRIPTION
sub-issue:
Virtual tables receive a schema representing a single column of structs containing the fields.
Failing example: select 1 is given the schema STRUCT<STRUCT<i32>>.