### PR TITLE
feat: window function calcite support

### DIFF
--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -585,6 +585,8 @@ public interface Expression extends FunctionArg {
 
     public abstract List<SortField> sort();
 
+    public abstract WindowBoundsType boundsType();
+
     public abstract WindowBound lowerBound();
 
     public abstract WindowBound upperBound();
@@ -603,6 +605,33 @@ public interface Expression extends FunctionArg {
 
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
       return visitor.visit(this);
+    }
+  }
+
+  enum WindowBoundsType {
+    UNSPECIFIED(io.substrait.proto.Expression.WindowFunction.BoundsType.BOUNDS_TYPE_UNSPECIFIED),
+    ROWS(io.substrait.proto.Expression.WindowFunction.BoundsType.BOUNDS_TYPE_ROWS),
+    RANGE(io.substrait.proto.Expression.WindowFunction.BoundsType.BOUNDS_TYPE_RANGE);
+
+    private final io.substrait.proto.Expression.WindowFunction.BoundsType proto;
+
+    WindowBoundsType(io.substrait.proto.Expression.WindowFunction.BoundsType proto) {
+      this.proto = proto;
+    }
+
+    public io.substrait.proto.Expression.WindowFunction.BoundsType toProto() {
+      return proto;
+    }
+
+    public static WindowBoundsType fromProto(
+        io.substrait.proto.Expression.WindowFunction.BoundsType proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
+          return v;
+        }
+      }
+
+      throw new IllegalArgumentException("Unknown type: " + proto);
     }
   }
 

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -320,6 +320,7 @@ public class ExpressionCreator {
       List<Expression.SortField> sort,
       Expression.AggregationInvocation invocation,
       List<Expression> partitionBy,
+      Expression.WindowBoundsType boundsType,
       WindowBound lowerBound,
       WindowBound upperBound,
       Iterable<? extends FunctionArg> arguments) {
@@ -329,6 +330,7 @@ public class ExpressionCreator {
         .aggregationPhase(phase)
         .sort(sort)
         .partitionBy(partitionBy)
+        .boundsType(boundsType)
         .lowerBound(lowerBound)
         .upperBound(upperBound)
         .invocation(invocation)
@@ -343,6 +345,7 @@ public class ExpressionCreator {
       List<Expression.SortField> sort,
       Expression.AggregationInvocation invocation,
       List<Expression> partitionBy,
+      Expression.WindowBoundsType boundsType,
       WindowBound lowerBound,
       WindowBound upperBound,
       FunctionArg... arguments) {
@@ -353,6 +356,7 @@ public class ExpressionCreator {
         .sort(sort)
         .invocation(invocation)
         .partitionBy(partitionBy)
+        .boundsType(boundsType)
         .lowerBound(lowerBound)
         .upperBound(upperBound)
         .addArguments(arguments)

--- a/core/src/main/java/io/substrait/expression/WindowBound.java
+++ b/core/src/main/java/io/substrait/expression/WindowBound.java
@@ -5,58 +5,62 @@ import org.immutables.value.Value;
 @Value.Enclosing
 public interface WindowBound {
 
-  public BoundedKind boundedKind();
+  interface WindowBoundVisitor<R, E extends Throwable> {
+    R visit(Preceding preceding);
 
-  enum BoundedKind {
-    UNBOUNDED,
-    BOUNDED,
-    CURRENT_ROW
+    R visit(Following following);
+
+    R visit(CurrentRow currentRow);
+
+    R visit(Unbounded unbounded);
   }
 
-  enum Direction {
-    PRECEDING,
-    FOLLOWING
-  }
+  <R, E extends Throwable> R accept(WindowBoundVisitor<R, E> visitor);
 
-  public static CurrentRowWindowBound CURRENT_ROW =
-      ImmutableWindowBound.CurrentRowWindowBound.builder().build();
+  CurrentRow CURRENT_ROW = ImmutableWindowBound.CurrentRow.builder().build();
+  Unbounded UNBOUNDED = ImmutableWindowBound.Unbounded.builder().build();
 
   @Value.Immutable
-  abstract static class UnboundedWindowBound implements WindowBound {
-    @Override
-    public BoundedKind boundedKind() {
-      return BoundedKind.UNBOUNDED;
-    }
-
-    public abstract Direction direction();
-
-    public static ImmutableWindowBound.UnboundedWindowBound.Builder builder() {
-      return ImmutableWindowBound.UnboundedWindowBound.builder();
-    }
-  }
-
-  @Value.Immutable
-  abstract static class BoundedWindowBound implements WindowBound {
-
-    @Override
-    public BoundedKind boundedKind() {
-      return BoundedKind.BOUNDED;
-    }
-
-    public abstract Direction direction();
-
+  abstract class Preceding implements WindowBound {
     public abstract long offset();
 
-    public static ImmutableWindowBound.BoundedWindowBound.Builder builder() {
-      return ImmutableWindowBound.BoundedWindowBound.builder();
+    public static Preceding of(long offset) {
+      return ImmutableWindowBound.Preceding.builder().offset(offset).build();
+    }
+
+    @Override
+    public <R, E extends Throwable> R accept(WindowBoundVisitor<R, E> visitor) {
+      return visitor.visit(this);
     }
   }
 
   @Value.Immutable
-  static class CurrentRowWindowBound implements WindowBound {
+  abstract class Following implements WindowBound {
+    public abstract long offset();
+
+    public static Following of(long offset) {
+      return ImmutableWindowBound.Following.builder().offset(offset).build();
+    }
+
     @Override
-    public BoundedKind boundedKind() {
-      return BoundedKind.CURRENT_ROW;
+    public <R, E extends Throwable> R accept(WindowBoundVisitor<R, E> visitor) {
+      return visitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract class CurrentRow implements WindowBound {
+    @Override
+    public <R, E extends Throwable> R accept(WindowBoundVisitor<R, E> visitor) {
+      return visitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract class Unbounded implements WindowBound {
+    @Override
+    public <R, E extends Throwable> R accept(WindowBoundVisitor<R, E> visitor) {
+      return visitor.visit(this);
     }
   }
 }

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -440,8 +440,8 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
                         .build())
             .collect(java.util.stream.Collectors.toList());
 
-    Expression.WindowFunction.Bound upperBound = expr.upperBound().accept(TO_BOUND_VISITOR);
-    Expression.WindowFunction.Bound lowerBound = expr.lowerBound().accept(TO_BOUND_VISITOR);
+    Expression.WindowFunction.Bound lowerBound = BoundConverter.convert(expr.lowerBound());
+    Expression.WindowFunction.Bound upperBound = BoundConverter.convert(expr.upperBound());
 
     return Expression.newBuilder()
         .setWindowFunction(
@@ -459,10 +459,16 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
         .build();
   }
 
-  private static final ToBoundVisitor TO_BOUND_VISITOR = new ToBoundVisitor();
-
-  static class ToBoundVisitor
+  static class BoundConverter
       implements WindowBound.WindowBoundVisitor<Expression.WindowFunction.Bound, RuntimeException> {
+
+    static Expression.WindowFunction.Bound convert(WindowBound bound) {
+      return bound.accept(TO_BOUND_VISITOR);
+    }
+
+    private static final BoundConverter TO_BOUND_VISITOR = new BoundConverter();
+
+    private BoundConverter() {}
 
     @Override
     public Expression.WindowFunction.Bound visit(WindowBound.Preceding preceding) {

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -453,6 +453,7 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
                 .setInvocation(expr.invocation().toProto())
                 .addAllSorts(sortFields)
                 .addAllPartitions(partitionExprs)
+                .setBoundsType(expr.boundsType().toProto())
                 .setLowerBound(lowerBound)
                 .setUpperBound(upperBound))
         .build();

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -148,6 +148,7 @@ public class ProtoExpressionConverter {
             .aggregationPhase(Expression.AggregationPhase.fromProto(windowFunction.getPhase()))
             .partitionBy(partitionExprs)
             .sort(sortFields)
+            .boundsType(Expression.WindowBoundsType.fromProto(windowFunction.getBoundsType()))
             .lowerBound(lowerBound)
             .upperBound(upperBound)
             .invocation(Expression.AggregationInvocation.fromProto(windowFunction.getInvocation()))

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -138,8 +138,8 @@ public class ProtoExpressionConverter {
                             .build())
                 .collect(java.util.stream.Collectors.toList());
 
-        WindowBound lowerBound = toLowerBound(windowFunction.getLowerBound());
-        WindowBound upperBound = toUpperBound(windowFunction.getUpperBound());
+        WindowBound lowerBound = toWindowBound(windowFunction.getLowerBound());
+        WindowBound upperBound = toWindowBound(windowFunction.getUpperBound());
 
         yield Expression.WindowFunctionInvocation.builder()
             .arguments(args)
@@ -247,35 +247,16 @@ public class ProtoExpressionConverter {
     };
   }
 
-  private WindowBound toLowerBound(io.substrait.proto.Expression.WindowFunction.Bound bound) {
-    return toWindowBound(
-        bound,
-        WindowBound.UnboundedWindowBound.builder()
-            .direction(WindowBound.Direction.PRECEDING)
-            .build());
-  }
-
-  private WindowBound toUpperBound(io.substrait.proto.Expression.WindowFunction.Bound bound) {
-    return toWindowBound(
-        bound,
-        WindowBound.UnboundedWindowBound.builder()
-            .direction(WindowBound.Direction.FOLLOWING)
-            .build());
-  }
-
-  private WindowBound toWindowBound(
-      io.substrait.proto.Expression.WindowFunction.Bound bound, WindowBound defaultBound) {
+  private WindowBound toWindowBound(io.substrait.proto.Expression.WindowFunction.Bound bound) {
     return switch (bound.getKindCase()) {
-      case PRECEDING -> WindowBound.BoundedWindowBound.builder()
-          .direction(WindowBound.Direction.PRECEDING)
-          .offset(bound.getPreceding().getOffset())
-          .build();
-      case FOLLOWING -> WindowBound.BoundedWindowBound.builder()
-          .direction(WindowBound.Direction.FOLLOWING)
-          .offset(bound.getFollowing().getOffset())
-          .build();
+      case PRECEDING -> WindowBound.Preceding.of(bound.getPreceding().getOffset());
+      case FOLLOWING -> WindowBound.Following.of(bound.getFollowing().getOffset());
       case CURRENT_ROW -> WindowBound.CURRENT_ROW;
-      case UNBOUNDED, KIND_NOT_SET -> defaultBound;
+      case UNBOUNDED -> WindowBound.UNBOUNDED;
+      case KIND_NOT_SET ->
+      // per the spec, the lower and upper bounds default to the start or end of the partition
+      // respectively if not set
+      WindowBound.UNBOUNDED;
     };
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -7,6 +7,7 @@ import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.expression.AggregateFunctionConverter;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
+import io.substrait.isthmus.expression.WindowFunctionConverter;
 import io.substrait.relation.AbstractRelVisitor;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.Cross;
@@ -72,6 +73,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
         relBuilder,
         new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory),
         new AggregateFunctionConverter(extensions.aggregateFunctions(), typeFactory),
+        new WindowFunctionConverter(extensions.windowFunctions(), typeFactory),
         TypeConverter.DEFAULT);
   }
 
@@ -80,6 +82,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
       RelBuilder relBuilder,
       ScalarFunctionConverter scalarFunctionConverter,
       AggregateFunctionConverter aggregateFunctionConverter,
+      WindowFunctionConverter windowFunctionConverter,
       TypeConverter typeConverter) {
     this.typeFactory = typeFactory;
     this.typeConverter = typeConverter;
@@ -89,7 +92,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
     this.aggregateFunctionConverter = aggregateFunctionConverter;
     this.expressionRexConverter =
         new ExpressionRexConverter(
-            typeFactory, scalarFunctionConverter, aggregateFunctionConverter, typeConverter);
+            typeFactory, scalarFunctionConverter, windowFunctionConverter, typeConverter);
   }
 
   public static RelNode convert(

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -36,8 +36,7 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
   private final TypeConverter typeConverter;
   private final RexBuilder rexBuilder;
   private final ScalarFunctionConverter scalarFunctionConverter;
-
-  private final AggregateFunctionConverter aggregateFunctionConverter;
+  private final WindowFunctionConverter windowFunctionConverter;
 
   private static final SqlIntervalQualifier YEAR_MONTH_INTERVAL =
       new SqlIntervalQualifier(
@@ -58,13 +57,13 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
   public ExpressionRexConverter(
       RelDataTypeFactory typeFactory,
       ScalarFunctionConverter scalarFunctionConverter,
-      AggregateFunctionConverter aggregateFunctionConverter,
+      WindowFunctionConverter windowFunctionConverter,
       TypeConverter typeConverter) {
     this.typeFactory = typeFactory;
     this.typeConverter = typeConverter;
     this.rexBuilder = new RexBuilder(typeFactory);
     this.scalarFunctionConverter = scalarFunctionConverter;
-    this.aggregateFunctionConverter = aggregateFunctionConverter;
+    this.windowFunctionConverter = windowFunctionConverter;
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -1,8 +1,13 @@
 package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
-import io.substrait.expression.*;
+import io.substrait.expression.AbstractExpressionVisitor;
+import io.substrait.expression.EnumArg;
+import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.SingleOrList;
+import io.substrait.expression.FieldReference;
+import io.substrait.expression.FunctionArg;
+import io.substrait.expression.WindowBound;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.StringTypeVisitor;

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -306,8 +306,13 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
             // per the spec, unbounded on the upper bound means the end of the partition
             .accept(new ToRexWindowBoundVisitor(rexBuilder, RexWindowBounds.UNBOUNDED_FOLLOWING));
 
-    // TODO: Bounds Type
-    boolean rowMode = true;
+    boolean rowMode =
+        switch (expr.boundsType()) {
+          case ROWS -> true;
+          case RANGE -> false;
+          case UNSPECIFIED -> throw new IllegalArgumentException(
+              "bounds type on window function must be specified");
+        };
 
     boolean distinct =
         switch (expr.invocation()) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -99,6 +99,10 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
 
   @Override
   public Expression visitOver(RexOver over) {
+    if (over.ignoreNulls()) {
+      throw new IllegalArgumentException("IGNORE NULLS cannot be expressed in Substrait");
+    }
+
     return windowFunctionConverter
         .convert(over, rexNode -> rexNode.accept(this), this)
         .orElseThrow(() -> new IllegalArgumentException(callConversionFailureMessage(over)));

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
@@ -117,7 +117,7 @@ public class WindowFunctionConverter
       }
       throw new IllegalArgumentException(
           String.format(
-              "substrait only supports integer window offsets. Received: %",
+              "substrait only supports integer window offsets. Received: %s",
               rexWindowBound.getOffset().getKind()));
     }
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
@@ -65,6 +65,9 @@ public class WindowFunctionConverter
             ? Expression.AggregationInvocation.DISTINCT
             : Expression.AggregationInvocation.ALL;
 
+    // Calcite only supports ROW or RANGE mode
+    Expression.WindowBoundsType boundsType =
+        window.isRows() ? Expression.WindowBoundsType.ROWS : Expression.WindowBoundsType.RANGE;
     WindowBound lowerBound = toWindowBound(window.getLowerBound());
     WindowBound upperBound = toWindowBound(window.getUpperBound());
 
@@ -75,6 +78,7 @@ public class WindowFunctionConverter
         sorts,
         invocation,
         partitionExprs,
+        boundsType,
         lowerBound,
         upperBound,
         arguments);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
@@ -66,8 +66,8 @@ public class WindowFunctionConverter
             ? Expression.AggregationInvocation.DISTINCT
             : Expression.AggregationInvocation.ALL;
 
-    WindowBound lowerBound = toWindowBound(window.getLowerBound(), call.rexExpressionConverter);
-    WindowBound upperBound = toWindowBound(window.getUpperBound(), call.rexExpressionConverter);
+    WindowBound lowerBound = toWindowBound(window.getLowerBound());
+    WindowBound upperBound = toWindowBound(window.getUpperBound());
 
     return ExpressionCreator.windowFunction(
         function,
@@ -98,8 +98,7 @@ public class WindowFunctionConverter
     return m.attemptMatch(wrapped, topLevelConverter);
   }
 
-  private WindowBound toWindowBound(
-      RexWindowBound rexWindowBound, RexExpressionConverter rexExpressionConverter) {
+  private WindowBound toWindowBound(RexWindowBound rexWindowBound) {
     if (rexWindowBound.isCurrentRow()) {
       return WindowBound.CURRENT_ROW;
     }

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -156,6 +156,7 @@ public class CustomFunctionTest extends PlanTestBase {
           relBuilder,
           scalarFunctionConverter,
           aggregateFunctionConverter,
+          windowFunctionConverter,
           typeConverter);
     }
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static io.substrait.isthmus.SqlConverterBase.EXTENSION_COLLECTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Charsets;
@@ -156,8 +157,6 @@ public class PlanTestBase {
       // Verify that POJOs are the same
       assertEquals(pojo1, pojo2);
 
-      /*
-      // TODO vbarua: go all the way once window function conversions are allowed
       // Substrait POJO 2 -> Calcite 2
       RelNode calcite2 = new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory).convert(pojo2);
       // It would be ideal to compare calcite1 and calcite2, however there isn't a good mechanism to
@@ -165,11 +164,11 @@ public class PlanTestBase {
       assertNotNull(calcite2);
 
       // Calcite 2 -> Substrait POJO 3
-      io.substrait.relation.Rel pojo3 = SubstraitRelVisitor.convert(calcite1, EXTENSION_COLLECTION);
+      io.substrait.relation.Rel pojo3 =
+          SubstraitRelVisitor.convert(RelRoot.of(calcite2, calcite1.kind), EXTENSION_COLLECTION);
 
       // Verify that POJOs are the same
       assertEquals(pojo1, pojo3);
-      */
     }
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
@@ -1,5 +1,7 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Nested;
@@ -135,5 +137,13 @@ public class WindowFunctionTest extends PlanTestBase {
           String.format(
               "select %s(L_LINENUMBER) over (partition BY L_PARTKEY) from lineitem", aggFunction));
     }
+  }
+
+  @Test
+  void rejectQueriesWithIgnoreNulls() {
+    // IGNORE NULLS cannot be specified in the Substrait representation.
+    // Queries using it should be rejected.
+    var query = "select last_value(L_LINENUMBER) ignore nulls over () from lineitem";
+    assertThrows(IllegalArgumentException.class, () -> assertFullRoundTrip(query));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
@@ -125,6 +125,30 @@ public class WindowFunctionTest extends PlanTestBase {
       assertFullRoundTrip(
           String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
     }
+
+    @Test
+    void rangePrecedingToCurrent() throws IOException, SqlParseException {
+      /*
+      LogicalProject(EXPR$0=[MIN($7) OVER (PARTITION BY $1 ORDER BY $3 RANGE 10 PRECEDING)])
+        LogicalTableScan(table=[[ORDERS]])
+      */
+      var overClause =
+          "partition by O_CUSTKEY order by O_TOTALPRICE range between 10 preceding and current row";
+      assertFullRoundTrip(
+          String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
+    }
+
+    @Test
+    void rangeCurrentToFollowing() throws IOException, SqlParseException {
+      /*
+      LogicalProject(EXPR$0=[MIN($7) OVER (PARTITION BY $1 ORDER BY $3 RANGE BETWEEN CURRENT ROW AND 11 FOLLOWING)])
+        LogicalTableScan(table=[[ORDERS]])
+      */
+      var overClause =
+          "partition by O_CUSTKEY order by O_TOTALPRICE range between current row and 11 following";
+      assertFullRoundTrip(
+          String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
+    }
   }
 
   @Nested


### PR DESCRIPTION
feat: support for window bounds type

BREAKING CHANGE:
* windowFunction expression creator now requires window bound type param
* the WindowBound POJO representation has been reworked to use visitation and more closely match the spec
* ExpressionRexConvert now requires a WindowFunctionConverter
