### PR TITLE
Fix issue #18

### DIFF
--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -108,7 +108,7 @@ public class ToTypeString
 
   @Override
   public String visit(final Type.Decimal expr) {
-    return "decimal";
+    return "dec";
   }
 
   @Override
@@ -143,7 +143,7 @@ public class ToTypeString
 
   @Override
   public String visit(ParameterizedType.Decimal expr) throws RuntimeException {
-    return "decimal";
+    return "dec";
   }
 
   @Override
@@ -164,7 +164,7 @@ public class ToTypeString
   @Override
   public String visit(ParameterizedType.StringLiteral expr) throws RuntimeException {
     if (expr.value().toLowerCase().startsWith("any")) {
-      return expr.value();
+      return "any";
     } else {
       return super.visit(expr);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -74,13 +74,13 @@ public class FunctionMappings {
             SqlStdOperatorTable.PLUS,
                 resolver(
                     SqlStdOperatorTable.PLUS,
-                    Set.of("i8", "i16", "i32", "i64", "f32", "f64", "decimal")),
+                    Set.of("i8", "i16", "i32", "i64", "f32", "f64", "dec")),
             SqlStdOperatorTable.DATETIME_PLUS,
                 resolver(SqlStdOperatorTable.PLUS, Set.of("date", "time", "timestamp")),
             SqlStdOperatorTable.MINUS,
                 resolver(
                     SqlStdOperatorTable.MINUS,
-                    Set.of("i8", "i16", "i32", "i64", "f32", "f64", "decimal")),
+                    Set.of("i8", "i16", "i32", "i64", "f32", "f64", "dec")),
             SqlStdOperatorTable.MINUS_DATE,
                 resolver(
                     SqlStdOperatorTable.MINUS_DATE, Set.of("date", "timestamp_tz", "timestamp")));


### PR DESCRIPTION
sub-issue:
The emitted function signatures don't follow the spec.
For example, decimal is used instead of dec, and any1 is used in place of just any.