### PR TITLE
refactor: Add FeatureBoard for configuring Isthmus

### DIFF
--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   implementation("com.google.code.findbugs:jsr305:3.0.2")
   implementation("com.github.ben-manes.caffeine:caffeine:3.0.4")
   implementation("org.immutables:value-annotations:2.8.8")
+  annotationProcessor("org.immutables:value:2.8.8")
   testImplementation("org.apache.calcite:calcite-plus:1.28.0")
   annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
   compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")

--- a/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
@@ -1,0 +1,39 @@
+package io.substrait.isthmus;
+
+import io.substrait.isthmus.SubstraitRelVisitor.CrossJoinPolicy;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.immutables.value.Value;
+
+/**
+ * A feature board is a collection of flags that are enabled or configurations that control the
+ * handling of a request to convert query [batch] to Substrait plans.
+ */
+@Value.Immutable
+public abstract class FeatureBoard {
+
+  /**
+   * @return true if parsing sql batch (multiple input sql statements) is enabled
+   */
+  @Value.Default
+  public boolean allowsSqlBatch() {
+    return false;
+  }
+
+  /**
+   * @return the selected built-in Calcite SQL compatibility mode. For e.g. APPLY is only supported
+   * in SQL Server mode. Calcite parser will throw an exception if the SQL statement contains
+   * operators that are not supported by the selected mode.
+   */
+  @Value.Default
+  public SqlConformanceEnum sqlConformanceMode() {
+    return SqlConformanceEnum.DEFAULT;
+  }
+
+  /**
+   * @return the selected cross join policy
+   */
+  @Value.Default
+  public CrossJoinPolicy crossJoinPolicy() {
+    return CrossJoinPolicy.KEEP_AS_CROSS_JOIN;
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
@@ -20,9 +20,11 @@ public abstract class FeatureBoard {
   }
 
   /**
-   * @return the selected built-in Calcite SQL compatibility mode. For e.g. APPLY is only supported
-   * in SQL Server mode. Calcite parser will throw an exception if the SQL statement contains
-   * operators that are not supported by the selected mode.
+   * Returns Calcite's SQL conformance mode used for the current request. For e.g. APPLY is only
+   * supported in SQL Server mode. Calcite's parser will throw an exception if the selected mode is
+   * not SQL Server and the SQL statement contains APPLY.
+   *
+   * @return the selected built-in Calcite SQL compatibility mode.
    */
   @Value.Default
   public SqlConformanceEnum sqlConformanceMode() {

--- a/isthmus/src/main/java/io/substrait/isthmus/PlanEntryPoint.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/PlanEntryPoint.java
@@ -12,12 +12,10 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import picocli.CommandLine;
-import picocli.CommandLine.PropertiesDefaultProvider;
 
 @Command(
     name = "isthmus",
     version = "isthmus 0.1",
-    defaultValueProvider = PropertiesDefaultProvider.class,
     description = "Converts a SQL query to a Substrait Plan")
 public class PlanEntryPoint implements Callable<Integer> {
 

--- a/isthmus/src/main/java/io/substrait/isthmus/PlanEntryPoint.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/PlanEntryPoint.java
@@ -1,22 +1,26 @@
 package io.substrait.isthmus;
 
-import static io.substrait.isthmus.SqlToSubstrait.StatementBatching.MULTI_STATEMENT;
-import static io.substrait.isthmus.SqlToSubstrait.StatementBatching.SINGLE_STATEMENT;
 import static picocli.CommandLine.Command;
 import static picocli.CommandLine.Option;
 import static picocli.CommandLine.Parameters;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.util.JsonFormat;
+import io.substrait.isthmus.SubstraitRelVisitor.CrossJoinPolicy;
 import io.substrait.proto.Plan;
 import java.util.List;
 import java.util.concurrent.Callable;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import picocli.CommandLine;
+import picocli.CommandLine.PropertiesDefaultProvider;
 
 @Command(
     name = "isthmus",
     version = "isthmus 0.1",
+    defaultValueProvider = PropertiesDefaultProvider.class,
     description = "Converts a SQL query to a Substrait Plan")
 public class PlanEntryPoint implements Callable<Integer> {
+
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PlanEntryPoint.class);
 
   @Parameters(index = "0", description = "The sql we should parse.")
@@ -33,20 +37,38 @@ public class PlanEntryPoint implements Callable<Integer> {
       description = "Allow multiple statements terminated with a semicolon")
   private boolean allowMultiStatement;
 
-  @Override
-  public Integer call() throws Exception {
-    SqlToSubstrait converter =
-        new SqlToSubstrait(
-            new SqlToSubstrait.Options(allowMultiStatement ? MULTI_STATEMENT : SINGLE_STATEMENT));
-    Plan plan = converter.execute(sql, createStatements);
-    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(plan));
-    return 0;
-  }
+  @Option(
+      names = {"--sqlconformancemode"},
+      description = "One of built-in Calcite SQL compatibility modes: ${COMPLETION-CANDIDATES}")
+  private SqlConformanceEnum sqlConformanceMode = SqlConformanceEnum.DEFAULT;
+
+  @Option(
+      names = {"--crossjoinpolicy"},
+      description = "One of built-in Calcite SQL compatibility modes: ${COMPLETION-CANDIDATES}")
+  private CrossJoinPolicy crossJoinPolicy = CrossJoinPolicy.KEEP_AS_CROSS_JOIN;
 
   // this example implements Callable, so parsing, error handling and handling user
   // requests for usage help or version help can be done with one line of code.
   public static void main(String... args) {
     int exitCode = new CommandLine(new PlanEntryPoint()).execute(args);
     System.exit(exitCode);
+  }
+
+  @Override
+  public Integer call() throws Exception {
+    FeatureBoard featureBoard = buildFeatureBoard();
+    SqlToSubstrait converter = new SqlToSubstrait(featureBoard);
+    Plan plan = converter.execute(sql, createStatements);
+    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(plan));
+    return 0;
+  }
+
+  @VisibleForTesting
+  FeatureBoard buildFeatureBoard() {
+    return ImmutableFeatureBoard.builder()
+        .allowsSqlBatch(allowMultiStatement)
+        .sqlConformanceMode(sqlConformanceMode)
+        .crossJoinPolicy(crossJoinPolicy)
+        .build();
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -51,7 +51,10 @@ class SqlConverterBase {
 
   final SqlParser.Config parserConfig;
 
-  protected SqlConverterBase() {
+  protected static final FeatureBoard FEATURES_DEFAULT = ImmutableFeatureBoard.builder().build();
+  final FeatureBoard featureBoard;
+
+  protected SqlConverterBase(FeatureBoard features) {
     this.factory = new JavaTypeFactoryImpl();
     this.config =
         CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
@@ -65,6 +68,7 @@ class SqlConverterBase {
           return new RelMetadataQuery(handler);
         });
     parserConfig = SqlParser.Config.DEFAULT.withParserFactory(SqlDdlParserImpl.FACTORY);
+    featureBoard = features == null ? FEATURES_DEFAULT : features;
   }
 
   protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION;
@@ -207,7 +211,9 @@ class SqlConverterBase {
     }
   }
 
-  /** A fully defined pre-specified table. */
+  /**
+   * A fully defined pre-specified table.
+   */
   protected static final class DefinedTable extends AbstractTable {
 
     private final String name;

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -211,9 +211,7 @@ class SqlConverterBase {
     }
   }
 
-  /**
-   * A fully defined pre-specified table.
-   */
+  /** A fully defined pre-specified table. */
   protected static final class DefinedTable extends AbstractTable {
 
     private final String name;

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -19,55 +19,17 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 
-/** Take a SQL statement and a set of table definitions and return a substrait plan. */
+/**
+ * Take a SQL statement and a set of table definitions and return a substrait plan.
+ */
 public class SqlToSubstrait extends SqlConverterBase {
-  private static final Options OPTIONS = new Options();
-
-  public enum StatementBatching {
-    SINGLE_STATEMENT,
-    MULTI_STATEMENT
-  }
-
-  private final Options options;
 
   public SqlToSubstrait() {
-    this(OPTIONS);
+    this(null);
   }
 
-  public SqlToSubstrait(Options options) {
-    this.options = options;
-  }
-
-  public static class Options {
-    private final StatementBatching statementBatching;
-    private final SubstraitRelVisitor.Options relToSubstraitOptions;
-
-    public Options() {
-      this(StatementBatching.SINGLE_STATEMENT, SubstraitRelVisitor.OPTIONS);
-    }
-
-    public Options(StatementBatching statementBatching) {
-      this(statementBatching, SubstraitRelVisitor.OPTIONS);
-    }
-
-    public Options(SubstraitRelVisitor.Options relToSubstraitOptions) {
-      this.statementBatching = StatementBatching.SINGLE_STATEMENT;
-      this.relToSubstraitOptions = relToSubstraitOptions;
-    }
-
-    public Options(
-        StatementBatching statementBatching, SubstraitRelVisitor.Options relToSubstraitOptions) {
-      this.statementBatching = statementBatching;
-      this.relToSubstraitOptions = relToSubstraitOptions;
-    }
-
-    public StatementBatching getStatementBatching() {
-      return this.statementBatching;
-    }
-
-    public SubstraitRelVisitor.Options getRelToSubstraitOptions() {
-      return this.relToSubstraitOptions;
-    }
+  public SqlToSubstrait(FeatureBoard features) {
+    super(features);
   }
 
   public Plan execute(String sql, Function<List<String>, NamedStruct> tableLookup)
@@ -120,7 +82,7 @@ public class SqlToSubstrait extends SqlConverterBase {
                                   SubstraitRelVisitor.convert(
                                           root,
                                           EXTENSION_COLLECTION,
-                                          options.getRelToSubstraitOptions())
+                                          featureBoard)
                                       .accept(relProtoConverter))
                               .addAllNames(
                                   TypeConverter.toNamedStruct(root.validatedRowType).names())));
@@ -134,8 +96,7 @@ public class SqlToSubstrait extends SqlConverterBase {
       throws SqlParseException {
     SqlParser parser = SqlParser.create(sql, parserConfig);
     var parsedList = parser.parseStmtList();
-    if (options.getStatementBatching() == StatementBatching.SINGLE_STATEMENT
-        && parsedList.size() > 1) {
+    if (!featureBoard.allowsSqlBatch() && parsedList.size() > 1) {
       throw new UnsupportedOperationException("SQL must contain only a single statement: " + sql);
     }
     SqlToRelConverter converter =

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -19,9 +19,7 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 
-/**
- * Take a SQL statement and a set of table definitions and return a substrait plan.
- */
+/** Take a SQL statement and a set of table definitions and return a substrait plan. */
 public class SqlToSubstrait extends SqlConverterBase {
 
   public SqlToSubstrait() {
@@ -80,9 +78,7 @@ public class SqlToSubstrait extends SqlConverterBase {
                           io.substrait.proto.RelRoot.newBuilder()
                               .setInput(
                                   SubstraitRelVisitor.convert(
-                                          root,
-                                          EXTENSION_COLLECTION,
-                                          featureBoard)
+                                          root, EXTENSION_COLLECTION, featureBoard)
                                       .accept(relProtoConverter))
                               .addAllNames(
                                   TypeConverter.toNamedStruct(root.validatedRowType).names())));

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -94,7 +94,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     this.converter = new RexExpressionConverter(this, converters, windowFunctionConverter);
     this.featureBoard = features;
   }
-  
+
   private Expression toExpression(RexNode node) {
     return node.accept(converter);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -6,8 +6,24 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FieldReference;
 import io.substrait.function.SimpleExtension;
-import io.substrait.isthmus.expression.*;
-import io.substrait.relation.*;
+import io.substrait.isthmus.expression.AggregateFunctionConverter;
+import io.substrait.isthmus.expression.CallConverters;
+import io.substrait.isthmus.expression.LiteralConverter;
+import io.substrait.isthmus.expression.RexExpressionConverter;
+import io.substrait.isthmus.expression.ScalarFunctionConverter;
+import io.substrait.isthmus.expression.WindowFunctionConverter;
+import io.substrait.relation.Aggregate;
+import io.substrait.relation.Cross;
+import io.substrait.relation.EmptyScan;
+import io.substrait.relation.Fetch;
+import io.substrait.relation.Filter;
+import io.substrait.relation.Join;
+import io.substrait.relation.NamedScan;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import io.substrait.relation.Set;
+import io.substrait.relation.Sort;
+import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +37,20 @@ import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.rel.logical.*;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalCalc;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalExchange;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalIntersect;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalMatch;
+import org.apache.calcite.rel.logical.LogicalMinus;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.logical.LogicalTableModify;
+import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexFieldAccess;
@@ -34,25 +63,24 @@ import org.immutables.value.Value;
 public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(SubstraitRelVisitor.class);
-  public static final Options OPTIONS = new Options();
+  private static final FeatureBoard FEATURES_DEFAULT = ImmutableFeatureBoard.builder().build();
   private static final Expression.BoolLiteral TRUE = ExpressionCreator.bool(false, true);
 
   private final SimpleExtension.ExtensionCollection extensions;
   private final RexExpressionConverter converter;
   private final AggregateFunctionConverter aggregateFunctionConverter;
+  private final FeatureBoard featureBoard;
   private Map<RexFieldAccess, Integer> fieldAccessDepthMap;
-
-  private final Options options;
 
   public SubstraitRelVisitor(
       RelDataTypeFactory typeFactory, SimpleExtension.ExtensionCollection extensions) {
-    this(typeFactory, extensions, OPTIONS);
+    this(typeFactory, extensions, FEATURES_DEFAULT);
   }
 
   public SubstraitRelVisitor(
       RelDataTypeFactory typeFactory,
       SimpleExtension.ExtensionCollection extensions,
-      Options options) {
+      FeatureBoard features) {
     this.extensions = extensions;
     var converters = new ArrayList<CallConverter>();
     converters.addAll(CallConverters.DEFAULTS);
@@ -64,9 +92,9 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
         new WindowFunctionConverter(
             extensions.windowFunctions(), typeFactory, aggregateFunctionConverter);
     this.converter = new RexExpressionConverter(this, converters, windowFunctionConverter);
-    this.options = options;
+    this.featureBoard = features;
   }
-
+  
   private Expression toExpression(RexNode node) {
     return node.accept(converter);
   }
@@ -155,7 +183,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
     if (joinType == Join.JoinType.INNER
         && TRUE.equals(condition)
-        && options.getCrossJoinPolicy() == KEEP_AS_CROSS_JOIN) {
+        && featureBoard.crossJoinPolicy().equals(KEEP_AS_CROSS_JOIN)) {
       return Cross.builder()
           .left(left)
           .right(right)
@@ -330,18 +358,18 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   }
 
   public static Rel convert(RelRoot root, SimpleExtension.ExtensionCollection extensions) {
-    return convert(root.rel, extensions, OPTIONS);
+    return convert(root.rel, extensions, FEATURES_DEFAULT);
   }
 
   public static Rel convert(
-      RelRoot root, SimpleExtension.ExtensionCollection extensions, Options options) {
-    return convert(root.rel, extensions, options);
+      RelRoot root, SimpleExtension.ExtensionCollection extensions, FeatureBoard features) {
+    return convert(root.rel, extensions, features);
   }
 
   private static Rel convert(
-      RelNode rel, SimpleExtension.ExtensionCollection extensions, Options options) {
+      RelNode rel, SimpleExtension.ExtensionCollection extensions, FeatureBoard features) {
     SubstraitRelVisitor visitor =
-        new SubstraitRelVisitor(rel.getCluster().getTypeFactory(), extensions, options);
+        new SubstraitRelVisitor(rel.getCluster().getTypeFactory(), extensions, features);
     visitor.popFieldAccessDepthMap(rel);
     return visitor.apply(rel);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
@@ -16,6 +16,7 @@ import org.apache.calcite.sql.parser.SqlParseException;
 public class SubstraitToSql extends SqlConverterBase {
 
   public SubstraitToSql() {
+    super(FEATURES_DEFAULT);
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanEntryPointTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanEntryPointTest.java
@@ -1,0 +1,54 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.isthmus.SubstraitRelVisitor.CrossJoinPolicy;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+import picocli.CommandLine.ParameterException;
+
+class PlanEntryPointTest {
+
+  /**
+   * Test that the default values are set correctly into the {@link FeatureBoard}.
+   */
+  @Test
+  void defaultFeatureBoard() {
+    PlanEntryPoint planEntryPoint = new PlanEntryPoint();
+    new CommandLine(planEntryPoint);
+    FeatureBoard features = planEntryPoint.buildFeatureBoard();
+    assertFalse(features.allowsSqlBatch());
+    assertEquals(SqlConformanceEnum.DEFAULT, features.sqlConformanceMode());
+    assertEquals(CrossJoinPolicy.KEEP_AS_CROSS_JOIN, features.crossJoinPolicy());
+  }
+
+  /**
+   * Test that the command line options are correctly parsed into the {@link FeatureBoard}.
+   */
+  @Test
+  void customFeatureBoard() {
+    PlanEntryPoint planEntryPoint = new PlanEntryPoint();
+    new CommandLine(planEntryPoint).parseArgs("--multistatement",
+        "--sqlconformancemode=SQL_SERVER_2008", "--crossjoinpolicy=CONVERT_TO_INNER_JOIN",
+        "SELECT * FROM foo");
+    FeatureBoard features = planEntryPoint.buildFeatureBoard();
+    assertTrue(features.allowsSqlBatch());
+    assertEquals(SqlConformanceEnum.SQL_SERVER_2008, features.sqlConformanceMode());
+    assertEquals(CrossJoinPolicy.CONVERT_TO_INNER_JOIN, features.crossJoinPolicy());
+  }
+
+  /**
+   * Test that the command line parser throws an exception when an invalid join policy is specified.
+   */
+  @Test
+  void invalidCmdOptions() {
+    PlanEntryPoint planEntryPoint = new PlanEntryPoint();
+    assertThrows(ParameterException.class,
+        () -> new CommandLine(planEntryPoint).parseArgs("--sqlconformancemode=SQL_SERVER_2008",
+            "--crossjoinpolicy=REWRITE_TO_INNER_JOIN"));
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanEntryPointTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanEntryPointTest.java
@@ -13,9 +13,7 @@ import picocli.CommandLine.ParameterException;
 
 class PlanEntryPointTest {
 
-  /**
-   * Test that the default values are set correctly into the {@link FeatureBoard}.
-   */
+  /** Test that the default values are set correctly into the {@link FeatureBoard}. */
   @Test
   void defaultFeatureBoard() {
     PlanEntryPoint planEntryPoint = new PlanEntryPoint();
@@ -26,15 +24,16 @@ class PlanEntryPointTest {
     assertEquals(CrossJoinPolicy.KEEP_AS_CROSS_JOIN, features.crossJoinPolicy());
   }
 
-  /**
-   * Test that the command line options are correctly parsed into the {@link FeatureBoard}.
-   */
+  /** Test that the command line options are correctly parsed into the {@link FeatureBoard}. */
   @Test
   void customFeatureBoard() {
     PlanEntryPoint planEntryPoint = new PlanEntryPoint();
-    new CommandLine(planEntryPoint).parseArgs("--multistatement",
-        "--sqlconformancemode=SQL_SERVER_2008", "--crossjoinpolicy=CONVERT_TO_INNER_JOIN",
-        "SELECT * FROM foo");
+    new CommandLine(planEntryPoint)
+        .parseArgs(
+            "--multistatement",
+            "--sqlconformancemode=SQL_SERVER_2008",
+            "--crossjoinpolicy=CONVERT_TO_INNER_JOIN",
+            "SELECT * FROM foo");
     FeatureBoard features = planEntryPoint.buildFeatureBoard();
     assertTrue(features.allowsSqlBatch());
     assertEquals(SqlConformanceEnum.SQL_SERVER_2008, features.sqlConformanceMode());
@@ -47,8 +46,12 @@ class PlanEntryPointTest {
   @Test
   void invalidCmdOptions() {
     PlanEntryPoint planEntryPoint = new PlanEntryPoint();
-    assertThrows(ParameterException.class,
-        () -> new CommandLine(planEntryPoint).parseArgs("--sqlconformancemode=SQL_SERVER_2008",
-            "--crossjoinpolicy=REWRITE_TO_INNER_JOIN"));
+    assertThrows(
+        ParameterException.class,
+        () ->
+            new CommandLine(planEntryPoint)
+                .parseArgs(
+                    "--sqlconformancemode=SQL_SERVER_2008",
+                    "--crossjoinpolicy=REWRITE_TO_INNER_JOIN"));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
@@ -80,8 +80,8 @@ public class ProtoPlanConverterTest extends PlanTestBase {
             return super.visit(cross);
           }
         };
-    FeatureBoard featureBoard = ImmutableFeatureBoard.builder().crossJoinPolicy(KEEP_AS_CROSS_JOIN)
-        .build();
+    FeatureBoard featureBoard =
+        ImmutableFeatureBoard.builder().crossJoinPolicy(KEEP_AS_CROSS_JOIN).build();
     Plan plan1 =
         assertProtoPlanRoundrip(
             "select\n"

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
@@ -80,6 +80,8 @@ public class ProtoPlanConverterTest extends PlanTestBase {
             return super.visit(cross);
           }
         };
+    FeatureBoard featureBoard = ImmutableFeatureBoard.builder().crossJoinPolicy(KEEP_AS_CROSS_JOIN)
+        .build();
     Plan plan1 =
         assertProtoPlanRoundrip(
             "select\n"
@@ -88,8 +90,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
                 + "from\n"
                 + "  \"customer\" c cross join\n"
                 + "  \"orders\" o",
-            new SqlToSubstrait(
-                new SqlToSubstrait.Options(new SubstraitRelVisitor.Options(KEEP_AS_CROSS_JOIN))));
+            new SqlToSubstrait(featureBoard));
     plan1.getRoots().forEach(t -> t.getInput().accept(visitor));
     assertEquals(1, counter[0]);
     Plan plan2 =
@@ -100,8 +101,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
                 + "from\n"
                 + "  \"customer\" c,\n"
                 + "  \"orders\" o",
-            new SqlToSubstrait(
-                new SqlToSubstrait.Options(new SubstraitRelVisitor.Options(KEEP_AS_CROSS_JOIN))));
+            new SqlToSubstrait(featureBoard));
     plan2.getRoots().forEach(t -> t.getInput().accept(visitor));
     assertEquals(2, counter[0]);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
@@ -54,10 +54,10 @@ public class SimplePlansTest extends PlanTestBase {
               "select l_orderkey from lineitem; select l_partkey from lineitem WHERE L_ORDERKEY > 20;");
         },
         "SQL must contain only a single statement");
+    var features = ImmutableFeatureBoard.builder().allowsSqlBatch(true).build();
     assertProtoPlanRoundrip(
         "select l_orderkey from lineitem; select l_partkey from lineitem WHERE L_ORDERKEY > 20;",
-        new SqlToSubstrait(
-            new SqlToSubstrait.Options(SqlToSubstrait.StatementBatching.MULTI_STATEMENT)));
+        new SqlToSubstrait(features));
   }
 
   @Test


### PR DESCRIPTION
This change adds a FeatureBoard, a collection of configuration and flags to control the behavior of SQL to Substrait conversion and vice versa. The original intent was to add a config for Calcite's conformance mode. Expecting more such changes in future, this PR adds a generic FeatureBoard which should provide sufficient hints to user (leveraging command-line help messages) and easier configuration using properties file (see picocli PropertiesDefaultProvider).

FeatureBoard replaces Options and is inspired by Feature Toggle design pattern. All configs are available in one place, instead of Options which required config hunting in multiple files. Also some Options were not accessible from command line. 

This change is backward compatible.