### PR TITLE
feat: registered `upper` & `lower` in function mapping

### DIFF
--- a/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
@@ -90,7 +90,7 @@ public class LocalFilesRoundtripTest {
           ImmutableFileFormat.Extension.builder()
               .extension(com.google.protobuf.Any.newBuilder().build())
               .build());
-      case FILEFORMAT_NOT_SET -> builder;
+      case FILEFORMAT_NOT_SET, DWRF -> builder;
     };
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -40,7 +40,9 @@ public class FunctionMappings {
                 s(SqlStdOperatorTable.EXTRACT, "extract"),
                 s(SqlStdOperatorTable.LIKE),
                 s(SqlStdOperatorTable.SUBSTRING, "substring"),
-                s(SqlStdOperatorTable.CONCAT, "concat"))
+                s(SqlStdOperatorTable.CONCAT, "concat"),
+                s(SqlStdOperatorTable.LOWER, "lower"),
+                s(SqlStdOperatorTable.UPPER, "upper"))
             .build();
 
     AGGREGATE_SIGS =

--- a/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
@@ -170,4 +170,15 @@ public class Substrait2SqlTest extends PlanTestBase {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey from lineitem where l_shipdate < date '1998-01-01' order by l_shipdate asc, l_discount desc nulls last");
   }
+
+  @Test
+  public void simpleStringOpTest() throws Exception {
+    assertSqlSubstraitRelRoundTrip("select substring(l_comment, 1, 5) from lineitem");
+
+    assertSqlSubstraitRelRoundTrip("select lower(l_comment) from lineitem");
+    assertSqlSubstraitRelRoundTrip("select l_comment from lineitem where lower(l_comment) <> l_comment");
+
+    assertSqlSubstraitRelRoundTrip("select upper(l_comment) from lineitem");
+    assertSqlSubstraitRelRoundTrip("select l_comment from lineitem where upper(l_comment) <> l_comment");
+  }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
@@ -176,9 +176,11 @@ public class Substrait2SqlTest extends PlanTestBase {
     assertSqlSubstraitRelRoundTrip("select substring(l_comment, 1, 5) from lineitem");
 
     assertSqlSubstraitRelRoundTrip("select lower(l_comment) from lineitem");
-    assertSqlSubstraitRelRoundTrip("select l_comment from lineitem where lower(l_comment) <> l_comment");
+    assertSqlSubstraitRelRoundTrip(
+        "select l_comment from lineitem where lower(l_comment) <> l_comment");
 
     assertSqlSubstraitRelRoundTrip("select upper(l_comment) from lineitem");
-    assertSqlSubstraitRelRoundTrip("select l_comment from lineitem where upper(l_comment) <> l_comment");
+    assertSqlSubstraitRelRoundTrip(
+        "select l_comment from lineitem where upper(l_comment) <> l_comment");
   }
 }


### PR DESCRIPTION
This PR added two string-related scalar functions in FunctionMappings.java to support generating query plans that involve `lower()` and `upper()` ops.

It included the following changes

- updated substrait version from 0.9.0 to 0.13.0 (which added string transform functions)
- added entries for `lower` and `upper` in FunctionMappings.java