### PR TITLE
feat: support proto <-> pojo custom type conversion

### DIFF
--- a/core/src/main/antlr/SubstraitType.g4
+++ b/core/src/main/antlr/SubstraitType.g4
@@ -59,6 +59,7 @@ NStruct  : N S T R U C T;
 List     : L I S T;
 Map      : M A P;
 ANY      : A N Y;
+UserDefined: U '!';
 
 
 // OPERATIONS
@@ -158,6 +159,7 @@ scalarType
 	| IntervalDay #intervalDay
 	| IntervalYear #intervalYear
 	| UUID #uuid
+	| UserDefined Identifier #userDefined
 	;
 
 parameterizedType

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -6,6 +6,7 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.ImmutableFieldReference;
 import io.substrait.function.SimpleExtension;
+import io.substrait.plan.ImmutablePlan;
 import io.substrait.plan.ImmutableRoot;
 import io.substrait.plan.Plan;
 import io.substrait.proto.AggregateFunction;
@@ -19,6 +20,7 @@ import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
 import io.substrait.relation.Set;
 import io.substrait.relation.Sort;
+import io.substrait.type.ImmutableType;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -300,10 +302,24 @@ public class SubstraitBuilder {
         .build();
   }
 
+  // Types
+
+  public Type.UserDefined userDefinedType(String namespace, String typeName) {
+    return ImmutableType.UserDefined.builder()
+        .uri(namespace)
+        .name(typeName)
+        .nullable(false)
+        .build();
+  }
+
   // Misc
 
   public Plan.Root root(Rel rel) {
     return ImmutableRoot.builder().input(rel).build();
+  }
+
+  public Plan plan(Plan.Root root) {
+    return ImmutablePlan.builder().addRoots(root).build();
   }
 
   public Rel.Remap remap(Integer... fields) {

--- a/core/src/main/java/io/substrait/expression/FunctionArg.java
+++ b/core/src/main/java/io/substrait/expression/FunctionArg.java
@@ -59,18 +59,24 @@ public interface FunctionArg {
     };
   }
 
+  /**
+   * Converts from {@link io.substrait.proto.FunctionArgument} to {@link
+   * io.substrait.expression.FunctionArg}
+   */
   class ProtoFrom {
-    private final ProtoExpressionConverter exprBuilder;
+    private final ProtoExpressionConverter protoExprConverter;
+    private final FromProto protoTypeConverter;
 
-    public ProtoFrom(ProtoExpressionConverter exprBuilder) {
-      this.exprBuilder = exprBuilder;
+    public ProtoFrom(ProtoExpressionConverter protoExprConverter, FromProto protoTypeConverter) {
+      this.protoExprConverter = protoExprConverter;
+      this.protoTypeConverter = protoTypeConverter;
     }
 
     public FunctionArg convert(
         SimpleExtension.Function funcDef, int argIdx, FunctionArgument fArg) {
       return switch (fArg.getArgTypeCase()) {
-        case TYPE -> FromProto.from(fArg.getType());
-        case VALUE -> exprBuilder.from(fArg.getValue());
+        case TYPE -> protoTypeConverter.from(fArg.getType());
+        case VALUE -> protoExprConverter.from(fArg.getValue());
         case ENUM -> {
           SimpleExtension.EnumArgument enumArgDef =
               (SimpleExtension.EnumArgument) funcDef.args().get(argIdx);

--- a/core/src/main/java/io/substrait/expression/FunctionLookup.java
+++ b/core/src/main/java/io/substrait/expression/FunctionLookup.java
@@ -2,10 +2,18 @@ package io.substrait.expression;
 
 import io.substrait.function.SimpleExtension;
 
+/**
+ * Interface with operations for resolving references to {@link
+ * io.substrait.proto.SimpleExtensionDeclaration}s within an individual plan to their corresponding
+ * functions or types.
+ */
 public interface FunctionLookup {
+  // TODO: Rename to ExtensionLookup and move to io.substrait.extension
   SimpleExtension.ScalarFunctionVariant getScalarFunction(
       int reference, SimpleExtension.ExtensionCollection extensions);
 
   SimpleExtension.AggregateFunctionVariant getAggregateFunction(
       int reference, SimpleExtension.ExtensionCollection extensions);
+
+  SimpleExtension.Type getType(int reference, SimpleExtension.ExtensionCollection extensions);
 }

--- a/core/src/main/java/io/substrait/expression/proto/AbstractFunctionLookup.java
+++ b/core/src/main/java/io/substrait/expression/proto/AbstractFunctionLookup.java
@@ -5,15 +5,20 @@ import io.substrait.function.SimpleExtension;
 import java.util.Map;
 
 public abstract class AbstractFunctionLookup implements FunctionLookup {
-  protected final Map<Integer, SimpleExtension.FunctionAnchor> map;
+  // TODO: Rename to AbstractExtensionLookup and move to io.substrait.extension
+  protected final Map<Integer, SimpleExtension.FunctionAnchor> functionAnchorMap;
+  protected final Map<Integer, SimpleExtension.TypeAnchor> typeAnchorMap;
 
-  public AbstractFunctionLookup(Map<Integer, SimpleExtension.FunctionAnchor> map) {
-    this.map = map;
+  public AbstractFunctionLookup(
+      Map<Integer, SimpleExtension.FunctionAnchor> functionAnchorMap,
+      Map<Integer, SimpleExtension.TypeAnchor> typeAnchorMap) {
+    this.functionAnchorMap = functionAnchorMap;
+    this.typeAnchorMap = typeAnchorMap;
   }
 
   public SimpleExtension.ScalarFunctionVariant getScalarFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = map.get(reference);
+    var anchor = functionAnchorMap.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
@@ -24,12 +29,23 @@ public abstract class AbstractFunctionLookup implements FunctionLookup {
 
   public SimpleExtension.AggregateFunctionVariant getAggregateFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = map.get(reference);
+    var anchor = functionAnchorMap.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
     }
 
     return extensions.getAggregateFunction(anchor);
+  }
+
+  public SimpleExtension.Type getType(
+      int reference, SimpleExtension.ExtensionCollection extensions) {
+    var anchor = typeAnchorMap.get(reference);
+    if (anchor == null) {
+      throw new IllegalArgumentException(
+          "Unknown type id. Make sure that the type id provided was shared in the extensions section of the plan.");
+    }
+
+    return extensions.getType(anchor);
   }
 }

--- a/core/src/main/java/io/substrait/function/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/function/SimpleExtension.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.substrait.expression.Expression;
 import io.substrait.type.Deserializers;
-import io.substrait.type.Type;
 import io.substrait.type.TypeExpressionEvaluator;
 import io.substrait.util.Util;
 import java.io.IOException;
@@ -26,12 +25,10 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
-/**
- * Classes used to deserialize YAML extension files. Currently, constrained to Function
- * deserialization.
- */
+/** Classes used to deserialize YAML extension files. Handles functions and types. */
 @Value.Enclosing
 public class SimpleExtension {
+  // TODO: Move to io.substrait.extension
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(SimpleExtension.class);
 
   private static final ObjectMapper MAPPER =
@@ -204,17 +201,26 @@ public class SimpleExtension {
     }
   }
 
-  @Value.Immutable
-  public interface FunctionAnchor {
+  public interface Anchor {
     String namespace();
 
     String key();
+  }
 
+  @Value.Immutable
+  public interface FunctionAnchor extends Anchor {
     static FunctionAnchor of(String namespace, String key) {
       return ImmutableSimpleExtension.FunctionAnchor.builder()
           .namespace(namespace)
           .key(key)
           .build();
+    }
+  }
+
+  @Value.Immutable
+  public interface TypeAnchor extends Anchor {
+    static TypeAnchor of(String namespace, String name) {
+      return ImmutableSimpleExtension.TypeAnchor.builder().namespace(namespace).key(name).build();
     }
   }
 
@@ -297,7 +303,8 @@ public class SimpleExtension {
                   .collect(java.util.stream.Collectors.toList());
             });
 
-    public static String constructKeyFromTypes(String name, List<Type> arguments) {
+    public static String constructKeyFromTypes(
+        String name, List<io.substrait.type.Type> arguments) {
       try {
         return name
             + ":"
@@ -345,7 +352,8 @@ public class SimpleExtension {
       return Util.IntRange.of(min, max);
     }
 
-    public void validateOutputType(List<Expression> argumentExpressions, Type outputType) {
+    public void validateOutputType(
+        List<Expression> argumentExpressions, io.substrait.type.Type outputType) {
       // TODO: support advanced output type validation using return expressions, parameters, etc.
       // The code below was too restrictive in the case of nullability conversion.
       return;
@@ -364,7 +372,7 @@ public class SimpleExtension {
       return keySupplier.get();
     }
 
-    public Type resolveType(List<Type> argumentTypes) {
+    public io.substrait.type.Type resolveType(List<io.substrait.type.Type> argumentTypes) {
       return TypeExpressionEvaluator.evaluateExpression(returnType(), args(), argumentTypes);
     }
   }
@@ -516,10 +524,43 @@ public class SimpleExtension {
     }
   }
 
+  @JsonDeserialize(as = ImmutableSimpleExtension.Type.class)
+  @JsonSerialize(as = ImmutableSimpleExtension.Type.class)
+  @Value.Immutable
+  public abstract static class Type {
+    public abstract String name();
+
+    // TODO: Handle conversion of structure object to Named Struct representation
+    protected abstract Optional<Object> structure();
+
+    @Value.Default
+    public String uri() {
+      // we can't use null detection here since we initially construct this without a uri, then
+      // resolve later.
+      return "";
+    }
+
+    public Type resolve(String uri) {
+      return ImmutableSimpleExtension.Type.builder().name(name()).uri(uri).build();
+    }
+
+    public TypeAnchor getAnchor() {
+      return anchorSupplier.get();
+    }
+
+    private final Supplier<TypeAnchor> anchorSupplier =
+        Util.memoize(() -> TypeAnchor.of(uri(), name()));
+  }
+
   @JsonDeserialize(as = ImmutableSimpleExtension.FunctionSignatures.class)
   @JsonSerialize(as = ImmutableSimpleExtension.FunctionSignatures.class)
   @Value.Immutable
   public abstract static class FunctionSignatures {
+    // TODO: Rename to ExtensionSignatures ???
+
+    @JsonProperty("types")
+    public abstract List<Type> types();
+
     @JsonProperty("scalar_functions")
     public abstract List<ScalarFunction> scalars();
 
@@ -530,7 +571,8 @@ public class SimpleExtension {
     public abstract List<WindowFunction> windows();
 
     public int size() {
-      return (scalars() == null ? 0 : scalars().size())
+      return (types() == null ? 0 : types().size())
+          + (scalars() == null ? 0 : scalars().size())
           + (aggregates() == null ? 0 : aggregates().size())
           + (windows() == null ? 0 : windows().size());
     }
@@ -548,6 +590,9 @@ public class SimpleExtension {
 
   @Value.Immutable
   public abstract static class ExtensionCollection {
+
+    public abstract List<Type> types();
+
     public abstract List<ScalarFunctionVariant> scalarFunctions();
 
     public abstract List<AggregateFunctionVariant> aggregateFunctions();
@@ -564,6 +609,13 @@ public class SimpleExtension {
                       windowFunctions().stream().map(Function::uri))
                   .collect(Collectors.toSet());
             });
+
+    private final Supplier<Map<TypeAnchor, Type>> typeLookup =
+        Util.memoize(
+            () ->
+                types().stream()
+                    .collect(
+                        Collectors.toMap(Type::getAnchor, java.util.function.Function.identity())));
     private final Supplier<Map<FunctionAnchor, ScalarFunctionVariant>> scalarFunctionsLookup =
         Util.memoize(
             () -> {
@@ -590,6 +642,18 @@ public class SimpleExtension {
                       Collectors.toMap(
                           Function::getAnchor, java.util.function.Function.identity()));
             });
+
+    public Type getType(TypeAnchor anchor) {
+      Type type = typeLookup.get().get(anchor);
+      if (type != null) {
+        return type;
+      }
+      checkNamespace(anchor.namespace());
+      throw new IllegalArgumentException(
+          String.format(
+              "Unexpected type with name %s. The namespace %s is loaded but no type with this name found.",
+              anchor.key(), anchor.namespace()));
+    }
 
     public ScalarFunctionVariant getScalarFunction(FunctionAnchor anchor) {
       ScalarFunctionVariant variant = scalarFunctionsLookup.get().get(anchor);
@@ -719,20 +783,24 @@ public class SimpleExtension {
   }
 
   public static ExtensionCollection buildExtensionCollection(
-      String namespace, SimpleExtension.FunctionSignatures functionSignatures) {
+      String namespace, SimpleExtension.FunctionSignatures extensionSignatures) {
     var collection =
         ImmutableSimpleExtension.ExtensionCollection.builder()
             .addAllAggregateFunctions(
-                functionSignatures.aggregates().stream()
+                extensionSignatures.aggregates().stream()
                     .flatMap(t -> t.resolve(namespace))
                     .collect(java.util.stream.Collectors.toList()))
             .addAllScalarFunctions(
-                functionSignatures.scalars().stream()
+                extensionSignatures.scalars().stream()
                     .flatMap(t -> t.resolve(namespace))
                     .collect(java.util.stream.Collectors.toList()))
             .addAllWindowFunctions(
-                functionSignatures.windows().stream()
+                extensionSignatures.windows().stream()
                     .flatMap(t -> t.resolve(namespace))
+                    .collect(java.util.stream.Collectors.toList()))
+            .addAllTypes(
+                extensionSignatures.types().stream()
+                    .map(t -> t.resolve(namespace))
                     .collect(java.util.stream.Collectors.toList()))
             .build();
     logger.debug(

--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -127,6 +127,11 @@ public class ToTypeString
   }
 
   @Override
+  public String visit(final Type.UserDefined expr) {
+    return String.format("u!%s", expr.name());
+  }
+
+  @Override
   public String visit(ParameterizedType.FixedChar expr) throws RuntimeException {
     return "fchar";
   }

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -8,6 +8,7 @@ import io.substrait.relation.RelProtoConverter;
 import java.util.ArrayList;
 import java.util.List;
 
+/** Converts from {@link io.substrait.plan.Plan} to {@link io.substrait.proto.Plan} */
 public class PlanProtoConverter {
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(PlanProtoConverter.class);
@@ -29,7 +30,7 @@ public class PlanProtoConverter {
         Plan.newBuilder()
             .addAllRelations(planRels)
             .addAllExpectedTypeUrls(plan.getExpectedTypeUrls());
-    functionCollector.addFunctionsToPlan(builder);
+    functionCollector.addExtensionsToPlan(builder);
     if (plan.getAdvancedExtension().isPresent()) {
       builder.setAdvancedExtensions(plan.getAdvancedExtension().get());
     }

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+/** Converts from {@link io.substrait.proto.Plan} to {@link io.substrait.plan.Plan} */
 public class ProtoPlanConverter {
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(io.substrait.plan.ProtoPlanConverter.class);

--- a/core/src/main/java/io/substrait/type/NamedStruct.java
+++ b/core/src/main/java/io/substrait/type/NamedStruct.java
@@ -14,8 +14,8 @@ public interface NamedStruct {
     return ImmutableNamedStruct.builder().addAllNames(names).struct(type).build();
   }
 
-  default io.substrait.proto.NamedStruct toProto() {
-    var type = struct().accept(TypeProtoConverter.INSTANCE);
+  default io.substrait.proto.NamedStruct toProto(TypeProtoConverter typeProtoConverter) {
+    var type = struct().accept(typeProtoConverter);
     return io.substrait.proto.NamedStruct.newBuilder()
         .setStruct(type.getStruct())
         .addAllNames(names())

--- a/core/src/main/java/io/substrait/type/StringTypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/StringTypeVisitor.java
@@ -126,4 +126,9 @@ public class StringTypeVisitor implements TypeVisitor<String, RuntimeException> 
     return String.format(
         "map<%s,%s>%s", type.key().accept(this), type.value().accept(this), n(type));
   }
+
+  @Override
+  public String visit(Type.UserDefined type) throws RuntimeException {
+    return String.format("u!%s%s", type.name(), n(type));
+  }
 }

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -319,4 +319,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
       return typeVisitor.visit(this);
     }
   }
+
+  @Value.Immutable
+  abstract static class UserDefined implements Type {
+
+    public abstract String uri();
+
+    public abstract String name();
+
+    public static ImmutableType.UserDefined.Builder builder() {
+      return ImmutableType.UserDefined.builder();
+    }
+
+    @Override
+    public <R, E extends Throwable> R accept(TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
+  }
 }

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -85,6 +85,10 @@ public class TypeCreator {
     return Type.Map.builder().nullable(nullable).key(key).value(value).build();
   }
 
+  public Type userDefined(String uri, String name) {
+    return Type.UserDefined.builder().nullable(nullable).uri(uri).name(name).build();
+  }
+
   public static TypeCreator of(boolean nullability) {
     return nullability ? NULLABLE : REQUIRED;
   }

--- a/core/src/main/java/io/substrait/type/TypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/TypeVisitor.java
@@ -47,6 +47,8 @@ public interface TypeVisitor<R, E extends Throwable> {
 
   R visit(Type.Map type) throws E;
 
+  R visit(Type.UserDefined type) throws E;
+
   public abstract static class TypeThrowsVisitor<R, E extends Throwable>
       implements TypeVisitor<R, E> {
 
@@ -172,6 +174,11 @@ public interface TypeVisitor<R, E extends Throwable> {
 
     @Override
     public R visit(Type.Map type) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(Type.UserDefined type) throws E {
       throw t();
     }
   }

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -140,6 +140,14 @@ public class ParseToPojo {
     }
 
     @Override
+    public Type visitUserDefined(SubstraitTypeParser.UserDefinedContext ctx) {
+      var name = ctx.Identifier().getSymbol().getText();
+      // The URI is added to the type as part of resolution when building the ExtensionCollection
+      var uri = "";
+      return withNull(ctx).userDefined(uri, name);
+    }
+
+    @Override
     public TypeExpression visitFixedChar(final SubstraitTypeParser.FixedCharContext ctx) {
       boolean nullable = ctx.isnull != null;
       return of(

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
@@ -101,6 +101,8 @@ abstract class BaseProtoTypes<T, I> {
 
   public abstract T map(T key, T value);
 
+  public abstract T userDefined(int ref);
+
   protected abstract T wrap(Object o);
 
   protected abstract I i(int integerValue);

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -1,5 +1,6 @@
 package io.substrait.type.proto;
 
+import io.substrait.expression.proto.FunctionCollector;
 import io.substrait.function.TypeExpression;
 import io.substrait.function.TypeExpressionVisitor;
 import io.substrait.proto.ParameterizedType;
@@ -10,8 +11,8 @@ public class ParameterizedProtoConverter
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(ParameterizedProtoConverter.class);
 
-  public ParameterizedProtoConverter() {
-    super("Parameterized types cannot include return type expressions.");
+  public ParameterizedProtoConverter(FunctionCollector extensionCollector) {
+    super(extensionCollector, "Parameterized types cannot include return type expressions.");
   }
 
   @Override
@@ -196,6 +197,12 @@ public class ParameterizedProtoConverter
               .setValue(value)
               .setNullability(Type.Nullability.NULLABILITY_NULLABLE)
               .build());
+    }
+
+    @Override
+    public ParameterizedType userDefined(int ref) {
+      throw new UnsupportedOperationException(
+          "User defined types are not supported in Parameterized Types for now");
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -1,5 +1,6 @@
 package io.substrait.type.proto;
 
+import io.substrait.expression.proto.FunctionCollector;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
 import io.substrait.proto.DerivationExpression;
@@ -10,8 +11,8 @@ public class TypeExpressionProtoVisitor
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(TypeExpressionProtoVisitor.class);
 
-  public TypeExpressionProtoVisitor() {
-    super("Unexpected expression type. This shouldn't happen.");
+  public TypeExpressionProtoVisitor(FunctionCollector extensionCollector) {
+    super(extensionCollector, "Unexpected expression type. This shouldn't happen.");
   }
 
   @Override
@@ -261,6 +262,12 @@ public class TypeExpressionProtoVisitor
               .setValue(value)
               .setNullability(Type.Nullability.NULLABILITY_REQUIRED)
               .build());
+    }
+
+    @Override
+    public DerivationExpression userDefined(int ref) {
+      throw new UnsupportedOperationException(
+          "User defined types are not supported in Derivation Expressions for now");
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -1,16 +1,15 @@
 package io.substrait.type.proto;
 
-import io.substrait.function.TypeExpressionVisitor;
+import io.substrait.expression.proto.FunctionCollector;
 import io.substrait.proto.Type;
 
+/** Convert from {@link io.substrait.type.Type} to {@link io.substrait.proto.Type} */
 public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(TypeProtoConverter.class);
 
-  public static TypeExpressionVisitor<Type, RuntimeException> INSTANCE = new TypeProtoConverter();
-
-  public TypeProtoConverter() {
-    super("Type literals cannot contain parameters or expressions.");
+  public TypeProtoConverter(FunctionCollector extensionCollector) {
+    super(extensionCollector, "Type literals cannot contain parameters or expressions.");
   }
 
   private static final BaseProtoTypes<Type, Integer> NULLABLE =
@@ -76,6 +75,12 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     }
 
     @Override
+    public Type userDefined(int ref) {
+      return wrap(
+          Type.UserDefined.newBuilder().setTypeReference(ref).setNullability(nullability).build());
+    }
+
+    @Override
     protected Type wrap(final Object o) {
       var bldr = Type.newBuilder();
       if (o instanceof Type.Boolean t) {
@@ -124,6 +129,8 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
         return bldr.setMap(t).build();
       } else if (o instanceof Type.UUID t) {
         return bldr.setUuid(t).build();
+      } else if (o instanceof Type.UserDefined t) {
+        return bldr.setUserDefined(t).build();
       }
       throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -1,0 +1,80 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.function.SimpleExtension;
+import io.substrait.plan.Plan;
+import io.substrait.plan.PlanProtoConverter;
+import io.substrait.plan.ProtoPlanConverter;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that user specified types can:
+ *
+ * <ul>
+ *   <li>Be read from extension files
+ *   <li>Be referenced by functions in extension files
+ *   <li>Roundtrip between POJO and Proto
+ * </ul>
+ */
+public class TypeExtensionTest {
+
+  static final TypeCreator R = TypeCreator.of(false);
+
+  static final String NAMESPACE = "/custom_extensions";
+  final io.substrait.function.SimpleExtension.ExtensionCollection extensionCollection;
+
+  {
+    InputStream inputStream =
+        this.getClass().getResourceAsStream("/extensions/custom_extensions.yaml");
+    extensionCollection = SimpleExtension.load(NAMESPACE, inputStream);
+  }
+
+  final SubstraitBuilder b = new SubstraitBuilder(extensionCollection);
+  Type customType1 = b.userDefinedType(NAMESPACE, "customType1");
+  Type customType2 = b.userDefinedType(NAMESPACE, "customType2");
+  final PlanProtoConverter planProtoConverter = new PlanProtoConverter();
+  final ProtoPlanConverter protoPlanConverter = new ProtoPlanConverter(extensionCollection);
+
+  @Test
+  void roundtripCustomType() {
+    // CREATE TABLE example (custom_type_column custom_type1, i64_column BIGINT);
+    List<String> tableName = Stream.of("example").collect(Collectors.toList());
+    List<String> columnNames =
+        Stream.of("custom_type_column", "i64_column").collect(Collectors.toList());
+    List<io.substrait.type.Type> types = Stream.of(customType1, R.I64).collect(Collectors.toList());
+
+    // SELECT custom_type_column, scalar1(custom_type_column), scalar2(i64_column)
+    // FROM example
+    Plan plan =
+        b.plan(
+            b.root(
+                b.project(
+                    input ->
+                        Stream.of(
+                                b.fieldReference(input, 0),
+                                b.scalarFn(
+                                    NAMESPACE,
+                                    "scalar1:u!customType1",
+                                    R.I64,
+                                    b.fieldReference(input, 0)),
+                                b.scalarFn(
+                                    NAMESPACE,
+                                    "scalar2:i64",
+                                    customType2,
+                                    b.fieldReference(input, 1)))
+                            .collect(Collectors.toList()),
+                    b.namedScan(tableName, columnNames, types))));
+
+    var protoPlan = planProtoConverter.toProto(plan);
+    var planReturned = protoPlanConverter.from(protoPlan);
+    assertEquals(plan, planReturned);
+  }
+}

--- a/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
+++ b/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
@@ -79,6 +79,7 @@ public class TestTypeParser {
     test(v, r.I64, "I64");
     test(v, r.FP32, "FP32");
     test(v, r.FP64, "FP64");
+    test(v, r.userDefined("", "foo"), "u!foo");
 
     // Nullable
     test(v, n.I8, "I8?");
@@ -87,6 +88,7 @@ public class TestTypeParser {
     test(v, n.I64, "i64?");
     test(v, n.FP32, "FP32?");
     test(v, n.FP64, "FP64?");
+    test(v, n.userDefined("", "foo"), "u!foo?");
   }
 
   private void compoundTests(ParseToPojo.Visitor v) {

--- a/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
+++ b/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
@@ -5,15 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.substrait.function.ParameterizedTypeCreator;
 import io.substrait.function.TypeExpression;
 import io.substrait.function.TypeExpressionCreator;
-import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import org.junit.jupiter.api.Test;
 
 public class TestTypeParser {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TestTypeParser.class);
 
-  private final TypeCreator n = Type.NULLABLE;
-  private final TypeCreator r = Type.REQUIRED;
+  private final TypeCreator n = TypeCreator.NULLABLE;
+  private final TypeCreator r = TypeCreator.REQUIRED;
 
   private final TypeExpressionCreator eo = TypeExpressionCreator.REQUIRED;
   private final TypeExpressionCreator en = TypeExpressionCreator.NULLABLE;

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -2,6 +2,8 @@ package io.substrait.type.proto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.substrait.expression.proto.FunctionCollector;
+import io.substrait.function.ImmutableSimpleExtension;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,14 +40,19 @@ public class TestTypeRoundtrip {
     t(creator(n).struct(creator(n).TIME, creator(n).TIMESTAMP, creator(n).TIMESTAMP_TZ));
   }
 
-  /**
+  private FunctionCollector lookup = new FunctionCollector();
+  private TypeProtoConverter typeProtoConverter = new TypeProtoConverter(lookup);
+
+  private FromProto protoTypeConverter =
+      new FromProto(lookup, ImmutableSimpleExtension.ExtensionCollection.builder().build());
+  /*
    * Test a type pojo -> proto -> pojo roundtrip.
    *
    * @param type
    */
   private void t(Type type) {
-    var converted = type.accept(new TypeProtoConverter());
-    assertEquals(type, FromProto.from(converted));
+    var converted = type.accept(typeProtoConverter);
+    assertEquals(type, protoTypeConverter.from(converted));
   }
 
   private TypeCreator creator(boolean nullable) {

--- a/core/src/test/resources/extensions/custom_extensions.yaml
+++ b/core/src/test/resources/extensions/custom_extensions.yaml
@@ -1,0 +1,24 @@
+%YAML 1.2
+---
+types:
+  - name: "customType1"
+  - name: "customType2"
+    structure:
+      field1: i32
+      field2: fp32
+
+scalar_functions:
+  - name: "scalar1"
+    description: "a custom scalar functions"
+    impls:
+      - args:
+          - name: arg1
+            value: u!customType1
+        return: i64
+  - name: "scalar2"
+    description: "a custom scalar functions"
+    impls:
+      - args:
+          - name: arg1
+            value: i64
+        return: u!customType2

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -85,7 +85,7 @@ public class SqlToSubstrait extends SqlConverterBase {
                               .addAllNames(
                                   TypeConverter.toNamedStruct(root.validatedRowType).names())));
             });
-    functionCollector.addFunctionsToPlan(plan);
+    functionCollector.addExtensionsToPlan(plan);
     return plan.build();
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
@@ -94,6 +94,11 @@ public class IgnoreNullableAndParameters
   }
 
   @Override
+  public Boolean visit(Type.UserDefined type) throws RuntimeException {
+    throw new UnsupportedOperationException("cannot handle user defined types for now");
+  }
+
+  @Override
   public Boolean visit(Type.FixedChar type) {
     return typeToMatch instanceof Type.FixedChar
         || typeToMatch instanceof ParameterizedType.FixedChar;


### PR DESCRIPTION
Adds machinery for reading type extensions and handling their conversion in POJOs to proto form and back.

All changes were motivated by the example in TestTypeRoundtrip, which:
* Reads user defined types from an extension
* Reads function using those types from the extension
* Builds a POJO using those types and functions.
* Converts the POJO -> Proto -> POJO and checks that the two POJOs are the same.

The majority of changes stem come from:
* Adding the new `io.substrait.type.Type.UserDefined` to the type visitors.
* Adding code to resolve and lookup types within a plan context.
* Updating static usages of TypeProtoConverter to instance specific usages to perform said resolution and lookup. TypeProtoConverter can no longer be static as resolution and lookup are plan specific.

There a number of classes w/ TODOs to apply renames and/or moves. I held off on applying them in this PR to keep the diff smaller and also check w/ the community to see if they were reasonable before investing time in them.