### PR TITLE
feat!: Set RelBuilder directly in SubstraitRelNodeConverter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
   security:
     name: Security validation
@@ -89,6 +89,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Check current status before next release
         run: ./ci/release/dry_run.sh

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitDef;
-import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
@@ -49,7 +49,7 @@ import org.apache.calcite.tools.RelBuilder;
 public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, RuntimeException> {
 
   private final RelOptCluster relOptCluster;
-  private final CalciteCatalogReader catalogReader;
+  private final Prepare.CatalogReader catalogReader;
 
   private final SimpleExtension.ExtensionCollection extensions;
 
@@ -63,7 +63,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
   public SubstraitRelNodeConverter(
       SimpleExtension.ExtensionCollection extensions,
       RelOptCluster relOptCluster,
-      CalciteCatalogReader catalogReader,
+      Prepare.CatalogReader catalogReader,
       RelBuilder relBuilder) {
     this.relOptCluster = relOptCluster;
     this.catalogReader = catalogReader;
@@ -87,7 +87,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
   public SubstraitRelNodeConverter(
       SimpleExtension.ExtensionCollection extensions,
       RelOptCluster relOptCluster,
-      CalciteCatalogReader catalogReader,
+      Prepare.CatalogReader catalogReader,
       SqlParser.Config parserConfig) {
     this.relOptCluster = relOptCluster;
     this.catalogReader = catalogReader;
@@ -118,20 +118,20 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
   public static RelNode convert(
       Rel relRoot,
       RelOptCluster relOptCluster,
-      CalciteCatalogReader calciteCatalogReader,
+      Prepare.CatalogReader catalogReader,
       SqlParser.Config parserConfig) {
     var relBuilder =
         RelBuilder.create(
             Frameworks.newConfigBuilder()
                 .parserConfig(parserConfig)
-                .defaultSchema(calciteCatalogReader.getRootSchema().plus())
+                .defaultSchema(catalogReader.getRootSchema().plus())
                 .traitDefs((List<RelTraitDef>) null)
                 .programs()
                 .build());
 
     return relRoot.accept(
         new SubstraitRelNodeConverter(
-            EXTENSION_COLLECTION, relOptCluster, calciteCatalogReader, relBuilder));
+            EXTENSION_COLLECTION, relOptCluster, catalogReader, relBuilder));
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -75,34 +75,6 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
             typeFactory, scalarFunctionConverter, aggregateFunctionConverter);
   }
 
-  @Deprecated
-  public SubstraitRelNodeConverter(
-      SimpleExtension.ExtensionCollection extensions,
-      RelOptCluster relOptCluster,
-      Prepare.CatalogReader catalogReader,
-      SqlParser.Config parserConfig) {
-    this.typeFactory = relOptCluster.getTypeFactory();
-
-    this.relBuilder =
-        RelBuilder.create(
-            Frameworks.newConfigBuilder()
-                .parserConfig(parserConfig)
-                .defaultSchema(catalogReader.getRootSchema().plus())
-                .traitDefs((List<RelTraitDef>) null)
-                .programs()
-                .build());
-
-    this.scalarFunctionConverter =
-        new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory);
-
-    this.aggregateFunctionConverter =
-        new AggregateFunctionConverter(extensions.aggregateFunctions(), typeFactory);
-
-    this.expressionRexConverter =
-        new ExpressionRexConverter(
-            typeFactory, scalarFunctionConverter, aggregateFunctionConverter);
-  }
-
   public static RelNode convert(
       Rel relRoot,
       RelOptCluster relOptCluster,

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -50,12 +50,8 @@ import org.apache.calcite.tools.RelBuilder;
 public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, RuntimeException> {
 
   private final RelDataTypeFactory typeFactory;
-  private final Prepare.CatalogReader catalogReader;
-
-  private final SimpleExtension.ExtensionCollection extensions;
 
   private final ScalarFunctionConverter scalarFunctionConverter;
-
   private final AggregateFunctionConverter aggregateFunctionConverter;
   private final ExpressionRexConverter expressionRexConverter;
 
@@ -64,15 +60,12 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
   public SubstraitRelNodeConverter(
       SimpleExtension.ExtensionCollection extensions,
       RelDataTypeFactory typeFactory,
-      Prepare.CatalogReader catalogReader,
       RelBuilder relBuilder) {
     this.typeFactory = typeFactory;
-    this.catalogReader = catalogReader;
-    this.extensions = extensions;
     this.relBuilder = relBuilder;
 
     this.scalarFunctionConverter =
-        new ScalarFunctionConverter(this.extensions.scalarFunctions(), typeFactory);
+        new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory);
 
     this.aggregateFunctionConverter =
         new AggregateFunctionConverter(extensions.aggregateFunctions(), typeFactory);
@@ -89,8 +82,6 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
       Prepare.CatalogReader catalogReader,
       SqlParser.Config parserConfig) {
     this.typeFactory = relOptCluster.getTypeFactory();
-    this.catalogReader = catalogReader;
-    this.extensions = extensions;
 
     this.relBuilder =
         RelBuilder.create(
@@ -102,7 +93,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
                 .build());
 
     this.scalarFunctionConverter =
-        new ScalarFunctionConverter(this.extensions.scalarFunctions(), typeFactory);
+        new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory);
 
     this.aggregateFunctionConverter =
         new AggregateFunctionConverter(extensions.aggregateFunctions(), typeFactory);
@@ -128,7 +119,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
 
     return relRoot.accept(
         new SubstraitRelNodeConverter(
-            EXTENSION_COLLECTION, relOptCluster.getTypeFactory(), catalogReader, relBuilder));
+            EXTENSION_COLLECTION, relOptCluster.getTypeFactory(), relBuilder));
   }
 
   @Override


### PR DESCRIPTION
Adds a new constructor for `SubstraitRelNodeConverter` that allows for directly setting the `RelBuilder`. This allows users to directly configure the `RelBuilder` and to apply optimizations successfully to the plans generated by the converter.

The first commit in these changes introduces the new constructor. The following commits are all quality of life refactors (in my opinion). If they are not desirable I'm happy to remove them.

# Context
I'm trying to leverage the work in Isthmus to convert a Substrait relational tree to a Calcite relational tree, and then apply optimizations. I'm using the `SubstraitRelNodeConverter` to achieve the conversion, which works great, however there is an issue that occurs when trying to optimize the converted plan.

# Problem
The problem stems from the following code in Calcite:
https://github.com/apache/calcite/blob/4bebdb07c2f45a95c9a4fdf81e9bcfbdd11a15de/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java#L1246-L1249

The issue is that the RelBuilder constructed in 
https://github.com/substrait-io/substrait-java/blob/63be6ea1f4858c59a3d7a5eaaf0937ac53cc4df4/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java#L73-L79
creates a new VolcanoPlanner, which is then used to the create the RelNodes in the converted plan, which get registered with that planner. The way we've set up our system, we already have VolcanoPlanner that we're using for optimization (with all of our own configs) and trying to use that to the optimize the converted plan triggers the assertion.

Generally as well, not being able to configure the RelBuilder directly also results in issues when using non-standard traits.