### PR TITLE
proposal: any type handling

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -6,6 +6,7 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.ImmutableFieldReference;
 import io.substrait.function.SimpleExtension;
+import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.plan.ImmutableRoot;
 import io.substrait.plan.Plan;
 import io.substrait.proto.AggregateFunction;
@@ -158,7 +159,7 @@ public class SubstraitBuilder {
 
   public NamedScan namedScan(
       Iterable<String> tableName, Iterable<String> columnNames, Iterable<Type> types) {
-    return namedScan(tableName, columnNames, types, Optional.empty());
+    return namedScan(tableName, columnNames, types, Optional.empty(), Optional.empty());
   }
 
   public NamedScan namedScan(
@@ -166,17 +167,32 @@ public class SubstraitBuilder {
       Iterable<String> columnNames,
       Iterable<Type> types,
       Rel.Remap remap) {
-    return namedScan(tableName, columnNames, types, Optional.of(remap));
+    return namedScan(tableName, columnNames, types, Optional.of(remap), Optional.empty());
+  }
+
+  public NamedScan namedScan(
+      Iterable<String> tableName,
+      Iterable<String> columnNames,
+      Iterable<Type> types,
+      AdvancedExtension advancedExtension) {
+    return namedScan(
+        tableName, columnNames, types, Optional.empty(), Optional.of(advancedExtension));
   }
 
   private NamedScan namedScan(
       Iterable<String> tableName,
       Iterable<String> columnNames,
       Iterable<Type> types,
-      Optional<Rel.Remap> remap) {
+      Optional<Rel.Remap> remap,
+      Optional<AdvancedExtension> advancedExtension) {
     var struct = Type.Struct.builder().addAllFields(types).nullable(false).build();
     var namedStruct = NamedStruct.of(columnNames, struct);
-    return NamedScan.builder().names(tableName).initialSchema(namedStruct).remap(remap).build();
+    return NamedScan.builder()
+        .names(tableName)
+        .initialSchema(namedStruct)
+        .remap(remap)
+        .extension(advancedExtension)
+        .build();
   }
 
   public Project project(Function<Rel, Iterable<? extends Expression>> expressionsFn, Rel input) {

--- a/core/src/main/java/io/substrait/io/substrait/extension/AdvancedExtension.java
+++ b/core/src/main/java/io/substrait/io/substrait/extension/AdvancedExtension.java
@@ -1,6 +1,24 @@
 package io.substrait.io.substrait.extension;
 
-public interface AdvancedExtension {
+import io.substrait.relation.Extension;
+import java.util.Optional;
+import org.immutables.value.Value;
 
-  io.substrait.proto.AdvancedExtension toProto();
+@Value.Immutable
+public abstract class AdvancedExtension {
+
+  public abstract Optional<Extension.Optimization> getOptimization();
+
+  public abstract Optional<Extension.Enhancement> getEnhancement();
+
+  public io.substrait.proto.AdvancedExtension toProto() {
+    var builder = io.substrait.proto.AdvancedExtension.newBuilder();
+    getEnhancement().ifPresent(e -> builder.setEnhancement(e.toProto()));
+    getOptimization().ifPresent(e -> builder.setOptimization(e.toProto()));
+    return builder.build();
+  }
+
+  public static ImmutableAdvancedExtension.Builder builder() {
+    return ImmutableAdvancedExtension.builder();
+  }
 }

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -59,7 +59,18 @@ public abstract class AbstractRelVisitor<OUTPUT, EXCEPTION extends Exception>
     return visitFallback(virtualTableScan);
   }
 
+  @Override
   public OUTPUT visit(Cross cross) throws EXCEPTION {
     return visitFallback(cross);
+  }
+
+  @Override
+  public OUTPUT visit(ExtensionSingleInput extensionSingleInput) throws EXCEPTION {
+    return visitFallback(extensionSingleInput);
+  }
+
+  @Override
+  public OUTPUT visit(ExtensionTable extensionTable) throws EXCEPTION {
+    return visitFallback(extensionTable);
   }
 }

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -1,0 +1,21 @@
+package io.substrait.relation;
+
+/** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
+public class Extension {
+
+  private interface ToProto {
+    com.google.protobuf.Any toProto();
+  }
+
+  public interface Optimization extends ToProto {}
+
+  public interface Enhancement extends ToProto {}
+
+  public interface LeafRelDetail extends ToProto {}
+
+  public interface SingleRelDetail extends ToProto {}
+
+  public interface MultiRelDetail extends ToProto {}
+
+  public interface ExtensionTableDetail extends ToProto {}
+}

--- a/core/src/main/java/io/substrait/relation/ExtensionSingleInput.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionSingleInput.java
@@ -1,0 +1,19 @@
+package io.substrait.relation;
+
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class ExtensionSingleInput extends SingleInputRel {
+
+  public abstract Optional<Extension.SingleRelDetail> getDetail();
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableExtensionSingleInput.Builder builder() {
+    return ImmutableExtensionSingleInput.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/ExtensionTable.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionTable.java
@@ -1,0 +1,18 @@
+package io.substrait.relation;
+
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class ExtensionTable extends AbstractReadRel {
+  public abstract Optional<Extension.ExtensionTableDetail> getDetail();
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableExtensionTable.Builder builder() {
+    return ImmutableExtensionTable.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -1,5 +1,6 @@
 package io.substrait.relation;
 
+import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.List;
@@ -9,6 +10,8 @@ import org.immutables.value.Value;
 
 public interface Rel {
   Optional<Remap> getRemap();
+
+  Optional<AdvancedExtension> getExtension();
 
   Type.Struct getRecordType();
 

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -24,4 +24,8 @@ public interface RelVisitor<OUTPUT, EXCEPTION extends Exception> {
   OUTPUT visit(Cross cross) throws EXCEPTION;
 
   OUTPUT visit(VirtualTableScan virtualTableScan) throws EXCEPTION;
+
+  OUTPUT visit(ExtensionSingleInput extensionSingleInput) throws EXCEPTION;
+
+  OUTPUT visit(ExtensionTable extensionTable) throws EXCEPTION;
 }

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -1,0 +1,16 @@
+package io.substrait.relation.extensions;
+
+import com.google.protobuf.Any;
+import io.substrait.relation.Extension;
+
+public class EmptyDetail
+    implements Extension.ExtensionTableDetail,
+        Extension.LeafRelDetail,
+        Extension.MultiRelDetail,
+        Extension.SingleRelDetail {
+
+  @Override
+  public Any toProto() {
+    return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
+  }
+}

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyEnhancement.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyEnhancement.java
@@ -1,0 +1,18 @@
+package io.substrait.relation.extensions;
+
+import com.google.protobuf.Any;
+import io.substrait.relation.Extension;
+
+/**
+ * Default type to which AdvancedExtension.enhancements are converted to.
+ *
+ * <p>Provide your own implementation of {@link
+ * io.substrait.relation.ProtoRelConverter#enhancementFromAdvancedExtension(Any)} if you have
+ * enhancements you wish to process.
+ */
+public class EmptyEnhancement implements Extension.Enhancement {
+  @Override
+  public Any toProto() {
+    return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
+  }
+}

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
@@ -1,0 +1,18 @@
+package io.substrait.relation.extensions;
+
+import com.google.protobuf.Any;
+import io.substrait.relation.Extension;
+
+/**
+ * Default type to which AdvancedExtension.optimization are converted to.
+ *
+ * <p>Provide your own implementation of {@link
+ * io.substrait.relation.ProtoRelConverter#enhancementFromAdvancedExtension(Any)} if you have
+ * optimizations you wish to process.
+ */
+public class EmptyOptimization implements Extension.Optimization {
+  @Override
+  public Any toProto() {
+    return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
+  }
+}

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -1,0 +1,128 @@
+package io.substrait.relation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.proto.FunctionCollector;
+import io.substrait.function.SimpleExtension;
+import io.substrait.io.substrait.extension.AdvancedExtension;
+import io.substrait.relation.utils.StringHolder;
+import io.substrait.relation.utils.StringHolderHandlingProtoRelConvert;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ProtoRelConverterTest {
+
+  final SimpleExtension.ExtensionCollection extensions;
+
+  {
+    try {
+      extensions = SimpleExtension.loadDefaults();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  final SubstraitBuilder b = new SubstraitBuilder(extensions);
+  final FunctionCollector functionCollector = new FunctionCollector();
+  final RelProtoConverter relProtoConverter = new RelProtoConverter(functionCollector);
+  final ProtoRelConverter protoRelConverter = new ProtoRelConverter(functionCollector, extensions);
+
+  @Nested
+  class AdvancedExtensions {
+
+    static final StringHolder ENHANCED = new StringHolder("ENHANCED");
+    static final StringHolder OPTIMIZED = new StringHolder("OPTIMIZED");
+
+    Rel relWithExtension(AdvancedExtension advancedExtension) {
+      return b.namedScan(
+          new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), advancedExtension);
+    }
+
+    Rel emptyAdvancedExtension = relWithExtension(AdvancedExtension.builder().build());
+    Rel advancedExtensionWithOptimization =
+        relWithExtension(AdvancedExtension.builder().optimization(OPTIMIZED).build());
+
+    Rel advancedExtensionWithEnhancement =
+        relWithExtension(AdvancedExtension.builder().enhancement(ENHANCED).build());
+
+    Rel advancedExtensionWithEnhancementAndOptimization =
+        relWithExtension(
+            AdvancedExtension.builder().enhancement(ENHANCED).optimization(OPTIMIZED).build());
+
+    @Nested
+    class DefaultProtoRelConverter {
+
+      @Test
+      void emptyAdvancedExtension() {
+        Rel rel = emptyAdvancedExtension;
+        io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+        Rel relReturned = protoRelConverter.from(protoRel);
+        assertEquals(rel, relReturned);
+      }
+
+      @Test
+      void enhancementOnlyAdvancedExtension() {
+        Rel rel = advancedExtensionWithEnhancement;
+        io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+        assertThrows(RuntimeException.class, () -> protoRelConverter.from(protoRel));
+      }
+
+      @Test
+      void optimizationOnlyAdvancedExtension() {
+        Rel rel = advancedExtensionWithOptimization;
+        io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+        Rel relReturned = protoRelConverter.from(protoRel);
+
+        // The optimization is serialized correctly to protobuf.
+        // When it is read back in, the default ProtoRelConverter drops it.
+        // As such they are not equal anymore.
+        assertNotEquals(rel, relReturned);
+      }
+
+      @Test
+      void advancedExtensionWithEnhancementAndOptimization() {
+        Rel rel = advancedExtensionWithEnhancementAndOptimization;
+        io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+        assertThrows(RuntimeException.class, () -> protoRelConverter.from(protoRel));
+      }
+    }
+
+    @Nested
+    class CustomProtoRelConverter {
+
+      final ProtoRelConverter protoRelConverter =
+          new StringHolderHandlingProtoRelConvert(functionCollector, extensions);
+
+      void verifyRoundTrip(Rel rel) {
+        io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+        Rel relReturned = protoRelConverter.from(protoRel);
+        assertEquals(rel, relReturned);
+      }
+
+      @Test
+      void emptyAdvancedExtension() {
+        verifyRoundTrip(emptyAdvancedExtension);
+      }
+
+      @Test
+      void enhancementOnlyAdvancedExtension() {
+        verifyRoundTrip(advancedExtensionWithEnhancement);
+      }
+
+      @Test
+      void optimizationOnlyAdvancedExtension() {
+        verifyRoundTrip(advancedExtensionWithOptimization);
+      }
+
+      @Test
+      void advancedExtensionWithEnhancementAndOptimization() {
+        verifyRoundTrip(advancedExtensionWithEnhancementAndOptimization);
+      }
+    }
+  }
+}

--- a/core/src/test/java/io/substrait/relation/utils/StringHolder.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolder.java
@@ -1,0 +1,37 @@
+package io.substrait.relation.utils;
+
+import com.google.protobuf.Any;
+import io.substrait.relation.Extension;
+import java.util.Objects;
+
+/**
+ * For use in {@link io.substrait.relation.ProtoRelConverterTest}
+ *
+ * <p>Used to verify serde of {@link com.google.protobuf.Any} fields in the spec
+ */
+public class StringHolder implements Extension.Enhancement, Extension.Optimization {
+
+  private final String value;
+
+  public StringHolder(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public Any toProto() {
+    return com.google.protobuf.Any.pack(com.google.protobuf.StringValue.of(this.value));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StringHolder that = (StringHolder) o;
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+}

--- a/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConvert.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConvert.java
@@ -1,0 +1,40 @@
+package io.substrait.relation.utils;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.StringValue;
+import io.substrait.expression.FunctionLookup;
+import io.substrait.function.SimpleExtension;
+import io.substrait.relation.Extension;
+import io.substrait.relation.ProtoRelConverter;
+
+/**
+ * Extends {@link ProtoRelConverter} with conversions from {@link com.google.protobuf.Any} to {@link
+ * StringHolder}
+ *
+ * <p>Used to verify serde of {@link com.google.protobuf.Any} fields in the spec
+ */
+public class StringHolderHandlingProtoRelConvert extends ProtoRelConverter {
+  public StringHolderHandlingProtoRelConvert(
+      FunctionLookup lookup, SimpleExtension.ExtensionCollection extensions) {
+    super(lookup, extensions);
+  }
+
+  @Override
+  protected Extension.Enhancement enhancementFromAdvancedExtension(Any any) {
+    try {
+      return new StringHolder(any.unpack(StringValue.class).getValue());
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected Extension.Optimization optimizationFromAdvancedExtension(Any any) {
+    try {
+      return new StringHolder(any.unpack(StringValue.class).getValue());
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
This PR is split into two commits:
* The first commits adds code for handling `google.protobuf.Any` types in the AdvanceExtension message, ReadRel.ExtensionTable message and ExtensionSingleRel messages.
* The second commit includes tests for the ProtoRelConverter, including a demonstration of how it would be overridden by the user to handle `google.protobuf.Any` types.

## Summary

`com.protobuf.Any` types are handled by methods in the `ProtoRelConverter` that are intended to be overriden by end users. For example:

```java
public class ProtoRelConverter {
  ...  
  protected Extension.Optimization optimizationFromAdvancedExtension(com.google.protobuf.Any any)
  ...
}
```
can be overriden by end users to convert the Any into their own Java equivalent. 

`Extension.Optimization` is a tag interface to be able to distinguish between various types of Any data (instead of having `Object` everywhere).

```java
/** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
public class Extension {

  private interface ToProto {
    com.google.protobuf.Any toProto();
  }

  public interface Optimization extends ToProto {}
 ...
```