### PR TITLE
Downgrade core to java 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,9 +42,12 @@ allprojects {
     javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
   }
   tasks.withType<JavaCompile> {
-    sourceCompatibility = "17"
-    options.release.set(11)
-
+    if (project.name != "core") {
+      sourceCompatibility = "17"
+      options.release.set(11)
+    } else {
+      sourceCompatibility = "8"
+    }
     dependsOn(submodulesUpdate)
   }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(11)) } }
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(8)) } }
 
 sourceSets {
   main {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
   compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(11)) } }
 
 sourceSets {
   main {

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -728,7 +728,8 @@ public interface Expression extends FunctionArg {
 
     public static PredicateOp fromProto(
         io.substrait.proto.Expression.Subquery.SetPredicate.PredicateOp proto) {
-      for (var v : values()) {
+
+      for (PredicateOp v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -758,7 +759,7 @@ public interface Expression extends FunctionArg {
     }
 
     public static AggregationPhase fromProto(io.substrait.proto.AggregationPhase proto) {
-      for (var v : values()) {
+      for (AggregationPhase v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -786,7 +787,7 @@ public interface Expression extends FunctionArg {
     }
 
     public static SortDirection fromProto(io.substrait.proto.SortField.SortDirection proto) {
-      for (var v : values()) {
+      for (SortDirection v : values()) {
         if (v.proto == proto) {
           return v;
         }

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -6,6 +6,7 @@ import io.substrait.proto.AggregateFunction;
 import io.substrait.type.Type;
 import io.substrait.util.DecimalUtil;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -77,7 +78,7 @@ public class ExpressionCreator {
   }
 
   public static Expression.TimestampLiteral timestamp(boolean nullable, LocalDateTime value) {
-    var epochMicro =
+    long epochMicro =
         TimeUnit.SECONDS.toMicros(value.toEpochSecond(ZoneOffset.UTC))
             + TimeUnit.NANOSECONDS.toMicros(value.toLocalTime().getNano());
     return timestamp(nullable, epochMicro);
@@ -103,7 +104,7 @@ public class ExpressionCreator {
   }
 
   public static Expression.TimestampTZLiteral timestampTZ(boolean nullable, Instant value) {
-    var epochMicro =
+    long epochMicro =
         TimeUnit.SECONDS.toMicros(value.getEpochSecond())
             + TimeUnit.NANOSECONDS.toMicros(value.getNano());
     return timestampTZ(nullable, epochMicro);
@@ -127,7 +128,7 @@ public class ExpressionCreator {
   }
 
   public static Expression.UUIDLiteral uuid(boolean nullable, ByteString uuid) {
-    var bb = uuid.asReadOnlyByteBuffer();
+    ByteBuffer bb = uuid.asReadOnlyByteBuffer();
     return Expression.UUIDLiteral.builder()
         .nullable(nullable)
         .value(new UUID(bb.getLong(), bb.getLong()))
@@ -169,7 +170,7 @@ public class ExpressionCreator {
 
   public static Expression.DecimalLiteral decimal(
       boolean nullable, BigDecimal value, int precision, int scale) {
-    var twosComplement = DecimalUtil.encodeDecimalIntoBytes(value, scale, 16);
+    byte[] twosComplement = DecimalUtil.encodeDecimalIntoBytes(value, scale, 16);
 
     return Expression.DecimalLiteral.builder()
         .nullable(nullable)

--- a/core/src/main/java/io/substrait/expression/FieldReference.java
+++ b/core/src/main/java/io/substrait/expression/FieldReference.java
@@ -29,7 +29,7 @@ public abstract class FieldReference implements Expression {
   }
 
   public boolean isSimpleRootReference() {
-    return segments().size() == 1 && inputExpression().isEmpty();
+    return segments().size() == 1 && !inputExpression().isPresent();
   }
 
   public FieldReference dereferenceStruct(int index) {

--- a/core/src/main/java/io/substrait/expression/FieldReference.java
+++ b/core/src/main/java/io/substrait/expression/FieldReference.java
@@ -218,7 +218,7 @@ public abstract class FieldReference implements Expression {
     Collections.reverse(segments);
     for (int i = 0; i < segments.size(); i++) {
       if (i == 0) {
-        var last = segments.get(0);
+        ReferenceSegment last = segments.get(0);
         reference =
             struct == null ? last.constructOnExpression(expression) : last.constructOnRoot(struct);
       } else {

--- a/core/src/main/java/io/substrait/expression/FunctionArg.java
+++ b/core/src/main/java/io/substrait/expression/FunctionArg.java
@@ -30,26 +30,24 @@ public interface FunctionArg {
       TypeExpressionVisitor<io.substrait.proto.Type, RuntimeException> typeVisitor,
       ExpressionVisitor<io.substrait.proto.Expression, RuntimeException> expressionVisitor) {
 
-    return new FuncArgVisitor<>() {
+    return new FuncArgVisitor<FunctionArgument, RuntimeException>() {
 
       @Override
       public FunctionArgument visitExpr(SimpleExtension.Function fnDef, int argIdx, Expression e)
           throws RuntimeException {
-        var pE = e.accept(expressionVisitor);
-        return FunctionArgument.newBuilder().setValue(pE).build();
+        return FunctionArgument.newBuilder().setValue(e.accept(expressionVisitor)).build();
       }
 
       @Override
       public FunctionArgument visitType(SimpleExtension.Function fnDef, int argIdx, Type t)
           throws RuntimeException {
-        var pTyp = t.accept(typeVisitor);
-        return FunctionArgument.newBuilder().setType(pTyp).build();
+        return FunctionArgument.newBuilder().setType(t.accept(typeVisitor)).build();
       }
 
       @Override
       public FunctionArgument visitEnumArg(SimpleExtension.Function fnDef, int argIdx, EnumArg ea)
           throws RuntimeException {
-        var enumBldr = FunctionArgument.Enum.newBuilder();
+        FunctionArgument.Enum.Builder enumBldr = FunctionArgument.Enum.newBuilder();
 
         if (ea.value().isPresent()) {
           enumBldr = enumBldr.setSpecified(ea.value().get());
@@ -78,7 +76,7 @@ public interface FunctionArg {
           {
             SimpleExtension.EnumArgument enumArgDef =
                 (SimpleExtension.EnumArgument) funcDef.args().get(argIdx);
-            var optionValue = fArg.getEnum().getSpecified();
+            String optionValue = fArg.getEnum().getSpecified();
             return optionValue == null
                 ? EnumArg.UNSPECIFIED_ENUM_ARG
                 : EnumArg.of(enumArgDef, optionValue);

--- a/core/src/main/java/io/substrait/expression/FunctionArg.java
+++ b/core/src/main/java/io/substrait/expression/FunctionArg.java
@@ -68,20 +68,25 @@ public interface FunctionArg {
 
     public FunctionArg convert(
         SimpleExtension.Function funcDef, int argIdx, FunctionArgument fArg) {
-      return switch (fArg.getArgTypeCase()) {
-        case TYPE -> FromProto.from(fArg.getType());
-        case VALUE -> exprBuilder.from(fArg.getValue());
-        case ENUM -> {
-          SimpleExtension.EnumArgument enumArgDef =
-              (SimpleExtension.EnumArgument) funcDef.args().get(argIdx);
-          var optionValue = fArg.getEnum().getSpecified();
-          yield optionValue == null
-              ? EnumArg.UNSPECIFIED_ENUM_ARG
-              : EnumArg.of(enumArgDef, optionValue);
-        }
-        default -> throw new UnsupportedOperationException(
-            String.format("Unable to convert FunctionArgument %s.", fArg));
-      };
+
+      switch (fArg.getArgTypeCase()) {
+        case TYPE:
+          return FromProto.from(fArg.getType());
+        case VALUE:
+          return exprBuilder.from(fArg.getValue());
+        case ENUM:
+          {
+            SimpleExtension.EnumArgument enumArgDef =
+                (SimpleExtension.EnumArgument) funcDef.args().get(argIdx);
+            var optionValue = fArg.getEnum().getSpecified();
+            return optionValue == null
+                ? EnumArg.UNSPECIFIED_ENUM_ARG
+                : EnumArg.of(enumArgDef, optionValue);
+          }
+        default:
+          throw new UnsupportedOperationException(
+              String.format("Unable to convert FunctionArgument %s.", fArg));
+      }
     }
   }
 }

--- a/core/src/main/java/io/substrait/expression/proto/AbstractFunctionLookup.java
+++ b/core/src/main/java/io/substrait/expression/proto/AbstractFunctionLookup.java
@@ -13,7 +13,7 @@ public abstract class AbstractFunctionLookup implements FunctionLookup {
 
   public SimpleExtension.ScalarFunctionVariant getScalarFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = map.get(reference);
+    SimpleExtension.FunctionAnchor anchor = map.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
@@ -24,7 +24,7 @@ public abstract class AbstractFunctionLookup implements FunctionLookup {
 
   public SimpleExtension.AggregateFunctionVariant getAggregateFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = map.get(reference);
+    SimpleExtension.FunctionAnchor anchor = map.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");

--- a/core/src/main/java/io/substrait/expression/proto/FunctionCollector.java
+++ b/core/src/main/java/io/substrait/expression/proto/FunctionCollector.java
@@ -36,11 +36,11 @@ public class FunctionCollector extends AbstractFunctionLookup {
   }
 
   public void addFunctionsToPlan(Plan.Builder builder) {
-    var uriPos = new AtomicInteger(1);
-    var uris = new HashMap<String, SimpleExtensionURI>();
+    AtomicInteger uriPos = new AtomicInteger(1);
+    HashMap<String, SimpleExtensionURI> uris = new HashMap<>();
 
-    var extensionList = new ArrayList<SimpleExtensionDeclaration>();
-    for (var e : funcMap.forwardMap.entrySet()) {
+    ArrayList<SimpleExtensionDeclaration> extensionList = new ArrayList<>();
+    for (Map.Entry<Integer, SimpleExtension.FunctionAnchor> e : funcMap.forwardMap.entrySet()) {
       SimpleExtensionURI uri =
           uris.computeIfAbsent(
               e.getValue().namespace(),
@@ -49,7 +49,7 @@ public class FunctionCollector extends AbstractFunctionLookup {
                       .setExtensionUriAnchor(uriPos.getAndIncrement())
                       .setUri(k)
                       .build());
-      var decl =
+      SimpleExtensionDeclaration decl =
           SimpleExtensionDeclaration.newBuilder()
               .setExtensionFunction(
                   SimpleExtensionDeclaration.ExtensionFunction.newBuilder()

--- a/core/src/main/java/io/substrait/expression/proto/ImmutableFunctionLookup.java
+++ b/core/src/main/java/io/substrait/expression/proto/ImmutableFunctionLookup.java
@@ -30,11 +30,11 @@ public class ImmutableFunctionLookup extends AbstractFunctionLookup {
 
     public Builder from(Plan p) {
       Map<Integer, String> namespaceMap = new HashMap<>();
-      for (var extension : p.getExtensionUrisList()) {
+      for (io.substrait.proto.SimpleExtensionURI extension : p.getExtensionUrisList()) {
         namespaceMap.put(extension.getExtensionUriAnchor(), extension.getUri());
       }
 
-      for (var extension : p.getExtensionsList()) {
+      for (io.substrait.proto.SimpleExtensionDeclaration extension : p.getExtensionsList()) {
         SimpleExtensionDeclaration.ExtensionFunction func = extension.getExtensionFunction();
         int reference = func.getFunctionAnchor();
         String namespace = namespaceMap.get(func.getExtensionUriReference());

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -34,176 +34,208 @@ public class ProtoExpressionConverter {
 
   public FieldReference from(io.substrait.proto.Expression.FieldReference reference) {
     switch (reference.getReferenceTypeCase()) {
-      case DIRECT_REFERENCE -> {
-        io.substrait.proto.Expression.ReferenceSegment segment = reference.getDirectReference();
+      case DIRECT_REFERENCE:
+        {
+          io.substrait.proto.Expression.ReferenceSegment segment = reference.getDirectReference();
 
-        var segments = new ArrayList<FieldReference.ReferenceSegment>();
-        while (segment != io.substrait.proto.Expression.ReferenceSegment.getDefaultInstance()) {
-          segments.add(
-              switch (segment.getReferenceTypeCase()) {
-                case MAP_KEY -> {
+          var segments = new ArrayList<FieldReference.ReferenceSegment>();
+          while (segment != io.substrait.proto.Expression.ReferenceSegment.getDefaultInstance()) {
+            FieldReference.ReferenceSegment seg = null;
+            switch (segment.getReferenceTypeCase()) {
+              case MAP_KEY:
+                {
                   var mapKey = segment.getMapKey();
                   segment = mapKey.getChild();
-                  yield FieldReference.MapKey.of(from(mapKey.getMapKey()));
+                  seg = FieldReference.MapKey.of(from(mapKey.getMapKey()));
+                  break;
                 }
-                case STRUCT_FIELD -> {
+              case STRUCT_FIELD:
+                {
                   var structField = segment.getStructField();
                   segment = structField.getChild();
-                  yield FieldReference.StructField.of(structField.getField());
+                  seg = FieldReference.StructField.of(structField.getField());
+                  break;
                 }
-                case LIST_ELEMENT -> {
+              case LIST_ELEMENT:
+                {
                   var listElement = segment.getListElement();
                   segment = listElement.getChild();
-                  yield FieldReference.ListElement.of(listElement.getOffset());
+                  seg = FieldReference.ListElement.of(listElement.getOffset());
+                  break;
                 }
-                case REFERENCETYPE_NOT_SET -> throw new IllegalArgumentException(
+              case REFERENCETYPE_NOT_SET:
+                throw new IllegalArgumentException(
                     "Unhandled type: " + segment.getReferenceTypeCase());
-              });
+            }
+            segments.add(seg);
+          }
+
+          FieldReference fieldReference = null;
+          switch (reference.getRootTypeCase()) {
+            case EXPRESSION:
+              fieldReference =
+                  FieldReference.ofExpression(from(reference.getExpression()), segments);
+              break;
+            case ROOT_REFERENCE:
+              fieldReference = FieldReference.ofRoot(rootType, segments);
+              break;
+            case OUTER_REFERENCE:
+              fieldReference =
+                  FieldReference.newRootStructOuterReference(
+                      reference.getDirectReference().getStructField().getField(),
+                      rootType,
+                      reference.getOuterReference().getStepsOut());
+              break;
+            case ROOTTYPE_NOT_SET:
+              throw new IllegalArgumentException("Unhandled type: " + reference.getRootTypeCase());
+          }
+
+          return fieldReference;
         }
-
-        var fieldReference =
-            switch (reference.getRootTypeCase()) {
-              case EXPRESSION -> FieldReference.ofExpression(
-                  from(reference.getExpression()), segments);
-              case ROOT_REFERENCE -> FieldReference.ofRoot(rootType, segments);
-              case OUTER_REFERENCE -> FieldReference.newRootStructOuterReference(
-                  reference.getDirectReference().getStructField().getField(),
-                  rootType,
-                  reference.getOuterReference().getStepsOut());
-              case ROOTTYPE_NOT_SET -> throw new IllegalArgumentException(
-                  "Unhandled type: " + reference.getRootTypeCase());
-            };
-
-        return fieldReference;
-      }
-      case MASKED_REFERENCE -> throw new IllegalArgumentException(
-          "Unsupported type: " + reference.getReferenceTypeCase());
-      default -> throw new IllegalArgumentException(
-          "Unhandled type: " + reference.getReferenceTypeCase());
+      case MASKED_REFERENCE:
+        throw new IllegalArgumentException("Unsupported type: " + reference.getReferenceTypeCase());
+      default:
+        throw new IllegalArgumentException("Unhandled type: " + reference.getReferenceTypeCase());
     }
   }
 
   public Expression from(io.substrait.proto.Expression expr) {
-    return switch (expr.getRexTypeCase()) {
-      case LITERAL -> from(expr.getLiteral());
-      case SELECTION -> from(expr.getSelection());
-      case SCALAR_FUNCTION -> {
-        var scalarFunction = expr.getScalarFunction();
-        var functionReference = scalarFunction.getFunctionReference();
-        var declaration = lookup.getScalarFunction(functionReference, extensions);
-        var pF = new FunctionArg.ProtoFrom(this);
-        var args =
-            IntStream.range(0, scalarFunction.getArgumentsCount())
-                .mapToObj(i -> pF.convert(declaration, i, scalarFunction.getArguments(i)))
-                .collect(java.util.stream.Collectors.toList());
-        yield ImmutableExpression.ScalarFunctionInvocation.builder()
-            .addAllArguments(args)
-            .declaration(declaration)
-            .outputType(from(expr.getScalarFunction().getOutputType()))
-            .build();
-      }
-      case IF_THEN -> {
-        var ifThen = expr.getIfThen();
-        var clauses =
-            ifThen.getIfsList().stream()
-                .map(t -> ExpressionCreator.ifThenClause(from(t.getIf()), from(t.getThen())))
-                .collect(java.util.stream.Collectors.toList());
-        yield ExpressionCreator.ifThenStatement(from(ifThen.getElse()), clauses);
-      }
-      case SWITCH_EXPRESSION -> {
-        var switchExpr = expr.getSwitchExpression();
-        var clauses =
-            switchExpr.getIfsList().stream()
-                .map(t -> ExpressionCreator.switchClause(from(t.getIf()), from(t.getThen())))
-                .collect(java.util.stream.Collectors.toList());
-        yield ExpressionCreator.switchStatement(from(switchExpr.getElse()), clauses);
-      }
-      case SINGULAR_OR_LIST -> {
-        var orList = expr.getSingularOrList();
-        var values =
-            orList.getOptionsList().stream()
-                .map(this::from)
-                .collect(java.util.stream.Collectors.toList());
-        yield ImmutableExpression.SingleOrList.builder()
-            .condition(from(orList.getValue()))
-            .addAllOptions(values)
-            .build();
-      }
-      case MULTI_OR_LIST -> {
-        var multiOrList = expr.getMultiOrList();
-        var values =
-            multiOrList.getOptionsList().stream()
-                .map(
-                    t ->
-                        ImmutableExpression.MultiOrListRecord.builder()
-                            .addAllValues(
-                                t.getFieldsList().stream()
-                                    .map(this::from)
-                                    .collect(java.util.stream.Collectors.toList()))
-                            .build())
-                .collect(java.util.stream.Collectors.toList());
-        yield ImmutableExpression.MultiOrList.builder()
-            .addAllOptionCombinations(values)
-            .addAllConditions(
-                multiOrList.getValueList().stream()
-                    .map(this::from)
-                    .collect(java.util.stream.Collectors.toList()))
-            .build();
-      }
-      case CAST -> ExpressionCreator.cast(
-          FromProto.from(expr.getCast().getType()), from(expr.getCast().getInput()));
-      case SUBQUERY -> {
-        switch (expr.getSubquery().getSubqueryTypeCase()) {
-          case SET_PREDICATE -> {
-            var rel =
-                new ProtoRelConverter(lookup, extensions)
-                    .from(expr.getSubquery().getSetPredicate().getTuples());
-            yield ImmutableExpression.SetPredicate.builder()
-                .tuples(rel)
-                .predicateOp(
-                    Expression.PredicateOp.fromProto(
-                        expr.getSubquery().getSetPredicate().getPredicateOp()))
-                .build();
-          }
-          case SCALAR -> {
-            var rel =
-                new ProtoRelConverter(lookup, extensions)
-                    .from(expr.getSubquery().getScalar().getInput());
-            yield ImmutableExpression.ScalarSubquery.builder()
-                .input(rel)
-                .type(rel.getRecordType())
-                .build();
-          }
-          case IN_PREDICATE -> {
-            var rel =
-                new ProtoRelConverter(lookup, extensions)
-                    .from(expr.getSubquery().getInPredicate().getHaystack());
-            var needles =
-                expr.getSubquery().getInPredicate().getNeedlesList().stream()
-                    .map(e -> this.from(e))
-                    .collect(java.util.stream.Collectors.toList());
-            yield ImmutableExpression.InPredicate.builder()
-                .haystack(rel)
-                .needles(needles)
-                .type(rel.getRecordType())
-                .build();
-          }
-          case SET_COMPARISON -> {
-            throw new UnsupportedOperationException(
-                "Unsupported subquery type: " + expr.getSubquery().getSubqueryTypeCase());
-          }
-          default -> {
-            throw new IllegalArgumentException(
-                "Unknown subquery type: " + expr.getSubquery().getSubqueryTypeCase());
+    switch (expr.getRexTypeCase()) {
+      case LITERAL:
+        return from(expr.getLiteral());
+      case SELECTION:
+        return from(expr.getSelection());
+      case SCALAR_FUNCTION:
+        {
+          var scalarFunction = expr.getScalarFunction();
+          var functionReference = scalarFunction.getFunctionReference();
+          var declaration = lookup.getScalarFunction(functionReference, extensions);
+          var pF = new FunctionArg.ProtoFrom(this);
+          var args =
+              IntStream.range(0, scalarFunction.getArgumentsCount())
+                  .mapToObj(i -> pF.convert(declaration, i, scalarFunction.getArguments(i)))
+                  .collect(java.util.stream.Collectors.toList());
+          return ImmutableExpression.ScalarFunctionInvocation.builder()
+              .addAllArguments(args)
+              .declaration(declaration)
+              .outputType(from(expr.getScalarFunction().getOutputType()))
+              .build();
+        }
+      case IF_THEN:
+        {
+          var ifThen = expr.getIfThen();
+          var clauses =
+              ifThen.getIfsList().stream()
+                  .map(t -> ExpressionCreator.ifThenClause(from(t.getIf()), from(t.getThen())))
+                  .collect(java.util.stream.Collectors.toList());
+          return ExpressionCreator.ifThenStatement(from(ifThen.getElse()), clauses);
+        }
+      case SWITCH_EXPRESSION:
+        {
+          var switchExpr = expr.getSwitchExpression();
+          var clauses =
+              switchExpr.getIfsList().stream()
+                  .map(t -> ExpressionCreator.switchClause(from(t.getIf()), from(t.getThen())))
+                  .collect(java.util.stream.Collectors.toList());
+          return ExpressionCreator.switchStatement(from(switchExpr.getElse()), clauses);
+        }
+      case SINGULAR_OR_LIST:
+        {
+          var orList = expr.getSingularOrList();
+          var values =
+              orList.getOptionsList().stream()
+                  .map(this::from)
+                  .collect(java.util.stream.Collectors.toList());
+          return ImmutableExpression.SingleOrList.builder()
+              .condition(from(orList.getValue()))
+              .addAllOptions(values)
+              .build();
+        }
+      case MULTI_OR_LIST:
+        {
+          var multiOrList = expr.getMultiOrList();
+          var values =
+              multiOrList.getOptionsList().stream()
+                  .map(
+                      t ->
+                          ImmutableExpression.MultiOrListRecord.builder()
+                              .addAllValues(
+                                  t.getFieldsList().stream()
+                                      .map(this::from)
+                                      .collect(java.util.stream.Collectors.toList()))
+                              .build())
+                  .collect(java.util.stream.Collectors.toList());
+          return ImmutableExpression.MultiOrList.builder()
+              .addAllOptionCombinations(values)
+              .addAllConditions(
+                  multiOrList.getValueList().stream()
+                      .map(this::from)
+                      .collect(java.util.stream.Collectors.toList()))
+              .build();
+        }
+      case CAST:
+        return ExpressionCreator.cast(
+            FromProto.from(expr.getCast().getType()), from(expr.getCast().getInput()));
+      case SUBQUERY:
+        {
+          switch (expr.getSubquery().getSubqueryTypeCase()) {
+            case SET_PREDICATE:
+              {
+                var rel =
+                    new ProtoRelConverter(lookup, extensions)
+                        .from(expr.getSubquery().getSetPredicate().getTuples());
+                return ImmutableExpression.SetPredicate.builder()
+                    .tuples(rel)
+                    .predicateOp(
+                        Expression.PredicateOp.fromProto(
+                            expr.getSubquery().getSetPredicate().getPredicateOp()))
+                    .build();
+              }
+            case SCALAR:
+              {
+                var rel =
+                    new ProtoRelConverter(lookup, extensions)
+                        .from(expr.getSubquery().getScalar().getInput());
+                return ImmutableExpression.ScalarSubquery.builder()
+                    .input(rel)
+                    .type(rel.getRecordType())
+                    .build();
+              }
+            case IN_PREDICATE:
+              {
+                var rel =
+                    new ProtoRelConverter(lookup, extensions)
+                        .from(expr.getSubquery().getInPredicate().getHaystack());
+                var needles =
+                    expr.getSubquery().getInPredicate().getNeedlesList().stream()
+                        .map(this::from)
+                        .collect(java.util.stream.Collectors.toList());
+                return ImmutableExpression.InPredicate.builder()
+                    .haystack(rel)
+                    .needles(needles)
+                    .type(rel.getRecordType())
+                    .build();
+              }
+            case SET_COMPARISON:
+              {
+                throw new UnsupportedOperationException(
+                    "Unsupported subquery type: " + expr.getSubquery().getSubqueryTypeCase());
+              }
+            default:
+              {
+                throw new IllegalArgumentException(
+                    "Unknown subquery type: " + expr.getSubquery().getSubqueryTypeCase());
+              }
           }
         }
-      }
 
         // TODO window, enum.
-      case WINDOW_FUNCTION, ENUM -> throw new UnsupportedOperationException(
-          "Unsupported type: " + expr.getRexTypeCase());
-      default -> throw new IllegalArgumentException("Unknown type: " + expr.getRexTypeCase());
-    };
+      case WINDOW_FUNCTION:
+      case ENUM:
+        throw new UnsupportedOperationException("Unsupported type: " + expr.getRexTypeCase());
+      default:
+        throw new IllegalArgumentException("Unknown type: " + expr.getRexTypeCase());
+    }
   }
 
   private static Type from(io.substrait.proto.Type type) {
@@ -211,57 +243,81 @@ public class ProtoExpressionConverter {
   }
 
   public static Expression.Literal from(io.substrait.proto.Expression.Literal literal) {
-    return switch (literal.getLiteralTypeCase()) {
-      case BOOLEAN -> ExpressionCreator.bool(literal.getNullable(), literal.getBoolean());
-      case I8 -> ExpressionCreator.i8(literal.getNullable(), literal.getI8());
-      case I16 -> ExpressionCreator.i16(literal.getNullable(), literal.getI16());
-      case I32 -> ExpressionCreator.i32(literal.getNullable(), literal.getI32());
-      case I64 -> ExpressionCreator.i64(literal.getNullable(), literal.getI64());
-      case FP32 -> ExpressionCreator.fp32(literal.getNullable(), literal.getFp32());
-      case FP64 -> ExpressionCreator.fp64(literal.getNullable(), literal.getFp64());
-      case STRING -> ExpressionCreator.string(literal.getNullable(), literal.getString());
-      case BINARY -> ExpressionCreator.binary(literal.getNullable(), literal.getBinary());
-      case TIMESTAMP -> ExpressionCreator.timestamp(literal.getNullable(), literal.getTimestamp());
-      case DATE -> ExpressionCreator.date(literal.getNullable(), literal.getDate());
-      case TIME -> ExpressionCreator.time(literal.getNullable(), literal.getTime());
-      case INTERVAL_YEAR_TO_MONTH -> ExpressionCreator.intervalYear(
-          literal.getNullable(),
-          literal.getIntervalYearToMonth().getYears(),
-          literal.getIntervalYearToMonth().getMonths());
-      case INTERVAL_DAY_TO_SECOND -> ExpressionCreator.intervalDay(
-          literal.getNullable(),
-          literal.getIntervalDayToSecond().getDays(),
-          literal.getIntervalDayToSecond().getSeconds());
-      case FIXED_CHAR -> ExpressionCreator.fixedChar(literal.getNullable(), literal.getFixedChar());
-      case VAR_CHAR -> ExpressionCreator.varChar(
-          literal.getNullable(), literal.getVarChar().getValue(), literal.getVarChar().getLength());
-      case FIXED_BINARY -> ExpressionCreator.fixedBinary(
-          literal.getNullable(), literal.getFixedBinary());
-      case DECIMAL -> ExpressionCreator.decimal(
-          literal.getNullable(),
-          literal.getDecimal().getValue(),
-          literal.getDecimal().getPrecision(),
-          literal.getDecimal().getScale());
-      case STRUCT -> ExpressionCreator.struct(
-          literal.getNullable(),
-          literal.getStruct().getFieldsList().stream()
-              .map(ProtoExpressionConverter::from)
-              .collect(java.util.stream.Collectors.toList()));
-      case MAP -> ExpressionCreator.map(
-          literal.getNullable(),
-          literal.getMap().getKeyValuesList().stream()
-              .collect(Collectors.toMap(kv -> from(kv.getKey()), kv -> from(kv.getValue()))));
-      case TIMESTAMP_TZ -> ExpressionCreator.timestampTZ(
-          literal.getNullable(), literal.getTimestampTz());
-      case UUID -> ExpressionCreator.uuid(literal.getNullable(), literal.getUuid());
-      case NULL -> ExpressionCreator.typedNull(from(literal.getNull()));
-      case LIST -> ExpressionCreator.list(
-          literal.getNullable(),
-          literal.getList().getValuesList().stream()
-              .map(ProtoExpressionConverter::from)
-              .collect(java.util.stream.Collectors.toList()));
-      default -> throw new IllegalStateException(
-          "Unexpected value: " + literal.getLiteralTypeCase());
-    };
+    switch (literal.getLiteralTypeCase()) {
+      case BOOLEAN:
+        return ExpressionCreator.bool(literal.getNullable(), literal.getBoolean());
+      case I8:
+        return ExpressionCreator.i8(literal.getNullable(), literal.getI8());
+      case I16:
+        return ExpressionCreator.i16(literal.getNullable(), literal.getI16());
+      case I32:
+        return ExpressionCreator.i32(literal.getNullable(), literal.getI32());
+      case I64:
+        return ExpressionCreator.i64(literal.getNullable(), literal.getI64());
+      case FP32:
+        return ExpressionCreator.fp32(literal.getNullable(), literal.getFp32());
+      case FP64:
+        return ExpressionCreator.fp64(literal.getNullable(), literal.getFp64());
+      case STRING:
+        return ExpressionCreator.string(literal.getNullable(), literal.getString());
+      case BINARY:
+        return ExpressionCreator.binary(literal.getNullable(), literal.getBinary());
+      case TIMESTAMP:
+        return ExpressionCreator.timestamp(literal.getNullable(), literal.getTimestamp());
+      case DATE:
+        return ExpressionCreator.date(literal.getNullable(), literal.getDate());
+      case TIME:
+        return ExpressionCreator.time(literal.getNullable(), literal.getTime());
+      case INTERVAL_YEAR_TO_MONTH:
+        return ExpressionCreator.intervalYear(
+            literal.getNullable(),
+            literal.getIntervalYearToMonth().getYears(),
+            literal.getIntervalYearToMonth().getMonths());
+      case INTERVAL_DAY_TO_SECOND:
+        return ExpressionCreator.intervalDay(
+            literal.getNullable(),
+            literal.getIntervalDayToSecond().getDays(),
+            literal.getIntervalDayToSecond().getSeconds());
+      case FIXED_CHAR:
+        return ExpressionCreator.fixedChar(literal.getNullable(), literal.getFixedChar());
+      case VAR_CHAR:
+        return ExpressionCreator.varChar(
+            literal.getNullable(),
+            literal.getVarChar().getValue(),
+            literal.getVarChar().getLength());
+      case FIXED_BINARY:
+        return ExpressionCreator.fixedBinary(literal.getNullable(), literal.getFixedBinary());
+      case DECIMAL:
+        return ExpressionCreator.decimal(
+            literal.getNullable(),
+            literal.getDecimal().getValue(),
+            literal.getDecimal().getPrecision(),
+            literal.getDecimal().getScale());
+      case STRUCT:
+        return ExpressionCreator.struct(
+            literal.getNullable(),
+            literal.getStruct().getFieldsList().stream()
+                .map(ProtoExpressionConverter::from)
+                .collect(java.util.stream.Collectors.toList()));
+      case MAP:
+        return ExpressionCreator.map(
+            literal.getNullable(),
+            literal.getMap().getKeyValuesList().stream()
+                .collect(Collectors.toMap(kv -> from(kv.getKey()), kv -> from(kv.getValue()))));
+      case TIMESTAMP_TZ:
+        return ExpressionCreator.timestampTZ(literal.getNullable(), literal.getTimestampTz());
+      case UUID:
+        return ExpressionCreator.uuid(literal.getNullable(), literal.getUuid());
+      case NULL:
+        return ExpressionCreator.typedNull(from(literal.getNull()));
+      case LIST:
+        return ExpressionCreator.list(
+            literal.getNullable(),
+            literal.getList().getValuesList().stream()
+                .map(ProtoExpressionConverter::from)
+                .collect(java.util.stream.Collectors.toList()));
+      default:
+        throw new IllegalStateException("Unexpected value: " + literal.getLiteralTypeCase());
+    }
   }
 }

--- a/core/src/main/java/io/substrait/function/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/function/SimpleExtension.java
@@ -592,7 +592,7 @@ public class SimpleExtension {
     }
 
     public AggregateFunctionVariant getAggregateFunction(FunctionAnchor anchor) {
-      var variant = aggregateFunctionsLookup.get().get(anchor);
+      AggregateFunctionVariant variant = aggregateFunctionsLookup.get().get(anchor);
       if (variant != null) {
         return variant;
       }
@@ -606,7 +606,7 @@ public class SimpleExtension {
     }
 
     public WindowFunctionVariant getWindowFunction(FunctionAnchor anchor) {
-      var variant = windowFunctionsLookup.get().get(anchor);
+      WindowFunctionVariant variant = windowFunctionsLookup.get().get(anchor);
       if (variant != null) {
         return variant;
       }
@@ -631,8 +631,8 @@ public class SimpleExtension {
   }
 
   public static ExtensionCollection loadDefaults() throws IOException {
-    var defaultFiles =
-        Arrays.asList(
+    List<String> defaultFiles =
+        Stream.of(
                 "boolean",
                 "aggregate_generic",
                 "aggregate_approx",
@@ -641,7 +641,6 @@ public class SimpleExtension {
                 "comparison",
                 "datetime",
                 "string")
-            .stream()
             .map(c -> String.format("/functions_%s.yaml", c))
             .collect(java.util.stream.Collectors.toList());
 
@@ -653,11 +652,11 @@ public class SimpleExtension {
       throw new IllegalArgumentException("Require at least one resource path.");
     }
 
-    var extensions =
+    List<ExtensionCollection> extensions =
         resourcePaths.stream()
             .map(
                 path -> {
-                  try (var stream = ExtensionCollection.class.getResourceAsStream(path)) {
+                  try (InputStream stream = ExtensionCollection.class.getResourceAsStream(path)) {
                     return load(path, stream);
                   } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -673,8 +672,9 @@ public class SimpleExtension {
 
   private static ExtensionCollection load(String namespace, InputStream stream) {
     try {
-      var doc = MAPPER.readValue(stream, SimpleExtension.FunctionSignatures.class);
-      var collection =
+      SimpleExtension.FunctionSignatures doc =
+          MAPPER.readValue(stream, SimpleExtension.FunctionSignatures.class);
+      ImmutableSimpleExtension.ExtensionCollection collection =
           ImmutableSimpleExtension.ExtensionCollection.builder()
               .addAllAggregateFunctions(
                   doc.aggregates().stream()

--- a/core/src/main/java/io/substrait/function/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/function/SimpleExtension.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -315,11 +316,17 @@ public class SimpleExtension {
       int max =
           variadic()
               .map(
-                  t ->
-                      t.getMax().stream()
-                          .map(x -> args().size() - 1 + x + 1)
-                          .findFirst()
-                          .orElse(Integer.MAX_VALUE))
+                  t -> {
+                    OptionalInt optionalMax = t.getMax();
+                    IntStream stream =
+                        optionalMax.isPresent()
+                            ? IntStream.of(optionalMax.getAsInt())
+                            : IntStream.empty();
+                    return stream
+                        .map(x -> args().size() - 1 + x + 1)
+                        .findFirst()
+                        .orElse(Integer.MAX_VALUE);
+                  })
               .orElse(args().size() + 1);
       int min =
           variadic().map(t -> args().size() - 1 + t.getMin()).orElse(requiredArguments().size());

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -37,7 +37,7 @@ public abstract class Join extends BiRel {
     }
 
     public static JoinType fromProto(JoinRel.JoinType proto) {
-      for (var v : values()) {
+      for (JoinType v : values()) {
         if (v.proto == proto) {
           return v;
         }

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -47,37 +47,47 @@ public class ProtoRelConverter {
   public Rel from(io.substrait.proto.Rel rel) {
     var relType = rel.getRelTypeCase();
     switch (relType) {
-      case READ -> {
-        return newRead(rel.getRead());
-      }
-      case FILTER -> {
-        return newFilter(rel.getFilter());
-      }
-      case FETCH -> {
-        return newFetch(rel.getFetch());
-      }
-      case AGGREGATE -> {
-        return newAggregate(rel.getAggregate());
-      }
-      case SORT -> {
-        return newSort(rel.getSort());
-      }
-      case JOIN -> {
-        return newJoin(rel.getJoin());
-      }
-      case SET -> {
-        return newSet(rel.getSet());
-      }
-      case PROJECT -> {
-        return newProject(rel.getProject());
-      }
-      case CROSS -> {
-        return newCross(rel.getCross());
-      }
-      default -> {
-        // TODO: add support for EXTENSION_SINGLE, EXTENSION_MULTI, EXTENSION_LEAF
-        throw new UnsupportedOperationException("Unsupported RelTypeCase of " + relType);
-      }
+      case READ:
+        {
+          return newRead(rel.getRead());
+        }
+      case FILTER:
+        {
+          return newFilter(rel.getFilter());
+        }
+      case FETCH:
+        {
+          return newFetch(rel.getFetch());
+        }
+      case AGGREGATE:
+        {
+          return newAggregate(rel.getAggregate());
+        }
+      case SORT:
+        {
+          return newSort(rel.getSort());
+        }
+      case JOIN:
+        {
+          return newJoin(rel.getJoin());
+        }
+      case SET:
+        {
+          return newSet(rel.getSet());
+        }
+      case PROJECT:
+        {
+          return newProject(rel.getProject());
+        }
+      case CROSS:
+        {
+          return newCross(rel.getCross());
+        }
+      default:
+        {
+          // TODO: add support for EXTENSION_SINGLE, EXTENSION_MULTI, EXTENSION_LEAF
+          throw new UnsupportedOperationException("Unsupported RelTypeCase of " + relType);
+        }
     }
   }
 
@@ -159,8 +169,7 @@ public class ProtoRelConverter {
                       .collect(java.util.stream.Collectors.toList()))
               .build());
     }
-    var fieldNames =
-        rel.getBaseSchema().getNamesList().stream().collect(java.util.stream.Collectors.toList());
+    var fieldNames = new ArrayList<>(rel.getBaseSchema().getNamesList());
     var converter = new ProtoExpressionConverter(lookup, extensions, EMPTY_TYPE);
     return VirtualTableScan.builder()
         .filter(Optional.ofNullable(rel.hasFilter() ? converter.from(rel.getFilter()) : null))

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -110,8 +110,11 @@ public class RelCopyOnWriteVisitor extends AbstractRelVisitor<Optional<Rel>, Run
             .from(join)
             .left(left.orElse(join.getLeft()))
             .right(right.orElse(join.getRight()))
-            .condition(condition.or(() -> join.getCondition()))
-            .postJoinFilter(postFilter.or(() -> join.getPostJoinFilter()))
+            .condition(
+                Optional.ofNullable(condition.orElseGet(() -> join.getCondition().orElse(null))))
+            .postJoinFilter(
+                Optional.ofNullable(
+                    postFilter.orElseGet(() -> join.getPostJoinFilter().orElse(null))))
             .build());
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -238,10 +238,12 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
   private RelCommon common(io.substrait.relation.Rel rel) {
     RelCommon.Builder builder = RelCommon.newBuilder();
-    rel.getRemap()
-        .ifPresentOrElse(
-            r -> builder.setEmit(RelCommon.Emit.newBuilder().addAllOutputMapping(r.indices())),
-            () -> builder.setDirect(RelCommon.Direct.getDefaultInstance()));
+    io.substrait.relation.Rel.Remap remap = rel.getRemap().orElse(null);
+    if (remap != null) {
+      builder.setEmit(RelCommon.Emit.newBuilder().addAllOutputMapping(remap.indices()));
+    } else {
+      builder.setDirect(RelCommon.Direct.getDefaultInstance());
+    }
     return builder.build();
   }
 }

--- a/core/src/main/java/io/substrait/relation/Set.java
+++ b/core/src/main/java/io/substrait/relation/Set.java
@@ -28,7 +28,7 @@ public abstract class Set extends AbstractRel {
     }
 
     public static Set.SetOp fromProto(SetRel.SetOp proto) {
-      for (var v : values()) {
+      for (SetOp v : values()) {
         if (v.proto == proto) {
           return v;
         }

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -22,8 +22,8 @@ public abstract class VirtualTableScan extends AbstractReadRel {
    */
   @Value.Check
   protected void check() {
-    var names = getDfsNames();
-    var rows = getRows();
+    List<String> names = getDfsNames();
+    List<Expression.StructLiteral> rows = getRows();
 
     assert rows.size() > 0
         && names.stream().noneMatch(s -> s == null)

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -41,7 +41,7 @@ public class Deserializers {
     @Override
     public T deserialize(final JsonParser p, final DeserializationContext ctxt)
         throws IOException, JsonProcessingException {
-      var typeString = p.getValueAsString();
+      String typeString = p.getValueAsString();
       try {
         return TypeStringParser.parse(typeString, converter);
       } catch (Exception ex) {

--- a/core/src/main/java/io/substrait/type/NamedStruct.java
+++ b/core/src/main/java/io/substrait/type/NamedStruct.java
@@ -15,7 +15,7 @@ public interface NamedStruct {
   }
 
   default io.substrait.proto.NamedStruct toProto() {
-    var type = struct().accept(TypeProtoConverter.INSTANCE);
+    io.substrait.proto.Type type = struct().accept(TypeProtoConverter.INSTANCE);
     return io.substrait.proto.NamedStruct.newBuilder()
         .setStruct(type.getStruct())
         .addAllNames(names())

--- a/core/src/main/java/io/substrait/type/YamlRead.java
+++ b/core/src/main/java/io/substrait/type/YamlRead.java
@@ -52,7 +52,8 @@ public class YamlRead {
           new ObjectMapper(new YAMLFactory())
               .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
               .registerModule(Deserializers.MODULE);
-      var doc = mapper.readValue(new File(name), SimpleExtension.FunctionSignatures.class);
+      SimpleExtension.FunctionSignatures doc =
+          mapper.readValue(new File(name), SimpleExtension.FunctionSignatures.class);
 
       logger.debug(
           "Parsed {} functions in file {}.",

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -1,5 +1,6 @@
 package io.substrait.type.parser;
 
+import io.substrait.function.ImmutableTypeExpression;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.ParameterizedTypeCreator;
 import io.substrait.function.TypeExpression;
@@ -8,6 +9,7 @@ import io.substrait.type.SubstraitTypeParser;
 import io.substrait.type.SubstraitTypeVisitor;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -213,7 +215,7 @@ public class ParseToPojo {
 
     @Override
     public TypeExpression visitStruct(final SubstraitTypeParser.StructContext ctx) {
-      var types =
+      List<TypeExpression> types =
           ctx.expr().stream()
               .map(t -> t.accept(this))
               .collect(java.util.stream.Collectors.toList());
@@ -329,17 +331,17 @@ public class ParseToPojo {
     public TypeExpression visitMultilineDefinition(
         final SubstraitTypeParser.MultilineDefinitionContext ctx) {
       checkExpression();
-      var exprs =
+      List<TypeExpression> exprs =
           ctx.expr().stream()
               .map(t -> t.accept(this))
               .collect(java.util.stream.Collectors.toList());
-      var identifiers =
+      List<String> identifiers =
           ctx.Identifier().stream()
-              .map(t -> t.getText())
+              .map(ParseTree::getText)
               .collect(java.util.stream.Collectors.toList());
-      var finalExpr = ctx.finalType.accept(this);
+      TypeExpression finalExpr = ctx.finalType.accept(this);
 
-      var bldr = TypeExpression.ReturnProgram.builder();
+      ImmutableTypeExpression.ReturnProgram.Builder bldr = TypeExpression.ReturnProgram.builder();
       for (int i = 0; i < exprs.size(); i++) {
         bldr.addAssignments(
             TypeExpression.ReturnProgram.Assignment.builder()
@@ -421,7 +423,7 @@ public class ParseToPojo {
       if (ctx.expr().size() != 2) {
         throw new IllegalStateException("Only two argument functions exist for type expressions.");
       }
-      var name = ctx.Identifier().getSymbol().getText().toUpperCase(Locale.ROOT);
+      String name = ctx.Identifier().getSymbol().getText().toUpperCase(Locale.ROOT);
       TypeExpression.BinaryOperation.OpType type;
       switch (name) {
         case "MIN":

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -355,20 +355,41 @@ public class ParseToPojo {
     @Override
     public TypeExpression visitBinaryExpr(final SubstraitTypeParser.BinaryExprContext ctx) {
       checkExpression();
-      TypeExpression.BinaryOperation.OpType type =
-          switch (ctx.op.getText().toUpperCase(Locale.ROOT)) {
-            case "+" -> TypeExpression.BinaryOperation.OpType.ADD;
-            case "-" -> TypeExpression.BinaryOperation.OpType.SUBTRACT;
-            case "*" -> TypeExpression.BinaryOperation.OpType.MULTIPLY;
-            case "/" -> TypeExpression.BinaryOperation.OpType.DIVIDE;
-            case ">" -> TypeExpression.BinaryOperation.OpType.GT;
-            case "<" -> TypeExpression.BinaryOperation.OpType.LT;
-            case "AND" -> TypeExpression.BinaryOperation.OpType.AND;
-            case "OR" -> TypeExpression.BinaryOperation.OpType.OR;
-            case "=" -> TypeExpression.BinaryOperation.OpType.EQ;
-            case ":=" -> TypeExpression.BinaryOperation.OpType.COVERS;
-            default -> throw new IllegalStateException();
-          };
+      TypeExpression.BinaryOperation.OpType type;
+      switch (ctx.op.getText().toUpperCase(Locale.ROOT)) {
+        case "+":
+          type = TypeExpression.BinaryOperation.OpType.ADD;
+          break;
+        case "-":
+          type = TypeExpression.BinaryOperation.OpType.SUBTRACT;
+          break;
+        case "*":
+          type = TypeExpression.BinaryOperation.OpType.MULTIPLY;
+          break;
+        case "/":
+          type = TypeExpression.BinaryOperation.OpType.DIVIDE;
+          break;
+        case ">":
+          type = TypeExpression.BinaryOperation.OpType.GT;
+          break;
+        case "<":
+          type = TypeExpression.BinaryOperation.OpType.LT;
+          break;
+        case "AND":
+          type = TypeExpression.BinaryOperation.OpType.AND;
+          break;
+        case "OR":
+          type = TypeExpression.BinaryOperation.OpType.OR;
+          break;
+        case "=":
+          type = TypeExpression.BinaryOperation.OpType.EQ;
+          break;
+        case ":=":
+          type = TypeExpression.BinaryOperation.OpType.COVERS;
+          break;
+        default:
+          throw new IllegalStateException();
+      }
       return TypeExpression.BinaryOperation.builder()
           .opType(type)
           .left(ctx.left.accept(this))
@@ -401,13 +422,17 @@ public class ParseToPojo {
         throw new IllegalStateException("Only two argument functions exist for type expressions.");
       }
       var name = ctx.Identifier().getSymbol().getText().toUpperCase(Locale.ROOT);
-      TypeExpression.BinaryOperation.OpType type =
-          switch (name) {
-            case "MIN" -> TypeExpression.BinaryOperation.OpType.MIN;
-            case "MAX" -> TypeExpression.BinaryOperation.OpType.MAX;
-            default -> throw new IllegalStateException(
-                "The following operation was unrecognized: " + name);
-          };
+      TypeExpression.BinaryOperation.OpType type;
+      switch (name) {
+        case "MIN":
+          type = TypeExpression.BinaryOperation.OpType.MIN;
+          break;
+        case "MAX":
+          type = TypeExpression.BinaryOperation.OpType.MAX;
+          break;
+        default:
+          throw new IllegalStateException("The following operation was unrecognized: " + name);
+      }
       return TypeExpression.BinaryOperation.builder()
           .opType(type)
           .left(ctx.expr(0).accept(this))

--- a/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
+++ b/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
@@ -30,11 +30,11 @@ public class TypeStringParser {
   }
 
   private static SubstraitTypeParser.StartContext parse(String str) {
-    var lexer = new SubstraitTypeLexer(CharStreams.fromString(str));
+    SubstraitTypeLexer lexer = new SubstraitTypeLexer(CharStreams.fromString(str));
     lexer.removeErrorListeners();
     lexer.addErrorListener(TypeErrorListener.INSTANCE);
-    var tokenStream = new CommonTokenStream(lexer);
-    var parser = new io.substrait.type.SubstraitTypeParser(tokenStream);
+    CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+    SubstraitTypeParser parser = new io.substrait.type.SubstraitTypeParser(tokenStream);
     parser.removeErrorListeners();
     parser.addErrorListener(TypeErrorListener.INSTANCE);
     return parser.start();

--- a/core/src/main/java/io/substrait/type/proto/FromProto.java
+++ b/core/src/main/java/io/substrait/type/proto/FromProto.java
@@ -8,42 +8,66 @@ public class FromProto {
   private FromProto() {}
 
   public static Type from(io.substrait.proto.Type type) {
-    return switch (type.getKindCase()) {
-      case BOOL -> n(type.getBool().getNullability()).BOOLEAN;
-      case I8 -> n(type.getI8().getNullability()).I8;
-      case I16 -> n(type.getI16().getNullability()).I16;
-      case I32 -> n(type.getI32().getNullability()).I32;
-      case I64 -> n(type.getI64().getNullability()).I64;
-      case FP32 -> n(type.getFp32().getNullability()).FP32;
-      case FP64 -> n(type.getFp64().getNullability()).FP64;
-      case STRING -> n(type.getString().getNullability()).STRING;
-      case BINARY -> n(type.getBinary().getNullability()).BINARY;
-      case TIMESTAMP -> n(type.getTimestamp().getNullability()).TIMESTAMP;
-      case DATE -> n(type.getDate().getNullability()).DATE;
-      case TIME -> n(type.getTime().getNullability()).TIME;
-      case INTERVAL_YEAR -> n(type.getIntervalYear().getNullability()).INTERVAL_YEAR;
-      case INTERVAL_DAY -> n(type.getIntervalDay().getNullability()).INTERVAL_DAY;
-      case TIMESTAMP_TZ -> n(type.getTimestampTz().getNullability()).TIMESTAMP_TZ;
-      case UUID -> n(type.getUuid().getNullability()).UUID;
-      case FIXED_CHAR -> n(type.getFixedChar().getNullability())
-          .fixedChar(type.getFixedChar().getLength());
-      case VARCHAR -> n(type.getVarchar().getNullability()).varChar(type.getVarchar().getLength());
-      case FIXED_BINARY -> n(type.getFixedBinary().getNullability())
-          .fixedBinary(type.getFixedBinary().getLength());
-      case DECIMAL -> n(type.getDecimal().getNullability())
-          .decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
-      case STRUCT -> n(type.getStruct().getNullability())
-          .struct(
-              type.getStruct().getTypesList().stream()
-                  .map(FromProto::from)
-                  .collect(java.util.stream.Collectors.toList()));
-      case LIST -> n(type.getList().getNullability()).list(from(type.getList().getType()));
-      case MAP -> n(type.getMap().getNullability())
-          .map(from(type.getMap().getKey()), from(type.getMap().getValue()));
-      case USER_DEFINED_TYPE_REFERENCE,
-          USER_DEFINED,
-          KIND_NOT_SET -> throw new UnsupportedOperationException();
-    };
+    switch (type.getKindCase()) {
+      case BOOL:
+        return n(type.getBool().getNullability()).BOOLEAN;
+      case I8:
+        return n(type.getI8().getNullability()).I8;
+      case I16:
+        return n(type.getI16().getNullability()).I16;
+      case I32:
+        return n(type.getI32().getNullability()).I32;
+      case I64:
+        return n(type.getI64().getNullability()).I64;
+      case FP32:
+        return n(type.getFp32().getNullability()).FP32;
+      case FP64:
+        return n(type.getFp64().getNullability()).FP64;
+      case STRING:
+        return n(type.getString().getNullability()).STRING;
+      case BINARY:
+        return n(type.getBinary().getNullability()).BINARY;
+      case TIMESTAMP:
+        return n(type.getTimestamp().getNullability()).TIMESTAMP;
+      case DATE:
+        return n(type.getDate().getNullability()).DATE;
+      case TIME:
+        return n(type.getTime().getNullability()).TIME;
+      case INTERVAL_YEAR:
+        return n(type.getIntervalYear().getNullability()).INTERVAL_YEAR;
+      case INTERVAL_DAY:
+        return n(type.getIntervalDay().getNullability()).INTERVAL_DAY;
+      case TIMESTAMP_TZ:
+        return n(type.getTimestampTz().getNullability()).TIMESTAMP_TZ;
+      case UUID:
+        return n(type.getUuid().getNullability()).UUID;
+      case FIXED_CHAR:
+        return n(type.getFixedChar().getNullability()).fixedChar(type.getFixedChar().getLength());
+      case VARCHAR:
+        return n(type.getVarchar().getNullability()).varChar(type.getVarchar().getLength());
+      case FIXED_BINARY:
+        return n(type.getFixedBinary().getNullability())
+            .fixedBinary(type.getFixedBinary().getLength());
+      case DECIMAL:
+        return n(type.getDecimal().getNullability())
+            .decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
+      case STRUCT:
+        return n(type.getStruct().getNullability())
+            .struct(
+                type.getStruct().getTypesList().stream()
+                    .map(FromProto::from)
+                    .collect(java.util.stream.Collectors.toList()));
+      case LIST:
+        return n(type.getList().getNullability()).list(from(type.getList().getType()));
+      case MAP:
+        return n(type.getMap().getNullability())
+            .map(from(type.getMap().getKey()), from(type.getMap().getValue()));
+      case USER_DEFINED_TYPE_REFERENCE:
+      case USER_DEFINED:
+      case KIND_NOT_SET:
+      default:
+        throw new UnsupportedOperationException();
+    }
   }
 
   public static boolean isNullable(io.substrait.proto.Type.Nullability nullability) {

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -200,7 +200,7 @@ public class ParameterizedProtoConverter
 
     @Override
     protected ParameterizedType wrap(final Object o) {
-      var bldr = ParameterizedType.newBuilder();
+      ParameterizedType.Builder bldr = ParameterizedType.newBuilder();
       if (o instanceof Type.Boolean) {
         return bldr.setBool((Type.Boolean) o).build();
       } else if (o instanceof Type.I8) {

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -201,52 +201,52 @@ public class ParameterizedProtoConverter
     @Override
     protected ParameterizedType wrap(final Object o) {
       var bldr = ParameterizedType.newBuilder();
-      if (o instanceof Type.Boolean t) {
-        return bldr.setBool(t).build();
-      } else if (o instanceof Type.I8 t) {
-        return bldr.setI8(t).build();
-      } else if (o instanceof Type.I16 t) {
-        return bldr.setI16(t).build();
-      } else if (o instanceof Type.I32 t) {
-        return bldr.setI32(t).build();
-      } else if (o instanceof Type.I64 t) {
-        return bldr.setI64(t).build();
-      } else if (o instanceof Type.FP32 t) {
-        return bldr.setFp32(t).build();
-      } else if (o instanceof Type.FP64 t) {
-        return bldr.setFp64(t).build();
-      } else if (o instanceof Type.String t) {
-        return bldr.setString(t).build();
-      } else if (o instanceof Type.Binary t) {
-        return bldr.setBinary(t).build();
-      } else if (o instanceof Type.Timestamp t) {
-        return bldr.setTimestamp(t).build();
-      } else if (o instanceof Type.Date t) {
-        return bldr.setDate(t).build();
-      } else if (o instanceof Type.Time t) {
-        return bldr.setTime(t).build();
-      } else if (o instanceof Type.TimestampTZ t) {
-        return bldr.setTimestampTz(t).build();
-      } else if (o instanceof Type.IntervalYear t) {
-        return bldr.setIntervalYear(t).build();
-      } else if (o instanceof Type.IntervalDay t) {
-        return bldr.setIntervalDay(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedFixedChar t) {
-        return bldr.setFixedChar(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedVarChar t) {
-        return bldr.setVarchar(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedFixedBinary t) {
-        return bldr.setFixedBinary(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedDecimal t) {
-        return bldr.setDecimal(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedStruct t) {
-        return bldr.setStruct(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedList t) {
-        return bldr.setList(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedMap t) {
-        return bldr.setMap(t).build();
-      } else if (o instanceof Type.UUID t) {
-        return bldr.setUuid(t).build();
+      if (o instanceof Type.Boolean) {
+        return bldr.setBool((Type.Boolean) o).build();
+      } else if (o instanceof Type.I8) {
+        return bldr.setI8((Type.I8) o).build();
+      } else if (o instanceof Type.I16) {
+        return bldr.setI16((Type.I16) o).build();
+      } else if (o instanceof Type.I32) {
+        return bldr.setI32((Type.I32) o).build();
+      } else if (o instanceof Type.I64) {
+        return bldr.setI64((Type.I64) o).build();
+      } else if (o instanceof Type.FP32) {
+        return bldr.setFp32((Type.FP32) o).build();
+      } else if (o instanceof Type.FP64) {
+        return bldr.setFp64((Type.FP64) o).build();
+      } else if (o instanceof Type.String) {
+        return bldr.setString((Type.String) o).build();
+      } else if (o instanceof Type.Binary) {
+        return bldr.setBinary((Type.Binary) o).build();
+      } else if (o instanceof Type.Timestamp) {
+        return bldr.setTimestamp((Type.Timestamp) o).build();
+      } else if (o instanceof Type.Date) {
+        return bldr.setDate((Type.Date) o).build();
+      } else if (o instanceof Type.Time) {
+        return bldr.setTime((Type.Time) o).build();
+      } else if (o instanceof Type.TimestampTZ) {
+        return bldr.setTimestampTz((Type.TimestampTZ) o).build();
+      } else if (o instanceof Type.IntervalYear) {
+        return bldr.setIntervalYear((Type.IntervalYear) o).build();
+      } else if (o instanceof Type.IntervalDay) {
+        return bldr.setIntervalDay((Type.IntervalDay) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedFixedChar) {
+        return bldr.setFixedChar((ParameterizedType.ParameterizedFixedChar) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedVarChar) {
+        return bldr.setVarchar((ParameterizedType.ParameterizedVarChar) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedFixedBinary) {
+        return bldr.setFixedBinary((ParameterizedType.ParameterizedFixedBinary) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedDecimal) {
+        return bldr.setDecimal((ParameterizedType.ParameterizedDecimal) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedStruct) {
+        return bldr.setStruct((ParameterizedType.ParameterizedStruct) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedList) {
+        return bldr.setList((ParameterizedType.ParameterizedList) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedMap) {
+        return bldr.setMap((ParameterizedType.ParameterizedMap) o).build();
+      } else if (o instanceof Type.UUID) {
+        return bldr.setUuid((Type.UUID) o).build();
       }
       throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -4,6 +4,7 @@ import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
 import io.substrait.proto.DerivationExpression;
 import io.substrait.proto.Type;
+import java.util.List;
 
 public class TypeExpressionProtoVisitor
     extends BaseProtoConverter<DerivationExpression, DerivationExpression> {
@@ -98,7 +99,7 @@ public class TypeExpressionProtoVisitor
 
   @Override
   public DerivationExpression visit(final TypeExpression.ReturnProgram expr) {
-    var assignments =
+    List<DerivationExpression.ReturnProgram.Assignment> assignments =
         expr.assignments().stream()
             .map(
                 a ->
@@ -107,7 +108,7 @@ public class TypeExpressionProtoVisitor
                         .setExpression(a.expr().accept(this))
                         .build())
             .collect(java.util.stream.Collectors.toList());
-    var finalExpr = expr.finalExpression().accept(this);
+    DerivationExpression finalExpr = expr.finalExpression().accept(this);
     return DerivationExpression.newBuilder()
         .setReturnProgram(
             DerivationExpression.ReturnProgram.newBuilder()
@@ -282,7 +283,7 @@ public class TypeExpressionProtoVisitor
 
     @Override
     protected DerivationExpression wrap(final Object o) {
-      var bldr = DerivationExpression.newBuilder();
+      DerivationExpression.Builder bldr = DerivationExpression.newBuilder();
       if (o instanceof Type.Boolean) {
         return bldr.setBool((Type.Boolean) o).build();
       } else if (o instanceof Type.I8) {

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -27,21 +27,38 @@ public class TypeExpressionProtoVisitor
 
   @Override
   public DerivationExpression visit(final TypeExpression.BinaryOperation expr) {
-    var opType =
-        switch (expr.opType()) {
-          case ADD -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_PLUS;
-          case SUBTRACT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
-          case MIN -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MIN;
-          case MAX -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MAX;
-          case LT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
-            // case LTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
-          case GT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_GREATER_THAN;
-            // case GTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
-            // case NOT_EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQ;
-          case EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQUALS;
-          case COVERS -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_COVERS;
-          default -> throw new IllegalStateException("Unexpected value: " + expr.opType());
-        };
+    DerivationExpression.BinaryOp.BinaryOpType opType;
+    switch (expr.opType()) {
+      case ADD:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_PLUS;
+        break;
+      case SUBTRACT:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
+        break;
+      case MIN:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MIN;
+        break;
+      case MAX:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MAX;
+        break;
+      case LT:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
+        break;
+        // case LTE : opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
+      case GT:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_GREATER_THAN;
+        break;
+        // case GTE : opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
+        // case NOT_EQ : opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQ;
+      case EQ:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQUALS;
+        break;
+      case COVERS:
+        opType = DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_COVERS;
+        break;
+      default:
+        throw new IllegalStateException("Unexpected value: " + expr.opType());
+    }
     return DerivationExpression.newBuilder()
         .setBinaryOp(
             DerivationExpression.BinaryOp.newBuilder()
@@ -266,52 +283,52 @@ public class TypeExpressionProtoVisitor
     @Override
     protected DerivationExpression wrap(final Object o) {
       var bldr = DerivationExpression.newBuilder();
-      if (o instanceof Type.Boolean t) {
-        return bldr.setBool(t).build();
-      } else if (o instanceof Type.I8 t) {
-        return bldr.setI8(t).build();
-      } else if (o instanceof Type.I16 t) {
-        return bldr.setI16(t).build();
-      } else if (o instanceof Type.I32 t) {
-        return bldr.setI32(t).build();
-      } else if (o instanceof Type.I64 t) {
-        return bldr.setI64(t).build();
-      } else if (o instanceof Type.FP32 t) {
-        return bldr.setFp32(t).build();
-      } else if (o instanceof Type.FP64 t) {
-        return bldr.setFp64(t).build();
-      } else if (o instanceof Type.String t) {
-        return bldr.setString(t).build();
-      } else if (o instanceof Type.Binary t) {
-        return bldr.setBinary(t).build();
-      } else if (o instanceof Type.Timestamp t) {
-        return bldr.setTimestamp(t).build();
-      } else if (o instanceof Type.Date t) {
-        return bldr.setDate(t).build();
-      } else if (o instanceof Type.Time t) {
-        return bldr.setTime(t).build();
-      } else if (o instanceof Type.TimestampTZ t) {
-        return bldr.setTimestampTz(t).build();
-      } else if (o instanceof Type.IntervalYear t) {
-        return bldr.setIntervalYear(t).build();
-      } else if (o instanceof Type.IntervalDay t) {
-        return bldr.setIntervalDay(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionFixedChar t) {
-        return bldr.setFixedChar(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionVarChar t) {
-        return bldr.setVarchar(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionFixedBinary t) {
-        return bldr.setFixedBinary(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionDecimal t) {
-        return bldr.setDecimal(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionStruct t) {
-        return bldr.setStruct(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionList t) {
-        return bldr.setList(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionMap t) {
-        return bldr.setMap(t).build();
-      } else if (o instanceof Type.UUID t) {
-        return bldr.setUuid(t).build();
+      if (o instanceof Type.Boolean) {
+        return bldr.setBool((Type.Boolean) o).build();
+      } else if (o instanceof Type.I8) {
+        return bldr.setI8((Type.I8) o).build();
+      } else if (o instanceof Type.I16) {
+        return bldr.setI16((Type.I16) o).build();
+      } else if (o instanceof Type.I32) {
+        return bldr.setI32((Type.I32) o).build();
+      } else if (o instanceof Type.I64) {
+        return bldr.setI64((Type.I64) o).build();
+      } else if (o instanceof Type.FP32) {
+        return bldr.setFp32((Type.FP32) o).build();
+      } else if (o instanceof Type.FP64) {
+        return bldr.setFp64((Type.FP64) o).build();
+      } else if (o instanceof Type.String) {
+        return bldr.setString((Type.String) o).build();
+      } else if (o instanceof Type.Binary) {
+        return bldr.setBinary((Type.Binary) o).build();
+      } else if (o instanceof Type.Timestamp) {
+        return bldr.setTimestamp((Type.Timestamp) o).build();
+      } else if (o instanceof Type.Date) {
+        return bldr.setDate((Type.Date) o).build();
+      } else if (o instanceof Type.Time) {
+        return bldr.setTime((Type.Time) o).build();
+      } else if (o instanceof Type.TimestampTZ) {
+        return bldr.setTimestampTz((Type.TimestampTZ) o).build();
+      } else if (o instanceof Type.IntervalYear) {
+        return bldr.setIntervalYear((Type.IntervalYear) o).build();
+      } else if (o instanceof Type.IntervalDay) {
+        return bldr.setIntervalDay((Type.IntervalDay) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionFixedChar) {
+        return bldr.setFixedChar((DerivationExpression.ExpressionFixedChar) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionVarChar) {
+        return bldr.setVarchar((DerivationExpression.ExpressionVarChar) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionFixedBinary) {
+        return bldr.setFixedBinary((DerivationExpression.ExpressionFixedBinary) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionDecimal) {
+        return bldr.setDecimal((DerivationExpression.ExpressionDecimal) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionStruct) {
+        return bldr.setStruct((DerivationExpression.ExpressionStruct) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionList) {
+        return bldr.setList((DerivationExpression.ExpressionList) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionMap) {
+        return bldr.setMap((DerivationExpression.ExpressionMap) o).build();
+      } else if (o instanceof Type.UUID) {
+        return bldr.setUuid((Type.UUID) o).build();
       }
       throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -78,52 +78,52 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     @Override
     protected Type wrap(final Object o) {
       var bldr = Type.newBuilder();
-      if (o instanceof Type.Boolean t) {
-        return bldr.setBool(t).build();
-      } else if (o instanceof Type.I8 t) {
-        return bldr.setI8(t).build();
-      } else if (o instanceof Type.I16 t) {
-        return bldr.setI16(t).build();
-      } else if (o instanceof Type.I32 t) {
-        return bldr.setI32(t).build();
-      } else if (o instanceof Type.I64 t) {
-        return bldr.setI64(t).build();
-      } else if (o instanceof Type.FP32 t) {
-        return bldr.setFp32(t).build();
-      } else if (o instanceof Type.FP64 t) {
-        return bldr.setFp64(t).build();
-      } else if (o instanceof Type.String t) {
-        return bldr.setString(t).build();
-      } else if (o instanceof Type.Binary t) {
-        return bldr.setBinary(t).build();
-      } else if (o instanceof Type.Timestamp t) {
-        return bldr.setTimestamp(t).build();
-      } else if (o instanceof Type.Date t) {
-        return bldr.setDate(t).build();
-      } else if (o instanceof Type.Time t) {
-        return bldr.setTime(t).build();
-      } else if (o instanceof Type.TimestampTZ t) {
-        return bldr.setTimestampTz(t).build();
-      } else if (o instanceof Type.IntervalYear t) {
-        return bldr.setIntervalYear(t).build();
-      } else if (o instanceof Type.IntervalDay t) {
-        return bldr.setIntervalDay(t).build();
-      } else if (o instanceof Type.FixedChar t) {
-        return bldr.setFixedChar(t).build();
-      } else if (o instanceof Type.VarChar t) {
-        return bldr.setVarchar(t).build();
-      } else if (o instanceof Type.FixedBinary t) {
-        return bldr.setFixedBinary(t).build();
-      } else if (o instanceof Type.Decimal t) {
-        return bldr.setDecimal(t).build();
-      } else if (o instanceof Type.Struct t) {
-        return bldr.setStruct(t).build();
-      } else if (o instanceof Type.List t) {
-        return bldr.setList(t).build();
-      } else if (o instanceof Type.Map t) {
-        return bldr.setMap(t).build();
-      } else if (o instanceof Type.UUID t) {
-        return bldr.setUuid(t).build();
+      if (o instanceof Type.Boolean) {
+        return bldr.setBool((Type.Boolean) o).build();
+      } else if (o instanceof Type.I8) {
+        return bldr.setI8((Type.I8) o).build();
+      } else if (o instanceof Type.I16) {
+        return bldr.setI16((Type.I16) o).build();
+      } else if (o instanceof Type.I32) {
+        return bldr.setI32((Type.I32) o).build();
+      } else if (o instanceof Type.I64) {
+        return bldr.setI64((Type.I64) o).build();
+      } else if (o instanceof Type.FP32) {
+        return bldr.setFp32((Type.FP32) o).build();
+      } else if (o instanceof Type.FP64) {
+        return bldr.setFp64((Type.FP64) o).build();
+      } else if (o instanceof Type.String) {
+        return bldr.setString((Type.String) o).build();
+      } else if (o instanceof Type.Binary) {
+        return bldr.setBinary((Type.Binary) o).build();
+      } else if (o instanceof Type.Timestamp) {
+        return bldr.setTimestamp((Type.Timestamp) o).build();
+      } else if (o instanceof Type.Date) {
+        return bldr.setDate((Type.Date) o).build();
+      } else if (o instanceof Type.Time) {
+        return bldr.setTime((Type.Time) o).build();
+      } else if (o instanceof Type.TimestampTZ) {
+        return bldr.setTimestampTz((Type.TimestampTZ) o).build();
+      } else if (o instanceof Type.IntervalYear) {
+        return bldr.setIntervalYear((Type.IntervalYear) o).build();
+      } else if (o instanceof Type.IntervalDay) {
+        return bldr.setIntervalDay((Type.IntervalDay) o).build();
+      } else if (o instanceof Type.FixedChar) {
+        return bldr.setFixedChar((Type.FixedChar) o).build();
+      } else if (o instanceof Type.VarChar) {
+        return bldr.setVarchar((Type.VarChar) o).build();
+      } else if (o instanceof Type.FixedBinary) {
+        return bldr.setFixedBinary((Type.FixedBinary) o).build();
+      } else if (o instanceof Type.Decimal) {
+        return bldr.setDecimal((Type.Decimal) o).build();
+      } else if (o instanceof Type.Struct) {
+        return bldr.setStruct((Type.Struct) o).build();
+      } else if (o instanceof Type.List) {
+        return bldr.setList((Type.List) o).build();
+      } else if (o instanceof Type.Map) {
+        return bldr.setMap((Type.Map) o).build();
+      } else if (o instanceof Type.UUID) {
+        return bldr.setUuid((Type.UUID) o).build();
       }
       throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -77,7 +77,7 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
 
     @Override
     protected Type wrap(final Object o) {
-      var bldr = Type.newBuilder();
+      Type.Builder bldr = Type.newBuilder();
       if (o instanceof Type.Boolean) {
         return bldr.setBool((Type.Boolean) o).build();
       } else if (o instanceof Type.I8) {

--- a/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
@@ -49,8 +49,8 @@ public class GenericRoundtripTest {
     // roundtrip to protobuff and back and check equality
     Expression val = (Expression) m.invoke(null, paramInst.toArray(new Object[0]));
 
-    var to = new ExpressionProtoConverter(null, null);
-    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE);
+    ExpressionProtoConverter to = new ExpressionProtoConverter(null, null);
+    ProtoExpressionConverter from = new ProtoExpressionConverter(null, null, EMPTY_TYPE);
     assertEquals(val, from.from(val.accept(to)));
   }
 

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -15,9 +15,10 @@ public class LiteralRoundtripTest {
 
   @Test
   void decimal() {
-    var val = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
-    var to = new ExpressionProtoConverter(null, null);
-    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE);
+    io.substrait.expression.Expression.DecimalLiteral val =
+        ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
+    ExpressionProtoConverter to = new ExpressionProtoConverter(null, null);
+    ProtoExpressionConverter from = new ProtoExpressionConverter(null, null, EMPTY_TYPE);
     assertEquals(val, from.from(val.accept(to)));
   }
 }

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -44,7 +44,7 @@ public class TestTypeRoundtrip {
    * @param type
    */
   private void t(Type type) {
-    var converted = type.accept(new TypeProtoConverter());
+    io.substrait.proto.Type converted = type.accept(new TypeProtoConverter());
     assertEquals(type, FromProto.from(converted));
   }
 


### PR DESCRIPTION
I currently work on [gluten](https://github.com/oap-project/gluten), which translates SparkPlan into a Substrait plan.  Although Java 8 is at the end of its life, as we know,  Spark currently mainly runs on JVM 8.  And hence, gluten has to focus on Java 8 in its first release. Jabel may be fine, but it needs to modify the byte code, which introduces some risks.

Based on https://github.com/substrait-io/substrait-java/pull/94, this patch downgrades the core module into Java 8.
1. remove` var`
2. Using java 8 `switch case`, which is a litter Cumbersome.
3. Replace `o instanceof Type.Boolean t` with explicitly cast

Using existed unit test is enoguth.

cc @jacques-n  @FelixYBW