### PR TITLE
refactor: Accept SqlConformance mode instead of SqlConformanceModeEnum in FeatureBoard

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus;
 
 import io.substrait.isthmus.SubstraitRelVisitor.CrossJoinPolicy;
+import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.immutables.value.Value;
 
@@ -27,7 +28,7 @@ public abstract class FeatureBoard {
    * @return the selected built-in Calcite SQL compatibility mode.
    */
   @Value.Default
-  public SqlConformanceEnum sqlConformanceMode() {
+  public SqlConformance sqlConformanceMode() {
     return SqlConformanceEnum.DEFAULT;
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanEntryPointTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanEntryPointTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.isthmus.SubstraitRelVisitor.CrossJoinPolicy;
+import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
@@ -36,7 +37,8 @@ class PlanEntryPointTest {
             "SELECT * FROM foo");
     FeatureBoard features = planEntryPoint.buildFeatureBoard();
     assertTrue(features.allowsSqlBatch());
-    assertEquals(SqlConformanceEnum.SQL_SERVER_2008, features.sqlConformanceMode());
+    assertEquals(
+        (SqlConformance) SqlConformanceEnum.SQL_SERVER_2008, features.sqlConformanceMode());
     assertEquals(CrossJoinPolicy.CONVERT_TO_INNER_JOIN, features.crossJoinPolicy());
   }
 


### PR DESCRIPTION
[SqlConformanceModeEnum](https://calcite.apache.org/javadocAggregate/org/apache/calcite/sql/validate/SqlConformanceEnum.html) extends SqlConformance, and has a fixed set of conformance modes. FeatureBoard accepting SqlConformance instead of SqlConformanceModeEnum enables more configurations. As an example, [FlinkSqlConformance](https://nightlies.apache.org/flink/flink-docs-master/api/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.html) can be passed in with this change. 