### PR TITLE
[Java][CI]: Publish Java packages to artifactory server

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,126 @@
+{
+  "rules": {
+    "body-leading-blank": [1, "always"],
+    "body-max-line-length": [2, "always", 100],
+    "footer-leading-blank": [1, "always"],
+    "footer-max-line-length": [2, "always", 100],
+    "header-max-length": [2, "always", 100],
+    "subject-case": [
+      2,
+      "never",
+      ["sentence-case", "start-case", "pascal-case", "upper-case"]
+    ],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test"
+      ]
+    ]
+  },
+  "prompt": {
+    "questions": {
+      "type": {
+        "description": "Select the type of change that you're committing",
+        "enum": {
+          "feat": {
+            "description": "A new feature",
+            "title": "Features",
+            "emoji": "✨"
+          },
+          "fix": {
+            "description": "A bug fix",
+            "title": "Bug Fixes",
+            "emoji": "🐛"
+          },
+          "docs": {
+            "description": "Documentation only changes",
+            "title": "Documentation",
+            "emoji": "📚"
+          },
+          "style": {
+            "description": "Changes that do not affect the meaning of the code (whitespace, formatting, missing semi-colons, etc)",
+            "title": "Styles",
+            "emoji": "💎"
+          },
+          "refactor": {
+            "description": "A code change that neither fixes a bug nor adds a feature",
+            "title": "Code Refactoring",
+            "emoji": "📦"
+          },
+          "perf": {
+            "description": "A code change that improves performance",
+            "title": "Performance Improvements",
+            "emoji": "🚀"
+          },
+          "test": {
+            "description": "Adding missing tests or fixing existing tests",
+            "title": "Tests",
+            "emoji": "🚨"
+          },
+          "build": {
+            "description": "Changes that affect the build system or external dependencies (example scopes: poetry, nix)",
+            "title": "Builds",
+            "emoji": "🛠"
+          },
+          "ci": {
+            "description": "Changes to our CI configuration files and scripts (example scopes: actions, gh-actions, github-actions)",
+            "title": "Continuous Integrations",
+            "emoji": "⚙️"
+          },
+          "chore": {
+            "description": "Other changes that don't modify source or test files",
+            "title": "Chores",
+            "emoji": "♻️"
+          },
+          "revert": {
+            "description": "Reverts a previous commit",
+            "title": "Reverts",
+            "emoji": "🗑"
+          }
+        }
+      },
+      "scope": {
+        "description": "What is the scope of this change (e.g. component or file name)"
+      },
+      "subject": {
+        "description": "Write a short, imperative tense description of the change"
+      },
+      "body": {
+        "description": "Provide a longer description of the change"
+      },
+      "isBreaking": {
+        "description": "Are there any breaking changes?"
+      },
+      "breakingBody": {
+        "description": "A BREAKING CHANGE commit requires a body. Please enter a longer description of the commit itself"
+      },
+      "breaking": {
+        "description": "Describe the breaking changes"
+      },
+      "isIssueAffected": {
+        "description": "Does this change affect any open issues?"
+      },
+      "issuesBody": {
+        "description": "If issues are closed, the commit requires a body. Please enter a longer description of the commit itself"
+      },
+      "issues": {
+        "description": "Add issue references (e.g. \"fix #123\", \"re #123\".)"
+      }
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.{yaml,yml}]
+indent_size = 2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,10 +1,28 @@
 name: PR Build Check
 
 on:
-  pull_request: 
+  pull_request:
 jobs:
+  editorconfig-checker:
+    name: Check editorconfig
+    runs-on: ubuntu-latest
+    steps:
+      - uses: editorconfig-checker/action-editorconfig-checker@v1
+  commitlint:
+    name: Lint commits for semantic-release
+    needs: editorconfig-checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - run: npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
   java:
     name: Build and Test Java
+    needs: commitlint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,8 +37,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
         run: gradle build
+      - run: ./ci/release/dry_run.sh
   isthmus-native-image-mac-linux:
     name: Build Isthmus Native Image
+    needs: java
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -28,7 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: recursive      
+        submodules: recursive
     - uses: DeLaGuardo/setup-graalvm@5.0
       with:
         graalvm: '22.0.0.2'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+#  TODO: Review with the team a time proposal to schedule a release
+#  schedule:
+#    # 2 AM on Sunday
+#    - cron: "0 2 * * 0"
+  workflow_dispatch:
+    inputs:
+      nexus_package:
+        description: Publish to Nexus Packages
+        required: false
+        default: '0'
+      github_package:
+        description: Publish to GitHub Packages
+        required: false
+        default: '0'
+      github_nexus_package:
+        description: Publish to GitHub & Nexus Packages
+        required: false
+        default: '0'
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: run semantic-release
+        run: ./ci/release/run.sh
+        id: semanticrelease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      new-release-version: ${{ steps.semanticrelease.outputs.new-release-version }}
+  release-artifacts:
+    runs-on: ubuntu-latest
+    needs: semantic-release
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Print branch version
+        run: echo v${{ needs.semantic-release.outputs.new-release-version }}
+      - uses: actions/checkout@v3
+        with:
+          ref: v${{ needs.semantic-release.outputs.new-release-version }}
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Publish package to Nexus Packages
+        if: ${{ github.event.inputs.nexus_package == '1' }}
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: publish -Pversion=${{ needs.semantic-release.outputs.new-release-version }}
+        env:
+          NEXUS_URL: https://f59f-191-97-56-158.ngrok.io/repository
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_INSECURE: false
+      - name: Publish package to GitHub Packages
+        if: ${{ github.event.inputs.github_package == '1' }}
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: publish -Pversion=${{ needs.semantic-release.outputs.new-release-version }}
+        env:
+          GITHUB_URL: https://maven.pkg.github.com/davisusanibar/gradle-kts-artifacts
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish package to GitHub & Nexus Packages
+        if: ${{ github.event.inputs.github_nexus_package == '1' }}
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: publish -Pversion=${{ needs.semantic-release.outputs.new-release-version }}
+        env:
+          GITHUB_URL: https://maven.pkg.github.com/davisusanibar/gradle-kts-artifacts
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXUS_URL: https://f59f-191-97-56-158.ngrok.io/repository
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          NEXUS_INSECURE: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           arguments: publish -Pversion=${{ needs.semantic-release.outputs.new-release-version }}
         env:
-          GITHUB_URL: https://maven.pkg.github.com/davisusanibar/gradle-kts-artifacts
+          GITHUB_URL: https://maven.pkg.github.com/substrait/substrait-java
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish package to GitHub & Nexus Packages
         if: ${{ github.event.inputs.github_nexus_package == '1' }}
@@ -81,7 +81,7 @@ jobs:
         with:
           arguments: publish -Pversion=${{ needs.semantic-release.outputs.new-release-version }}
         env:
-          GITHUB_URL: https://maven.pkg.github.com/davisusanibar/gradle-kts-artifacts
+          GITHUB_URL: https://maven.pkg.github.com/substrait/substrait-java
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXUS_URL: https://f59f-191-97-56-158.ngrok.io/repository
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ gen
 *.iml
 out/**
 *.iws
+substrait/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.26.0
+  hooks:
+  - id: yamllint
+    args: [-c=.yamllint.yaml]
+- repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+  rev: v8.0.0
+  hooks:
+  - id: commitlint
+    stages: [commit-msg]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,41 @@
+{
+  "branches": ["main"],
+  "preset": "conventionalcommits",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          {"breaking": true, "release": "minor"}
+        ]
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogTitle": "Release Notes\n---",
+        "changelogFile": "CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "echo ::set-output name=new-release-version::${nextRelease.version}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version}"
+      }
+    ]
+  ]
+}

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,9 @@
+rules:
+  line-length:
+    max: 120
+  brackets:
+    forbid: false
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,34 +12,44 @@ plugins {
 
 // publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
 publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
+  publications { create<MavenPublication>("maven") { from(components["java"]) } }
+  repositories {
+    maven {
+      name = "GITHUB"
+      val releasesRepoUrl =
+        System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() }
+          ?: extra["GITHUB_URL"].toString()
+      url = uri(releasesRepoUrl)
+      credentials {
+        username =
+          System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() }
+            ?: extra["GITHUB_ACTOR"].toString()
+        password =
+          System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() }
+            ?: extra["GITHUB_TOKEN"].toString()
+      }
     }
-    repositories {
-        maven {
-            name = "GITHUB"
-            val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
-            url = uri(releasesRepoUrl)
-            credentials {
-                username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
-                password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
-            }
-        }
-        maven {
-            name = "NEXUS"
-            val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
-            val releasesRepoUrl = nexusUrl + "/maven-releases"
-            val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
-            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-            isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
-            credentials {
-                username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
-                password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
-            }
-        }
+    maven {
+      name = "NEXUS"
+      val nexusUrl =
+        System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() }
+          ?: extra["NEXUS_URL"].toString()
+      val releasesRepoUrl = nexusUrl + "/maven-releases"
+      val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
+      url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+      isAllowInsecureProtocol =
+        System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false }
+          ?: extra["NEXUS_INSECURE"].toString().toBoolean()
+      credentials {
+        username =
+          System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() }
+            ?: extra["NEXUS_USERNAME"].toString()
+        password =
+          System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() }
+            ?: extra["NEXUS_PASSWORD"].toString()
+      }
     }
+  }
 }
 
 repositories { mavenCentral() }
@@ -95,6 +105,4 @@ allprojects {
       }
     }
   }
-
-
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,38 @@ plugins {
   id("com.diffplug.spotless") version "6.11.0"
 }
 
+// publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+    repositories {
+        maven {
+            name = "GITHUB"
+            val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
+            url = uri(releasesRepoUrl)
+            credentials {
+                username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
+                password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
+            }
+        }
+        maven {
+            name = "NEXUS"
+            val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
+            val releasesRepoUrl = nexusUrl + "/maven-releases"
+            val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+            isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
+            credentials {
+                username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
+                password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
+            }
+        }
+    }
+}
+
 repositories { mavenCentral() }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
@@ -64,34 +96,5 @@ allprojects {
     }
   }
 
-    publishing {
-      publications {
-        create<MavenPublication>("maven") {
-          from(components["java"])
-        }
-      }
-      repositories {
-        maven {
-          name = "GITHUB"
-          val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
-          url = uri(releasesRepoUrl)
-          credentials {
-            username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
-            password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
-          }
-        }
-        maven {
-          name = "NEXUS"
-          val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
-          val releasesRepoUrl = nexusUrl + "/maven-releases"
-          val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
-          url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-          isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
-          credentials {
-            username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
-            password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
-          }
-        }
-      }
-    }
+
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,6 @@ plugins {
   id("com.diffplug.spotless") version "6.11.0"
 }
 
-publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
-
 repositories { mavenCentral() }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
@@ -65,4 +63,35 @@ allprojects {
       }
     }
   }
+
+    publishing {
+      publications {
+        create<MavenPublication>("maven") {
+          from(components["java"])
+        }
+      }
+      repositories {
+        maven {
+          name = "GITHUB"
+          val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
+          url = uri(releasesRepoUrl)
+          credentials {
+            username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
+            password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
+          }
+        }
+        maven {
+          name = "NEXUS"
+          val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
+          val releasesRepoUrl = nexusUrl + "/maven-releases"
+          val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
+          url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+          isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
+          credentials {
+            username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
+            password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
+          }
+        }
+      }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ allprojects {
   }
 
   group = "io.substrait"
-  version = "1.0-SNAPSHOT"
+  version = "${version}"
 
   plugins.withType<SpotlessPlugin>().configureEach {
     configure<SpotlessExtension> {

--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+curdir="$PWD"
+worktree="$(mktemp -d)"
+branch="$(basename "$worktree")"
+
+git worktree add "$worktree"
+
+function cleanup() {
+  cd "$curdir" || exit 1
+  git worktree remove "$worktree"
+  git worktree prune
+  git branch -D "$branch"
+}
+
+trap cleanup EXIT ERR
+
+cd "$worktree" || exit 1
+
+export GITHUB_REF="$branch"
+
+npx --yes \
+  -p semantic-release \
+  -p "@semantic-release/commit-analyzer" \
+  -p "@semantic-release/release-notes-generator" \
+  -p "@semantic-release/changelog" \
+  -p "@semantic-release/exec" \
+  -p "@semantic-release/git" \
+  -p "conventional-changelog-conventionalcommits" \
+  semantic-release \
+  --ci false \
+  --dry-run \
+  --preset conventionalcommits \
+  --plugins \
+  --analyze-commits "@semantic-release/commit-analyzer" \
+  --generate-notes "@semantic-release/release-notes-generator" \
+  --verify-conditions "@semantic-release/changelog,@semantic-release/exec,@semantic-release/git" \
+  --prepare "@semantic-release/changelog,@semantic-release/exec" \
+  --branches "$branch" \
+  --repository-url "file://$PWD"

--- a/ci/release/readme.md
+++ b/ci/release/readme.md
@@ -1,0 +1,7 @@
+Substrait Java Code CI/CD
+
+Semantic Release
+
+
+Publish Java Artifacts
+

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+npx --yes \
+  -p semantic-release \
+  -p "@semantic-release/commit-analyzer" \
+  -p "@semantic-release/release-notes-generator" \
+  -p "@semantic-release/changelog" \
+  -p "@semantic-release/github" \
+  -p "@semantic-release/exec" \
+  -p "@semantic-release/git" \
+  -p "conventional-changelog-conventionalcommits" \
+  semantic-release --ci

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,8 +11,6 @@ plugins {
   id("com.diffplug.spotless") version "6.11.0"
 }
 
-publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
-
 dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
   testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.0")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,6 +11,38 @@ plugins {
   id("com.diffplug.spotless") version "6.11.0"
 }
 
+// publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+    repositories {
+        maven {
+            name = "GITHUB"
+            val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
+            url = uri(releasesRepoUrl)
+            credentials {
+                username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
+                password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
+            }
+        }
+        maven {
+            name = "NEXUS"
+            val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
+            val releasesRepoUrl = nexusUrl + "/maven-releases"
+            val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+            isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
+            credentials {
+                username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
+                password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
+            }
+        }
+    }
+}
+
 dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
   testImplementation("org.junit.jupiter:junit-jupiter-params:5.6.0")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,34 +13,44 @@ plugins {
 
 // publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
 publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
+  publications { create<MavenPublication>("maven") { from(components["java"]) } }
+  repositories {
+    maven {
+      name = "GITHUB"
+      val releasesRepoUrl =
+        System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() }
+          ?: extra["GITHUB_URL"].toString()
+      url = uri(releasesRepoUrl)
+      credentials {
+        username =
+          System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() }
+            ?: extra["GITHUB_ACTOR"].toString()
+        password =
+          System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() }
+            ?: extra["GITHUB_TOKEN"].toString()
+      }
     }
-    repositories {
-        maven {
-            name = "GITHUB"
-            val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
-            url = uri(releasesRepoUrl)
-            credentials {
-                username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
-                password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
-            }
-        }
-        maven {
-            name = "NEXUS"
-            val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
-            val releasesRepoUrl = nexusUrl + "/maven-releases"
-            val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
-            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-            isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
-            credentials {
-                username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
-                password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
-            }
-        }
+    maven {
+      name = "NEXUS"
+      val nexusUrl =
+        System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() }
+          ?: extra["NEXUS_URL"].toString()
+      val releasesRepoUrl = nexusUrl + "/maven-releases"
+      val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
+      url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+      isAllowInsecureProtocol =
+        System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false }
+          ?: extra["NEXUS_INSECURE"].toString().toBoolean()
+      credentials {
+        username =
+          System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() }
+            ?: extra["NEXUS_USERNAME"].toString()
+        password =
+          System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() }
+            ?: extra["NEXUS_PASSWORD"].toString()
+      }
     }
+  }
 }
 
 dependencies {

--- a/dev/readme.md
+++ b/dev/readme.md
@@ -1,0 +1,78 @@
+Substrait Java Code Development
+
+# Semantic Release conventions
+
+
+## Commit Conventions
+
+Substrait Java follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit message structure. You can use [`pre-commit`](https://pre-commit.com/) to check your messages for you, but note that you must install pre-commit using `pre-commit install --hook-type commit-msg` for this to work. CI will also lint your commit messages. Please also ensure that your PR title and initial comment together form a valid commit message; that will save us some work formatting the merge commit message when we merge your PR.
+
+```bash
+$ pre-commit install --hook-type commit-msg
+pre-commit installed at .git/hooks/commit-msg
+```
+
+Examples of commit messages can be seen [here](https://www.conventionalcommits.org/en/v1.0.0/#examples).
+
+
+# Use Substrait Java artifacts
+
+## Maven Use
+
+pom.xml
+```xml
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/davisusanibar/substrait-java</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.substrait</groupId>
+            <artifactId>substrait-java</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+```
+
+settings.xml
+````xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>github</id>
+      <username>davisusanibar</username>
+      <password>YOUR_TOKEN_WITH_READ_ACCESS</password>
+    </server>
+  </servers>
+</settings>
+````
+
+## Gradle Use
+
+build.gradle
+```shell
+repositories {
+    mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/davisusanibar/substrait-java")
+        credentials {
+            username = System.getenv("USERNAME")
+            password = System.getenv("GITHUB_TOKEN_READ")
+        }
+    }
+}
+
+dependencies {
+    implementation 'io.substrait:substrait-java:0.0.1-SNAPSHOT'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+}
+```
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,13 @@ junit5.version=5.8.1
 protobuf.version=3.17.1
 slf4j.version=1.7.25
 jackson.version=2.12.4
+
+# Maven repository to publish Java artifacts
+GITHUB_URL=https://maven.pkg.github.com/davisusanibar/substrait-java
+GITHUB_ACTOR=secret-user
+GITHUB_TOKEN=secret-password
+
+NEXUS_URL=http://localhost:8081/repository
+NEXUS_USERNAME=secret-user
+NEXUS_PASSWORD=secret-password
+NEXUS_INSECURE=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,8 @@ protobuf.version=3.17.1
 slf4j.version=1.7.25
 jackson.version=2.12.4
 
+version=1.0.0-SNAPSHOT
+
 # Maven repository to publish Java artifacts
 GITHUB_URL=https://maven.pkg.github.com/davisusanibar/substrait-java
 GITHUB_ACTOR=secret-user

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
   id("com.diffplug.spotless") version "6.11.0"
 }
 
-publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
-
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 dependencies {

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -6,6 +6,38 @@ plugins {
   id("com.diffplug.spotless") version "6.11.0"
 }
 
+// publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+        }
+    }
+    repositories {
+        maven {
+            name = "GITHUB"
+            val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
+            url = uri(releasesRepoUrl)
+            credentials {
+                username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
+                password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
+            }
+        }
+        maven {
+            name = "NEXUS"
+            val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
+            val releasesRepoUrl = nexusUrl + "/maven-releases"
+            val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
+            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+            isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
+            credentials {
+                username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
+                password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
+            }
+        }
+    }
+}
+
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 dependencies {

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -8,34 +8,44 @@ plugins {
 
 // publishing { publications { create<MavenPublication>("maven") { from(components["java"]) } } }
 publishing {
-    publications {
-        create<MavenPublication>("maven") {
-            from(components["java"])
-        }
+  publications { create<MavenPublication>("maven") { from(components["java"]) } }
+  repositories {
+    maven {
+      name = "GITHUB"
+      val releasesRepoUrl =
+        System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() }
+          ?: extra["GITHUB_URL"].toString()
+      url = uri(releasesRepoUrl)
+      credentials {
+        username =
+          System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() }
+            ?: extra["GITHUB_ACTOR"].toString()
+        password =
+          System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() }
+            ?: extra["GITHUB_TOKEN"].toString()
+      }
     }
-    repositories {
-        maven {
-            name = "GITHUB"
-            val releasesRepoUrl = System.getenv("GITHUB_URL").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_URL"].toString()
-            url = uri(releasesRepoUrl)
-            credentials {
-                username = System.getenv("GITHUB_ACTOR").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_ACTOR"].toString()
-                password = System.getenv("GITHUB_TOKEN").takeUnless { it.isNullOrEmpty() } ?: extra["GITHUB_TOKEN"].toString()
-            }
-        }
-        maven {
-            name = "NEXUS"
-            val nexusUrl = System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_URL"].toString()
-            val releasesRepoUrl = nexusUrl + "/maven-releases"
-            val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
-            url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
-            isAllowInsecureProtocol = System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false } ?: extra["NEXUS_INSECURE"].toString().toBoolean()
-            credentials {
-                username = System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_USERNAME"].toString()
-                password = System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() } ?: extra["NEXUS_PASSWORD"].toString()
-            }
-        }
+    maven {
+      name = "NEXUS"
+      val nexusUrl =
+        System.getenv("NEXUS_URL").takeUnless { it.isNullOrEmpty() }
+          ?: extra["NEXUS_URL"].toString()
+      val releasesRepoUrl = nexusUrl + "/maven-releases"
+      val snapshotsRepoUrl = nexusUrl + "/maven-snapshots"
+      url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
+      isAllowInsecureProtocol =
+        System.getenv().containsKey("NEXUS_INSECURE").takeUnless { it == false }
+          ?: extra["NEXUS_INSECURE"].toString().toBoolean()
+      credentials {
+        username =
+          System.getenv("NEXUS_USERNAME").takeUnless { it.isNullOrEmpty() }
+            ?: extra["NEXUS_USERNAME"].toString()
+        password =
+          System.getenv("NEXUS_PASSWORD").takeUnless { it.isNullOrEmpty() }
+            ?: extra["NEXUS_PASSWORD"].toString()
+      }
     }
+  }
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }


### PR DESCRIPTION
Related to #43 

This PR use the same proposal that Substrait use for release process + Maven publish Java artifacts

Pre activities:
- [ ] To deploy to Github packages repository:
Setup Personal access tokens (classic) GITHUB_TOKEN (token with `repo, write:packages` access)

- [ ] To deploy to Archiva / Nexus / Other:
Setup repository secret for NEXUS_USERNAME
Setup repository secret for NEXUS_PASSWORD

- [ ] For semantic-release:
By default we could start with 1.0.0-SNAPSHOT (if not, is needed to create tag 0.0.0 and release process will use semantic-release to increment version number 0.0.1)

Activities:
- [X] Implement [semantic-release](https://github.com/semantic-release/semantic-release) (the same that Substrait project use)
- [X] Implement Java artifact publishing (tested in locally project: [release](https://github.com/daviddalisusanibararce/substrait-java/releases/tag/v1.0.0) + [maven publish](https://github.com/daviddalisusanibararce/substrait-java/packages/1690919))
- [x] Publish to Github packages repository  (`production`)
- [ ] Testing local project consuming Github packages repository  (`production`)
- [ ] Publish to Archiva / Nexus / Other repository (`staging`)
- [ ] Testing local project consuming Archiva / Nexus / Other repository (`staging`)
- [ ] Move from Staging to Release Maven Central (`production`)
- [ ] Testing publish to release Maven Central (`production`)
- [ ] Setup schedule for workflows needed (i.e.: release every weekend, ...)
- [ ] Document process for: Release / Development


