### PR TITLE
Convert 'or' function call to 'singleOrList' exression

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -159,6 +159,16 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
   }
 
   @Override
+  public RexNode visit(Expression.FixedCharLiteral expr) throws RuntimeException {
+    return rexBuilder.makeLiteral(expr.value(), TypeConverter.convert(typeFactory, expr.getType()));
+  }
+
+  @Override
+  public RexNode visit(Expression.VarCharLiteral expr) throws RuntimeException {
+    return rexBuilder.makeLiteral(expr.value(), TypeConverter.convert(typeFactory, expr.getType()),true);
+  }
+
+  @Override
   public RexNode visit(Expression.ScalarFunctionInvocation expr) throws RuntimeException {
     var eArgs = expr.arguments();
     var args =

--- a/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
@@ -170,4 +170,10 @@ public class Substrait2SqlTest extends PlanTestBase {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey from lineitem where l_shipdate < date '1998-01-01' order by l_shipdate asc, l_discount desc nulls last");
   }
+
+  @Test
+  public void simpleTestSingleOrList() throws Exception {
+    assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where L_PARTKEY in (1,2,3)");
+    assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where L_PARTKEY = 1 or L_PARTKEY = 2 or L_PARTKEY = 3 ");
+  }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
@@ -175,5 +175,9 @@ public class Substrait2SqlTest extends PlanTestBase {
   public void simpleTestSingleOrList() throws Exception {
     assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where L_PARTKEY in (1,2,3)");
     assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where L_PARTKEY = 1 or L_PARTKEY = 2 or L_PARTKEY = 3 ");
+    assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where L_COMMENT in ('0000', '1111', '2222') ");
+    assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where L_COMMENT = '0000' or L_COMMENT = '1111' or L_COMMENT = '2222' ");
+    assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where SUBSTRING(L_COMMENT, 0, 3) in ('0000', '1111', '2222') ");
+    assertSqlSubstraitRelRoundTrip("select l_partkey from lineitem where SUBSTRING(L_COMMENT, 0, 3) = '0000' or SUBSTRING(L_COMMENT, 0, 3) = '1111' or SUBSTRING(L_COMMENT, 0, 3) = '2222' ");
   }
 }


### PR DESCRIPTION
 Convert 'or' call to substrait singleOrList in case of calcite optimize the 'in' expression as 'or' expression.
