### PR TITLE
fix: open, close and promote from staging to maven

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
-        run: gradle build
+        run: gradle build --no-build-cache
   isthmus-native-image-mac-linux:
     name: Build Isthmus Native Image
     needs: java

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
-        run: gradle build --no-build-cache
+        run: gradle build
   isthmus-native-image-mac-linux:
     name: Build Isthmus Native Image
     needs: java

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -4,4 +4,4 @@
 set -euo pipefail
 
 gradle wrapper
-./gradlew clean :core:publishToSonatype :isthmus:publishToSonatype closeSonatypeStagingRepository
+./gradlew clean :core:publishToSonatype :isthmus:publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
To implement automatic promote from Staging to Maven Central on weekly releases.

Base on discussion on PR https://github.com/substrait-io/substrait-java/pull/104 (scenario 1 & 2).