### PR TITLE
Downgrade java jar file output to java 11.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
   id("java")
   id("idea")
   id("com.github.vlsi.gradle-extensions") version "1.74"
-  id("com.diffplug.spotless") version "6.5.1"
+  id("com.diffplug.spotless") version "6.11.0"
 }
 
 publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
@@ -22,6 +22,8 @@ dependencies {
   implementation("org.slf4j:slf4j-jdk14:1.7.30")
   annotationProcessor("org.immutables:value:2.8.8")
   compileOnly("org.immutables:value-annotations:2.8.8")
+  annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
+  compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
 val submodulesUpdate by
@@ -34,12 +36,19 @@ val submodulesUpdate by
 allprojects {
   repositories { mavenCentral() }
 
-  tasks.configureEach<Test> { useJUnitPlatform() }
-  tasks.withType<JavaCompile> { dependsOn(submodulesUpdate) }
+  tasks.configureEach<Test> {
+    val javaToolchains = project.extensions.getByType<JavaToolchainService>()
+    useJUnitPlatform()
+    // javaLauncher.set(javaToolchains.launcherFor {
+    // languageVersion.set(JavaLanguageVersion.of(8))
+    // })
+  }
+  tasks.withType<JavaCompile> {
+    sourceCompatibility = "17"
+    options.release.set(11)
 
-  tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("--enable-preview") }
-
-  tasks.withType<Test>().configureEach { jvmArgs("--enable-preview") }
+    dependsOn(submodulesUpdate)
+  }
 
   group = "io.substrait"
   version = "1.0-SNAPSHOT"
@@ -51,9 +60,7 @@ allprojects {
         googleJavaFormat()
         removeUnusedImports()
         trimTrailingWhitespace()
-        targetExclude(
-          "**/build*/**",
-        )
+        targetExclude("**/build/**")
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,9 +39,7 @@ allprojects {
   tasks.configureEach<Test> {
     val javaToolchains = project.extensions.getByType<JavaToolchainService>()
     useJUnitPlatform()
-    // javaLauncher.set(javaToolchains.launcherFor {
-    // languageVersion.set(JavaLanguageVersion.of(8))
-    // })
+    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
   }
   tasks.withType<JavaCompile> {
     sourceCompatibility = "17"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
   id("idea")
   id("antlr")
   id("com.google.protobuf") version "0.8.17"
-  id("com.diffplug.spotless") version "6.5.1"
+  id("com.diffplug.spotless") version "6.11.0"
 }
 
 publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
@@ -18,10 +18,10 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.0")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
   implementation("com.google.protobuf:protobuf-java:3.17.3")
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.12.4")
-  implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.4")
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4")
-  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
+  implementation("com.fasterxml.jackson.core:jackson-annotations:2.13.4")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4")
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4")
   implementation("com.google.code.findbugs:jsr305:3.0.2")
 
   antlr("org.antlr:antlr4:4.9.2")
@@ -29,6 +29,8 @@ dependencies {
   implementation("org.antlr:antlr4:4.9.2")
   annotationProcessor("org.immutables:value:2.8.8")
   compileOnly("org.immutables:value-annotations:2.8.8")
+  annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
+  compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -451,7 +451,10 @@ public interface Expression extends FunctionArg {
 
     public Type getType() {
       return Type.withNullability(nullable())
-          .struct(fields().stream().map(Literal::getType).toList());
+          .struct(
+              fields().stream()
+                  .map(Literal::getType)
+                  .collect(java.util.stream.Collectors.toList()));
     }
 
     public static ImmutableExpression.StructLiteral.Builder builder() {

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -95,7 +95,7 @@ public class ProtoExpressionConverter {
         var args =
             IntStream.range(0, scalarFunction.getArgumentsCount())
                 .mapToObj(i -> pF.convert(declaration, i, scalarFunction.getArguments(i)))
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
         yield ImmutableExpression.ScalarFunctionInvocation.builder()
             .addAllArguments(args)
             .declaration(declaration)
@@ -107,7 +107,7 @@ public class ProtoExpressionConverter {
         var clauses =
             ifThen.getIfsList().stream()
                 .map(t -> ExpressionCreator.ifThenClause(from(t.getIf()), from(t.getThen())))
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
         yield ExpressionCreator.ifThenStatement(from(ifThen.getElse()), clauses);
       }
       case SWITCH_EXPRESSION -> {
@@ -115,12 +115,15 @@ public class ProtoExpressionConverter {
         var clauses =
             switchExpr.getIfsList().stream()
                 .map(t -> ExpressionCreator.switchClause(from(t.getIf()), from(t.getThen())))
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
         yield ExpressionCreator.switchStatement(from(switchExpr.getElse()), clauses);
       }
       case SINGULAR_OR_LIST -> {
         var orList = expr.getSingularOrList();
-        var values = orList.getOptionsList().stream().map(this::from).toList();
+        var values =
+            orList.getOptionsList().stream()
+                .map(this::from)
+                .collect(java.util.stream.Collectors.toList());
         yield ImmutableExpression.SingleOrList.builder()
             .condition(from(orList.getValue()))
             .addAllOptions(values)
@@ -133,12 +136,18 @@ public class ProtoExpressionConverter {
                 .map(
                     t ->
                         ImmutableExpression.MultiOrListRecord.builder()
-                            .addAllValues(t.getFieldsList().stream().map(this::from).toList())
+                            .addAllValues(
+                                t.getFieldsList().stream()
+                                    .map(this::from)
+                                    .collect(java.util.stream.Collectors.toList()))
                             .build())
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
         yield ImmutableExpression.MultiOrList.builder()
             .addAllOptionCombinations(values)
-            .addAllConditions(multiOrList.getValueList().stream().map(this::from).toList())
+            .addAllConditions(
+                multiOrList.getValueList().stream()
+                    .map(this::from)
+                    .collect(java.util.stream.Collectors.toList()))
             .build();
       }
       case CAST -> ExpressionCreator.cast(
@@ -172,7 +181,7 @@ public class ProtoExpressionConverter {
             var needles =
                 expr.getSubquery().getInPredicate().getNeedlesList().stream()
                     .map(e -> this.from(e))
-                    .toList();
+                    .collect(java.util.stream.Collectors.toList());
             yield ImmutableExpression.InPredicate.builder()
                 .haystack(rel)
                 .needles(needles)
@@ -237,7 +246,7 @@ public class ProtoExpressionConverter {
           literal.getNullable(),
           literal.getStruct().getFieldsList().stream()
               .map(ProtoExpressionConverter::from)
-              .toList());
+              .collect(java.util.stream.Collectors.toList()));
       case MAP -> ExpressionCreator.map(
           literal.getNullable(),
           literal.getMap().getKeyValuesList().stream()
@@ -248,7 +257,9 @@ public class ProtoExpressionConverter {
       case NULL -> ExpressionCreator.typedNull(from(literal.getNull()));
       case LIST -> ExpressionCreator.list(
           literal.getNullable(),
-          literal.getList().getValuesList().stream().map(ProtoExpressionConverter::from).toList());
+          literal.getList().getValuesList().stream()
+              .map(ProtoExpressionConverter::from)
+              .collect(java.util.stream.Collectors.toList()));
       default -> throw new IllegalStateException(
           "Unexpected value: " + literal.getLiteralTypeCase());
     };

--- a/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
@@ -51,7 +51,26 @@ public class TypeExpressionCreator extends TypeCreator
     return TypeExpression.Map.builder().nullable(nullable).key(key).value(value).build();
   }
 
-  public record Assign(String name, TypeExpression expr) {}
+  public static class Assign {
+
+    public Assign() {}
+
+    public Assign(final String name, final TypeExpression expr) {
+      this.name = name;
+      this.expr = expr;
+    }
+
+    String name;
+    TypeExpression expr;
+
+    public String name() {
+      return name;
+    }
+
+    public TypeExpression expr() {
+      return expr;
+    }
+  }
   ;
 
   public static TypeExpression program(TypeExpression finalExpr, Assign... assignments) {
@@ -65,7 +84,7 @@ public class TypeExpressionCreator extends TypeCreator
                             .name(a.name())
                             .expr(a.expr())
                             .build())
-                .toList())
+                .collect(java.util.stream.Collectors.toList()))
         .build();
   }
 

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -109,7 +109,10 @@ public class ProtoRelConverter {
         .names(namedStruct.getNamesList())
         .struct(
             Type.Struct.builder()
-                .fields(struct.getTypesList().stream().map(FromProto::from).toList())
+                .fields(
+                    struct.getTypesList().stream()
+                        .map(FromProto::from)
+                        .collect(java.util.stream.Collectors.toList()))
                 .nullable(FromProto.isNullable(struct.getNullability()))
                 .build())
         .build();
@@ -150,10 +153,14 @@ public class ProtoRelConverter {
     for (var struct : virtualTable.getValuesList()) {
       structLiterals.add(
           ImmutableExpression.StructLiteral.builder()
-              .fields(struct.getFieldsList().stream().map(ProtoExpressionConverter::from).toList())
+              .fields(
+                  struct.getFieldsList().stream()
+                      .map(ProtoExpressionConverter::from)
+                      .collect(java.util.stream.Collectors.toList()))
               .build());
     }
-    var fieldNames = rel.getBaseSchema().getNamesList().stream().toList();
+    var fieldNames =
+        rel.getBaseSchema().getNamesList().stream().collect(java.util.stream.Collectors.toList());
     var converter = new ProtoExpressionConverter(lookup, extensions, EMPTY_TYPE);
     return VirtualTableScan.builder()
         .filter(Optional.ofNullable(rel.hasFilter() ? converter.from(rel.getFilter()) : null))
@@ -179,7 +186,10 @@ public class ProtoRelConverter {
     return Project.builder()
         .input(input)
         .remap(optionalRelmap(rel.getCommon()))
-        .expressions(rel.getExpressionsList().stream().map(converter::from).toList())
+        .expressions(
+            rel.getExpressionsList().stream()
+                .map(converter::from)
+                .collect(java.util.stream.Collectors.toList()))
         .build();
   }
 
@@ -191,7 +201,9 @@ public class ProtoRelConverter {
       groupings.add(
           Aggregate.Grouping.builder()
               .expressions(
-                  grouping.getGroupingExpressionsList().stream().map(converter::from).toList())
+                  grouping.getGroupingExpressionsList().stream()
+                      .map(converter::from)
+                      .collect(java.util.stream.Collectors.toList()))
               .build());
     }
     List<Aggregate.Measure> measures = new ArrayList<>(rel.getMeasuresCount());
@@ -202,7 +214,7 @@ public class ProtoRelConverter {
       var args =
           IntStream.range(0, measure.getMeasure().getArgumentsCount())
               .mapToObj(i -> pF.convert(funcDecl, i, measure.getMeasure().getArguments(i)))
-              .toList();
+              .collect(java.util.stream.Collectors.toList());
       measures.add(
           Aggregate.Measure.builder()
               .function(
@@ -240,7 +252,7 @@ public class ProtoRelConverter {
                             .direction(Expression.SortDirection.fromProto(field.getDirection()))
                             .expr(converter.from(field.getExpr()))
                             .build())
-                .toList())
+                .collect(java.util.stream.Collectors.toList()))
         .build();
   }
 
@@ -278,7 +290,10 @@ public class ProtoRelConverter {
   }
 
   private Set newSet(SetRel rel) {
-    List<Rel> inputs = rel.getInputsList().stream().map(inputRel -> from(inputRel)).toList();
+    List<Rel> inputs =
+        rel.getInputsList().stream()
+            .map(inputRel -> from(inputRel))
+            .collect(java.util.stream.Collectors.toList());
     return Set.builder()
         .inputs(inputs)
         .setOp(Set.SetOp.fromProto(rel.getOp()))

--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -28,7 +28,10 @@ public interface Rel {
     }
 
     public static Remap offset(int start, int length) {
-      return of(IntStream.range(start, start + length).mapToObj(i -> i).toList());
+      return of(
+          IntStream.range(start, start + length)
+              .mapToObj(i -> i)
+              .collect(java.util.stream.Collectors.toList()));
     }
   }
 

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -43,12 +43,12 @@ public class RelCopyOnWriteVisitor extends AbstractRelVisitor<Optional<Rel>, Run
   private Optional<List<FunctionArg>> transformFuncArgs(List<FunctionArg> oldExpressions) {
     return transformList(
         oldExpressions,
-        t ->
-            switch (t) {
-              case Expression e -> this.visitExpression(e)
-                  .flatMap(ex -> Optional.<FunctionArg>of(ex));
-              default -> Optional.of(t);
-            });
+        t -> {
+          if (t instanceof Expression) {
+            return this.visitExpression((Expression) t).flatMap(ex -> Optional.<FunctionArg>of(ex));
+          }
+          return Optional.of(t);
+        });
   }
 
   private static boolean allEmpty(Optional<?>... optionals) {

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -33,7 +33,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
   }
 
   private List<io.substrait.proto.Expression> toProto(Collection<Expression> expressions) {
-    return expressions.stream().map(this::toProto).toList();
+    return expressions.stream().map(this::toProto).collect(java.util.stream.Collectors.toList());
   }
 
   private io.substrait.proto.Expression toProto(Expression expression) {
@@ -57,7 +57,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                   .setExpr(toProto(s.expr()))
                   .build();
             })
-        .toList();
+        .collect(java.util.stream.Collectors.toList());
   }
 
   @Override
@@ -66,8 +66,14 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
         AggregateRel.newBuilder()
             .setInput(toProto(aggregate.getInput()))
             .setCommon(common(aggregate))
-            .addAllGroupings(aggregate.getGroupings().stream().map(this::toProto).toList())
-            .addAllMeasures(aggregate.getMeasures().stream().map(this::toProto).toList());
+            .addAllGroupings(
+                aggregate.getGroupings().stream()
+                    .map(this::toProto)
+                    .collect(java.util.stream.Collectors.toList()))
+            .addAllMeasures(
+                aggregate.getMeasures().stream()
+                    .map(this::toProto)
+                    .collect(java.util.stream.Collectors.toList()));
 
     return Rel.newBuilder().setAggregate(builder).build();
   }
@@ -85,7 +91,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .addAllArguments(
                 IntStream.range(0, args.size())
                     .mapToObj(i -> args.get(i).accept(aggFuncDef, i, argVisitor))
-                    .toList())
+                    .collect(java.util.stream.Collectors.toList()))
             .addAllSorts(toProtoS(measure.getFunction().sort()))
             .setFunctionReference(
                 functionCollector.getFunctionReference(measure.getFunction().declaration()));
@@ -180,7 +186,10 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
         ProjectRel.newBuilder()
             .setCommon(common(project))
             .setInput(toProto(project.getInput()))
-            .addAllExpressions(project.getExpressions().stream().map(this::toProto).toList());
+            .addAllExpressions(
+                project.getExpressions().stream()
+                    .map(this::toProto)
+                    .collect(java.util.stream.Collectors.toList()));
 
     return Rel.newBuilder().setProject(builder).build();
   }
@@ -217,7 +226,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                             virtualTableScan.getRows().stream()
                                 .map(this::toProto)
                                 .map(t -> t.getLiteral().getStruct())
-                                .toList())
+                                .collect(java.util.stream.Collectors.toList()))
                         .build())
                 .setBaseSchema(virtualTableScan.getInitialSchema().toProto())
                 .build())

--- a/core/src/main/java/io/substrait/type/YamlRead.java
+++ b/core/src/main/java/io/substrait/type/YamlRead.java
@@ -38,7 +38,7 @@ public class YamlRead {
     return loadFunctions(
         FUNCTIONS.stream()
             .map(c -> String.format("/src/substrait/extensions/functions_%s.yaml", c))
-            .toList());
+            .collect(java.util.stream.Collectors.toList()));
   }
 
   public static List<SimpleExtension.Function> loadFunctions(List<String> files) {

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -213,14 +213,23 @@ public class ParseToPojo {
 
     @Override
     public TypeExpression visitStruct(final SubstraitTypeParser.StructContext ctx) {
-      var types = ctx.expr().stream().map(t -> t.accept(this)).toList();
+      var types =
+          ctx.expr().stream()
+              .map(t -> t.accept(this))
+              .collect(java.util.stream.Collectors.toList());
       if (types.stream().allMatch(t -> t instanceof Type)) {
-        return withNull(ctx).struct(types.stream().map(t -> ((Type) t)).toList());
+        return withNull(ctx)
+            .struct(
+                types.stream().map(t -> ((Type) t)).collect(java.util.stream.Collectors.toList()));
       }
 
       if (types.stream().allMatch(t -> t instanceof ParameterizedType)) {
         checkParameterizedOrExpression();
-        return withNullP(ctx).structE(types.stream().map(t -> ((ParameterizedType) t)).toList());
+        return withNullP(ctx)
+            .structE(
+                types.stream()
+                    .map(t -> ((ParameterizedType) t))
+                    .collect(java.util.stream.Collectors.toList()));
       }
 
       checkExpression();
@@ -320,8 +329,14 @@ public class ParseToPojo {
     public TypeExpression visitMultilineDefinition(
         final SubstraitTypeParser.MultilineDefinitionContext ctx) {
       checkExpression();
-      var exprs = ctx.expr().stream().map(t -> t.accept(this)).toList();
-      var identifiers = ctx.Identifier().stream().map(t -> t.getText()).toList();
+      var exprs =
+          ctx.expr().stream()
+              .map(t -> t.accept(this))
+              .collect(java.util.stream.Collectors.toList());
+      var identifiers =
+          ctx.Identifier().stream()
+              .map(t -> t.getText())
+              .collect(java.util.stream.Collectors.toList());
       var finalExpr = ctx.finalType.accept(this);
 
       var bldr = TypeExpression.ReturnProgram.builder();

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -121,7 +121,11 @@ abstract class BaseProtoConverter<T, I>
 
   @Override
   public final T visit(final Type.Struct expr) {
-    return typeContainer(expr).struct(expr.fields().stream().map(t -> t.accept(this)).toList());
+    return typeContainer(expr)
+        .struct(
+            expr.fields().stream()
+                .map(t -> t.accept(this))
+                .collect(java.util.stream.Collectors.toList()));
   }
 
   @Override

--- a/core/src/main/java/io/substrait/type/proto/FromProto.java
+++ b/core/src/main/java/io/substrait/type/proto/FromProto.java
@@ -33,7 +33,10 @@ public class FromProto {
       case DECIMAL -> n(type.getDecimal().getNullability())
           .decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
       case STRUCT -> n(type.getStruct().getNullability())
-          .struct(type.getStruct().getTypesList().stream().map(FromProto::from).toList());
+          .struct(
+              type.getStruct().getTypesList().stream()
+                  .map(FromProto::from)
+                  .collect(java.util.stream.Collectors.toList()));
       case LIST -> n(type.getList().getNullability()).list(from(type.getList().getType()));
       case MAP -> n(type.getMap().getNullability())
           .map(from(type.getMap().getKey()), from(type.getMap().getValue()));

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -56,7 +56,11 @@ public class ParameterizedProtoConverter
   @Override
   public ParameterizedType visit(io.substrait.function.ParameterizedType.Struct expr)
       throws RuntimeException {
-    return typeContainer(expr).struct(expr.fields().stream().map(f -> f.accept(this)).toList());
+    return typeContainer(expr)
+        .struct(
+            expr.fields().stream()
+                .map(f -> f.accept(this))
+                .collect(java.util.stream.Collectors.toList()));
   }
 
   @Override
@@ -197,33 +201,54 @@ public class ParameterizedProtoConverter
     @Override
     protected ParameterizedType wrap(final Object o) {
       var bldr = ParameterizedType.newBuilder();
-      return switch (o) {
-        case Type.Boolean t -> bldr.setBool(t).build();
-        case Type.I8 t -> bldr.setI8(t).build();
-        case Type.I16 t -> bldr.setI16(t).build();
-        case Type.I32 t -> bldr.setI32(t).build();
-        case Type.I64 t -> bldr.setI64(t).build();
-        case Type.FP32 t -> bldr.setFp32(t).build();
-        case Type.FP64 t -> bldr.setFp64(t).build();
-        case Type.String t -> bldr.setString(t).build();
-        case Type.Binary t -> bldr.setBinary(t).build();
-        case Type.Timestamp t -> bldr.setTimestamp(t).build();
-        case Type.Date t -> bldr.setDate(t).build();
-        case Type.Time t -> bldr.setTime(t).build();
-        case Type.TimestampTZ t -> bldr.setTimestampTz(t).build();
-        case Type.IntervalYear t -> bldr.setIntervalYear(t).build();
-        case Type.IntervalDay t -> bldr.setIntervalDay(t).build();
-        case ParameterizedType.ParameterizedFixedChar t -> bldr.setFixedChar(t).build();
-        case ParameterizedType.ParameterizedVarChar t -> bldr.setVarchar(t).build();
-        case ParameterizedType.ParameterizedFixedBinary t -> bldr.setFixedBinary(t).build();
-        case ParameterizedType.ParameterizedDecimal t -> bldr.setDecimal(t).build();
-        case ParameterizedType.ParameterizedStruct t -> bldr.setStruct(t).build();
-        case ParameterizedType.ParameterizedList t -> bldr.setList(t).build();
-        case ParameterizedType.ParameterizedMap t -> bldr.setMap(t).build();
-        case Type.UUID t -> bldr.setUuid(t).build();
-        default -> throw new UnsupportedOperationException(
-            "Unable to wrap type of " + o.getClass());
-      };
+      if (o instanceof Type.Boolean t) {
+        return bldr.setBool(t).build();
+      } else if (o instanceof Type.I8 t) {
+        return bldr.setI8(t).build();
+      } else if (o instanceof Type.I16 t) {
+        return bldr.setI16(t).build();
+      } else if (o instanceof Type.I32 t) {
+        return bldr.setI32(t).build();
+      } else if (o instanceof Type.I64 t) {
+        return bldr.setI64(t).build();
+      } else if (o instanceof Type.FP32 t) {
+        return bldr.setFp32(t).build();
+      } else if (o instanceof Type.FP64 t) {
+        return bldr.setFp64(t).build();
+      } else if (o instanceof Type.String t) {
+        return bldr.setString(t).build();
+      } else if (o instanceof Type.Binary t) {
+        return bldr.setBinary(t).build();
+      } else if (o instanceof Type.Timestamp t) {
+        return bldr.setTimestamp(t).build();
+      } else if (o instanceof Type.Date t) {
+        return bldr.setDate(t).build();
+      } else if (o instanceof Type.Time t) {
+        return bldr.setTime(t).build();
+      } else if (o instanceof Type.TimestampTZ t) {
+        return bldr.setTimestampTz(t).build();
+      } else if (o instanceof Type.IntervalYear t) {
+        return bldr.setIntervalYear(t).build();
+      } else if (o instanceof Type.IntervalDay t) {
+        return bldr.setIntervalDay(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedFixedChar t) {
+        return bldr.setFixedChar(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedVarChar t) {
+        return bldr.setVarchar(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedFixedBinary t) {
+        return bldr.setFixedBinary(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedDecimal t) {
+        return bldr.setDecimal(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedStruct t) {
+        return bldr.setStruct(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedList t) {
+        return bldr.setList(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedMap t) {
+        return bldr.setMap(t).build();
+      } else if (o instanceof Type.UUID t) {
+        return bldr.setUuid(t).build();
+      }
+      throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }
   }
 }

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -89,7 +89,7 @@ public class TypeExpressionProtoVisitor
                         .setName(a.name())
                         .setExpression(a.expr().accept(this))
                         .build())
-            .toList();
+            .collect(java.util.stream.Collectors.toList());
     var finalExpr = expr.finalExpression().accept(this);
     return DerivationExpression.newBuilder()
         .setReturnProgram(
@@ -122,7 +122,11 @@ public class TypeExpressionProtoVisitor
 
   @Override
   public DerivationExpression visit(ParameterizedType.Struct expr) {
-    return typeContainer(expr).struct(expr.fields().stream().map(f -> f.accept(this)).toList());
+    return typeContainer(expr)
+        .struct(
+            expr.fields().stream()
+                .map(f -> f.accept(this))
+                .collect(java.util.stream.Collectors.toList()));
   }
 
   @Override
@@ -162,7 +166,11 @@ public class TypeExpressionProtoVisitor
 
   @Override
   public DerivationExpression visit(TypeExpression.Struct expr) {
-    return typeContainer(expr).struct(expr.fields().stream().map(f -> f.accept(this)).toList());
+    return typeContainer(expr)
+        .struct(
+            expr.fields().stream()
+                .map(f -> f.accept(this))
+                .collect(java.util.stream.Collectors.toList()));
   }
 
   @Override
@@ -258,33 +266,54 @@ public class TypeExpressionProtoVisitor
     @Override
     protected DerivationExpression wrap(final Object o) {
       var bldr = DerivationExpression.newBuilder();
-      return switch (o) {
-        case Type.Boolean t -> bldr.setBool(t).build();
-        case Type.I8 t -> bldr.setI8(t).build();
-        case Type.I16 t -> bldr.setI16(t).build();
-        case Type.I32 t -> bldr.setI32(t).build();
-        case Type.I64 t -> bldr.setI64(t).build();
-        case Type.FP32 t -> bldr.setFp32(t).build();
-        case Type.FP64 t -> bldr.setFp64(t).build();
-        case Type.String t -> bldr.setString(t).build();
-        case Type.Binary t -> bldr.setBinary(t).build();
-        case Type.Timestamp t -> bldr.setTimestamp(t).build();
-        case Type.Date t -> bldr.setDate(t).build();
-        case Type.Time t -> bldr.setTime(t).build();
-        case Type.TimestampTZ t -> bldr.setTimestampTz(t).build();
-        case Type.IntervalYear t -> bldr.setIntervalYear(t).build();
-        case Type.IntervalDay t -> bldr.setIntervalDay(t).build();
-        case DerivationExpression.ExpressionFixedChar t -> bldr.setFixedChar(t).build();
-        case DerivationExpression.ExpressionVarChar t -> bldr.setVarchar(t).build();
-        case DerivationExpression.ExpressionFixedBinary t -> bldr.setFixedBinary(t).build();
-        case DerivationExpression.ExpressionDecimal t -> bldr.setDecimal(t).build();
-        case DerivationExpression.ExpressionStruct t -> bldr.setStruct(t).build();
-        case DerivationExpression.ExpressionList t -> bldr.setList(t).build();
-        case DerivationExpression.ExpressionMap t -> bldr.setMap(t).build();
-        case Type.UUID t -> bldr.setUuid(t).build();
-        default -> throw new UnsupportedOperationException(
-            "Unable to wrap type of " + o.getClass());
-      };
+      if (o instanceof Type.Boolean t) {
+        return bldr.setBool(t).build();
+      } else if (o instanceof Type.I8 t) {
+        return bldr.setI8(t).build();
+      } else if (o instanceof Type.I16 t) {
+        return bldr.setI16(t).build();
+      } else if (o instanceof Type.I32 t) {
+        return bldr.setI32(t).build();
+      } else if (o instanceof Type.I64 t) {
+        return bldr.setI64(t).build();
+      } else if (o instanceof Type.FP32 t) {
+        return bldr.setFp32(t).build();
+      } else if (o instanceof Type.FP64 t) {
+        return bldr.setFp64(t).build();
+      } else if (o instanceof Type.String t) {
+        return bldr.setString(t).build();
+      } else if (o instanceof Type.Binary t) {
+        return bldr.setBinary(t).build();
+      } else if (o instanceof Type.Timestamp t) {
+        return bldr.setTimestamp(t).build();
+      } else if (o instanceof Type.Date t) {
+        return bldr.setDate(t).build();
+      } else if (o instanceof Type.Time t) {
+        return bldr.setTime(t).build();
+      } else if (o instanceof Type.TimestampTZ t) {
+        return bldr.setTimestampTz(t).build();
+      } else if (o instanceof Type.IntervalYear t) {
+        return bldr.setIntervalYear(t).build();
+      } else if (o instanceof Type.IntervalDay t) {
+        return bldr.setIntervalDay(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionFixedChar t) {
+        return bldr.setFixedChar(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionVarChar t) {
+        return bldr.setVarchar(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionFixedBinary t) {
+        return bldr.setFixedBinary(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionDecimal t) {
+        return bldr.setDecimal(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionStruct t) {
+        return bldr.setStruct(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionList t) {
+        return bldr.setList(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionMap t) {
+        return bldr.setMap(t).build();
+      } else if (o instanceof Type.UUID t) {
+        return bldr.setUuid(t).build();
+      }
+      throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -78,33 +78,54 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     @Override
     protected Type wrap(final Object o) {
       var bldr = Type.newBuilder();
-      return switch (o) {
-        case Type.Boolean t -> bldr.setBool(t).build();
-        case Type.I8 t -> bldr.setI8(t).build();
-        case Type.I16 t -> bldr.setI16(t).build();
-        case Type.I32 t -> bldr.setI32(t).build();
-        case Type.I64 t -> bldr.setI64(t).build();
-        case Type.FP32 t -> bldr.setFp32(t).build();
-        case Type.FP64 t -> bldr.setFp64(t).build();
-        case Type.String t -> bldr.setString(t).build();
-        case Type.Binary t -> bldr.setBinary(t).build();
-        case Type.Timestamp t -> bldr.setTimestamp(t).build();
-        case Type.Date t -> bldr.setDate(t).build();
-        case Type.Time t -> bldr.setTime(t).build();
-        case Type.TimestampTZ t -> bldr.setTimestampTz(t).build();
-        case Type.IntervalYear t -> bldr.setIntervalYear(t).build();
-        case Type.IntervalDay t -> bldr.setIntervalDay(t).build();
-        case Type.FixedChar t -> bldr.setFixedChar(t).build();
-        case Type.VarChar t -> bldr.setVarchar(t).build();
-        case Type.FixedBinary t -> bldr.setFixedBinary(t).build();
-        case Type.Decimal t -> bldr.setDecimal(t).build();
-        case Type.Struct t -> bldr.setStruct(t).build();
-        case Type.List t -> bldr.setList(t).build();
-        case Type.Map t -> bldr.setMap(t).build();
-        case Type.UUID t -> bldr.setUuid(t).build();
-        default -> throw new UnsupportedOperationException(
-            "Unable to wrap type of " + o.getClass());
-      };
+      if (o instanceof Type.Boolean t) {
+        return bldr.setBool(t).build();
+      } else if (o instanceof Type.I8 t) {
+        return bldr.setI8(t).build();
+      } else if (o instanceof Type.I16 t) {
+        return bldr.setI16(t).build();
+      } else if (o instanceof Type.I32 t) {
+        return bldr.setI32(t).build();
+      } else if (o instanceof Type.I64 t) {
+        return bldr.setI64(t).build();
+      } else if (o instanceof Type.FP32 t) {
+        return bldr.setFp32(t).build();
+      } else if (o instanceof Type.FP64 t) {
+        return bldr.setFp64(t).build();
+      } else if (o instanceof Type.String t) {
+        return bldr.setString(t).build();
+      } else if (o instanceof Type.Binary t) {
+        return bldr.setBinary(t).build();
+      } else if (o instanceof Type.Timestamp t) {
+        return bldr.setTimestamp(t).build();
+      } else if (o instanceof Type.Date t) {
+        return bldr.setDate(t).build();
+      } else if (o instanceof Type.Time t) {
+        return bldr.setTime(t).build();
+      } else if (o instanceof Type.TimestampTZ t) {
+        return bldr.setTimestampTz(t).build();
+      } else if (o instanceof Type.IntervalYear t) {
+        return bldr.setIntervalYear(t).build();
+      } else if (o instanceof Type.IntervalDay t) {
+        return bldr.setIntervalDay(t).build();
+      } else if (o instanceof Type.FixedChar t) {
+        return bldr.setFixedChar(t).build();
+      } else if (o instanceof Type.VarChar t) {
+        return bldr.setVarchar(t).build();
+      } else if (o instanceof Type.FixedBinary t) {
+        return bldr.setFixedBinary(t).build();
+      } else if (o instanceof Type.Decimal t) {
+        return bldr.setDecimal(t).build();
+      } else if (o instanceof Type.Struct t) {
+        return bldr.setStruct(t).build();
+      } else if (o instanceof Type.List t) {
+        return bldr.setList(t).build();
+      } else if (o instanceof Type.Map t) {
+        return bldr.setMap(t).build();
+      } else if (o instanceof Type.UUID t) {
+        return bldr.setUuid(t).build();
+      }
+      throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }
 
     @Override

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
   id("java")
   id("idea")
   id("com.palantir.graal") version "0.10.0"
-  id("com.diffplug.spotless") version "6.5.1"
+  id("com.diffplug.spotless") version "6.11.0"
 }
 
 publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
@@ -19,9 +19,9 @@ dependencies {
   implementation("com.google.guava:guava:29.0-jre")
   implementation("org.graalvm.sdk:graal-sdk:22.0.0.2")
   implementation("info.picocli:picocli:4.6.1")
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.12.4")
-  implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.4")
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.4")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.4")
+  implementation("com.fasterxml.jackson.core:jackson-annotations:2.13.4")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.4")
   implementation("com.google.protobuf:protobuf-java-util:3.17.3") {
     exclude("com.google.guava", "guava")
       .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
@@ -30,6 +30,8 @@ dependencies {
   implementation("com.github.ben-manes.caffeine:caffeine:3.0.4")
   implementation("org.immutables:value-annotations:2.8.8")
   testImplementation("org.apache.calcite:calcite-plus:1.28.0")
+  annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
+  compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
 graal {

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -159,7 +159,7 @@ public class SqlToSubstrait extends SqlConverterBase {
                   }
                   return root;
                 })
-            .toList();
+            .collect(java.util.stream.Collectors.toList());
     return roots;
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -116,7 +116,9 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
   public RelNode visit(Project project) throws RuntimeException {
     RelNode child = project.getInput().accept(this);
     List<RexNode> rexList =
-        project.getExpressions().stream().map(expr -> expr.accept(expressionRexConverter)).toList();
+        project.getExpressions().stream()
+            .map(expr -> expr.accept(expressionRexConverter))
+            .collect(java.util.stream.Collectors.toList());
 
     return relBuilder.push(child).project(rexList).build();
   }
@@ -186,14 +188,16 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
                 gr ->
                     gr.getExpressions().stream()
                         .map(expr -> expr.accept(expressionRexConverter))
-                        .toList())
-            .toList();
+                        .collect(java.util.stream.Collectors.toList()))
+            .collect(java.util.stream.Collectors.toList());
     List<RexNode> groupExprs =
         groupExprLists.stream().flatMap(Collection::stream).collect(Collectors.toList());
     RelBuilder.GroupKey groupKey = relBuilder.groupKey(groupExprs, groupExprLists);
 
     List<AggregateCall> aggregateCalls =
-        aggregate.getMeasures().stream().map(this::fromMeasure).toList();
+        aggregate.getMeasures().stream()
+            .map(this::fromMeasure)
+            .collect(java.util.stream.Collectors.toList());
     return relBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
   }
 
@@ -206,7 +210,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
                     eArgs
                         .get(i)
                         .accept(measure.getFunction().declaration(), i, expressionRexConverter))
-            .toList();
+            .collect(java.util.stream.Collectors.toList());
     var operator =
         aggregateFunctionConverter.getSqlOperatorFromSubstraitFunc(
             measure.getFunction().declaration().key(), measure.getFunction().outputType());
@@ -270,7 +274,9 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
   public RelNode visit(Sort sort) throws RuntimeException {
     RelNode child = sort.getInput().accept(this);
     List<RelFieldCollation> relFieldCollations =
-        sort.getSortFields().stream().map(sortField -> toRelFieldCollation(sortField)).toList();
+        sort.getSortFields().stream()
+            .map(sortField -> toRelFieldCollation(sortField))
+            .collect(java.util.stream.Collectors.toList());
     if (relFieldCollations.isEmpty()) {
       return relBuilder.push(child).sort(Collections.EMPTY_LIST).build();
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -122,7 +122,10 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     var input = apply(project.getInput());
     this.converter.setInputRel(project.getInput());
     this.converter.setInputType(input.getRecordType());
-    var expressions = project.getProjects().stream().map(this::toExpression).toList();
+    var expressions =
+        project.getProjects().stream()
+            .map(this::toExpression)
+            .collect(java.util.stream.Collectors.toList());
     this.converter.setInputRel(null);
     this.converter.setInputType(null);
 
@@ -246,7 +249,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     var fields =
         sort.getCollation().getFieldCollations().stream()
             .map(t -> toSortField(t, input.getRecordType()))
-            .toList();
+            .collect(java.util.stream.Collectors.toList());
     var convertedSort = Sort.builder().addAllSortFields(fields).input(input).build();
     if (sort.fetch == null && sort.offset == null) {
       return convertedSort;
@@ -262,11 +265,12 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
   private long asLong(RexNode rex) {
     var expr = toExpression(rex);
-    return switch (expr) {
-      case Expression.I64Literal i -> i.value();
-      case Expression.I32Literal i -> i.value();
-      default -> throw new UnsupportedOperationException("Unknown type: " + rex);
-    };
+    if (expr instanceof Expression.I64Literal i) {
+      return i.value();
+    } else if (expr instanceof Expression.I32Literal i) {
+      return i.value();
+    }
+    throw new UnsupportedOperationException("Unknown type: " + rex);
   }
 
   public static Expression.SortField toSortField(
@@ -320,7 +324,9 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   }
 
   public List<Rel> apply(List<RelNode> inputs) {
-    return inputs.stream().map(inputRel -> apply(inputRel)).toList();
+    return inputs.stream()
+        .map(inputRel -> apply(inputRel))
+        .collect(java.util.stream.Collectors.toList());
   }
 
   public static Rel convert(RelRoot root, SimpleExtension.ExtensionCollection extensions) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
@@ -51,7 +51,7 @@ public class AggregateFunctionConverter
         agg.getCollation() != null
             ? agg.getCollation().getFieldCollations().stream()
                 .map(r -> SubstraitRelVisitor.toSortField(r, call.inputType))
-                .toList()
+                .collect(java.util.stream.Collectors.toList())
             : Collections.emptyList();
     AggregateFunction.AggregationInvocation invocation =
         agg.isDistinct()

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -51,7 +51,8 @@ public class CallConverters {
         // else)
         assert call.getOperands().size() % 2 == 1;
 
-        var caseArgs = call.getOperands().stream().map(visitor).toList();
+        var caseArgs =
+            call.getOperands().stream().map(visitor).collect(java.util.stream.Collectors.toList());
 
         var last = caseArgs.size() - 1;
         // for if/else, process in reverse to maintain query order

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/EnumConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/EnumConverter.java
@@ -69,10 +69,11 @@ public class EnumConverter {
         return Optional.empty();
       }
       var arg = args.get(enumAnchor.argIdx);
-      return switch (arg) {
-        case SimpleExtension.EnumArgument ea -> Optional.of(ea);
-        default -> Optional.empty();
-      };
+      if (arg instanceof SimpleExtension.EnumArgument ea) {
+        return Optional.of(ea);
+      } else {
+        return Optional.empty();
+      }
     }
   }
 
@@ -105,7 +106,15 @@ public class EnumConverter {
         && value.getType().getSqlTypeName() == SqlTypeName.SYMBOL;
   }
 
-  private record ArgAnchor(SimpleExtension.FunctionAnchor fn, int argIdx) {}
+  private static class ArgAnchor {
+    public final SimpleExtension.FunctionAnchor fn;
+    public final int argIdx;
+
+    public ArgAnchor(final SimpleExtension.FunctionAnchor fn, final int argIdx) {
+      this.fn = fn;
+      this.argIdx = argIdx;
+    }
+  }
 
   private static ArgAnchor argAnchor(String fnNS, String fnSig, int argIdx) {
     return new ArgAnchor(SimpleExtension.FunctionAnchor.of(fnNS, fnSig), argIdx);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
@@ -87,16 +87,17 @@ public class FieldSelectionConverter implements CallConverter {
   }
 
   private Optional<Integer> toInt(Expression.Literal l) {
-    return switch (l) {
-      case Expression.I8Literal i8 -> Optional.of(i8.value());
-      case Expression.I16Literal i16 -> Optional.of(i16.value());
-      case Expression.I32Literal i32 -> Optional.of(i32.value());
-      case Expression.I64Literal i64 -> Optional.of((int) i64.value());
-      default -> {
-        logger.warn("Literal expected to be int type but was not. {}.", l);
-        yield Optional.empty();
-      }
-    };
+    if (l instanceof Expression.I8Literal i8) {
+      return Optional.of(i8.value());
+    } else if (l instanceof Expression.I16Literal i16) {
+      return Optional.of(i16.value());
+    } else if (l instanceof Expression.I32Literal i32) {
+      return Optional.of(i32.value());
+    } else if (l instanceof Expression.I64Literal i64) {
+      return Optional.of((int) i64.value());
+    }
+    logger.warn("Literal expected to be int type but was not. {}.", l);
+    return Optional.empty();
   }
 
   public Optional<String> toString(Expression.Literal l) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -112,7 +112,7 @@ public abstract class FunctionConverter<
                 operator ->
                     resolver.containsKey(operator)
                         && resolver.get(operator).types().contains(outputTypeStr))
-            .toList();
+            .collect(java.util.stream.Collectors.toList());
     // only one SqlOperator is possible
     if (resolvedOperators.size() == 1) {
       return Optional.of(resolvedOperators.get(0));
@@ -263,7 +263,7 @@ public abstract class FunctionConverter<
                       }
                       return isOption ? List.of("req", "opt") : List.of(opType);
                     })
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
 
         return Utils.crossProduct(argTypeLists)
             .map(typList -> typList.stream().collect(Collectors.joining("_")));
@@ -278,16 +278,20 @@ public abstract class FunctionConverter<
        * Once a FunctionVariant is resolved we can map the String Literal
        * to a EnumArg.
        */
-      var operands = call.getOperands().map(topLevelConverter).toList();
-      var opTypes = operands.stream().map(Expression::getType).toList();
+      var operands =
+          call.getOperands().map(topLevelConverter).collect(java.util.stream.Collectors.toList());
+      var opTypes =
+          operands.stream().map(Expression::getType).collect(java.util.stream.Collectors.toList());
 
       var outputType = TypeConverter.convert(call.getType());
 
       // try to do a direct match
       var possibleKeys =
           matchKeys(
-              call.getOperands().toList(),
-              opTypes.stream().map(t -> t.accept(ToTypeString.INSTANCE)).toList());
+              call.getOperands().collect(java.util.stream.Collectors.toList()),
+              opTypes.stream()
+                  .map(t -> t.accept(ToTypeString.INSTANCE))
+                  .collect(java.util.stream.Collectors.toList()));
 
       var directMatchKey =
           possibleKeys
@@ -310,7 +314,7 @@ public abstract class FunctionConverter<
                         return o;
                       }
                     })
-                .toList();
+                .collect(java.util.stream.Collectors.toList());
         var allArgsMapped = funcArgs.stream().filter(e -> e == null).findFirst().isEmpty();
         if (allArgsMapped) {
           return Optional.of(generateBinding(call, variant, funcArgs, outputType));
@@ -321,7 +325,10 @@ public abstract class FunctionConverter<
 
       if (singularInputType.isPresent()) {
         RelDataType leastRestrictive =
-            typeFactory.leastRestrictive(call.getOperands().map(RexNode::getType).toList());
+            typeFactory.leastRestrictive(
+                call.getOperands()
+                    .map(RexNode::getType)
+                    .collect(java.util.stream.Collectors.toList()));
         if (leastRestrictive == null) {
           return Optional.empty();
         }
@@ -336,7 +343,9 @@ public abstract class FunctionConverter<
               generateBinding(
                   call,
                   out.get(),
-                  coercedArgs.stream().map(FunctionArg.class::cast).toList(),
+                  coercedArgs.stream()
+                      .map(FunctionArg.class::cast)
+                      .collect(java.util.stream.Collectors.toList()),
                   outputType));
         }
       }
@@ -365,7 +374,7 @@ public abstract class FunctionConverter<
               }
               return a;
             })
-        .toList();
+        .collect(java.util.stream.Collectors.toList());
   }
 
   protected abstract T generateBinding(

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -100,11 +100,44 @@ public class FunctionMappings {
     return s(operator, operator.getName().toLowerCase(Locale.ROOT));
   }
 
-  record Sig(SqlOperator operator, String name) {}
+  public static class Sig {
+    public final SqlOperator operator;
+    public final String name;
+
+    public Sig(final SqlOperator operator, final String name) {
+      this.operator = operator;
+      this.name = name;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public SqlOperator operator() {
+      return operator;
+    }
+  }
 
   public static TypeBasedResolver resolver(SqlOperator operator, Set<String> outTypes) {
     return new TypeBasedResolver(operator, outTypes);
   }
 
-  record TypeBasedResolver(SqlOperator operator, Set<String> types) {}
+  public static class TypeBasedResolver {
+
+    public final SqlOperator operator;
+    public final Set<String> types;
+
+    public TypeBasedResolver(final SqlOperator operator, final Set<String> types) {
+      this.operator = operator;
+      this.types = types;
+    }
+
+    public SqlOperator operator() {
+      return operator;
+    }
+
+    public Set<String> types() {
+      return types;
+    }
+  }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlArrayValueConstructor;
 import org.apache.calcite.sql.fun.SqlMapValueConstructor;
 
@@ -20,27 +21,26 @@ public class LiteralConstructorConverter implements CallConverter {
   @Override
   public Optional<Expression> convert(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
-    return switch (call.getOperator()) {
-      case SqlArrayValueConstructor array -> Optional.of(
+    SqlOperator operator = call.getOperator();
+    if (operator instanceof SqlArrayValueConstructor) {
+      return Optional.of(
           ExpressionCreator.list(
               false,
               call.operands.stream()
                   .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
-                  .toList()));
-
-      case SqlMapValueConstructor map -> {
-        List<Expression.Literal> literals =
-            call.operands.stream()
-                .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
-                .toList();
-        Map<Expression.Literal, Expression.Literal> items = new HashMap<>();
-        assert literals.size() % 2 == 0;
-        for (int i = 0; i < literals.size(); i += 2) {
-          items.put(literals.get(i), literals.get(i + 1));
-        }
-        yield Optional.of(ExpressionCreator.map(false, items));
+                  .collect(java.util.stream.Collectors.toList())));
+    } else if (operator instanceof SqlMapValueConstructor) {
+      List<Expression.Literal> literals =
+          call.operands.stream()
+              .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
+              .collect(java.util.stream.Collectors.toList());
+      Map<Expression.Literal, Expression.Literal> items = new HashMap<>();
+      assert literals.size() % 2 == 0;
+      for (int i = 0; i < literals.size(); i += 2) {
+        items.put(literals.get(i), literals.get(i + 1));
       }
-      default -> Optional.empty();
-    };
+      return Optional.of(ExpressionCreator.map(false, items));
+    }
+    return Optional.empty();
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
@@ -65,7 +65,7 @@ public class WindowFunctionConverter
         agg.getCollation() != null
             ? agg.getCollation().getFieldCollations().stream()
                 .map(r -> SubstraitRelVisitor.toSortField(r, call.inputType))
-                .toList()
+                .collect(java.util.stream.Collectors.toList())
             : Collections.emptyList();
     AggregateFunction.AggregationInvocation invocation =
         agg.isDistinct()
@@ -90,7 +90,10 @@ public class WindowFunctionConverter
     var lowerBound = toWindowBound(over.getWindow().getLowerBound(), rexExpressionConverter);
     var upperBound = toWindowBound(over.getWindow().getUpperBound(), rexExpressionConverter);
     var sqlAggFunction = over.getAggOperator();
-    var argList = over.getOperands().stream().map(r -> ((RexSlot) r).getIndex()).toList();
+    var argList =
+        over.getOperands().stream()
+            .map(r -> ((RexSlot) r).getIndex())
+            .collect(java.util.stream.Collectors.toList());
     boolean approximate = false;
     int filterArg = -1;
     var call =
@@ -134,9 +137,13 @@ public class WindowFunctionConverter
     }
     var window = over.getWindow();
     var partitionExps =
-        window.partitionKeys.stream().map(r -> r.accept(rexExpressionConverter)).toList();
+        window.partitionKeys.stream()
+            .map(r -> r.accept(rexExpressionConverter))
+            .collect(java.util.stream.Collectors.toList());
     var sortFields =
-        window.orderKeys.stream().map(r -> toSortField(r, rexExpressionConverter)).toList();
+        window.orderKeys.stream()
+            .map(r -> toSortField(r, rexExpressionConverter))
+            .collect(java.util.stream.Collectors.toList());
 
     return windowBuilder
         .addAllOrderBy(sortFields)

--- a/isthmus/src/test/java/io/substrait/isthmus/KeyConstraintsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/KeyConstraintsTest.java
@@ -12,7 +12,10 @@ public class KeyConstraintsTest extends PlanTestBase {
   public void tpcds(int query) throws Exception {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("keyconstraints_schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     var plan = s.execute(asString(String.format("tpcds/queries/%02d.sql", query)), creates);
     System.out.println(JsonFormat.printer().print(plan));
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -39,7 +39,10 @@ public class PlanTestBase {
   protected Plan assertProtoPlanRoundrip(String query, SqlToSubstrait s)
       throws IOException, SqlParseException {
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     io.substrait.proto.Plan protoPlan1 = s.execute(query, creates);
     Plan plan = new ProtoPlanConverter(EXTENSION_COLLECTION).from(protoPlan1);
     io.substrait.proto.Plan protoPlan2 = new PlanProtoConverter().toProto(plan);
@@ -65,7 +68,10 @@ public class PlanTestBase {
     // Assert (sql -> substrait) and (sql -> substrait -> calcite rel -> substrait) are same.
     // Return list of sql -> substrait rel -> Calcite rel.
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     List<RelNode> relNodeList = new ArrayList<>();
 
     // 1. sql -> substrait rel

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
@@ -26,7 +26,10 @@ public class ProtoPlanConverterTest extends PlanTestBase {
       throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     return s.execute(query1, creates);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -72,7 +72,10 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
   private Plan buildPlanFromQuery(String query) throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     io.substrait.proto.Plan protoPlan1 = s.execute(query, creates);
     return new ProtoPlanConverter().from(protoPlan1);
   }
@@ -133,7 +136,10 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
     // convert newPlan back to sql
     var pojoRel = newPlan.getRoots().get(0).getInput();
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     RelNode relnodeRoot = new SubstraitToSql().substraitRelToCalciteRel(pojoRel, creates);
     String newSql = SubstraitToSql.toSql(relnodeRoot);
     assertTrue(newSql.toUpperCase().contains("APPROX_COUNT_DISTINCT"));

--- a/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
@@ -20,7 +20,10 @@ public class SubqueryPlanTest {
   public void existsCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     Plan plan =
         s.execute(
             "select l_partkey from lineitem where exists (select o_orderdate from orders where o_orderkey = l_orderkey)",
@@ -63,7 +66,10 @@ public class SubqueryPlanTest {
   public void uniqueCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     Plan plan =
         s.execute(
             "select l_partkey from lineitem where unique (select o_orderdate from orders where o_orderkey = l_orderkey)",
@@ -111,7 +117,10 @@ public class SubqueryPlanTest {
     String[] values = asString("tpch/schema.sql").split(";");
     String sql =
         "select l_orderkey from lineitem where l_partkey in (select p_partkey from part where p_partkey = l_partkey)";
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     Plan plan = s.execute(sql, creates);
 
     Expression.Subquery subquery =
@@ -151,7 +160,10 @@ public class SubqueryPlanTest {
     String[] values = asString("tpch/schema.sql").split(";");
     String sql =
         "select l_orderkey from lineitem where l_partkey not in (select p_partkey from part where p_partkey = l_partkey)";
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     Plan plan = s.execute(sql, creates);
     Expression.Subquery subquery =
         plan.getRelations(0)
@@ -205,7 +217,10 @@ public class SubqueryPlanTest {
             + "          FROM partsupp ps\n"
             + "          WHERE ps.ps_partkey = p.p_partkey\n"
             + "          AND   PS.ps_suppkey = l.l_suppkey))";
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     Plan plan = s.execute(sql, creates);
 
     Expression.Subquery outer_subquery =
@@ -281,7 +296,10 @@ public class SubqueryPlanTest {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
     String sql = asString("subquery/nested_scalar_subquery_in_filter.sql");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     Plan plan = s.execute(sql, creates);
     String planText = JsonFormat.printer().includingDefaultValueFields().print(plan);
 
@@ -358,7 +376,10 @@ public class SubqueryPlanTest {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
     String sql = asString("subquery/nested_scalar_subquery_in_select.sql");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> {

--- a/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TableLookupTest.java
@@ -58,7 +58,10 @@ public class TableLookupTest extends PlanTestBase {
     SqlToSubstrait s2s1 = new SqlToSubstrait();
     SqlToSubstrait s2s2 = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     String query = asString("tpch/queries/01.sql");
     var plan1 = s2s1.execute(query, creates);
     var plan2 =

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
@@ -14,7 +14,10 @@ public class TpchQueryNoValidation extends PlanTestBase {
   public void tpch(int query) throws Exception {
     SqlToSubstrait s = new SqlToSubstrait();
     String[] values = asString("tpch/schema.sql").split(";");
-    var creates = Arrays.stream(values).filter(t -> !t.trim().isBlank()).toList();
+    var creates =
+        Arrays.stream(values)
+            .filter(t -> !t.trim().isBlank())
+            .collect(java.util.stream.Collectors.toList());
     var plan = s.execute(asString(String.format("tpch/queries/%02d.sql", query)), creates);
     System.out.println(JsonFormat.printer().print(plan));
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,8 @@ pluginManagement {
     idv("org.jetbrains.gradle.plugin.idea-ext")
     kotlin("jvm") version "kotlin".v()
   }
-  if (extra.has("enableMavenLocal") &&
+  if (
+    extra.has("enableMavenLocal") &&
       extra["enableMavenLocal"].toString().ifBlank { "true" }.toBoolean()
   ) {
     repositories {


### PR DESCRIPTION
- Remove Preview Features (pattern matching).
- Remove use of java16 Stream.toList().
- Remove use of java record (jabel doesn't support de-sugaring).
- Enable Jabel to support recent sugared syntax back to Java 11 target.

Spot checked generated jar files to confirm java 11 bytecode (version 55).