### PR TITLE
ci: setup node v18 for semantic release process

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: '18'
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
   security:
     name: Security validation
@@ -36,13 +36,19 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: version 01
+        uses: gradle -version
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
+      - name: version 02
+        uses: gradle -version
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+      - name: version 03
+        uses: gradle -version
       - name: Build with Gradle
         run: gradle build
   isthmus-native-image-mac-linux:
@@ -89,6 +95,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: '18'
       - name: Check current status before next release
         run: ./ci/release/dry_run.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,6 +89,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Check current status before next release
         run: ./ci/release/dry_run.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Download isthmus-ubuntu-latest binary


### PR DESCRIPTION
To close #118

Upgrade node version for last changes on Semantic Release node version used:
https://github.com/semantic-release/semantic-release/commit/ba05e08303fe010c2b47f72acaaf9c137f297e83