### PR TITLE
Add ReadRel LocalFiles

### DIFF
--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -40,6 +40,11 @@ public abstract class AbstractRelVisitor<OUTPUT, EXCEPTION extends Exception>
   }
 
   @Override
+  public OUTPUT visit(LocalFiles localFiles) throws EXCEPTION {
+    return visitFallback(localFiles);
+  }
+
+  @Override
   public OUTPUT visit(Project project) throws EXCEPTION {
     return visitFallback(project);
   }

--- a/core/src/main/java/io/substrait/relation/LocalFiles.java
+++ b/core/src/main/java/io/substrait/relation/LocalFiles.java
@@ -1,0 +1,26 @@
+package io.substrait.relation;
+
+import io.substrait.io.substrait.extension.AdvancedExtension;
+import io.substrait.relation.files.FileOrFiles;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class LocalFiles extends AbstractReadRel {
+
+  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LocalFiles.class);
+
+  public abstract List<FileOrFiles> getItems();
+
+  public abstract Optional<AdvancedExtension> getExtension();
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableLocalFiles.Builder builder() {
+    return ImmutableLocalFiles.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -15,6 +15,8 @@ public interface RelVisitor<OUTPUT, EXCEPTION extends Exception> {
 
   OUTPUT visit(NamedScan namedScan) throws EXCEPTION;
 
+  OUTPUT visit(LocalFiles localFiles) throws EXCEPTION;
+
   OUTPUT visit(Project project) throws EXCEPTION;
 
   OUTPUT visit(Sort sort) throws EXCEPTION;

--- a/core/src/main/java/io/substrait/relation/files/FileFormat.java
+++ b/core/src/main/java/io/substrait/relation/files/FileFormat.java
@@ -1,0 +1,21 @@
+package io.substrait.relation.files;
+
+import org.immutables.value.Value;
+
+@Value.Enclosing
+public interface FileFormat {
+
+  @Value.Immutable
+  abstract static class ParquetReadOptions implements FileFormat {}
+
+  @Value.Immutable
+  abstract static class ArrowReadOptions implements FileFormat {}
+
+  @Value.Immutable
+  abstract static class OrcReadOptions implements FileFormat {}
+
+  @Value.Immutable
+  abstract static class Extension implements FileFormat {
+    public abstract com.google.protobuf.Any getExtension();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/files/FileOrFiles.java
+++ b/core/src/main/java/io/substrait/relation/files/FileOrFiles.java
@@ -1,0 +1,71 @@
+package io.substrait.relation.files;
+
+import io.substrait.proto.ReadRel;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface FileOrFiles {
+
+  Optional<PathType> pathType();
+
+  enum PathType {
+    URI_PATH,
+    URI_PATH_GLOB,
+    URI_FILE,
+    URI_FOLDER
+  }
+
+  Optional<String> getPath();
+
+  long getPartitionIndex();
+
+  long getStart();
+
+  long getLength();
+
+  Optional<FileFormat> getFileFormat();
+
+  default ReadRel.LocalFiles.FileOrFiles toProto() {
+    ReadRel.LocalFiles.FileOrFiles.Builder builder = ReadRel.LocalFiles.FileOrFiles.newBuilder();
+
+    getFileFormat()
+        .ifPresent(
+            fileFormat -> {
+              if (fileFormat instanceof FileFormat.ParquetReadOptions options) {
+                builder.setParquet(
+                    ReadRel.LocalFiles.FileOrFiles.ParquetReadOptions.newBuilder().build());
+              } else if (fileFormat instanceof FileFormat.ArrowReadOptions options) {
+                builder.setArrow(
+                    ReadRel.LocalFiles.FileOrFiles.ArrowReadOptions.newBuilder().build());
+              } else if (fileFormat instanceof FileFormat.OrcReadOptions options) {
+                builder.setOrc(ReadRel.LocalFiles.FileOrFiles.OrcReadOptions.newBuilder().build());
+              } else if (fileFormat instanceof FileFormat.Extension options) {
+                builder.setExtension(options.getExtension());
+              } else {
+                throw new UnsupportedOperationException(
+                    "Unable to convert file format of " + fileFormat.getClass());
+              }
+            });
+
+    pathType()
+        .ifPresent(
+            pathType ->
+                getPath()
+                    .ifPresent(
+                        path -> {
+                          switch (pathType) {
+                            case URI_PATH -> builder.setUriPath(path);
+                            case URI_PATH_GLOB -> builder.setUriPathGlob(path);
+                            case URI_FILE -> builder.setUriFile(path);
+                            case URI_FOLDER -> builder.setUriFolder(path);
+                          }
+                        }));
+
+    return builder
+        .setPartitionIndex(getPartitionIndex())
+        .setStart(getStart())
+        .setLength(getLength())
+        .build();
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
@@ -1,0 +1,114 @@
+package io.substrait.type.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.expression.FieldReference;
+import io.substrait.expression.ImmutableFieldReference;
+import io.substrait.expression.proto.FunctionCollector;
+import io.substrait.function.SimpleExtension;
+import io.substrait.proto.ReadRel;
+import io.substrait.relation.LocalFiles;
+import io.substrait.relation.ProtoRelConverter;
+import io.substrait.relation.RelProtoConverter;
+import io.substrait.relation.files.FileOrFiles;
+import io.substrait.relation.files.ImmutableFileFormat;
+import io.substrait.relation.files.ImmutableFileOrFiles;
+import io.substrait.type.ImmutableNamedStruct;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.io.IOException;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class LocalFilesRoundtripTest {
+
+  SimpleExtension.ExtensionCollection extensions = SimpleExtension.loadDefaults();
+
+  public LocalFilesRoundtripTest() throws IOException {}
+
+  private void assertLocalFilesRoundtrip(FileOrFiles file) {
+    FunctionCollector functionCollector = new FunctionCollector();
+    RelProtoConverter to = new RelProtoConverter(functionCollector);
+    ProtoRelConverter from = new ProtoRelConverter(functionCollector, extensions);
+
+    var builder =
+        LocalFiles.builder()
+            .initialSchema(
+                ImmutableNamedStruct.builder()
+                    .addNames("id")
+                    .struct(
+                        Type.Struct.builder()
+                            .nullable(false)
+                            .addFields(TypeCreator.REQUIRED.I32)
+                            .build())
+                    .build())
+            .addItems(file);
+
+    extensions.scalarFunctions().stream()
+        .filter(s -> s.name().equalsIgnoreCase("equal"))
+        .findFirst()
+        .map(
+            declaration ->
+                ExpressionCreator.scalarFunction(
+                    declaration,
+                    TypeCreator.REQUIRED.BOOLEAN,
+                    ImmutableFieldReference.builder()
+                        .addSegments(FieldReference.StructField.of(0))
+                        .type(TypeCreator.REQUIRED.I32)
+                        .build(),
+                    ExpressionCreator.i32(false, 1)))
+        .ifPresent(builder::filter);
+
+    var localFiles = builder.build();
+    var protoFileRel = to.toProto(localFiles);
+    assertTrue(protoFileRel.getRead().hasFilter());
+    assertEquals(protoFileRel, to.toProto(from.from(protoFileRel)));
+  }
+
+  private ImmutableFileOrFiles.Builder setPath(
+      ImmutableFileOrFiles.Builder builder,
+      ReadRel.LocalFiles.FileOrFiles.PathTypeCase pathTypeCase) {
+    return switch (pathTypeCase) {
+      case URI_PATH -> builder.pathType(FileOrFiles.PathType.URI_PATH).path("path");
+      case URI_PATH_GLOB -> builder.pathType(FileOrFiles.PathType.URI_PATH_GLOB).path("path");
+      case URI_FILE -> builder.pathType(FileOrFiles.PathType.URI_FILE).path("path");
+      case URI_FOLDER -> builder.pathType(FileOrFiles.PathType.URI_FOLDER).path("path");
+      case PATHTYPE_NOT_SET -> builder;
+    };
+  }
+
+  private ImmutableFileOrFiles.Builder setFileFormat(
+      ImmutableFileOrFiles.Builder builder,
+      ReadRel.LocalFiles.FileOrFiles.FileFormatCase fileFormatCase) {
+    return switch (fileFormatCase) {
+      case PARQUET -> builder.fileFormat(ImmutableFileFormat.ParquetReadOptions.builder().build());
+      case ARROW -> builder.fileFormat(ImmutableFileFormat.ArrowReadOptions.builder().build());
+      case ORC -> builder.fileFormat(ImmutableFileFormat.OrcReadOptions.builder().build());
+      case EXTENSION -> builder.fileFormat(
+          ImmutableFileFormat.Extension.builder()
+              .extension(com.google.protobuf.Any.newBuilder().build())
+              .build());
+      case FILEFORMAT_NOT_SET -> builder;
+    };
+  }
+
+  @Test
+  void localFilesRoundtrip() {
+    Arrays.stream(ReadRel.LocalFiles.FileOrFiles.FileFormatCase.values())
+        .forEach(
+            fileFormatCase ->
+                Arrays.stream(ReadRel.LocalFiles.FileOrFiles.PathTypeCase.values())
+                    .forEach(
+                        pathTypeCase ->
+                            assertLocalFilesRoundtrip(
+                                setFileFormat(
+                                        setPath(ImmutableFileOrFiles.builder(), pathTypeCase),
+                                        fileFormatCase)
+                                    .partitionIndex(0)
+                                    .start(2)
+                                    .length(10000)
+                                    .build())));
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -13,6 +13,7 @@ import io.substrait.relation.Cross;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
 import io.substrait.relation.Join;
+import io.substrait.relation.LocalFiles;
 import io.substrait.relation.NamedScan;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
@@ -110,6 +111,11 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
   @Override
   public RelNode visit(NamedScan namedScan) throws RuntimeException {
     return relBuilder.scan(namedScan.getNames()).build();
+  }
+
+  @Override
+  public RelNode visit(LocalFiles localFiles) throws RuntimeException {
+    throw new UnsupportedOperationException("LocalFiles is not supported");
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -115,7 +115,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
 
   @Override
   public RelNode visit(LocalFiles localFiles) throws RuntimeException {
-    throw new UnsupportedOperationException("LocalFiles is not supported");
+    return visitFallback(localFiles);
   }
 
   @Override


### PR DESCRIPTION
Currently substrait-java doesn't implement `LocalFiles` ReadRel,  this patch adds this missing `Rel`.  

## How to test

Add a new UT `LocalFilesRoundtripTest`