### PR TITLE
ci: setup node v18 for semantic release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Download isthmus-ubuntu-latest binary


### PR DESCRIPTION
To close #118

Upgrade node version for last changes on Semantic Release node version used:
semantic-release/semantic-release@ba05e08