### PR TITLE
feat: add support for current_date and current_timestamp

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -63,7 +63,9 @@ public class FunctionMappings {
                 s(SqlStdOperatorTable.UPPER, "upper"),
                 s(SqlStdOperatorTable.BETWEEN),
                 s(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM, "is_not_distinct_from"),
-                s(SqlStdOperatorTable.COALESCE, "coalesce"))
+                s(SqlStdOperatorTable.COALESCE, "coalesce"),
+                s(SqlStdOperatorTable.CURRENT_DATE, "current_date"),
+                s(SqlStdOperatorTable.CURRENT_TIMESTAMP, "current_timestamp"))
             .build();
 
     AGGREGATE_SIGS =

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
@@ -100,6 +100,16 @@ public class CalciteCallTest extends CalciteObjs {
     test("not:bool", rex.makeCall(NOT, c(false, SqlTypeName.BOOLEAN)));
   }
 
+  @Test
+  public void currentDate() throws IOException {
+    test("current_date:", rex.makeCall(CURRENT_DATE));
+  }
+
+  @Test
+  public void currentTimestamp() throws IOException {
+    test("current_timestamp:", rex.makeCall(CURRENT_TIMESTAMP) );
+  }
+
   private void test(String expectedName, RexNode call) {
     test(expectedName, call, c -> {}, true);
   }


### PR DESCRIPTION
current_timestamp return type is of unsupported precision 0

needs a bump to substrait submodule: https://github.com/substrait-io/substrait/pull/524