### PR TITLE
feat: implement fractional second intervals, with tests

### DIFF
--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -297,6 +297,8 @@ public interface Expression extends FunctionArg {
 
     public abstract int seconds();
 
+    public abstract int microseconds();
+
     public Type getType() {
       return Type.withNullability(nullable()).INTERVAL_DAY;
     }

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -120,10 +120,16 @@ public class ExpressionCreator {
   }
 
   public static Expression.IntervalDayLiteral intervalDay(boolean nullable, int days, int seconds) {
+    return intervalDay(nullable, days, seconds, 0);
+  }
+
+  public static Expression.IntervalDayLiteral intervalDay(
+      boolean nullable, int days, int seconds, int microseconds) {
     return Expression.IntervalDayLiteral.builder()
         .nullable(nullable)
         .days(days)
         .seconds(seconds)
+        .microseconds(microseconds)
         .build();
   }
 

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -126,7 +126,8 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
                 .setIntervalDayToSecond(
                     Expression.Literal.IntervalDayToSecond.newBuilder()
                         .setDays(expr.days())
-                        .setSeconds(expr.seconds())));
+                        .setSeconds(expr.seconds())
+                        .setMicroseconds(expr.microseconds())));
   }
 
   @Override

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -227,7 +227,8 @@ public class ProtoExpressionConverter {
       case INTERVAL_DAY_TO_SECOND -> ExpressionCreator.intervalDay(
           literal.getNullable(),
           literal.getIntervalDayToSecond().getDays(),
-          literal.getIntervalDayToSecond().getSeconds());
+          literal.getIntervalDayToSecond().getSeconds(),
+          literal.getIntervalDayToSecond().getMicroseconds());
       case FIXED_CHAR -> ExpressionCreator.fixedChar(literal.getNullable(), literal.getFixedChar());
       case VAR_CHAR -> ExpressionCreator.varChar(
           literal.getNullable(), literal.getVarChar().getValue(), literal.getVarChar().getLength());

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -1,9 +1,12 @@
 package io.substrait.isthmus;
 
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
@@ -42,4 +45,12 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   public static RelDataTypeFactory createTypeFactory() {
     return new JavaTypeFactoryImpl(TYPE_SYSTEM);
   }
+
+  // Interval qualifier from year to month
+  public static final SqlIntervalQualifier YEAR_MONTH_INTERVAL =
+      new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO);
+
+  // Interval qualifier from day to fractional second at microsecond precision
+  public static final SqlIntervalQualifier DAY_SECOND_INTERVAL =
+      new SqlIntervalQualifier(TimeUnit.DAY, -1, TimeUnit.SECOND, 6, SqlParserPos.ZERO);
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -1,5 +1,8 @@
 package io.substrait.isthmus;
 
+import static io.substrait.isthmus.SubstraitTypeSystem.DAY_SECOND_INTERVAL;
+import static io.substrait.isthmus.SubstraitTypeSystem.YEAR_MONTH_INTERVAL;
+
 import io.substrait.function.NullableType;
 import io.substrait.function.TypeExpression;
 import io.substrait.type.NamedStruct;
@@ -9,11 +12,8 @@ import io.substrait.type.TypeVisitor;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.sql.SqlIntervalQualifier;
-import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -41,11 +41,6 @@ public class TypeConverter {
   public TypeConverter(UserTypeMapper userTypeMapper) {
     this.userTypeMapper = userTypeMapper;
   }
-
-  static final SqlIntervalQualifier INTERVAL_YEAR =
-      new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO);
-  static final SqlIntervalQualifier INTERVAL_DAY =
-      new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.SECOND, SqlParserPos.ZERO);
 
   public Type toSubstrait(RelDataType type) {
     return toSubstrait(type, new ArrayList<>());
@@ -248,13 +243,13 @@ public class TypeConverter {
     @Override
     public RelDataType visit(Type.IntervalYear expr) {
       return typeFactory.createTypeWithNullability(
-          typeFactory.createSqlIntervalType(INTERVAL_YEAR), n(expr));
+          typeFactory.createSqlIntervalType(YEAR_MONTH_INTERVAL), n(expr));
     }
 
     @Override
     public RelDataType visit(Type.IntervalDay expr) {
       return typeFactory.createTypeWithNullability(
-          typeFactory.createSqlIntervalType(INTERVAL_DAY), n(expr));
+          typeFactory.createSqlIntervalType(DAY_SECOND_INTERVAL), n(expr));
     }
 
     @Override

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static io.substrait.expression.ExpressionCreator.*;
 import static io.substrait.isthmus.SqlToSubstrait.EXTENSION_COLLECTION;
+import static io.substrait.isthmus.SubstraitTypeSystem.YEAR_MONTH_INTERVAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
@@ -154,15 +155,7 @@ public class CalciteLiteralTest extends CalciteObjs {
   @Test
   void tIntervalYearMonth() {
     BigDecimal bd = new BigDecimal(3 * 12 + 5); // '3-5' year to month
-    RexLiteral intervalYearMonth =
-        rex.makeIntervalLiteral(
-            bd,
-            new SqlIntervalQualifier(
-                org.apache.calcite.avatica.util.TimeUnit.YEAR,
-                -1,
-                org.apache.calcite.avatica.util.TimeUnit.MONTH,
-                -1,
-                SqlParserPos.QUOTED_ZERO));
+    RexLiteral intervalYearMonth = rex.makeIntervalLiteral(bd, YEAR_MONTH_INTERVAL);
     var intervalYearMonthExpr = intervalYear(false, 3, 5);
     bitest(intervalYearMonthExpr, intervalYearMonth);
   }
@@ -212,7 +205,7 @@ public class CalciteLiteralTest extends CalciteObjs {
                 -1,
                 org.apache.calcite.avatica.util.TimeUnit.SECOND,
                 3,
-                SqlParserPos.QUOTED_ZERO));
+                SqlParserPos.ZERO));
     var intervalDaySecondExpr = intervalDay(false, 3, 5 * 3600 + 7 * 60 + 9, 500_000);
     bitest(intervalDaySecondExpr, intervalDaySecond);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -195,6 +195,29 @@ public class CalciteLiteralTest extends CalciteObjs {
   }
 
   @Test
+  void tIntervalDaySecond() {
+    // Calcite stores milliseconds since Epoch, so test only millisecond precision
+    BigDecimal bd =
+        new BigDecimal(
+            TimeUnit.DAYS.toMillis(3)
+                + TimeUnit.HOURS.toMillis(5)
+                + TimeUnit.MINUTES.toMillis(7)
+                + TimeUnit.SECONDS.toMillis(9)
+                + 500); // '3-5:7:9.500' day to second (6)
+    RexLiteral intervalDaySecond =
+        rex.makeIntervalLiteral(
+            bd,
+            new SqlIntervalQualifier(
+                org.apache.calcite.avatica.util.TimeUnit.DAY,
+                -1,
+                org.apache.calcite.avatica.util.TimeUnit.SECOND,
+                3,
+                SqlParserPos.QUOTED_ZERO));
+    var intervalDaySecondExpr = intervalDay(false, 3, 5 * 3600 + 7 * 60 + 9, 500_000);
+    bitest(intervalDaySecondExpr, intervalDaySecond);
+  }
+
+  @Test
   void tIntervalYear() {
     BigDecimal bd = new BigDecimal(123 * 12); // '123' year(3)
     RexLiteral intervalYear =
@@ -243,10 +266,6 @@ public class CalciteLiteralTest extends CalciteObjs {
         intervalMonth.getValueAs(BigDecimal.class).longValue(),
         convertedRex.getValueAs(BigDecimal.class).longValue());
   }
-
-  @Disabled("NYI")
-  @Test
-  void tIntervalDay() {}
 
   @Test
   void tFixedChar() {

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -195,7 +195,7 @@ public class CalciteLiteralTest extends CalciteObjs {
   }
 
   @Test
-  void tIntervalDaySecond() {
+  void tIntervalMillisecond() {
     // Calcite stores milliseconds since Epoch, so test only millisecond precision
     BigDecimal bd =
         new BigDecimal(

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -92,7 +92,7 @@ class CalciteTypeTest extends CalciteObjs {
   void intervalYear(boolean nullable) {
     testType(
         Type.withNullability(nullable).INTERVAL_YEAR,
-        type.createSqlIntervalType(TypeConverter.INTERVAL_YEAR),
+        type.createSqlIntervalType(SubstraitTypeSystem.YEAR_MONTH_INTERVAL),
         nullable);
   }
 
@@ -101,7 +101,7 @@ class CalciteTypeTest extends CalciteObjs {
   void intervalDay(boolean nullable) {
     testType(
         Type.withNullability(nullable).INTERVAL_DAY,
-        type.createSqlIntervalType(TypeConverter.INTERVAL_DAY),
+        type.createSqlIntervalType(SubstraitTypeSystem.DAY_SECOND_INTERVAL),
         nullable);
   }
 


### PR DESCRIPTION
This PR :

- adds fractional second intervals to substrait-java
- fixes isthmus for INTERVAL_DAY conversion and add other day-time intervals
- adds literal conversion tests to isthmus

Fractional seconds where added to the Substrait specifications [in this PR from May 2022](https://github.com/substrait-io/substrait/pull/199).
