### PR TITLE
feat: support parsing of SQL queries with APPLY

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.md
+++ b/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.md
@@ -14,7 +14,7 @@ WHERE p_size <
                 AND   PS.ps_suppkey = l.l_suppkey))
 
 
-          Filter     ---  $coor0
+          Filter     ---  $corr0
           /      \ condition
          /  p_size <  RexSubquery
        Scan(P)            |
@@ -23,7 +23,7 @@ WHERE p_size <
                           |
                       Project
                           |
-                        Filter   --- $coor2
+                        Filter   --- $corr2
                         /      \
                        /        \
                 Scan (L)         \

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -1,6 +1,5 @@
 package io.substrait.isthmus;
 
-import io.substrait.function.ImmutableSimpleExtension;
 import io.substrait.function.SimpleExtension;
 import io.substrait.type.NamedStruct;
 import java.io.IOException;
@@ -77,8 +76,7 @@ class SqlConverterBase {
   protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION;
 
   static {
-    SimpleExtension.ExtensionCollection defaults =
-        ImmutableSimpleExtension.ExtensionCollection.builder().build();
+    SimpleExtension.ExtensionCollection defaults;
     try {
       defaults = SimpleExtension.loadDefaults();
     } catch (IOException e) {

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -67,8 +67,11 @@ class SqlConverterBase {
               new ProxyingMetadataHandlerProvider(DefaultRelMetadataProvider.INSTANCE);
           return new RelMetadataQuery(handler);
         });
-    parserConfig = SqlParser.Config.DEFAULT.withParserFactory(SqlDdlParserImpl.FACTORY);
     featureBoard = features == null ? FEATURES_DEFAULT : features;
+    parserConfig =
+        SqlParser.Config.DEFAULT
+            .withParserFactory(SqlDdlParserImpl.FACTORY)
+            .withConformance(featureBoard.sqlConformanceMode());
   }
 
   protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION;

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -207,8 +207,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
         switch (correlate.getJoinType()) {
           case INNER -> Join.JoinType.INNER; // corresponds to CROSS APPLY join
           case LEFT -> Join.JoinType.LEFT; // corresponds to OUTER APPLY join
-          default -> throw new UnsupportedOperationException(
-              "Unsupported correlated join type: " + correlate.getJoinType());
+          default -> throw new IllegalArgumentException(
+              "Invalid correlated join type: " + correlate.getJoinType());
         };
     return super.visit(correlate);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -61,6 +61,7 @@ import org.immutables.value.Value;
 @SuppressWarnings("UnstableApiUsage")
 @Value.Enclosing
 public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
+
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(SubstraitRelVisitor.class);
   private static final FeatureBoard FEATURES_DEFAULT = ImmutableFeatureBoard.builder().build();
@@ -196,6 +197,19 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
   @Override
   public Rel visit(LogicalCorrelate correlate) {
+    // left input of correlated-join is similar to the left input of a logical join
+    apply(correlate.getLeft());
+
+    // right input of correlated-join is similar to a correlated sub-query
+    apply(correlate.getRight());
+
+    var joinType =
+        switch (correlate.getJoinType()) {
+          case INNER -> Join.JoinType.INNER; // corresponds to CROSS APPLY join
+          case LEFT -> Join.JoinType.LEFT; // corresponds to OUTER APPLY join
+          default -> throw new UnsupportedOperationException(
+              "Unsupported correlated join type: " + correlate.getJoinType());
+        };
     return super.visit(correlate);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
@@ -1,27 +1,74 @@
 package io.substrait.isthmus;
 
+import java.util.Map;
 import org.apache.calcite.adapter.tpcds.TpcdsSchema;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ApplyJoinPlanTest {
 
+  private static RelRoot getCalcitePlan(SqlToSubstrait s, TpcdsSchema schema, String sql)
+      throws SqlParseException {
+    var pair = s.registerSchema("tpcds", schema);
+    var converter = s.createSqlToRelConverter(pair.left, pair.right);
+    SqlParser parser = SqlParser.create(sql, s.parserConfig);
+    var root = s.getBestExpRelRoot(converter, parser.parseQuery());
+    return root;
+  }
+
+  private static void validateOuterRef(
+      Map<RexFieldAccess, Integer> fieldAccessDepthMap, String refName, String colName) {
+    var rexField =
+        fieldAccessDepthMap.keySet().stream()
+            .filter(f -> f.getReferenceExpr().toString().equals(refName))
+            .findFirst();
+    Assertions.assertTrue(rexField.isPresent());
+    Assertions.assertEquals(colName, rexField.get().getField().getKey());
+  }
+
+  private static Map<RexFieldAccess, Integer> buildOuterFieldRefMap(RelRoot root) {
+    final OuterReferenceResolver resolver = new OuterReferenceResolver();
+    var fieldAccessDepthMap = resolver.getFieldAccessDepthMap();
+    Assertions.assertEquals(0, fieldAccessDepthMap.size());
+    resolver.apply(root.rel);
+    return fieldAccessDepthMap;
+  }
+
   @Test
-  public void lateralJoinQuery() {
+  public void lateralJoinQuery() throws SqlParseException {
     TpcdsSchema schema = new TpcdsSchema(1.0);
     String sql;
     sql =
         """
-        SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
-        FROM store_sales CROSS JOIN LATERAL
-          (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+            SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
+            FROM store_sales CROSS JOIN LATERAL
+              (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
 
-    SqlToSubstrait s = new SqlToSubstrait();
+    /* the calcite plan for the above query is:
+      LogicalProject(SS_SOLD_DATE_SK=[$0], SS_ITEM_SK=[$2], SS_CUSTOMER_SK=[$3])
+       LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+         LogicalTableScan(table=[[tpcds, STORE_SALES]])
+         LogicalProject(I_ITEM_SK=[$0])
+           LogicalFilter(condition=[=($0, $cor0.SS_ITEM_SK)])
+             LogicalTableScan(table=[[tpcds, ITEM]])
+    */
+
+    // validate outer reference map
+    RelRoot root = getCalcitePlan(new SqlToSubstrait(), schema, sql);
+    Map<RexFieldAccess, Integer> fieldAccessDepthMap = buildOuterFieldRefMap(root);
+    Assertions.assertEquals(1, fieldAccessDepthMap.size());
+    validateOuterRef(fieldAccessDepthMap, "$cor0", "SS_ITEM_SK");
+
+    // TODO validate end to end conversion
+    var sE2E = new SqlToSubstrait();
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> s.execute(sql, "tpcds", schema),
+        () -> sE2E.execute(sql, "tpcds", schema),
         "Lateral join is not supported");
   }
 
@@ -31,15 +78,22 @@ public class ApplyJoinPlanTest {
     String sql;
     sql =
         """
-        SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
-        FROM store_sales OUTER APPLY
-          (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+            SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
+            FROM store_sales OUTER APPLY
+              (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
 
     FeatureBoard featureBoard =
         ImmutableFeatureBoard.builder()
             .sqlConformanceMode(SqlConformanceEnum.SQL_SERVER_2008)
             .build();
     SqlToSubstrait s = new SqlToSubstrait(featureBoard);
+    RelRoot root = getCalcitePlan(s, schema, sql);
+
+    Map<RexFieldAccess, Integer> fieldAccessDepthMap = buildOuterFieldRefMap(root);
+    Assertions.assertEquals(1, fieldAccessDepthMap.size());
+    validateOuterRef(fieldAccessDepthMap, "$cor0", "SS_ITEM_SK");
+
+    // TODO validate end to end conversion
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> s.execute(sql, "tpcds", schema),
@@ -52,15 +106,17 @@ public class ApplyJoinPlanTest {
     String sql;
     sql =
         """
-        SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
-        FROM store_sales CROSS APPLY
-          (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+            SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
+            FROM store_sales CROSS APPLY
+              (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
 
     FeatureBoard featureBoard =
         ImmutableFeatureBoard.builder()
             .sqlConformanceMode(SqlConformanceEnum.SQL_SERVER_2008)
             .build();
     SqlToSubstrait s = new SqlToSubstrait(featureBoard);
+
+    // TODO validate end to end conversion
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> s.execute(sql, "tpcds", schema),

--- a/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
@@ -1,0 +1,69 @@
+package io.substrait.isthmus;
+
+import org.apache.calcite.adapter.tpcds.TpcdsSchema;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ApplyJoinPlanTest {
+
+  @Test
+  public void lateralJoinQuery() {
+    TpcdsSchema schema = new TpcdsSchema(1.0);
+    String sql;
+    sql =
+        """
+        SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
+        FROM store_sales CROSS JOIN LATERAL
+          (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+
+    SqlToSubstrait s = new SqlToSubstrait();
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> s.execute(sql, "tpcds", schema),
+        "Lateral join is not supported");
+  }
+
+  @Test
+  public void outerApplyQuery() throws SqlParseException {
+    TpcdsSchema schema = new TpcdsSchema(1.0);
+    String sql;
+    sql =
+        """
+        SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
+        FROM store_sales OUTER APPLY
+          (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+
+    FeatureBoard featureBoard =
+        ImmutableFeatureBoard.builder()
+            .sqlConformanceMode(SqlConformanceEnum.SQL_SERVER_2008)
+            .build();
+    SqlToSubstrait s = new SqlToSubstrait(featureBoard);
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> s.execute(sql, "tpcds", schema),
+        "APPLY is not supported");
+  }
+
+  @Test
+  public void crossApplyQuery() throws SqlParseException {
+    TpcdsSchema schema = new TpcdsSchema(1.0);
+    String sql;
+    sql =
+        """
+        SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
+        FROM store_sales CROSS APPLY
+          (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+
+    FeatureBoard featureBoard =
+        ImmutableFeatureBoard.builder()
+            .sqlConformanceMode(SqlConformanceEnum.SQL_SERVER_2008)
+            .build();
+    SqlToSubstrait s = new SqlToSubstrait(featureBoard);
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> s.execute(sql, "tpcds", schema),
+        "APPLY is not supported");
+  }
+}


### PR DESCRIPTION
This change adds support for parsing of SQL queries with APPLY (join with
correlated subquery), and to build OuterReferences map of correlated variables
present in the query's join predicates. The OuterRefs will be used while
constructing Substrait plans to bind correlated variables. The change also
adds few example queries which depend on APPLY / LATERAL operators.

This change still does not map calcite-correlated-join to Substrait, as the
spec for APPLY is still not approved. As such, while the parsing of calcite
query plans will succeed after this change, the unit tests and run time
conversion will continue to fail in the final step of building the
Substrait plan. Additional changes are needed to support APPLY.

Refs #substrait-io/substrait/issues/357