### PR TITLE
feat: google.protobuf.Any handling

### DIFF
--- a/core/src/main/java/io/substrait/io/substrait/extension/AdvancedExtension.java
+++ b/core/src/main/java/io/substrait/io/substrait/extension/AdvancedExtension.java
@@ -1,6 +1,24 @@
 package io.substrait.io.substrait.extension;
 
-public interface AdvancedExtension {
+import io.substrait.relation.Extension;
+import java.util.Optional;
+import org.immutables.value.Value;
 
-  io.substrait.proto.AdvancedExtension toProto();
+@Value.Immutable
+public abstract class AdvancedExtension {
+
+  public abstract Optional<Extension.Optimization> getOptimization();
+
+  public abstract Optional<Extension.Enhancement> getEnhancement();
+
+  public io.substrait.proto.AdvancedExtension toProto() {
+    var builder = io.substrait.proto.AdvancedExtension.newBuilder();
+    getEnhancement().ifPresent(e -> builder.setEnhancement(e.toProto()));
+    getOptimization().ifPresent(e -> builder.setOptimization(e.toProto()));
+    return builder.build();
+  }
+
+  public static ImmutableAdvancedExtension.Builder builder() {
+    return ImmutableAdvancedExtension.builder();
+  }
 }

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -15,7 +15,7 @@ public class ProtoPlanConverter {
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(io.substrait.plan.ProtoPlanConverter.class);
 
-  private final SimpleExtension.ExtensionCollection extensionCollection;
+  protected final SimpleExtension.ExtensionCollection extensionCollection;
 
   public ProtoPlanConverter() throws IOException {
     this(SimpleExtension.loadDefaults());
@@ -25,9 +25,13 @@ public class ProtoPlanConverter {
     this.extensionCollection = extensionCollection;
   }
 
+  protected ProtoRelConverter getProtoRelConverter(FunctionLookup functionLookup) {
+    return new ProtoRelConverter(functionLookup, this.extensionCollection);
+  }
+
   public Plan from(io.substrait.proto.Plan plan) {
     FunctionLookup functionLookup = ImmutableFunctionLookup.builder().from(plan).build();
-    ProtoRelConverter relConverter = new ProtoRelConverter(functionLookup, extensionCollection);
+    ProtoRelConverter relConverter = getProtoRelConverter(functionLookup);
     List<Plan.Root> roots = new ArrayList<>();
     for (PlanRel planRel : plan.getRelationsList()) {
       io.substrait.proto.RelRoot root = planRel.getRoot();

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -25,6 +25,7 @@ public class ProtoPlanConverter {
     this.extensionCollection = extensionCollection;
   }
 
+  /** Override hook for providing custom {@link ProtoRelConverter} implementations */
   protected ProtoRelConverter getProtoRelConverter(FunctionLookup functionLookup) {
     return new ProtoRelConverter(functionLookup, this.extensionCollection);
   }

--- a/core/src/main/java/io/substrait/relation/AbstractReadRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractReadRel.java
@@ -1,7 +1,6 @@
 package io.substrait.relation;
 
 import io.substrait.expression.Expression;
-import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import java.util.Optional;
@@ -14,8 +13,6 @@ public abstract class AbstractReadRel extends ZeroInputRel {
 
   // TODO:
   // public abstract Optional<MaskExpression>
-
-  public abstract Optional<AdvancedExtension> getGeneralExtension();
 
   @Override
   protected final Type.Struct deriveRecordType() {

--- a/core/src/main/java/io/substrait/relation/AbstractReadRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractReadRel.java
@@ -5,7 +5,7 @@ import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import java.util.Optional;
 
-public abstract class AbstractReadRel extends ZeroInputRel {
+public abstract class AbstractReadRel extends ZeroInputRel implements HasExtension {
 
   public abstract NamedStruct getInitialSchema();
 

--- a/core/src/main/java/io/substrait/relation/AbstractRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRel.java
@@ -1,14 +1,10 @@
 package io.substrait.relation;
 
-import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.type.Type;
 import io.substrait.util.Util;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 public abstract class AbstractRel implements Rel {
-
-  public abstract Optional<AdvancedExtension> getGeneralExtension();
 
   private Supplier<Type.Struct> recordType =
       Util.memoize(

--- a/core/src/main/java/io/substrait/relation/AbstractRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRel.java
@@ -1,10 +1,14 @@
 package io.substrait.relation;
 
+import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.type.Type;
 import io.substrait.util.Util;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public abstract class AbstractRel implements Rel {
+
+  public abstract Optional<AdvancedExtension> getGeneralExtension();
 
   private Supplier<Type.Struct> recordType =
       Util.memoize(

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -59,6 +59,7 @@ public abstract class AbstractRelVisitor<OUTPUT, EXCEPTION extends Exception>
     return visitFallback(virtualTableScan);
   }
 
+  @Override
   public OUTPUT visit(Cross cross) throws EXCEPTION {
     return visitFallback(cross);
   }

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -78,4 +78,9 @@ public abstract class AbstractRelVisitor<OUTPUT, EXCEPTION extends Exception>
   public OUTPUT visit(ExtensionMulti extensionMulti) throws EXCEPTION {
     return visitFallback(extensionMulti);
   }
+
+  @Override
+  public OUTPUT visit(ExtensionTable extensionTable) throws EXCEPTION {
+    return visitFallback(extensionTable);
+  }
 }

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -63,4 +63,19 @@ public abstract class AbstractRelVisitor<OUTPUT, EXCEPTION extends Exception>
   public OUTPUT visit(Cross cross) throws EXCEPTION {
     return visitFallback(cross);
   }
+
+  @Override
+  public OUTPUT visit(ExtensionLeaf extensionLeaf) throws EXCEPTION {
+    return visitFallback(extensionLeaf);
+  }
+
+  @Override
+  public OUTPUT visit(ExtensionSingle extensionSingle) throws EXCEPTION {
+    return visitFallback(extensionSingle);
+  }
+
+  @Override
+  public OUTPUT visit(ExtensionMulti extensionMulti) throws EXCEPTION {
+    return visitFallback(extensionMulti);
+  }
 }

--- a/core/src/main/java/io/substrait/relation/Aggregate.java
+++ b/core/src/main/java/io/substrait/relation/Aggregate.java
@@ -12,7 +12,7 @@ import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Aggregate extends SingleInputRel {
+public abstract class Aggregate extends SingleInputRel implements HasExtension {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Aggregate.class);
 
   public abstract List<Grouping> getGroupings();

--- a/core/src/main/java/io/substrait/relation/Cross.java
+++ b/core/src/main/java/io/substrait/relation/Cross.java
@@ -6,7 +6,7 @@ import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Cross extends BiRel {
+public abstract class Cross extends BiRel implements HasExtension {
 
   @Override
   protected Type.Struct deriveRecordType() {

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -7,33 +7,29 @@ import java.util.List;
 /** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
 public class Extension {
 
-  private interface ToProto {
-    com.google.protobuf.Any toProto();
-  }
-
   /**
    * Optimization associated with an {@link io.substrait.proto.AdvancedExtension}
    *
    * <p>An optimization is helpful information that don't influence semantics. May be ignored by a
    * consumer.
    */
-  public interface Optimization extends ToProto {}
+  public interface Optimization extends ToProto<com.google.protobuf.Any> {}
 
   /**
    * Enhancement associated with an {@link io.substrait.proto.AdvancedExtension}
    *
    * <p>An enhancement alter semantics. Cannot be ignored by a consumer.
    */
-  public interface Enhancement extends ToProto {}
+  public interface Enhancement extends ToProto<com.google.protobuf.Any> {}
 
-  public interface LeafRelDetail extends ToProto {
+  public interface LeafRelDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @return the record layout for the associated {@link ExtensionLeaf} relation
      */
     Type.Struct deriveRecordType();
   }
 
-  public interface SingleRelDetail extends ToProto {
+  public interface SingleRelDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @param input to the associated {@link ExtensionSingle} relation
      * @return the record layout for the associated {@link ExtensionSingle} relation
@@ -41,7 +37,7 @@ public class Extension {
     Type.Struct deriveRecordType(Rel input);
   }
 
-  public interface MultiRelDetail extends ToProto {
+  public interface MultiRelDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @param inputs to the associated {@link ExtensionMulti} relation
      * @return the record layout for the associated {@link ExtensionMulti} relation
@@ -49,7 +45,7 @@ public class Extension {
     Type.Struct deriveRecordType(List<Rel> inputs);
   }
 
-  public interface ExtensionTableDetail extends ToProto {
+  public interface ExtensionTableDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @return the table schema for the associated {@link ExtensionTable} relation
      */

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -10,4 +10,10 @@ public class Extension {
   public interface Optimization extends ToProto {}
 
   public interface Enhancement extends ToProto {}
+
+  public interface LeafRelDetail extends ToProto {}
+
+  public interface SingleRelDetail extends ToProto {}
+
+  public interface MultiRelDetail extends ToProto {}
 }

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -1,5 +1,7 @@
 package io.substrait.relation;
 
+import io.substrait.type.Type;
+
 /** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
 public class Extension {
 
@@ -11,11 +13,18 @@ public class Extension {
 
   public interface Enhancement extends ToProto {}
 
-  public interface LeafRelDetail extends ToProto {}
+  public interface LeafRelDetail extends ToProto {
 
-  public interface SingleRelDetail extends ToProto {}
+    Type.Struct deriveRecordType();
+  }
 
-  public interface MultiRelDetail extends ToProto {}
+  public interface SingleRelDetail extends ToProto {
+    Type.Struct deriveRecordType(Rel input);
+  }
+
+  public interface MultiRelDetail extends ToProto {
+    Type.Struct deriveRecordType(Rel... inputs);
+  }
 
   public interface ExtensionTableDetail extends ToProto {}
 }

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -1,5 +1,6 @@
 package io.substrait.relation;
 
+import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 
 /** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
@@ -14,7 +15,6 @@ public class Extension {
   public interface Enhancement extends ToProto {}
 
   public interface LeafRelDetail extends ToProto {
-
     Type.Struct deriveRecordType();
   }
 
@@ -26,5 +26,7 @@ public class Extension {
     Type.Struct deriveRecordType(Rel... inputs);
   }
 
-  public interface ExtensionTableDetail extends ToProto {}
+  public interface ExtensionTableDetail extends ToProto {
+    NamedStruct deriveSchema();
+  }
 }

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -2,6 +2,7 @@ package io.substrait.relation;
 
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
+import java.util.List;
 
 /** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
 public class Extension {
@@ -23,7 +24,7 @@ public class Extension {
   }
 
   public interface MultiRelDetail extends ToProto {
-    Type.Struct deriveRecordType(Rel... inputs);
+    Type.Struct deriveRecordType(List<Rel> inputs);
   }
 
   public interface ExtensionTableDetail extends ToProto {

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -16,4 +16,6 @@ public class Extension {
   public interface SingleRelDetail extends ToProto {}
 
   public interface MultiRelDetail extends ToProto {}
+
+  public interface ExtensionTableDetail extends ToProto {}
 }

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -11,8 +11,18 @@ public class Extension {
     com.google.protobuf.Any toProto();
   }
 
+  /**
+   * Optimization associated with an {@link io.substrait.proto.AdvancedExtension}
+   *
+   * <p>An enhancement alter semantics. Cannot be ignored by a consumer.
+   */
   public interface Optimization extends ToProto {}
 
+  /**
+   * Enhancement associated with an {@link io.substrait.proto.AdvancedExtension}
+   *
+   * <p>An enhancement alter semantics. Cannot be ignored by a consumer.
+   */
   public interface Enhancement extends ToProto {}
 
   public interface LeafRelDetail extends ToProto {

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -16,18 +16,32 @@ public class Extension {
   public interface Enhancement extends ToProto {}
 
   public interface LeafRelDetail extends ToProto {
+    /**
+     * @return the record layout for the associated {@link ExtensionLeaf} relation
+     */
     Type.Struct deriveRecordType();
   }
 
   public interface SingleRelDetail extends ToProto {
+    /**
+     * @param input to the associated {@link ExtensionSingle} relation
+     * @return the record layout for the associated {@link ExtensionSingle} relation
+     */
     Type.Struct deriveRecordType(Rel input);
   }
 
   public interface MultiRelDetail extends ToProto {
+    /**
+     * @param inputs to the associated {@link ExtensionMulti} relation
+     * @return the record layout for the associated {@link ExtensionMulti} relation
+     */
     Type.Struct deriveRecordType(List<Rel> inputs);
   }
 
   public interface ExtensionTableDetail extends ToProto {
+    /**
+     * @return the table schema for the associated {@link ExtensionTable} relation
+     */
     NamedStruct deriveSchema();
   }
 }

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -1,0 +1,13 @@
+package io.substrait.relation;
+
+/** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
+public class Extension {
+
+  private interface ToProto {
+    com.google.protobuf.Any toProto();
+  }
+
+  public interface Optimization extends ToProto {}
+
+  public interface Enhancement extends ToProto {}
+}

--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -14,7 +14,8 @@ public class Extension {
   /**
    * Optimization associated with an {@link io.substrait.proto.AdvancedExtension}
    *
-   * <p>An enhancement alter semantics. Cannot be ignored by a consumer.
+   * <p>An optimization is helpful information that don't influence semantics. May be ignored by a
+   * consumer.
    */
   public interface Optimization extends ToProto {}
 

--- a/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
@@ -1,0 +1,19 @@
+package io.substrait.relation;
+
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class ExtensionLeaf extends ZeroInputRel {
+
+  public abstract Optional<Extension.LeafRelDetail> getDetail();
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableExtensionLeaf.Builder builder() {
+    return ImmutableExtensionLeaf.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
@@ -1,12 +1,11 @@
 package io.substrait.relation;
 
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class ExtensionLeaf extends ZeroInputRel {
 
-  public abstract Optional<Extension.LeafRelDetail> getDetail();
+  public abstract Extension.LeafRelDetail getDetail();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
@@ -13,7 +13,9 @@ public abstract class ExtensionLeaf extends ZeroInputRel {
     return visitor.visit(this);
   }
 
-  public static ImmutableExtensionLeaf.Builder builder() {
-    return ImmutableExtensionLeaf.builder();
+  public static ImmutableExtensionLeaf.Builder from(Extension.LeafRelDetail detail) {
+    return ImmutableExtensionLeaf.builder()
+        .detail(detail)
+        .deriveRecordType(detail.deriveRecordType());
   }
 }

--- a/core/src/main/java/io/substrait/relation/ExtensionMulti.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionMulti.java
@@ -13,6 +13,14 @@ public abstract class ExtensionMulti extends AbstractRel {
     return visitor.visit(this);
   }
 
+  public static ImmutableExtensionMulti.Builder from(
+      Extension.MultiRelDetail detail, Rel... inputs) {
+    return ImmutableExtensionMulti.builder()
+        .addInputs(inputs)
+        .detail(detail)
+        .deriveRecordType(detail.deriveRecordType(inputs));
+  }
+
   public static ImmutableExtensionMulti.Builder builder() {
     return ImmutableExtensionMulti.builder();
   }

--- a/core/src/main/java/io/substrait/relation/ExtensionMulti.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionMulti.java
@@ -1,5 +1,8 @@
 package io.substrait.relation;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -14,13 +17,14 @@ public abstract class ExtensionMulti extends AbstractRel {
 
   public static ImmutableExtensionMulti.Builder from(
       Extension.MultiRelDetail detail, Rel... inputs) {
-    return ImmutableExtensionMulti.builder()
-        .addInputs(inputs)
-        .detail(detail)
-        .deriveRecordType(detail.deriveRecordType(inputs));
+    return from(detail, Arrays.stream(inputs).collect(Collectors.toList()));
   }
 
-  public static ImmutableExtensionMulti.Builder builder() {
-    return ImmutableExtensionMulti.builder();
+  public static ImmutableExtensionMulti.Builder from(
+      Extension.MultiRelDetail detail, List<Rel> inputs) {
+    return ImmutableExtensionMulti.builder()
+        .addAllInputs(inputs)
+        .detail(detail)
+        .deriveRecordType(detail.deriveRecordType(inputs));
   }
 }

--- a/core/src/main/java/io/substrait/relation/ExtensionMulti.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionMulti.java
@@ -1,12 +1,11 @@
 package io.substrait.relation;
 
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class ExtensionMulti extends AbstractRel {
 
-  public abstract Optional<Extension.MultiRelDetail> getDetail();
+  public abstract Extension.MultiRelDetail getDetail();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/ExtensionMulti.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionMulti.java
@@ -1,0 +1,19 @@
+package io.substrait.relation;
+
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class ExtensionMulti extends AbstractRel {
+
+  public abstract Optional<Extension.MultiRelDetail> getDetail();
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableExtensionMulti.Builder builder() {
+    return ImmutableExtensionMulti.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/ExtensionSingle.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionSingle.java
@@ -13,7 +13,10 @@ public abstract class ExtensionSingle extends SingleInputRel {
     return visitor.visit(this);
   }
 
-  public static ImmutableExtensionSingle.Builder builder() {
-    return ImmutableExtensionSingle.builder();
+  public static ImmutableExtensionSingle.Builder from(Extension.SingleRelDetail detail, Rel input) {
+    return ImmutableExtensionSingle.builder()
+        .input(input)
+        .detail(detail)
+        .deriveRecordType(detail.deriveRecordType(input));
   }
 }

--- a/core/src/main/java/io/substrait/relation/ExtensionSingle.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionSingle.java
@@ -1,0 +1,19 @@
+package io.substrait.relation;
+
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class ExtensionSingle extends SingleInputRel {
+
+  public abstract Optional<Extension.SingleRelDetail> getDetail();
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableExtensionSingle.Builder builder() {
+    return ImmutableExtensionSingle.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/ExtensionSingle.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionSingle.java
@@ -1,12 +1,11 @@
 package io.substrait.relation;
 
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class ExtensionSingle extends SingleInputRel {
 
-  public abstract Optional<Extension.SingleRelDetail> getDetail();
+  public abstract Extension.SingleRelDetail getDetail();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/ExtensionTable.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionTable.java
@@ -1,12 +1,11 @@
 package io.substrait.relation;
 
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class ExtensionTable extends AbstractReadRel {
 
-  public abstract Optional<Extension.ExtensionTableDetail> getDetail();
+  public abstract Extension.ExtensionTableDetail getDetail();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/ExtensionTable.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionTable.java
@@ -1,0 +1,19 @@
+package io.substrait.relation;
+
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class ExtensionTable extends AbstractReadRel {
+
+  public abstract Optional<Extension.ExtensionTableDetail> getDetail();
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableExtensionTable.Builder builder() {
+    return ImmutableExtensionTable.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/ExtensionTable.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionTable.java
@@ -13,7 +13,7 @@ public abstract class ExtensionTable extends AbstractReadRel {
     return visitor.visit(this);
   }
 
-  public static ImmutableExtensionTable.Builder builder() {
-    return ImmutableExtensionTable.builder();
+  public static ImmutableExtensionTable.Builder from(Extension.ExtensionTableDetail detail) {
+    return ImmutableExtensionTable.builder().initialSchema(detail.deriveSchema()).detail(detail);
   }
 }

--- a/core/src/main/java/io/substrait/relation/Fetch.java
+++ b/core/src/main/java/io/substrait/relation/Fetch.java
@@ -5,7 +5,7 @@ import java.util.OptionalLong;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Fetch extends SingleInputRel {
+public abstract class Fetch extends SingleInputRel implements HasExtension {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Fetch.class);
 
   public abstract long getOffset();

--- a/core/src/main/java/io/substrait/relation/Filter.java
+++ b/core/src/main/java/io/substrait/relation/Filter.java
@@ -5,7 +5,7 @@ import io.substrait.type.Type;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Filter extends SingleInputRel {
+public abstract class Filter extends SingleInputRel implements HasExtension {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Filter.class);
 
   public abstract Expression getCondition();

--- a/core/src/main/java/io/substrait/relation/HasExtension.java
+++ b/core/src/main/java/io/substrait/relation/HasExtension.java
@@ -10,5 +10,8 @@ import java.util.Optional;
  * extensions. See {@link ExtensionLeaf}, {@link ExtensionSingle}, {@link ExtensionMulti}).
  */
 public interface HasExtension {
+  /**
+   * @return the {@link AdvancedExtension} associated directly with the relation, if present
+   */
   Optional<AdvancedExtension> getRelExtension();
 }

--- a/core/src/main/java/io/substrait/relation/HasExtension.java
+++ b/core/src/main/java/io/substrait/relation/HasExtension.java
@@ -1,0 +1,14 @@
+package io.substrait.relation;
+
+import io.substrait.io.substrait.extension.AdvancedExtension;
+import java.util.Optional;
+
+/**
+ * Used to indicate the presence of an {@link AdvancedExtension} directly on a relation
+ *
+ * <p>This exists outside of {@link Rel} because there are relations that do not have advanced
+ * extensions. See {@link ExtensionLeaf}, {@link ExtensionSingle}, {@link ExtensionMulti}).
+ */
+public interface HasExtension {
+  Optional<AdvancedExtension> getGeneralExtension();
+}

--- a/core/src/main/java/io/substrait/relation/HasExtension.java
+++ b/core/src/main/java/io/substrait/relation/HasExtension.java
@@ -10,5 +10,5 @@ import java.util.Optional;
  * extensions. See {@link ExtensionLeaf}, {@link ExtensionSingle}, {@link ExtensionMulti}).
  */
 public interface HasExtension {
-  Optional<AdvancedExtension> getGeneralExtension();
+  Optional<AdvancedExtension> getRelExtension();
 }

--- a/core/src/main/java/io/substrait/relation/HasExtension.java
+++ b/core/src/main/java/io/substrait/relation/HasExtension.java
@@ -3,15 +3,10 @@ package io.substrait.relation;
 import io.substrait.io.substrait.extension.AdvancedExtension;
 import java.util.Optional;
 
-/**
- * Used to indicate the presence of an {@link AdvancedExtension} directly on a relation
- *
- * <p>This exists outside of {@link Rel} because there are relations that do not have advanced
- * extensions. See {@link ExtensionLeaf}, {@link ExtensionSingle}, {@link ExtensionMulti}).
- */
+/** Used to indicate the potential presence of an {@link AdvancedExtension} */
 public interface HasExtension {
   /**
-   * @return the {@link AdvancedExtension} associated directly with the relation, if present
+   * @return the {@link AdvancedExtension} associated directly with the class
    */
-  Optional<AdvancedExtension> getRelExtension();
+  Optional<AdvancedExtension> getExtension();
 }

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Join extends BiRel {
+public abstract class Join extends BiRel implements HasExtension {
 
   public abstract Optional<Expression> getCondition();
 

--- a/core/src/main/java/io/substrait/relation/LocalFiles.java
+++ b/core/src/main/java/io/substrait/relation/LocalFiles.java
@@ -13,7 +13,7 @@ public abstract class LocalFiles extends AbstractReadRel {
 
   public abstract List<FileOrFiles> getItems();
 
-  public abstract Optional<AdvancedExtension> getExtension();
+  public abstract Optional<AdvancedExtension> getCommonExtension();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/LocalFiles.java
+++ b/core/src/main/java/io/substrait/relation/LocalFiles.java
@@ -1,9 +1,7 @@
 package io.substrait.relation;
 
-import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.relation.files.FileOrFiles;
 import java.util.List;
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -12,8 +10,6 @@ public abstract class LocalFiles extends AbstractReadRel {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(LocalFiles.class);
 
   public abstract List<FileOrFiles> getItems();
-
-  public abstract Optional<AdvancedExtension> getCommonExtension();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/NamedScan.java
+++ b/core/src/main/java/io/substrait/relation/NamedScan.java
@@ -10,7 +10,7 @@ public abstract class NamedScan extends AbstractReadRel {
 
   public abstract List<String> getNames();
 
-  public abstract Optional<AdvancedExtension> getExtension();
+  public abstract Optional<AdvancedExtension> getCommonExtension();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/NamedScan.java
+++ b/core/src/main/java/io/substrait/relation/NamedScan.java
@@ -1,16 +1,12 @@
 package io.substrait.relation;
 
-import io.substrait.io.substrait.extension.AdvancedExtension;
 import java.util.List;
-import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class NamedScan extends AbstractReadRel {
 
   public abstract List<String> getNames();
-
-  public abstract Optional<AdvancedExtension> getCommonExtension();
 
   @Override
   public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/relation/Project.java
+++ b/core/src/main/java/io/substrait/relation/Project.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Project extends SingleInputRel {
+public abstract class Project extends SingleInputRel implements HasExtension {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Project.class);
 
   public abstract List<Expression> getExpressions();

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -123,7 +123,7 @@ public class ProtoRelConverter {
                     .from(rel.getCondition()));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -160,7 +160,7 @@ public class ProtoRelConverter {
                         : null));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -171,7 +171,7 @@ public class ProtoRelConverter {
   private ExtensionLeaf newExtensionLeaf(ExtensionLeafRel rel) {
     var builder =
         ExtensionLeaf.builder()
-            .extension(optionalAdvancedExtension(rel.getCommon()))
+            .commonExtension(optionalAdvancedExtension(rel.getCommon()))
             .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasDetail()) {
       builder.detail(detailFromExtensionLeafRel(rel.getDetail()));
@@ -184,7 +184,7 @@ public class ProtoRelConverter {
     var builder =
         ExtensionSingle.builder()
             .input(input)
-            .extension(optionalAdvancedExtension(rel.getCommon()))
+            .commonExtension(optionalAdvancedExtension(rel.getCommon()))
             .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasDetail()) {
       builder.detail(detailFromExtensionSingleRel(rel.getDetail()));
@@ -197,7 +197,7 @@ public class ProtoRelConverter {
     var builder =
         ExtensionMulti.builder()
             .addAllInputs(inputs)
-            .extension(optionalAdvancedExtension(rel.getCommon()))
+            .commonExtension(optionalAdvancedExtension(rel.getCommon()))
             .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasDetail()) {
       builder.detail(detailFromExtensionMultiRel(rel.getDetail()));
@@ -219,7 +219,7 @@ public class ProtoRelConverter {
                         : null));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -237,7 +237,7 @@ public class ProtoRelConverter {
     }
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -263,7 +263,7 @@ public class ProtoRelConverter {
                         : null));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -323,7 +323,7 @@ public class ProtoRelConverter {
             .rows(structLiterals);
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -336,7 +336,7 @@ public class ProtoRelConverter {
     var builder = Fetch.builder().input(input).count(rel.getCount()).offset(rel.getOffset());
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -356,7 +356,7 @@ public class ProtoRelConverter {
                     .collect(java.util.stream.Collectors.toList()));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -404,7 +404,7 @@ public class ProtoRelConverter {
     var builder = Aggregate.builder().input(input).groupings(groupings).measures(measures);
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -429,7 +429,7 @@ public class ProtoRelConverter {
                     .collect(java.util.stream.Collectors.toList()));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -455,7 +455,7 @@ public class ProtoRelConverter {
                     rel.hasPostJoinFilter() ? converter.from(rel.getPostJoinFilter()) : null));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -469,7 +469,7 @@ public class ProtoRelConverter {
     var builder = Cross.builder().left(left).right(right);
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
@@ -485,7 +485,7 @@ public class ProtoRelConverter {
     var builder = Set.builder().inputs(inputs).setOp(Set.SetOp.fromProto(rel.getOp()));
 
     builder
-        .extension(optionalAdvancedExtension(rel.getCommon()))
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -160,41 +160,7 @@ public class ProtoRelConverter {
         .remap(optionalRelmap(rel.getCommon()))
         .addAllItems(
             rel.getLocalFiles().getItemsList().stream()
-                .map(
-                    file -> {
-                      ImmutableFileOrFiles.Builder builder =
-                          ImmutableFileOrFiles.builder()
-                              .partitionIndex(file.getPartitionIndex())
-                              .start(file.getStart())
-                              .length(file.getLength());
-                      if (file.hasParquet()) {
-                        builder.fileFormat(
-                            ImmutableFileFormat.ParquetReadOptions.builder().build());
-                      } else if (file.hasOrc()) {
-                        builder.fileFormat(ImmutableFileFormat.OrcReadOptions.builder().build());
-                      } else if (file.hasArrow()) {
-                        builder.fileFormat(ImmutableFileFormat.ArrowReadOptions.builder().build());
-                      } else if (file.hasDwrf()) {
-                        builder.fileFormat(ImmutableFileFormat.DwrfReadOptions.builder().build());
-                      } else if (file.hasExtension()) {
-                        builder.fileFormat(
-                            ImmutableFileFormat.Extension.builder()
-                                .extension(file.getExtension())
-                                .build());
-                      }
-                      if (file.hasUriFile()) {
-                        builder.pathType(FileOrFiles.PathType.URI_FILE).path(file.getUriFile());
-                      } else if (file.hasUriFolder()) {
-                        builder.pathType(FileOrFiles.PathType.URI_FOLDER).path(file.getUriFolder());
-                      } else if (file.hasUriPath()) {
-                        builder.pathType(FileOrFiles.PathType.URI_PATH).path(file.getUriPath());
-                      } else if (file.hasUriPathGlob()) {
-                        builder
-                            .pathType(FileOrFiles.PathType.URI_PATH_GLOB)
-                            .path(file.getUriPathGlob());
-                      }
-                      return builder.build();
-                    })
+                .map(this::newFileOrFiles)
                 .collect(java.util.stream.Collectors.toList()))
         .filter(
             Optional.ofNullable(
@@ -203,6 +169,36 @@ public class ProtoRelConverter {
                         .from(rel.getFilter())
                     : null))
         .build();
+  }
+
+  private FileOrFiles newFileOrFiles(ReadRel.LocalFiles.FileOrFiles file) {
+    ImmutableFileOrFiles.Builder builder =
+        ImmutableFileOrFiles.builder()
+            .partitionIndex(file.getPartitionIndex())
+            .start(file.getStart())
+            .length(file.getLength());
+    if (file.hasParquet()) {
+      builder.fileFormat(ImmutableFileFormat.ParquetReadOptions.builder().build());
+    } else if (file.hasOrc()) {
+      builder.fileFormat(ImmutableFileFormat.OrcReadOptions.builder().build());
+    } else if (file.hasArrow()) {
+      builder.fileFormat(ImmutableFileFormat.ArrowReadOptions.builder().build());
+    } else if (file.hasDwrf()) {
+      builder.fileFormat(ImmutableFileFormat.DwrfReadOptions.builder().build());
+    } else if (file.hasExtension()) {
+      builder.fileFormat(
+          ImmutableFileFormat.Extension.builder().extension(file.getExtension()).build());
+    }
+    if (file.hasUriFile()) {
+      builder.pathType(FileOrFiles.PathType.URI_FILE).path(file.getUriFile());
+    } else if (file.hasUriFolder()) {
+      builder.pathType(FileOrFiles.PathType.URI_FOLDER).path(file.getUriFolder());
+    } else if (file.hasUriPath()) {
+      builder.pathType(FileOrFiles.PathType.URI_PATH).path(file.getUriPath());
+    } else if (file.hasUriPathGlob()) {
+      builder.pathType(FileOrFiles.PathType.URI_PATH_GLOB).path(file.getUriPathGlob());
+    }
+    return builder.build();
   }
 
   private VirtualTableScan newVirtualTable(ReadRel rel) {

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-/** Converts from proto to pojo rel representation TODO: AdvancedExtension */
+/** Converts from proto to pojo rel representation */
 public class ProtoRelConverter {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProtoRelConverter.class);
 
@@ -178,7 +178,6 @@ public class ProtoRelConverter {
   }
 
   private ExtensionSingle newExtensionSingle(ExtensionSingleRel rel) {
-    assert rel.hasDetail();
     Extension.SingleRelDetail detail = detailFromExtensionSingleRel(rel.getDetail());
     Rel input = from(rel.getInput());
     var builder =
@@ -189,7 +188,6 @@ public class ProtoRelConverter {
   }
 
   private ExtensionMulti newExtensionMulti(ExtensionMultiRel rel) {
-    assert rel.hasDetail();
     Extension.MultiRelDetail detail = detailFromExtensionMultiRel(rel.getDetail());
     List<Rel> inputs = rel.getInputsList().stream().map(this::from).collect(Collectors.toList());
     var builder =
@@ -511,27 +509,41 @@ public class ProtoRelConverter {
     return builder.build();
   }
 
-  // Override the following methods to provide custom handling for Any types.
+  /**
+   * Override to provide a custom converter for {@link
+   * io.substrait.proto.AdvancedExtension#getOptimization()} data
+   */
   protected Extension.Optimization optimizationFromAdvancedExtension(com.google.protobuf.Any any) {
     return new EmptyOptimization();
   }
 
+  /**
+   * Override to provide a custom converter for {@link
+   * io.substrait.proto.AdvancedExtension#getEnhancement()} data
+   */
   protected Extension.Enhancement enhancementFromAdvancedExtension(com.google.protobuf.Any any) {
     throw new RuntimeException("enhancements cannot be ignored by consumers");
   }
 
+  /** Override to provide a custom converter for {@link ExtensionLeafRel#getDetail()} data */
   protected Extension.LeafRelDetail detailFromExtensionLeafRel(com.google.protobuf.Any any) {
     return emptyDetail();
   }
 
+  /** Override to provide a custom converter for {@link ExtensionSingleRel#getDetail()} data */
   protected Extension.SingleRelDetail detailFromExtensionSingleRel(com.google.protobuf.Any any) {
     return emptyDetail();
   }
 
+  /** Override to provide a custom converter for {@link ExtensionMultiRel#getDetail()} data */
   protected Extension.MultiRelDetail detailFromExtensionMultiRel(com.google.protobuf.Any any) {
     return emptyDetail();
   }
 
+  /**
+   * Override to provide a custom converter for {@link
+   * io.substrait.proto.ReadRel.ExtensionTable#getDetail()} data
+   */
   protected Extension.ExtensionTableDetail detailFromExtensionTable(com.google.protobuf.Any any) {
     return emptyDetail();
   }

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -169,7 +169,6 @@ public class ProtoRelConverter {
   }
 
   private ExtensionLeaf newExtensionLeaf(ExtensionLeafRel rel) {
-    assert rel.hasDetail();
     Extension.LeafRelDetail detail = detailFromExtensionLeafRel(rel.getDetail());
     var builder =
         ExtensionLeaf.from(detail)

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -106,6 +106,8 @@ public class ProtoRelConverter {
       return newNamedScan(rel);
     } else if (rel.hasLocalFiles()) {
       return newLocalFiles(rel);
+    } else if (rel.hasExtensionTable()) {
+      return newExtensionTable(rel);
     } else {
       return newEmptyScan(rel);
     }
@@ -205,6 +207,22 @@ public class ProtoRelConverter {
                         .from(rel.getFilter())
                     : null))
         .build();
+  }
+
+  private ExtensionTable newExtensionTable(ReadRel rel) {
+    NamedStruct namedStruct = newNamedStruct(rel);
+    var builder =
+        ExtensionTable.builder()
+            .initialSchema(namedStruct)
+            .extension(optionalAdvancedExtension(rel.getCommon()))
+            .remap(optionalRelmap(rel.getCommon()));
+
+    ReadRel.ExtensionTable extensionTable = rel.getExtensionTable();
+    if (extensionTable.hasDetail()) {
+      builder.detail(detailFromExtensionTable(extensionTable.getDetail()));
+    }
+
+    return builder.build();
   }
 
   private LocalFiles newLocalFiles(ReadRel rel) {
@@ -458,6 +476,10 @@ public class ProtoRelConverter {
   }
 
   protected Extension.MultiRelDetail detailFromExtensionMultiRel(com.google.protobuf.Any any) {
+    return emptyDetail();
+  }
+
+  protected Extension.ExtensionTableDetail detailFromExtensionTable(com.google.protobuf.Any any) {
     return emptyDetail();
   }
 

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -169,30 +169,29 @@ public class ProtoRelConverter {
   }
 
   private ExtensionLeaf newExtensionLeaf(ExtensionLeafRel rel) {
+    assert rel.hasDetail();
+    Extension.LeafRelDetail detail = detailFromExtensionLeafRel(rel.getDetail());
     var builder =
-        ExtensionLeaf.builder()
+        ExtensionLeaf.from(detail)
             .commonExtension(optionalAdvancedExtension(rel.getCommon()))
             .remap(optionalRelmap(rel.getCommon()));
-    if (rel.hasDetail()) {
-      builder.detail(detailFromExtensionLeafRel(rel.getDetail()));
-    }
     return builder.build();
   }
 
   private ExtensionSingle newExtensionSingle(ExtensionSingleRel rel) {
+    assert rel.hasDetail();
+    Extension.SingleRelDetail detail = detailFromExtensionSingleRel(rel.getDetail());
     Rel input = from(rel.getInput());
     var builder =
-        ExtensionSingle.builder()
-            .input(input)
+        ExtensionSingle.from(detail, input)
             .commonExtension(optionalAdvancedExtension(rel.getCommon()))
             .remap(optionalRelmap(rel.getCommon()));
-    if (rel.hasDetail()) {
-      builder.detail(detailFromExtensionSingleRel(rel.getDetail()));
-    }
     return builder.build();
   }
 
   private ExtensionMulti newExtensionMulti(ExtensionMultiRel rel) {
+    assert rel.hasDetail();
+    Extension.MultiRelDetail detail = detailFromExtensionMultiRel(rel.getDetail());
     List<Rel> inputs = rel.getInputsList().stream().map(this::from).collect(Collectors.toList());
     var builder =
         ExtensionMulti.builder()

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -126,7 +126,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -163,7 +163,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -217,7 +217,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -231,7 +231,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -257,7 +257,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -317,7 +317,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -330,7 +330,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -350,7 +350,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -398,7 +398,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -423,7 +423,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -449,7 +449,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -463,7 +463,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -479,7 +479,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -193,8 +193,7 @@ public class ProtoRelConverter {
     Extension.MultiRelDetail detail = detailFromExtensionMultiRel(rel.getDetail());
     List<Rel> inputs = rel.getInputsList().stream().map(this::from).collect(Collectors.toList());
     var builder =
-        ExtensionMulti.builder()
-            .addAllInputs(inputs)
+        ExtensionMulti.from(detail, inputs)
             .commonExtension(optionalAdvancedExtension(rel.getCommon()))
             .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasDetail()) {

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -42,8 +42,8 @@ import java.util.stream.IntStream;
 public class ProtoRelConverter {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ProtoRelConverter.class);
 
-  private final FunctionLookup lookup;
-  private final SimpleExtension.ExtensionCollection extensions;
+  protected final FunctionLookup lookup;
+  protected final SimpleExtension.ExtensionCollection extensions;
 
   public ProtoRelConverter(FunctionLookup lookup) throws IOException {
     this(lookup, SimpleExtension.loadDefaults());

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -226,13 +226,9 @@ public class ProtoRelConverter {
   }
 
   private ExtensionTable newExtensionTable(ReadRel rel) {
-    NamedStruct namedStruct = newNamedStruct(rel);
-    var builder = ExtensionTable.builder().initialSchema(namedStruct);
-
-    ReadRel.ExtensionTable extensionTable = rel.getExtensionTable();
-    if (extensionTable.hasDetail()) {
-      builder.detail(detailFromExtensionTable(extensionTable.getDetail()));
-    }
+    Extension.ExtensionTableDetail detail =
+        detailFromExtensionTable(rel.getExtensionTable().getDetail());
+    var builder = ExtensionTable.from(detail);
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -126,7 +126,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -163,7 +163,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -222,7 +222,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -240,7 +240,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -266,7 +266,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -326,7 +326,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -339,7 +339,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -359,7 +359,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -407,7 +407,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -432,7 +432,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -458,7 +458,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -472,7 +472,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }
@@ -488,7 +488,7 @@ public class ProtoRelConverter {
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
-      builder.generalExtension(advancedExtension(rel.getAdvancedExtension()));
+      builder.relExtension(advancedExtension(rel.getAdvancedExtension()));
     }
     return builder.build();
   }

--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -11,6 +11,10 @@ import org.immutables.value.Value;
 public interface Rel {
   Optional<Remap> getRemap();
 
+  /**
+   * @return the {@link AdvancedExtension} associated with a {@link io.substrait.proto.RelCommon}
+   *     message, if present
+   */
   Optional<AdvancedExtension> getCommonExtension();
 
   Type.Struct getRecordType();

--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -11,7 +11,7 @@ import org.immutables.value.Value;
 public interface Rel {
   Optional<Remap> getRemap();
 
-  Optional<AdvancedExtension> getExtension();
+  Optional<AdvancedExtension> getCommonExtension();
 
   Type.Struct getRecordType();
 

--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -1,5 +1,6 @@
 package io.substrait.relation;
 
+import io.substrait.io.substrait.extension.AdvancedExtension;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.List;
@@ -9,6 +10,8 @@ import org.immutables.value.Value;
 
 public interface Rel {
   Optional<Remap> getRemap();
+
+  Optional<AdvancedExtension> getExtension();
 
   Type.Struct getRecordType();
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -288,8 +288,10 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
   @Override
   public Rel visit(ExtensionLeaf extensionLeaf) throws RuntimeException {
-    var builder = ExtensionLeafRel.newBuilder().setCommon(common(extensionLeaf));
-    extensionLeaf.getDetail().ifPresent(detail -> builder.setDetail(detail.toProto()));
+    var builder =
+        ExtensionLeafRel.newBuilder()
+            .setCommon(common(extensionLeaf))
+            .setDetail(extensionLeaf.getDetail().toProto());
     return Rel.newBuilder().setExtensionLeaf(builder).build();
   }
 
@@ -298,8 +300,8 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
     var builder =
         ExtensionSingleRel.newBuilder()
             .setCommon(common(extensionSingle))
-            .setInput(toProto(extensionSingle.getInput()));
-    extensionSingle.getDetail().ifPresent(detail -> builder.setDetail(detail.toProto()));
+            .setInput(toProto(extensionSingle.getInput()))
+            .setDetail(extensionSingle.getDetail().toProto());
     return Rel.newBuilder().setExtensionSingle(builder).build();
   }
 
@@ -308,8 +310,10 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
     List<Rel> inputs =
         extensionMulti.getInputs().stream().map(this::toProto).collect(Collectors.toList());
     var builder =
-        ExtensionMultiRel.newBuilder().setCommon(common(extensionMulti)).addAllInputs(inputs);
-    extensionMulti.getDetail().ifPresent(detail -> builder.setDetail(detail.toProto()));
+        ExtensionMultiRel.newBuilder()
+            .setCommon(common(extensionMulti))
+            .addAllInputs(inputs)
+            .setDetail(extensionMulti.getDetail().toProto());
     return Rel.newBuilder().setExtensionMulti(builder).build();
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -213,11 +213,8 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
   @Override
   public Rel visit(ExtensionTable extensionTable) throws RuntimeException {
-    ReadRel.ExtensionTable.Builder extensionTableBuilder = ReadRel.ExtensionTable.newBuilder();
-    extensionTable
-        .getDetail()
-        .ifPresent(detail -> extensionTableBuilder.setDetail(detail.toProto()));
-
+    ReadRel.ExtensionTable.Builder extensionTableBuilder =
+        ReadRel.ExtensionTable.newBuilder().setDetail(extensionTable.getDetail().toProto());
     var builder =
         ReadRel.newBuilder()
             .setCommon(common(extensionTable))

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -80,6 +80,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .map(this::toProto)
                     .collect(java.util.stream.Collectors.toList()));
 
+    aggregate.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setAggregate(builder).build();
   }
 
@@ -134,6 +135,8 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setOffset(fetch.getOffset());
 
     fetch.getCount().ifPresent(f -> builder.setCount(f));
+
+    fetch.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setFetch(builder).build();
   }
 
@@ -145,6 +148,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setInput(toProto(filter.getInput()))
             .setCondition(filter.getCondition().accept(protoConverter));
 
+    filter.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setFilter(builder).build();
   }
 
@@ -159,6 +163,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
     join.getCondition().ifPresent(t -> builder.setExpression(toProto(t)));
 
+    join.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setJoin(builder).build();
   }
 
@@ -170,19 +175,21 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             inputRel -> {
               builder.addInputs(toProto(inputRel));
             });
+
+    set.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setSet(builder).build();
   }
 
   @Override
   public Rel visit(NamedScan namedScan) throws RuntimeException {
-    return Rel.newBuilder()
-        .setRead(
-            ReadRel.newBuilder()
-                .setCommon(common(namedScan))
-                .setNamedTable(ReadRel.NamedTable.newBuilder().addAllNames(namedScan.getNames()))
-                .setBaseSchema(namedScan.getInitialSchema().toProto())
-                .build())
-        .build();
+    var builder =
+        ReadRel.newBuilder()
+            .setCommon(common(namedScan))
+            .setNamedTable(ReadRel.NamedTable.newBuilder().addAllNames(namedScan.getNames()))
+            .setBaseSchema(namedScan.getInitialSchema().toProto());
+
+    namedScan.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    return Rel.newBuilder().setRead(builder).build();
   }
 
   @Override
@@ -200,6 +207,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setBaseSchema(localFiles.getInitialSchema().toProto());
     localFiles.getFilter().ifPresent(t -> builder.setFilter(toProto(t)));
 
+    localFiles.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder.build()).build();
   }
 
@@ -216,6 +224,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setBaseSchema(extensionTable.getInitialSchema().toProto())
             .setExtensionTable(extensionTableBuilder);
 
+    extensionTable.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder).build();
   }
 
@@ -230,6 +239,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .map(this::toProto)
                     .collect(java.util.stream.Collectors.toList()));
 
+    project.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setProject(builder).build();
   }
 
@@ -240,6 +250,8 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setCommon(common(sort))
             .setInput(toProto(sort.getInput()))
             .addAllSorts(toProtoS(sort.getSortFields()));
+
+    sort.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setSort(builder).build();
   }
 
@@ -250,26 +262,28 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setCommon(common(cross))
             .setLeft(toProto(cross.getLeft()))
             .setRight(toProto(cross.getRight()));
+
+    cross.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setCross(builder).build();
   }
 
   @Override
   public Rel visit(VirtualTableScan virtualTableScan) throws RuntimeException {
-    return Rel.newBuilder()
-        .setRead(
-            ReadRel.newBuilder()
-                .setCommon(common(virtualTableScan))
-                .setVirtualTable(
-                    ReadRel.VirtualTable.newBuilder()
-                        .addAllValues(
-                            virtualTableScan.getRows().stream()
-                                .map(this::toProto)
-                                .map(t -> t.getLiteral().getStruct())
-                                .collect(java.util.stream.Collectors.toList()))
-                        .build())
-                .setBaseSchema(virtualTableScan.getInitialSchema().toProto())
-                .build())
-        .build();
+    var builder =
+        ReadRel.newBuilder()
+            .setCommon(common(virtualTableScan))
+            .setVirtualTable(
+                ReadRel.VirtualTable.newBuilder()
+                    .addAllValues(
+                        virtualTableScan.getRows().stream()
+                            .map(this::toProto)
+                            .map(t -> t.getLiteral().getStruct())
+                            .collect(java.util.stream.Collectors.toList()))
+                    .build())
+            .setBaseSchema(virtualTableScan.getInitialSchema().toProto());
+
+    virtualTableScan.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    return Rel.newBuilder().setRead(builder).build();
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -80,7 +80,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .map(this::toProto)
                     .collect(java.util.stream.Collectors.toList()));
 
-    aggregate.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    aggregate.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setAggregate(builder).build();
   }
 
@@ -136,7 +136,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
     fetch.getCount().ifPresent(f -> builder.setCount(f));
 
-    fetch.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    fetch.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setFetch(builder).build();
   }
 
@@ -148,7 +148,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setInput(toProto(filter.getInput()))
             .setCondition(filter.getCondition().accept(protoConverter));
 
-    filter.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    filter.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setFilter(builder).build();
   }
 
@@ -163,7 +163,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
     join.getCondition().ifPresent(t -> builder.setExpression(toProto(t)));
 
-    join.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    join.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setJoin(builder).build();
   }
 
@@ -176,7 +176,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
               builder.addInputs(toProto(inputRel));
             });
 
-    set.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    set.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setSet(builder).build();
   }
 
@@ -188,7 +188,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setNamedTable(ReadRel.NamedTable.newBuilder().addAllNames(namedScan.getNames()))
             .setBaseSchema(namedScan.getInitialSchema().toProto());
 
-    namedScan.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    namedScan.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder).build();
   }
 
@@ -207,7 +207,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setBaseSchema(localFiles.getInitialSchema().toProto());
     localFiles.getFilter().ifPresent(t -> builder.setFilter(toProto(t)));
 
-    localFiles.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    localFiles.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder.build()).build();
   }
 
@@ -221,7 +221,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setBaseSchema(extensionTable.getInitialSchema().toProto())
             .setExtensionTable(extensionTableBuilder);
 
-    extensionTable.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    extensionTable.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder).build();
   }
 
@@ -236,7 +236,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .map(this::toProto)
                     .collect(java.util.stream.Collectors.toList()));
 
-    project.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    project.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setProject(builder).build();
   }
 
@@ -248,7 +248,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setInput(toProto(sort.getInput()))
             .addAllSorts(toProtoS(sort.getSortFields()));
 
-    sort.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    sort.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setSort(builder).build();
   }
 
@@ -260,7 +260,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setLeft(toProto(cross.getLeft()))
             .setRight(toProto(cross.getRight()));
 
-    cross.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    cross.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setCross(builder).build();
   }
 
@@ -279,7 +279,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .build())
             .setBaseSchema(virtualTableScan.getInitialSchema().toProto());
 
-    virtualTableScan.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    virtualTableScan.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder).build();
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -204,6 +204,22 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
   }
 
   @Override
+  public Rel visit(ExtensionTable extensionTable) throws RuntimeException {
+    ReadRel.ExtensionTable.Builder extensionTableBuilder = ReadRel.ExtensionTable.newBuilder();
+    extensionTable
+        .getDetail()
+        .ifPresent(detail -> extensionTableBuilder.setDetail(detail.toProto()));
+
+    var builder =
+        ReadRel.newBuilder()
+            .setCommon(common(extensionTable))
+            .setBaseSchema(extensionTable.getInitialSchema().toProto())
+            .setExtensionTable(extensionTableBuilder);
+
+    return Rel.newBuilder().setRead(builder).build();
+  }
+
+  @Override
   public Rel visit(Project project) throws RuntimeException {
     var builder =
         ProjectRel.newBuilder()

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -80,7 +80,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .map(this::toProto)
                     .collect(java.util.stream.Collectors.toList()));
 
-    aggregate.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    aggregate.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setAggregate(builder).build();
   }
 
@@ -136,7 +136,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
     fetch.getCount().ifPresent(f -> builder.setCount(f));
 
-    fetch.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    fetch.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setFetch(builder).build();
   }
 
@@ -148,7 +148,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setInput(toProto(filter.getInput()))
             .setCondition(filter.getCondition().accept(protoConverter));
 
-    filter.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    filter.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setFilter(builder).build();
   }
 
@@ -163,7 +163,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
     join.getCondition().ifPresent(t -> builder.setExpression(toProto(t)));
 
-    join.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    join.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setJoin(builder).build();
   }
 
@@ -176,7 +176,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
               builder.addInputs(toProto(inputRel));
             });
 
-    set.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    set.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setSet(builder).build();
   }
 
@@ -188,7 +188,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setNamedTable(ReadRel.NamedTable.newBuilder().addAllNames(namedScan.getNames()))
             .setBaseSchema(namedScan.getInitialSchema().toProto());
 
-    namedScan.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    namedScan.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder).build();
   }
 
@@ -207,7 +207,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setBaseSchema(localFiles.getInitialSchema().toProto());
     localFiles.getFilter().ifPresent(t -> builder.setFilter(toProto(t)));
 
-    localFiles.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    localFiles.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder.build()).build();
   }
 
@@ -224,7 +224,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setBaseSchema(extensionTable.getInitialSchema().toProto())
             .setExtensionTable(extensionTableBuilder);
 
-    extensionTable.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    extensionTable.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder).build();
   }
 
@@ -239,7 +239,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .map(this::toProto)
                     .collect(java.util.stream.Collectors.toList()));
 
-    project.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    project.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setProject(builder).build();
   }
 
@@ -251,7 +251,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setInput(toProto(sort.getInput()))
             .addAllSorts(toProtoS(sort.getSortFields()));
 
-    sort.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    sort.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setSort(builder).build();
   }
 
@@ -263,7 +263,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
             .setLeft(toProto(cross.getLeft()))
             .setRight(toProto(cross.getRight()));
 
-    cross.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    cross.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setCross(builder).build();
   }
 
@@ -282,7 +282,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                     .build())
             .setBaseSchema(virtualTableScan.getInitialSchema().toProto());
 
-    virtualTableScan.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
+    virtualTableScan.getRelExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setRead(builder).build();
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -7,6 +7,9 @@ import io.substrait.expression.proto.FunctionCollector;
 import io.substrait.proto.AggregateFunction;
 import io.substrait.proto.AggregateRel;
 import io.substrait.proto.CrossRel;
+import io.substrait.proto.ExtensionLeafRel;
+import io.substrait.proto.ExtensionMultiRel;
+import io.substrait.proto.ExtensionSingleRel;
 import io.substrait.proto.FetchRel;
 import io.substrait.proto.FilterRel;
 import io.substrait.proto.JoinRel;
@@ -21,6 +24,7 @@ import io.substrait.relation.files.FileOrFiles;
 import io.substrait.type.proto.TypeProtoConverter;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
@@ -250,6 +254,33 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
                 .setBaseSchema(virtualTableScan.getInitialSchema().toProto())
                 .build())
         .build();
+  }
+
+  @Override
+  public Rel visit(ExtensionLeaf extensionLeaf) throws RuntimeException {
+    var builder = ExtensionLeafRel.newBuilder().setCommon(common(extensionLeaf));
+    extensionLeaf.getDetail().ifPresent(detail -> builder.setDetail(detail.toProto()));
+    return Rel.newBuilder().setExtensionLeaf(builder).build();
+  }
+
+  @Override
+  public Rel visit(ExtensionSingle extensionSingle) throws RuntimeException {
+    var builder =
+        ExtensionSingleRel.newBuilder()
+            .setCommon(common(extensionSingle))
+            .setInput(toProto(extensionSingle.getInput()));
+    extensionSingle.getDetail().ifPresent(detail -> builder.setDetail(detail.toProto()));
+    return Rel.newBuilder().setExtensionSingle(builder).build();
+  }
+
+  @Override
+  public Rel visit(ExtensionMulti extensionMulti) throws RuntimeException {
+    List<Rel> inputs =
+        extensionMulti.getInputs().stream().map(this::toProto).collect(Collectors.toList());
+    var builder =
+        ExtensionMultiRel.newBuilder().setCommon(common(extensionMulti)).addAllInputs(inputs);
+    extensionMulti.getDetail().ifPresent(detail -> builder.setDetail(detail.toProto()));
+    return Rel.newBuilder().setExtensionMulti(builder).build();
   }
 
   private RelCommon common(io.substrait.relation.Rel rel) {

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -315,7 +315,8 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
   private RelCommon common(io.substrait.relation.Rel rel) {
     var builder = RelCommon.newBuilder();
-    rel.getExtension().ifPresent(extension -> builder.setAdvancedExtension(extension.toProto()));
+    rel.getCommonExtension()
+        .ifPresent(extension -> builder.setAdvancedExtension(extension.toProto()));
 
     var remap = rel.getRemap().orElse(null);
     if (remap != null) {

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -254,6 +254,8 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
   private RelCommon common(io.substrait.relation.Rel rel) {
     var builder = RelCommon.newBuilder();
+    rel.getExtension().ifPresent(extension -> builder.setAdvancedExtension(extension.toProto()));
+
     var remap = rel.getRemap().orElse(null);
     if (remap != null) {
       builder.setEmit(RelCommon.Emit.newBuilder().addAllOutputMapping(remap.indices()));

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -30,4 +30,6 @@ public interface RelVisitor<OUTPUT, EXCEPTION extends Exception> {
   OUTPUT visit(ExtensionSingle extensionSingle) throws EXCEPTION;
 
   OUTPUT visit(ExtensionMulti extensionMulti) throws EXCEPTION;
+
+  OUTPUT visit(ExtensionTable extensionTable) throws EXCEPTION;
 }

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -24,4 +24,10 @@ public interface RelVisitor<OUTPUT, EXCEPTION extends Exception> {
   OUTPUT visit(Cross cross) throws EXCEPTION;
 
   OUTPUT visit(VirtualTableScan virtualTableScan) throws EXCEPTION;
+
+  OUTPUT visit(ExtensionLeaf extensionLeaf) throws EXCEPTION;
+
+  OUTPUT visit(ExtensionSingle extensionSingle) throws EXCEPTION;
+
+  OUTPUT visit(ExtensionMulti extensionMulti) throws EXCEPTION;
 }

--- a/core/src/main/java/io/substrait/relation/Set.java
+++ b/core/src/main/java/io/substrait/relation/Set.java
@@ -5,7 +5,7 @@ import io.substrait.type.Type;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Set extends AbstractRel {
+public abstract class Set extends AbstractRel implements HasExtension {
   public abstract Set.SetOp getSetOp();
 
   public static enum SetOp {

--- a/core/src/main/java/io/substrait/relation/Sort.java
+++ b/core/src/main/java/io/substrait/relation/Sort.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public abstract class Sort extends SingleInputRel {
+public abstract class Sort extends SingleInputRel implements HasExtension {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Sort.class);
 
   public abstract List<Expression.SortField> getSortFields();

--- a/core/src/main/java/io/substrait/relation/ToProto.java
+++ b/core/src/main/java/io/substrait/relation/ToProto.java
@@ -1,0 +1,7 @@
+package io.substrait.relation;
+
+import com.google.protobuf.Message;
+
+public interface ToProto<T extends Message> {
+  T toProto();
+}

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -4,7 +4,10 @@ import com.google.protobuf.Any;
 import io.substrait.relation.Extension;
 
 public class EmptyDetail
-    implements Extension.LeafRelDetail, Extension.MultiRelDetail, Extension.SingleRelDetail {
+    implements Extension.LeafRelDetail,
+        Extension.MultiRelDetail,
+        Extension.SingleRelDetail,
+        Extension.ExtensionTableDetail {
 
   @Override
   public Any toProto() {

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -2,6 +2,9 @@ package io.substrait.relation.extensions;
 
 import com.google.protobuf.Any;
 import io.substrait.relation.Extension;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
 
 public class EmptyDetail
     implements Extension.LeafRelDetail,
@@ -12,5 +15,35 @@ public class EmptyDetail
   @Override
   public Any toProto() {
     return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
+  }
+
+  @Override
+  public Type.Struct deriveRecordType() {
+    return TypeCreator.NULLABLE.struct();
+  }
+
+  @Override
+  public Type.Struct deriveRecordType(Rel input) {
+    return TypeCreator.NULLABLE.struct();
+  }
+
+  @Override
+  public Type.Struct deriveRecordType(Rel... inputs) {
+    return TypeCreator.NULLABLE.struct();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof EmptyDetail;
+  }
+
+  @Override
+  public int hashCode() {
+    return EmptyDetail.class.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "EmptyDetail{}";
   }
 }

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -9,6 +9,10 @@ import io.substrait.type.TypeCreator;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Default type to which google.protobuf.Any detail messages are converted to by the {@link
+ * io.substrait.relation.ProtoRelConverter}
+ */
 public class EmptyDetail
     implements Extension.LeafRelDetail,
         Extension.MultiRelDetail,

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -1,0 +1,13 @@
+package io.substrait.relation.extensions;
+
+import com.google.protobuf.Any;
+import io.substrait.relation.Extension;
+
+public class EmptyDetail
+    implements Extension.LeafRelDetail, Extension.MultiRelDetail, Extension.SingleRelDetail {
+
+  @Override
+  public Any toProto() {
+    return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
+  }
+}

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -3,8 +3,10 @@ package io.substrait.relation.extensions;
 import com.google.protobuf.Any;
 import io.substrait.relation.Extension;
 import io.substrait.relation.Rel;
+import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import java.util.Collections;
 
 public class EmptyDetail
     implements Extension.LeafRelDetail,
@@ -30,6 +32,11 @@ public class EmptyDetail
   @Override
   public Type.Struct deriveRecordType(Rel... inputs) {
     return TypeCreator.NULLABLE.struct();
+  }
+
+  @Override
+  public NamedStruct deriveSchema() {
+    return NamedStruct.of(Collections.emptyList(), Type.Struct.builder().nullable(true).build());
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -7,6 +7,7 @@ import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.Collections;
+import java.util.List;
 
 public class EmptyDetail
     implements Extension.LeafRelDetail,
@@ -30,7 +31,7 @@ public class EmptyDetail
   }
 
   @Override
-  public Type.Struct deriveRecordType(Rel... inputs) {
+  public Type.Struct deriveRecordType(List<Rel> inputs) {
     return TypeCreator.NULLABLE.struct();
   }
 

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
@@ -1,0 +1,18 @@
+package io.substrait.relation.extensions;
+
+import com.google.protobuf.Any;
+import io.substrait.relation.Extension;
+
+/**
+ * Default type to which AdvancedExtension.optimization are converted to.
+ *
+ * <p>Provide your own implementation of {@link
+ * io.substrait.relation.ProtoRelConverter#enhancementFromAdvancedExtension(Any)} if you have
+ * optimizations you wish to process.
+ */
+public class EmptyOptimization implements Extension.Optimization {
+  @Override
+  public Any toProto() {
+    return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
+  }
+}

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
@@ -4,11 +4,8 @@ import com.google.protobuf.Any;
 import io.substrait.relation.Extension;
 
 /**
- * Default type to which AdvancedExtension.optimization are converted to.
- *
- * <p>Provide your own implementation of {@link
- * io.substrait.relation.ProtoRelConverter#enhancementFromAdvancedExtension(Any)} if you have
- * optimizations you wish to process.
+ * Default type to which {@link io.substrait.proto.AdvancedExtension#getOptimization()} data is
+ * converted to by the {@link io.substrait.relation.ProtoRelConverter}
  */
 public class EmptyOptimization implements Extension.Optimization {
   @Override

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -1,0 +1,144 @@
+package io.substrait.relation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.proto.FunctionCollector;
+import io.substrait.function.SimpleExtension;
+import io.substrait.io.substrait.extension.AdvancedExtension;
+import io.substrait.relation.utils.StringHolder;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ProtoRelConverterTest {
+
+  final SimpleExtension.ExtensionCollection extensions;
+
+  {
+    try {
+      extensions = SimpleExtension.loadDefaults();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  final SubstraitBuilder b = new SubstraitBuilder(extensions);
+  final FunctionCollector functionCollector = new FunctionCollector();
+  final RelProtoConverter relProtoConverter = new RelProtoConverter(functionCollector);
+  final ProtoRelConverter protoRelConverter = new ProtoRelConverter(functionCollector, extensions);
+
+  /**
+   * Verify default behaviour of {@link ProtoRelConverter} in the presence of {@link
+   * AdvancedExtension} data
+   */
+  @Nested
+  class DefaultAdvancedExtensionTests {
+
+    static final StringHolder ENHANCED = new StringHolder("ENHANCED");
+    static final StringHolder OPTIMIZED = new StringHolder("OPTIMIZED");
+
+    Rel relWithExtension(AdvancedExtension advancedExtension) {
+      return NamedScan.builder()
+          .from(
+              b.namedScan(
+                  Collections.emptyList(), Collections.emptyList(), Collections.emptyList()))
+          .commonExtension(advancedExtension)
+          .relExtension(advancedExtension)
+          .build();
+    }
+
+    Rel emptyAdvancedExtension = relWithExtension(AdvancedExtension.builder().build());
+    Rel advancedExtensionWithOptimization =
+        relWithExtension(AdvancedExtension.builder().optimization(OPTIMIZED).build());
+
+    Rel advancedExtensionWithEnhancement =
+        relWithExtension(AdvancedExtension.builder().enhancement(ENHANCED).build());
+
+    Rel advancedExtensionWithEnhancementAndOptimization =
+        relWithExtension(
+            AdvancedExtension.builder().enhancement(ENHANCED).optimization(OPTIMIZED).build());
+
+    @Test
+    void emptyAdvancedExtension() {
+      Rel rel = emptyAdvancedExtension;
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      Rel relReturned = protoRelConverter.from(protoRel);
+      assertEquals(rel, relReturned);
+    }
+
+    @Test
+    void enhancementOnlyAdvancedExtension() {
+      Rel rel = advancedExtensionWithEnhancement;
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      // Enhancements are not handled by the default ProtoRelConverter
+      assertThrows(RuntimeException.class, () -> protoRelConverter.from(protoRel));
+    }
+
+    @Test
+    void optimizationOnlyAdvancedExtension() {
+      Rel rel = advancedExtensionWithOptimization;
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      Rel relReturned = protoRelConverter.from(protoRel);
+
+      // The optimization is serialized correctly to protobuf.
+      // When it is read back in, the default ProtoRelConverter drops it.
+      // As such they are not equal anymore.
+      assertNotEquals(rel, relReturned);
+    }
+
+    @Test
+    void advancedExtensionWithEnhancementAndOptimization() {
+      Rel rel = advancedExtensionWithEnhancementAndOptimization;
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      // Enhancements are not handled by the default ProtoRelConverter
+      assertThrows(RuntimeException.class, () -> protoRelConverter.from(protoRel));
+    }
+  }
+
+  /** Verify behaviour of {@link ProtoRelConverter} in the presence of Detail data */
+  @Nested
+  class DetailsTest {
+    final Rel commonTable =
+        b.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+    @Test
+    void extensionLeaf() {
+      Rel rel = ExtensionLeaf.from(new StringHolder("DETAILS")).build();
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      Rel relReturned = protoRelConverter.from(protoRel);
+
+      assertNotEquals(rel, relReturned);
+    }
+
+    @Test
+    void extensionSingle() {
+      Rel rel = ExtensionSingle.from(new StringHolder("DETAILS"), commonTable).build();
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      Rel relReturned = protoRelConverter.from(protoRel);
+
+      assertNotEquals(rel, relReturned);
+    }
+
+    @Test
+    void extensionMulti() {
+      Rel rel = ExtensionMulti.from(new StringHolder("DETAILS"), commonTable, commonTable).build();
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      Rel relReturned = protoRelConverter.from(protoRel);
+
+      assertNotEquals(rel, relReturned);
+    }
+
+    @Test
+    void extensionTable() {
+      Rel rel = ExtensionTable.from(new StringHolder("DETAILS")).build();
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+      Rel relReturned = protoRelConverter.from(protoRel);
+
+      assertNotEquals(rel, relReturned);
+    }
+  }
+}

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -31,9 +31,12 @@ public class ProtoRelConverterTest {
   final RelProtoConverter relProtoConverter = new RelProtoConverter(functionCollector);
   final ProtoRelConverter protoRelConverter = new ProtoRelConverter(functionCollector, extensions);
 
+  final NamedScan commonTable =
+      b.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
   /**
    * Verify default behaviour of {@link ProtoRelConverter} in the presence of {@link
-   * AdvancedExtension} data
+   * AdvancedExtension} data.
    */
   @Nested
   class DefaultAdvancedExtensionTests {
@@ -43,9 +46,7 @@ public class ProtoRelConverterTest {
 
     Rel relWithExtension(AdvancedExtension advancedExtension) {
       return NamedScan.builder()
-          .from(
-              b.namedScan(
-                  Collections.emptyList(), Collections.emptyList(), Collections.emptyList()))
+          .from(commonTable)
           .commonExtension(advancedExtension)
           .relExtension(advancedExtension)
           .build();
@@ -54,10 +55,8 @@ public class ProtoRelConverterTest {
     Rel emptyAdvancedExtension = relWithExtension(AdvancedExtension.builder().build());
     Rel advancedExtensionWithOptimization =
         relWithExtension(AdvancedExtension.builder().optimization(OPTIMIZED).build());
-
     Rel advancedExtensionWithEnhancement =
         relWithExtension(AdvancedExtension.builder().enhancement(ENHANCED).build());
-
     Rel advancedExtensionWithEnhancementAndOptimization =
         relWithExtension(
             AdvancedExtension.builder().enhancement(ENHANCED).optimization(OPTIMIZED).build());
@@ -99,11 +98,12 @@ public class ProtoRelConverterTest {
     }
   }
 
-  /** Verify behaviour of {@link ProtoRelConverter} in the presence of Detail data */
+  /**
+   * Verify default behaviour of {@link ProtoRelConverter} in the presence of Detail data. Messages
+   * do NOT round trip because the default ProtoRelConverter does not handle custom Detail data.
+   */
   @Nested
   class DetailsTest {
-    final Rel commonTable =
-        b.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
 
     @Test
     void extensionLeaf() {

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -48,7 +48,7 @@ public class ProtoRelConverterTest {
       return NamedScan.builder()
           .from(commonTable)
           .commonExtension(advancedExtension)
-          .relExtension(advancedExtension)
+          .extension(advancedExtension)
           .build();
     }
 

--- a/core/src/test/java/io/substrait/relation/utils/StringHolder.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolder.java
@@ -2,6 +2,12 @@ package io.substrait.relation.utils;
 
 import com.google.protobuf.Any;
 import io.substrait.relation.Extension;
+import io.substrait.relation.Rel;
+import io.substrait.type.NamedStruct;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -10,7 +16,13 @@ import java.util.Objects;
  *
  * <p>Used to verify serde of {@link com.google.protobuf.Any} fields in the spec.
  */
-public class StringHolder implements Extension.Enhancement, Extension.Optimization {
+public class StringHolder
+    implements Extension.Enhancement,
+        Extension.Optimization,
+        Extension.LeafRelDetail,
+        Extension.SingleRelDetail,
+        Extension.MultiRelDetail,
+        Extension.ExtensionTableDetail {
 
   private final String value;
 
@@ -21,6 +33,26 @@ public class StringHolder implements Extension.Enhancement, Extension.Optimizati
   @Override
   public Any toProto() {
     return com.google.protobuf.Any.pack(com.google.protobuf.StringValue.of(this.value));
+  }
+
+  @Override
+  public Type.Struct deriveRecordType() {
+    return TypeCreator.NULLABLE.struct();
+  }
+
+  @Override
+  public Type.Struct deriveRecordType(Rel input) {
+    return TypeCreator.NULLABLE.struct();
+  }
+
+  @Override
+  public Type.Struct deriveRecordType(List<Rel> inputs) {
+    return TypeCreator.NULLABLE.struct();
+  }
+
+  @Override
+  public NamedStruct deriveSchema() {
+    return NamedStruct.of(Collections.emptyList(), Type.Struct.builder().nullable(true).build());
   }
 
   @Override

--- a/core/src/test/java/io/substrait/relation/utils/StringHolder.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolder.java
@@ -1,0 +1,43 @@
+package io.substrait.relation.utils;
+
+import com.google.protobuf.Any;
+import io.substrait.relation.Extension;
+import java.util.Objects;
+
+/**
+ * For use in {@link io.substrait.relation.ProtoRelConverterTest} and {@link
+ * io.substrait.type.proto.ExtensionRoundtripTest}
+ *
+ * <p>Used to verify serde of {@link com.google.protobuf.Any} fields in the spec.
+ */
+public class StringHolder implements Extension.Enhancement, Extension.Optimization {
+
+  private final String value;
+
+  public StringHolder(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public Any toProto() {
+    return com.google.protobuf.Any.pack(com.google.protobuf.StringValue.of(this.value));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    StringHolder that = (StringHolder) o;
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConvert.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConvert.java
@@ -1,0 +1,40 @@
+package io.substrait.relation.utils;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.StringValue;
+import io.substrait.expression.FunctionLookup;
+import io.substrait.function.SimpleExtension;
+import io.substrait.relation.Extension;
+import io.substrait.relation.ProtoRelConverter;
+
+/**
+ * Extends {@link ProtoRelConverter} with conversions from {@link com.google.protobuf.Any} to {@link
+ * StringHolder}
+ *
+ * <p>Used to verify serde of {@link com.google.protobuf.Any} fields in the spec
+ */
+public class StringHolderHandlingProtoRelConvert extends ProtoRelConverter {
+  public StringHolderHandlingProtoRelConvert(
+      FunctionLookup lookup, SimpleExtension.ExtensionCollection extensions) {
+    super(lookup, extensions);
+  }
+
+  @Override
+  protected Extension.Enhancement enhancementFromAdvancedExtension(Any any) {
+    try {
+      return new StringHolder(any.unpack(StringValue.class).getValue());
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected Extension.Optimization optimizationFromAdvancedExtension(Any any) {
+    try {
+      return new StringHolder(any.unpack(StringValue.class).getValue());
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConverter.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConverter.java
@@ -14,14 +14,13 @@ import io.substrait.relation.ProtoRelConverter;
  *
  * <p>Used to verify serde of {@link com.google.protobuf.Any} fields in the spec
  */
-public class StringHolderHandlingProtoRelConvert extends ProtoRelConverter {
-  public StringHolderHandlingProtoRelConvert(
+public class StringHolderHandlingProtoRelConverter extends ProtoRelConverter {
+  public StringHolderHandlingProtoRelConverter(
       FunctionLookup lookup, SimpleExtension.ExtensionCollection extensions) {
     super(lookup, extensions);
   }
 
-  @Override
-  protected Extension.Enhancement enhancementFromAdvancedExtension(Any any) {
+  StringHolder asStringHolder(Any any) {
     try {
       return new StringHolder(any.unpack(StringValue.class).getValue());
     } catch (InvalidProtocolBufferException e) {
@@ -30,11 +29,32 @@ public class StringHolderHandlingProtoRelConvert extends ProtoRelConverter {
   }
 
   @Override
+  protected Extension.Enhancement enhancementFromAdvancedExtension(Any any) {
+    return asStringHolder(any);
+  }
+
+  @Override
   protected Extension.Optimization optimizationFromAdvancedExtension(Any any) {
-    try {
-      return new StringHolder(any.unpack(StringValue.class).getValue());
-    } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeException(e);
-    }
+    return asStringHolder(any);
+  }
+
+  @Override
+  protected Extension.LeafRelDetail detailFromExtensionLeafRel(Any any) {
+    return asStringHolder(any);
+  }
+
+  @Override
+  protected Extension.SingleRelDetail detailFromExtensionSingleRel(Any any) {
+    return asStringHolder(any);
+  }
+
+  @Override
+  protected Extension.MultiRelDetail detailFromExtensionMultiRel(Any any) {
+    return asStringHolder(any);
+  }
+
+  @Override
+  protected Extension.ExtensionTableDetail detailFromExtensionTable(Any any) {
+    return asStringHolder(any);
   }
 }

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -1,0 +1,237 @@
+package io.substrait.type.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.Expression;
+import io.substrait.expression.proto.FunctionCollector;
+import io.substrait.function.SimpleExtension;
+import io.substrait.io.substrait.extension.AdvancedExtension;
+import io.substrait.relation.Aggregate;
+import io.substrait.relation.Cross;
+import io.substrait.relation.ExtensionLeaf;
+import io.substrait.relation.ExtensionMulti;
+import io.substrait.relation.ExtensionSingle;
+import io.substrait.relation.ExtensionTable;
+import io.substrait.relation.Fetch;
+import io.substrait.relation.Filter;
+import io.substrait.relation.Join;
+import io.substrait.relation.LocalFiles;
+import io.substrait.relation.NamedScan;
+import io.substrait.relation.Project;
+import io.substrait.relation.ProtoRelConverter;
+import io.substrait.relation.Rel;
+import io.substrait.relation.RelProtoConverter;
+import io.substrait.relation.Set;
+import io.substrait.relation.Sort;
+import io.substrait.relation.VirtualTableScan;
+import io.substrait.relation.extensions.EmptyDetail;
+import io.substrait.relation.utils.StringHolder;
+import io.substrait.relation.utils.StringHolderHandlingProtoRelConvert;
+import io.substrait.type.NamedStruct;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify that the various extension types in {@link io.substrait.relation.Extension} roundtrip
+ * correctly.
+ */
+public class ExtensionRoundtripTest {
+
+  TypeCreator R = TypeCreator.REQUIRED;
+
+  final SimpleExtension.ExtensionCollection extensions;
+
+  {
+    try {
+      extensions = SimpleExtension.loadDefaults();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  final SubstraitBuilder b = new SubstraitBuilder(extensions);
+  final FunctionCollector functionCollector = new FunctionCollector();
+  final RelProtoConverter relProtoConverter = new RelProtoConverter(functionCollector);
+  final ProtoRelConverter protoRelConverter =
+      new StringHolderHandlingProtoRelConvert(functionCollector, extensions);
+
+  final Rel commonTable =
+      b.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+  final AdvancedExtension commonExtension =
+      AdvancedExtension.builder()
+          .enhancement(new StringHolder("COMMON ENHANCEMENT"))
+          .optimization(new StringHolder("COMMON OPTIMIZATION"))
+          .build();
+
+  final AdvancedExtension relExtension =
+      AdvancedExtension.builder()
+          .enhancement(new StringHolder("REL ENHANCEMENT"))
+          .optimization(new StringHolder("REL OPTIMIZATION"))
+          .build();
+
+  void verifyRoundTrip(Rel rel) {
+    io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
+    Rel relReturned = protoRelConverter.from(protoRel);
+    assertEquals(rel, relReturned);
+  }
+
+  @Test
+  void virtualTable() {
+    Rel rel =
+        VirtualTableScan.builder()
+            .addRows(Expression.StructLiteral.builder().fields(Collections.emptyList()).build())
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void localFiles() {
+    Rel rel =
+        LocalFiles.builder()
+            .initialSchema(
+                NamedStruct.of(
+                    Collections.emptyList(), Type.Struct.builder().nullable(false).build()))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void namedScan() {
+    Rel rel =
+        NamedScan.builder()
+            .from(
+                b.namedScan(
+                    Collections.emptyList(), Collections.emptyList(), Collections.emptyList()))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void extensionTable() {
+    Rel rel = ExtensionTable.from(new EmptyDetail()).build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void filter() {
+    Rel rel =
+        Filter.builder()
+            .from(b.filter(__ -> b.bool(true), commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void fetch() {
+    Rel rel =
+        Fetch.builder()
+            .from(b.fetch(1, 2, commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void aggregate() {
+    Rel rel =
+        Aggregate.builder()
+            .from(b.aggregate(b::grouping, __ -> Collections.emptyList(), commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void sort() {
+    Rel rel =
+        Sort.builder()
+            .from(b.sort(__ -> Collections.emptyList(), commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void join() {
+    Rel rel =
+        Join.builder()
+            .from(b.innerJoin(__ -> b.bool(true), commonTable, commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void project() {
+    Rel rel =
+        Project.builder()
+            .from(b.project(__ -> Collections.emptyList(), commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void set() {
+    Rel rel =
+        Set.builder()
+            .from(b.set(Set.SetOp.UNION_ALL, commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void extensionSingleRel() {
+    Rel rel =
+        ExtensionSingle.from(new EmptyDetail(), commonTable)
+            .commonExtension(commonExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void extensionMultiRel() {
+    Rel rel =
+        ExtensionMulti.from(new EmptyDetail(), commonTable, commonTable)
+            .commonExtension(commonExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void extensionLeafRel() {
+    Rel rel = ExtensionLeaf.from(new EmptyDetail()).commonExtension(commonExtension).build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void cross() {
+    Rel rel =
+        Cross.builder()
+            .from(b.cross(commonTable, commonTable))
+            .commonExtension(commonExtension)
+            .relExtension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -25,9 +25,8 @@ import io.substrait.relation.RelProtoConverter;
 import io.substrait.relation.Set;
 import io.substrait.relation.Sort;
 import io.substrait.relation.VirtualTableScan;
-import io.substrait.relation.extensions.EmptyDetail;
 import io.substrait.relation.utils.StringHolder;
-import io.substrait.relation.utils.StringHolderHandlingProtoRelConvert;
+import io.substrait.relation.utils.StringHolderHandlingProtoRelConverter;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -57,7 +56,7 @@ public class ExtensionRoundtripTest {
   final FunctionCollector functionCollector = new FunctionCollector();
   final RelProtoConverter relProtoConverter = new RelProtoConverter(functionCollector);
   final ProtoRelConverter protoRelConverter =
-      new StringHolderHandlingProtoRelConvert(functionCollector, extensions);
+      new StringHolderHandlingProtoRelConverter(functionCollector, extensions);
 
   final Rel commonTable =
       b.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
@@ -67,6 +66,8 @@ public class ExtensionRoundtripTest {
           .enhancement(new StringHolder("COMMON ENHANCEMENT"))
           .optimization(new StringHolder("COMMON OPTIMIZATION"))
           .build();
+
+  final StringHolder detail = new StringHolder("DETAIL");
 
   final AdvancedExtension relExtension =
       AdvancedExtension.builder()
@@ -119,7 +120,7 @@ public class ExtensionRoundtripTest {
 
   @Test
   void extensionTable() {
-    Rel rel = ExtensionTable.from(new EmptyDetail()).build();
+    Rel rel = ExtensionTable.from(detail).build();
     verifyRoundTrip(rel);
   }
 
@@ -202,17 +203,14 @@ public class ExtensionRoundtripTest {
 
   @Test
   void extensionSingleRel() {
-    Rel rel =
-        ExtensionSingle.from(new EmptyDetail(), commonTable)
-            .commonExtension(commonExtension)
-            .build();
+    Rel rel = ExtensionSingle.from(detail, commonTable).commonExtension(commonExtension).build();
     verifyRoundTrip(rel);
   }
 
   @Test
   void extensionMultiRel() {
     Rel rel =
-        ExtensionMulti.from(new EmptyDetail(), commonTable, commonTable)
+        ExtensionMulti.from(detail, commonTable, commonTable)
             .commonExtension(commonExtension)
             .build();
     verifyRoundTrip(rel);
@@ -220,7 +218,7 @@ public class ExtensionRoundtripTest {
 
   @Test
   void extensionLeafRel() {
-    Rel rel = ExtensionLeaf.from(new EmptyDetail()).commonExtension(commonExtension).build();
+    Rel rel = ExtensionLeaf.from(detail).commonExtension(commonExtension).build();
     verifyRoundTrip(rel);
   }
 

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -87,7 +87,7 @@ public class ExtensionRoundtripTest {
         VirtualTableScan.builder()
             .addRows(Expression.StructLiteral.builder().fields(Collections.emptyList()).build())
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -100,7 +100,7 @@ public class ExtensionRoundtripTest {
                 NamedStruct.of(
                     Collections.emptyList(), Type.Struct.builder().nullable(false).build()))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -113,7 +113,7 @@ public class ExtensionRoundtripTest {
                 b.namedScan(
                     Collections.emptyList(), Collections.emptyList(), Collections.emptyList()))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -130,7 +130,7 @@ public class ExtensionRoundtripTest {
         Filter.builder()
             .from(b.filter(__ -> b.bool(true), commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -141,7 +141,7 @@ public class ExtensionRoundtripTest {
         Fetch.builder()
             .from(b.fetch(1, 2, commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -152,7 +152,7 @@ public class ExtensionRoundtripTest {
         Aggregate.builder()
             .from(b.aggregate(b::grouping, __ -> Collections.emptyList(), commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -163,7 +163,7 @@ public class ExtensionRoundtripTest {
         Sort.builder()
             .from(b.sort(__ -> Collections.emptyList(), commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -174,7 +174,7 @@ public class ExtensionRoundtripTest {
         Join.builder()
             .from(b.innerJoin(__ -> b.bool(true), commonTable, commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -185,7 +185,7 @@ public class ExtensionRoundtripTest {
         Project.builder()
             .from(b.project(__ -> Collections.emptyList(), commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -196,7 +196,7 @@ public class ExtensionRoundtripTest {
         Set.builder()
             .from(b.set(Set.SetOp.UNION_ALL, commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }
@@ -228,7 +228,7 @@ public class ExtensionRoundtripTest {
         Cross.builder()
             .from(b.cross(commonTable, commonTable))
             .commonExtension(commonExtension)
-            .relExtension(relExtension)
+            .extension(relExtension)
             .build();
     verifyRoundTrip(rel);
   }


### PR DESCRIPTION
Adds support for handling the `google.protobuf.Any` data in the spec. This includes `Any` data in:
* `AdvancedExtension` messages. Both in `RelCommon` and directly on Rels.
* `ReadRel.ExtensionTable` messages.
* `ExtensionLeafRel`, `ExtensionSingleRel` and `ExtensionMultiRel` messages.

This is achieved by adding extension hooks to the `ProtoRelConverter`, which users can override to provide custom conversions from `Any` data to POJOs.

This code includes tests for:
* The default behaviour of the `ProtoRelConverter` in the face of various pieces of `Any` data.
* Round trip behaviour for an extended `ProtoRelConverter` with custom data handling.