### PR TITLE
Downgrade core to java 8 via Jabel

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,11 @@ allprojects {
   }
   tasks.withType<JavaCompile> {
     sourceCompatibility = "17"
-    options.release.set(11)
-
+    if (project.name != "core") {
+      options.release.set(11)
+    } else {
+      options.release.set(8)
+    }
     dependsOn(submodulesUpdate)
   }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -33,7 +33,12 @@ dependencies {
   compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(17))
+    withSourcesJar()
+  }
+}
 
 sourceSets {
   main {

--- a/core/src/main/java/io/substrait/expression/FieldReference.java
+++ b/core/src/main/java/io/substrait/expression/FieldReference.java
@@ -29,7 +29,7 @@ public abstract class FieldReference implements Expression {
   }
 
   public boolean isSimpleRootReference() {
-    return segments().size() == 1 && inputExpression().isEmpty();
+    return segments().size() == 1 && !inputExpression().isPresent();
   }
 
   public FieldReference dereferenceStruct(int index) {

--- a/core/src/main/java/io/substrait/function/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/function/SimpleExtension.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
@@ -315,11 +316,17 @@ public class SimpleExtension {
       int max =
           variadic()
               .map(
-                  t ->
-                      t.getMax().stream()
-                          .map(x -> args().size() - 1 + x + 1)
-                          .findFirst()
-                          .orElse(Integer.MAX_VALUE))
+                  t -> {
+                    OptionalInt optionalMax = t.getMax();
+                    IntStream stream =
+                        optionalMax.isPresent()
+                            ? IntStream.of(optionalMax.getAsInt())
+                            : IntStream.empty();
+                    return stream
+                        .map(x -> args().size() - 1 + x + 1)
+                        .findFirst()
+                        .orElse(Integer.MAX_VALUE);
+                  })
               .orElse(args().size() + 1);
       int min =
           variadic().map(t -> args().size() - 1 + t.getMin()).orElse(requiredArguments().size());

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -110,8 +110,11 @@ public class RelCopyOnWriteVisitor extends AbstractRelVisitor<Optional<Rel>, Run
             .from(join)
             .left(left.orElse(join.getLeft()))
             .right(right.orElse(join.getRight()))
-            .condition(condition.or(() -> join.getCondition()))
-            .postJoinFilter(postFilter.or(() -> join.getPostJoinFilter()))
+            .condition(
+                Optional.ofNullable(condition.orElseGet(() -> join.getCondition().orElse(null))))
+            .postJoinFilter(
+                Optional.ofNullable(
+                    postFilter.orElseGet(() -> join.getPostJoinFilter().orElse(null))))
             .build());
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -235,10 +235,12 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
   private RelCommon common(io.substrait.relation.Rel rel) {
     var builder = RelCommon.newBuilder();
-    rel.getRemap()
-        .ifPresentOrElse(
-            r -> builder.setEmit(RelCommon.Emit.newBuilder().addAllOutputMapping(r.indices())),
-            () -> builder.setDirect(RelCommon.Direct.getDefaultInstance()));
+    var remap = rel.getRemap().orElse(null);
+    if (remap != null) {
+      builder.setEmit(RelCommon.Emit.newBuilder().addAllOutputMapping(remap.indices()));
+    } else {
+      builder.setDirect(RelCommon.Direct.getDefaultInstance());
+    }
     return builder.build();
   }
 }


### PR DESCRIPTION
This patch does the same thing as https://github.com/substrait-io/substrait-java/pull/95, but using jabel