### PR TITLE
refactor(pojos)!: avoid using raw proto enums in POJO layer

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -12,7 +12,6 @@ import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.ImmutablePlan;
 import io.substrait.plan.ImmutableRoot;
 import io.substrait.plan.Plan;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.Cross;
 import io.substrait.relation.Fetch;
@@ -286,7 +285,7 @@ public class SubstraitBuilder {
         .outputType(outputType)
         .declaration(declaration)
         .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
-        .invocation(AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_ALL)
+        .invocation(Expression.AggregationInvocation.ALL)
         .build();
   }
 
@@ -304,7 +303,7 @@ public class SubstraitBuilder {
         .outputType(R.I64)
         .declaration(declaration)
         .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
-        .invocation(AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_ALL)
+        .invocation(Expression.AggregationInvocation.ALL)
         .build();
   }
 

--- a/core/src/main/java/io/substrait/expression/AggregateFunctionInvocation.java
+++ b/core/src/main/java/io/substrait/expression/AggregateFunctionInvocation.java
@@ -1,7 +1,6 @@
 package io.substrait.expression;
 
 import io.substrait.extension.SimpleExtension;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.type.Type;
 import java.util.List;
 import java.util.Map;
@@ -25,7 +24,7 @@ public abstract class AggregateFunctionInvocation {
     return outputType();
   }
 
-  public abstract AggregateFunction.AggregationInvocation invocation();
+  public abstract Expression.AggregationInvocation invocation();
 
   public static ImmutableAggregateFunctionInvocation.Builder builder() {
     return ImmutableAggregateFunctionInvocation.builder();

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -2,6 +2,7 @@ package io.substrait.expression;
 
 import com.google.protobuf.ByteString;
 import io.substrait.extension.SimpleExtension;
+import io.substrait.proto.AggregateFunction;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.Rel;
 import io.substrait.type.Type;
@@ -736,6 +737,32 @@ public interface Expression extends FunctionArg {
 
     public static PredicateOp fromProto(
         io.substrait.proto.Expression.Subquery.SetPredicate.PredicateOp proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
+          return v;
+        }
+      }
+
+      throw new IllegalArgumentException("Unknown type: " + proto);
+    }
+  }
+
+  enum AggregationInvocation {
+    UNSPECIFIED(AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_UNSPECIFIED),
+    ALL(AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_ALL),
+    DISTINCT(AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_DISTINCT);
+
+    private final io.substrait.proto.AggregateFunction.AggregationInvocation proto;
+
+    AggregationInvocation(io.substrait.proto.AggregateFunction.AggregationInvocation proto) {
+      this.proto = proto;
+    }
+
+    public io.substrait.proto.AggregateFunction.AggregationInvocation toProto() {
+      return proto;
+    }
+
+    public static AggregationInvocation fromProto(AggregateFunction.AggregationInvocation proto) {
       for (var v : values()) {
         if (v.proto == proto) {
           return v;

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -2,7 +2,6 @@ package io.substrait.expression;
 
 import com.google.protobuf.ByteString;
 import io.substrait.extension.SimpleExtension;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.type.Type;
 import io.substrait.util.DecimalUtil;
 import java.math.BigDecimal;
@@ -279,7 +278,7 @@ public class ExpressionCreator {
       Type outputType,
       Expression.AggregationPhase phase,
       List<Expression.SortField> sort,
-      AggregateFunction.AggregationInvocation invocation,
+      Expression.AggregationInvocation invocation,
       Iterable<? extends FunctionArg> arguments) {
     return AggregateFunctionInvocation.builder()
         .declaration(declaration)
@@ -296,7 +295,7 @@ public class ExpressionCreator {
       Type outputType,
       Expression.AggregationPhase phase,
       List<Expression.SortField> sort,
-      AggregateFunction.AggregationInvocation invocation,
+      Expression.AggregationInvocation invocation,
       FunctionArg... arguments) {
     return AggregateFunctionInvocation.builder()
         .declaration(declaration)
@@ -313,7 +312,7 @@ public class ExpressionCreator {
       Type outputType,
       Expression.AggregationPhase phase,
       List<Expression.SortField> sort,
-      AggregateFunction.AggregationInvocation invocation,
+      Expression.AggregationInvocation invocation,
       Iterable<? extends FunctionArg> arguments) {
     return WindowFunctionInvocation.builder()
         .declaration(declaration)
@@ -330,7 +329,7 @@ public class ExpressionCreator {
       Type outputType,
       Expression.AggregationPhase phase,
       List<Expression.SortField> sort,
-      AggregateFunction.AggregationInvocation invocation,
+      Expression.AggregationInvocation invocation,
       FunctionArg... arguments) {
     return WindowFunctionInvocation.builder()
         .declaration(declaration)

--- a/core/src/main/java/io/substrait/expression/WindowFunctionInvocation.java
+++ b/core/src/main/java/io/substrait/expression/WindowFunctionInvocation.java
@@ -1,7 +1,6 @@
 package io.substrait.expression;
 
 import io.substrait.extension.SimpleExtension;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.type.Type;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +25,7 @@ public abstract class WindowFunctionInvocation {
     return outputType();
   }
 
-  public abstract AggregateFunction.AggregationInvocation invocation();
+  public abstract Expression.AggregationInvocation invocation();
 
   public static ImmutableWindowFunctionInvocation.Builder builder() {
     return ImmutableWindowFunctionInvocation.builder();

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -391,7 +391,7 @@ public class ProtoRelConverter {
                       .declaration(funcDecl)
                       .outputType(protoTypeConverter.from(func.getOutputType()))
                       .aggregationPhase(Expression.AggregationPhase.fromProto(func.getPhase()))
-                      .invocation(func.getInvocation())
+                      .invocation(Expression.AggregationInvocation.fromProto(func.getInvocation()))
                       .build())
               .preMeasureFilter(
                   Optional.ofNullable(

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -95,7 +95,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
     var func =
         AggregateFunction.newBuilder()
             .setPhase(measure.getFunction().aggregationPhase().toProto())
-            .setInvocation(measure.getFunction().invocation())
+            .setInvocation(measure.getFunction().invocation().toProto())
             .setOutputType(toProto(measure.getFunction().getType()))
             .addAllArguments(
                 IntStream.range(0, args.size())

--- a/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
@@ -8,7 +8,6 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.ImmutableExpression;
 import io.substrait.extension.ExtensionCollector;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.ImmutableAggregate;
 import io.substrait.relation.ProtoRelConverter;
@@ -25,7 +24,7 @@ public class AggregateRoundtripTest extends TestBase {
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(AggregateRoundtripTest.class);
 
-  private void assertAggregateRoundtrip(AggregateFunction.AggregationInvocation invocation) {
+  private void assertAggregateRoundtrip(Expression.AggregationInvocation invocation) {
     var expression = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
     Expression.StructLiteral literal =
         ImmutableExpression.StructLiteral.builder().from(expression).build();
@@ -51,16 +50,14 @@ public class AggregateRoundtripTest extends TestBase {
     var protoAggRel = to.toProto(aggRel);
     assertEquals(
         protoAggRel.getAggregate().getMeasuresList().get(0).getMeasure().getInvocation(),
-        invocation);
+        invocation.toProto());
     assertEquals(protoAggRel, to.toProto(from.from(protoAggRel)));
   }
 
   @Test
   void aggregateInvocationRoundtrip() throws IOException {
-    for (var invocation : AggregateFunction.AggregationInvocation.values()) {
-      if (invocation != AggregateFunction.AggregationInvocation.UNRECOGNIZED) {
-        assertAggregateRoundtrip(invocation);
-      }
+    for (var invocation : Expression.AggregationInvocation.values()) {
+      assertAggregateRoundtrip(invocation);
     }
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -253,12 +253,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
     }
 
     boolean distinct =
-        switch (measure.getFunction().invocation()) {
-          case AGGREGATION_INVOCATION_DISTINCT:
-            yield true;
-          default:
-            yield false;
-        };
+        measure.getFunction().invocation().equals(Expression.AggregationInvocation.DISTINCT);
 
     SqlAggFunction aggFunction;
     RelDataType returnType = typeConverter.toCalcite(typeFactory, measure.getFunction().getType());

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
@@ -8,7 +8,6 @@ import io.substrait.expression.FunctionArg;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.SubstraitRelVisitor;
 import io.substrait.isthmus.TypeConverter;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.type.Type;
 import java.util.Collections;
 import java.util.List;
@@ -62,10 +61,10 @@ public class AggregateFunctionConverter
                 .map(r -> SubstraitRelVisitor.toSortField(r, call.inputType))
                 .collect(java.util.stream.Collectors.toList())
             : Collections.emptyList();
-    AggregateFunction.AggregationInvocation invocation =
+    Expression.AggregationInvocation invocation =
         agg.isDistinct()
-            ? AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_DISTINCT
-            : AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_ALL;
+            ? Expression.AggregationInvocation.DISTINCT
+            : Expression.AggregationInvocation.ALL;
     return ExpressionCreator.aggregateFunction(
         function,
         outputType,

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
@@ -11,7 +11,6 @@ import io.substrait.expression.WindowFunctionInvocation;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.SubstraitRelVisitor;
 import io.substrait.isthmus.TypeConverter;
-import io.substrait.proto.AggregateFunction;
 import io.substrait.relation.Aggregate;
 import io.substrait.type.Type;
 import java.util.Collections;
@@ -68,10 +67,10 @@ public class WindowFunctionConverter
                 .map(r -> SubstraitRelVisitor.toSortField(r, call.inputType))
                 .collect(java.util.stream.Collectors.toList())
             : Collections.emptyList();
-    AggregateFunction.AggregationInvocation invocation =
+    Expression.AggregationInvocation invocation =
         agg.isDistinct()
-            ? AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_DISTINCT
-            : AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_ALL;
+            ? Expression.AggregationInvocation.DISTINCT
+            : Expression.AggregationInvocation.ALL;
     return ExpressionCreator.windowFunction(
         function,
         outputType,

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -1,13 +1,12 @@
 package io.substrait.isthmus;
 
-import static io.substrait.proto.AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_ALL;
-import static io.substrait.proto.AggregateFunction.AggregationInvocation.AGGREGATION_INVOCATION_DISTINCT;
 import static io.substrait.relation.RelCopyOnWriteVisitor.transformList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.Expression;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.ImmutablePlan;
 import io.substrait.plan.ImmutableRoot;
@@ -218,7 +217,9 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
                 .filter(
                     m ->
                         m.getFunction().declaration().getAnchor().equals(COUNT)
-                            && m.getFunction().invocation() == AGGREGATION_INVOCATION_DISTINCT)
+                            && m.getFunction()
+                                .invocation()
+                                .equals(Expression.AggregationInvocation.DISTINCT))
                 .count();
         return super.visit(aggregate);
       }
@@ -284,7 +285,7 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
         return transformList(
                 aggregate.getMeasures(),
                 m -> {
-                  if (m.getFunction().invocation() == AGGREGATION_INVOCATION_DISTINCT
+                  if (m.getFunction().invocation().equals(Expression.AggregationInvocation.DISTINCT)
                       && m.getFunction().declaration().getAnchor().equals(COUNT)) {
                     return Optional.of(
                         Aggregate.Measure.builder()
@@ -293,7 +294,7 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
                                 AggregateFunctionInvocation.builder()
                                     .from(m.getFunction())
                                     .declaration(approxFunc)
-                                    .invocation(AGGREGATION_INVOCATION_ALL)
+                                    .invocation(Expression.AggregationInvocation.ALL)
                                     .build())
                             .build());
                   }


### PR DESCRIPTION
BREAKING CHANGE: various public functions that took the
AggregateFunction.AggregationInvocation proto now take the POJO
equivalent Expression.AggregationInvocation.