### PR TITLE
feat(calcite): dedicated Substrait MAX, MIN, SUM, SUM0 and AVG functions

### DIFF
--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -5,6 +5,7 @@ import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.AggregateFunction;
 import io.substrait.relation.Rel;
 import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -642,7 +643,7 @@ public interface Expression extends FunctionArg {
     public abstract List<Expression> options();
 
     public Type getType() {
-      return Type.NULLABLE.BOOLEAN;
+      return TypeCreator.NULLABLE.BOOLEAN;
     }
 
     public static ImmutableExpression.SingleOrList.Builder builder() {
@@ -661,7 +662,7 @@ public interface Expression extends FunctionArg {
     public abstract List<MultiOrListRecord> optionCombinations();
 
     public Type getType() {
-      return Type.NULLABLE.BOOLEAN;
+      return TypeCreator.NULLABLE.BOOLEAN;
     }
 
     public static ImmutableExpression.MultiOrList.Builder builder() {
@@ -702,7 +703,7 @@ public interface Expression extends FunctionArg {
     public abstract Rel tuples();
 
     public Type getType() {
-      return Type.REQUIRED.BOOLEAN;
+      return TypeCreator.REQUIRED.BOOLEAN;
     }
 
     public static ImmutableExpression.SetPredicate.Builder builder() {
@@ -734,7 +735,7 @@ public interface Expression extends FunctionArg {
     public abstract List<Expression> needles();
 
     public Type getType() {
-      return Type.REQUIRED.BOOLEAN;
+      return TypeCreator.REQUIRED.BOOLEAN;
     }
 
     public static ImmutableExpression.InPredicate.Builder builder() {

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -3,32 +3,7 @@ package io.substrait.relation;
 import io.substrait.expression.Expression;
 import io.substrait.proto.JoinRel;
 import io.substrait.type.Type;
-import io.substrait.type.Type.Binary;
-import io.substrait.type.Type.Bool;
-import io.substrait.type.Type.Date;
-import io.substrait.type.Type.Decimal;
-import io.substrait.type.Type.FP32;
-import io.substrait.type.Type.FP64;
-import io.substrait.type.Type.FixedBinary;
-import io.substrait.type.Type.FixedChar;
-import io.substrait.type.Type.I16;
-import io.substrait.type.Type.I32;
-import io.substrait.type.Type.I64;
-import io.substrait.type.Type.I8;
-import io.substrait.type.Type.IntervalDay;
-import io.substrait.type.Type.IntervalYear;
-import io.substrait.type.Type.ListType;
-import io.substrait.type.Type.Map;
-import io.substrait.type.Type.Str;
-import io.substrait.type.Type.Struct;
-import io.substrait.type.Type.Time;
-import io.substrait.type.Type.Timestamp;
-import io.substrait.type.Type.TimestampTZ;
-import io.substrait.type.Type.UUID;
-import io.substrait.type.Type.UserDefined;
-import io.substrait.type.Type.VarChar;
 import io.substrait.type.TypeCreator;
-import io.substrait.type.TypeVisitor;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
@@ -72,142 +47,18 @@ public abstract class Join extends BiRel implements HasExtension {
     }
   }
 
-  private static final class NullableTypeVisitor implements TypeVisitor<Type, RuntimeException> {
-
-    @Override
-    public Type visit(Bool type) throws RuntimeException {
-      return TypeCreator.NULLABLE.BOOLEAN;
-    }
-
-    @Override
-    public Type visit(I8 type) throws RuntimeException {
-      return TypeCreator.NULLABLE.I8;
-    }
-
-    @Override
-    public Type visit(I16 type) throws RuntimeException {
-      return TypeCreator.NULLABLE.I16;
-    }
-
-    @Override
-    public Type visit(I32 type) throws RuntimeException {
-      return TypeCreator.NULLABLE.I32;
-    }
-
-    @Override
-    public Type visit(I64 type) throws RuntimeException {
-      return TypeCreator.NULLABLE.I64;
-    }
-
-    @Override
-    public Type visit(FP32 type) throws RuntimeException {
-      return TypeCreator.NULLABLE.FP32;
-    }
-
-    @Override
-    public Type visit(FP64 type) throws RuntimeException {
-      return TypeCreator.NULLABLE.FP64;
-    }
-
-    @Override
-    public Type visit(Str type) throws RuntimeException {
-      return TypeCreator.NULLABLE.STRING;
-    }
-
-    @Override
-    public Type visit(Binary type) throws RuntimeException {
-      return TypeCreator.NULLABLE.BINARY;
-    }
-
-    @Override
-    public Type visit(Date type) throws RuntimeException {
-      return TypeCreator.NULLABLE.DATE;
-    }
-
-    @Override
-    public Type visit(Time type) throws RuntimeException {
-      return TypeCreator.NULLABLE.TIME;
-    }
-
-    @Override
-    public Type visit(TimestampTZ type) throws RuntimeException {
-      return TypeCreator.NULLABLE.TIMESTAMP_TZ;
-    }
-
-    @Override
-    public Type visit(Timestamp type) throws RuntimeException {
-      return TypeCreator.NULLABLE.TIMESTAMP;
-    }
-
-    @Override
-    public Type visit(IntervalYear type) throws RuntimeException {
-      return TypeCreator.NULLABLE.INTERVAL_YEAR;
-    }
-
-    @Override
-    public Type visit(IntervalDay type) throws RuntimeException {
-      return TypeCreator.NULLABLE.INTERVAL_DAY;
-    }
-
-    @Override
-    public Type visit(UUID type) throws RuntimeException {
-      return TypeCreator.NULLABLE.UUID;
-    }
-
-    @Override
-    public Type visit(FixedChar type) throws RuntimeException {
-      return TypeCreator.NULLABLE.fixedChar(type.length());
-    }
-
-    @Override
-    public Type visit(VarChar type) throws RuntimeException {
-      return TypeCreator.NULLABLE.varChar(type.length());
-    }
-
-    @Override
-    public Type visit(FixedBinary type) throws RuntimeException {
-      return TypeCreator.NULLABLE.fixedBinary(type.length());
-    }
-
-    @Override
-    public Type visit(Decimal type) throws RuntimeException {
-      return TypeCreator.NULLABLE.decimal(type.precision(), type.scale());
-    }
-
-    @Override
-    public Type visit(Struct type) throws RuntimeException {
-      return TypeCreator.NULLABLE.struct(type.fields());
-    }
-
-    @Override
-    public Type visit(ListType type) throws RuntimeException {
-      return TypeCreator.NULLABLE.list(type.elementType());
-    }
-
-    @Override
-    public Type visit(Map type) throws RuntimeException {
-      return TypeCreator.NULLABLE.map(type.key(), type.value());
-    }
-
-    @Override
-    public Type visit(UserDefined type) throws RuntimeException {
-      return TypeCreator.NULLABLE.userDefined(type.uri(), type.name());
-    }
-  }
-
   @Override
   protected Type.Struct deriveRecordType() {
-    var nullable = new NullableTypeVisitor();
     Stream<Type> leftTypes =
         switch (getJoinType()) {
           case RIGHT, OUTER -> getLeft().getRecordType().fields().stream()
-              .map(t -> t.accept(nullable));
+              .map(TypeCreator::asNullable);
           default -> getLeft().getRecordType().fields().stream();
         };
     Stream<Type> rightTypes =
         switch (getJoinType()) {
           case LEFT, OUTER -> getRight().getRecordType().fields().stream()
-              .map(t -> t.accept(nullable));
+              .map(TypeCreator::asNullable);
           default -> getRight().getRecordType().fields().stream();
         };
     return TypeCreator.REQUIRED.struct(Stream.concat(leftTypes, rightTypes));

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -11,9 +11,6 @@ import org.immutables.value.Value;
 public interface Type extends TypeExpression, ParameterizedType, NullableType, FunctionArg {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Type.class);
 
-  public static final TypeCreator REQUIRED = TypeCreator.REQUIRED;
-  public static final TypeCreator NULLABLE = TypeCreator.NULLABLE;
-
   public static TypeCreator withNullability(boolean nullable) {
     return nullable ? TypeCreator.NULLABLE : TypeCreator.REQUIRED;
   }

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -92,4 +92,147 @@ public class TypeCreator {
   public static TypeCreator of(boolean nullability) {
     return nullability ? NULLABLE : REQUIRED;
   }
+
+  public static Type asNullable(Type type) {
+    return type.nullable() ? type : type.accept(NULLABLE_TRUE_VISITOR);
+  }
+
+  public static Type asNotNullable(Type type) {
+    return type.nullable() ? type.accept(NULLABLE_FALSE_VISITOR) : type;
+  }
+
+  private static NullableSettingTypeVisitor NULLABLE_TRUE_VISITOR =
+      new NullableSettingTypeVisitor(true);
+  private static NullableSettingTypeVisitor NULLABLE_FALSE_VISITOR =
+      new NullableSettingTypeVisitor(false);
+
+  private static final class NullableSettingTypeVisitor
+      implements TypeVisitor<Type, RuntimeException> {
+
+    private final boolean nullability;
+
+    NullableSettingTypeVisitor(boolean nullability) {
+      this.nullability = nullability;
+    }
+
+    @Override
+    public Type visit(Type.Bool type) throws RuntimeException {
+      return Type.Bool.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.I8 type) throws RuntimeException {
+      return Type.I8.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.I16 type) throws RuntimeException {
+      return Type.I16.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.I32 type) throws RuntimeException {
+      return Type.I32.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.I64 type) throws RuntimeException {
+      return Type.I64.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.FP32 type) throws RuntimeException {
+      return Type.FP32.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.FP64 type) throws RuntimeException {
+      return Type.FP64.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Str type) throws RuntimeException {
+      return Type.Str.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Binary type) throws RuntimeException {
+      return Type.Binary.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Date type) throws RuntimeException {
+      return Type.Date.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Time type) throws RuntimeException {
+      return Type.Time.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.TimestampTZ type) throws RuntimeException {
+      return Type.TimestampTZ.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Timestamp type) throws RuntimeException {
+      return Type.Timestamp.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.IntervalYear type) throws RuntimeException {
+      return Type.IntervalYear.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.IntervalDay type) throws RuntimeException {
+      return Type.IntervalDay.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.UUID type) throws RuntimeException {
+      return Type.UUID.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.FixedChar type) throws RuntimeException {
+      return Type.FixedChar.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.VarChar type) throws RuntimeException {
+      return Type.VarChar.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.FixedBinary type) throws RuntimeException {
+      return Type.FixedBinary.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Decimal type) throws RuntimeException {
+      return Type.Decimal.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Struct type) throws RuntimeException {
+      return Type.Struct.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.ListType type) throws RuntimeException {
+      return Type.ListType.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.Map type) throws RuntimeException {
+      return Type.Map.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.UserDefined type) throws RuntimeException {
+      return Type.UserDefined.builder().from(type).nullable(nullability).build();
+    }
+  }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -71,6 +71,13 @@ public class AggregateFunctions {
     }
 
     @Override
+    public String getName() {
+      // the default name for this function is `$sum0`
+      // override this to `sum0` which is a nicer name to use in queries
+      return "sum0";
+    }
+
+    @Override
     public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
       return ReturnTypes.BIGINT.inferReturnType(opBinding);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -1,0 +1,78 @@
+package io.substrait.isthmus;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.fun.SqlAvgAggFunction;
+import org.apache.calcite.sql.fun.SqlMinMaxAggFunction;
+import org.apache.calcite.sql.fun.SqlSumAggFunction;
+import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
+import org.apache.calcite.sql.type.ReturnTypes;
+
+public class AggregateFunctions {
+
+  // For some arithmetic aggregate functions, the default Calcite aggregate function implementations
+  // will infer returns types that differ from those expected by Substrait.
+  // This type mismatch can cause conversion and planning failures.
+
+  public static SqlAggFunction MIN = new SubstraitSqlMinMaxAggFunction(SqlKind.MIN);
+  public static SqlAggFunction MAX = new SubstraitSqlMinMaxAggFunction(SqlKind.MAX);
+  public static SqlAggFunction AVG = new SubstraitAvgAggFunction(SqlKind.AVG);
+  public static SqlAggFunction SUM = new SubstraitSumAggFunction();
+  public static SqlAggFunction SUM0 = new SubstraitSumEmptyIsZeroAggFunction();
+
+  /** Extension of {@link SqlMinMaxAggFunction} that ALWAYS infers a nullable return type */
+  private static class SubstraitSqlMinMaxAggFunction extends SqlMinMaxAggFunction {
+    public SubstraitSqlMinMaxAggFunction(SqlKind kind) {
+      super(kind);
+    }
+
+    @Override
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+      return ReturnTypes.ARG0_FORCE_NULLABLE.inferReturnType(opBinding);
+    }
+  }
+
+  /** Extension of {@link SqlSumAggFunction} that ALWAYS infers a nullable return type */
+  private static class SubstraitSumAggFunction extends SqlSumAggFunction {
+    public SubstraitSumAggFunction() {
+      // This is intentionally null
+      // See the instantiation of SqlSumAggFunction in SqlStdOperatorTable
+      super(null);
+    }
+
+    @Override
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+      return ReturnTypes.ARG0_FORCE_NULLABLE.inferReturnType(opBinding);
+    }
+  }
+
+  /** Extension of {@link SqlAvgAggFunction} that ALWAYS infers a nullable return type */
+  private static class SubstraitAvgAggFunction extends SqlAvgAggFunction {
+    public SubstraitAvgAggFunction(SqlKind kind) {
+      super(kind);
+    }
+
+    @Override
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+      return ReturnTypes.ARG0_FORCE_NULLABLE.inferReturnType(opBinding);
+    }
+  }
+
+  /**
+   * Extension of {@link SqlSumEmptyIsZeroAggFunction} that ALWAYS infers a NOT NULL BIGINT return
+   * type
+   */
+  private static class SubstraitSumEmptyIsZeroAggFunction
+      extends org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction {
+    public SubstraitSumEmptyIsZeroAggFunction() {
+      super();
+    }
+
+    @Override
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+      return ReturnTypes.BIGINT.inferReturnType(opBinding);
+    }
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -13,7 +13,7 @@ import org.apache.calcite.sql.type.ReturnTypes;
 public class AggregateFunctions {
 
   // For some arithmetic aggregate functions, the default Calcite aggregate function implementations
-  // will infer returns types that differ from those expected by Substrait.
+  // will infer return types that differ from those expected by Substrait.
   // This type mismatch can cause conversion and planning failures.
 
   public static SqlAggFunction MIN = new SubstraitSqlMinMaxAggFunction(SqlKind.MIN);

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus;
 
 import io.substrait.extension.SimpleExtension;
+import io.substrait.isthmus.calcite.SubstraitOperatorTable;
 import io.substrait.type.NamedStruct;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,7 +32,6 @@ import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.ddl.SqlColumnDeclaration;
 import org.apache.calcite.sql.ddl.SqlCreateTable;
 import org.apache.calcite.sql.ddl.SqlKeyConstraint;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -208,7 +208,7 @@ class SqlConverterBase {
 
     public static Validator create(
         RelDataTypeFactory factory, CalciteCatalogReader catalog, SqlValidator.Config config) {
-      return new Validator(SqlStdOperatorTable.instance(), catalog, factory, config);
+      return new Validator(SubstraitOperatorTable.INSTANCE, catalog, factory, config);
     }
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
@@ -1,0 +1,73 @@
+package io.substrait.isthmus.calcite;
+
+import io.substrait.isthmus.AggregateFunctions;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.util.SqlOperatorTables;
+import org.apache.calcite.sql.validate.SqlNameMatcher;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Overrides SQL operator lookups to return Substrait specific functions variants (e.g. {@link
+ * AggregateFunctions#MAX}} when they are available.
+ */
+public class SubstraitOperatorTable implements SqlOperatorTable {
+
+  public static SubstraitOperatorTable INSTANCE = new SubstraitOperatorTable();
+
+  private static final SqlOperatorTable SUBSTRAIT_OPERATOR_TABLE =
+      SqlOperatorTables.of(
+          List.of(
+              AggregateFunctions.MAX,
+              AggregateFunctions.MIN,
+              AggregateFunctions.AVG,
+              AggregateFunctions.SUM,
+              AggregateFunctions.SUM0));
+
+  // kinds for which Substrait specific operators are provided
+  private static final Set<SqlKind> OVERRIDE_KINDS =
+      Set.of(SqlKind.MAX, SqlKind.MIN, SqlKind.AVG, SqlKind.SUM, SqlKind.SUM0);
+
+  private static final SqlOperatorTable STANDARD_OPERATOR_TABLE = SqlStdOperatorTable.instance();
+
+  private static final List<SqlOperator> OPERATOR_LIST =
+      Stream.concat(
+              SUBSTRAIT_OPERATOR_TABLE.getOperatorList().stream(),
+              // filter out the kinds that have been overriden from the standard operator table
+              STANDARD_OPERATOR_TABLE.getOperatorList().stream()
+                  .filter(op -> !OVERRIDE_KINDS.contains(op.kind)))
+          .collect(Collectors.toUnmodifiableList());
+
+  @Override
+  public void lookupOperatorOverloads(
+      SqlIdentifier opName,
+      @Nullable SqlFunctionCategory category,
+      SqlSyntax syntax,
+      List<SqlOperator> operatorList,
+      SqlNameMatcher nameMatcher) {
+    SUBSTRAIT_OPERATOR_TABLE.lookupOperatorOverloads(
+        opName, category, syntax, operatorList, nameMatcher);
+    if (!operatorList.isEmpty()) {
+      // if a match for a Substrait operator is found, return it immediately
+      // without this, Calcite will find multiple matches for the same operator
+      // it then fails to resolve a specific operator as it can't pick between them
+      return;
+    }
+    STANDARD_OPERATOR_TABLE.lookupOperatorOverloads(
+        opName, category, syntax, operatorList, nameMatcher);
+  }
+
+  @Override
+  public List<SqlOperator> getOperatorList() {
+    return OPERATOR_LIST;
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
+import io.substrait.isthmus.AggregateFunctions;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -69,13 +70,13 @@ public class FunctionMappings {
     AGGREGATE_SIGS =
         ImmutableList.<Sig>builder()
             .add(
-                s(SqlStdOperatorTable.MIN, "min"),
-                s(SqlStdOperatorTable.MAX, "max"),
-                s(SqlStdOperatorTable.SUM, "sum"),
-                s(SqlStdOperatorTable.SUM0, "sum0"),
+                s(AggregateFunctions.MIN, "min"),
+                s(AggregateFunctions.MAX, "max"),
+                s(AggregateFunctions.SUM, "sum"),
+                s(AggregateFunctions.SUM0, "sum0"),
                 s(SqlStdOperatorTable.COUNT, "count"),
                 s(SqlStdOperatorTable.APPROX_COUNT_DISTINCT, "approx_count_distinct"),
-                s(SqlStdOperatorTable.AVG, "avg"))
+                s(AggregateFunctions.AVG, "avg"))
             .build();
 
     WINDOW_SIGS =

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -63,7 +63,7 @@ public class AggregationFunctionsTest extends PlanTestBase {
 
   @ParameterizedTest
   @ValueSource(strings = {"max", "min", "sum", "sum0", "avg"})
-  void maxNoGrouping(String aggFunction) {
+  void emptyGrouping(String aggFunction) {
     var rel =
         b.aggregate(
             input -> b.grouping(input), input -> functions(input, aggFunction), numericTypesTable);
@@ -72,7 +72,7 @@ public class AggregationFunctionsTest extends PlanTestBase {
 
   @ParameterizedTest
   @ValueSource(strings = {"max", "min", "sum", "sum0", "avg"})
-  void maxWithGrouping(String aggFunction) {
+  void withGrouping(String aggFunction) {
     var rel =
         b.aggregate(
             input -> b.grouping(input, 0),

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -1,0 +1,83 @@
+package io.substrait.isthmus;
+
+import com.google.common.collect.Streams;
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.relation.NamedScan;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class AggregationFunctionsTest extends PlanTestBase {
+
+  SubstraitBuilder b = new SubstraitBuilder(extensions);
+
+  static final TypeCreator R = TypeCreator.of(false);
+  static final TypeCreator N = TypeCreator.of(true);
+
+  // Create a table with that has a column of every numeric type, both NOT NULL and NULL
+  private List<Type> numericTypesR = List.of(R.I8, R.I16, R.I32, R.I64, R.FP32, R.FP64);
+  private List<Type> numericTypesN = List.of(N.I8, N.I16, N.I32, N.I64, N.FP32, N.FP64);
+  private List<Type> numericTypes =
+      Stream.concat(numericTypesR.stream(), numericTypesN.stream()).collect(Collectors.toList());
+
+  private List<Type> tableTypes =
+      Stream.concat(
+              // Column to Group By
+              Stream.of(N.I8),
+              // Columns with Numeric Types
+              numericTypes.stream())
+          .collect(Collectors.toList());
+  private List<String> columnNames =
+      Streams.mapWithIndex(tableTypes.stream(), (t, index) -> String.valueOf(index))
+          .collect(Collectors.toList());
+  private NamedScan numericTypesTable = b.namedScan(List.of("example"), columnNames, tableTypes);
+
+  // Create the given function call on the given field of the input
+  private AggregateFunctionInvocation functionPicker(Rel input, int field, String fname) {
+    return switch (fname) {
+      case "min" -> b.min(input, field);
+      case "max" -> b.max(input, field);
+      case "sum" -> b.sum(input, field);
+      case "sum0" -> b.sum0(input, field);
+      case "avg" -> b.avg(input, field);
+      default -> throw new RuntimeException(
+          String.format("no function is associated with %s", fname));
+    };
+  }
+
+  // Create one function call per numeric type column
+  private List<AggregateFunctionInvocation> functions(Rel input, String fname) {
+    // first column is for grouping, skip it
+    return IntStream.range(1, tableTypes.size())
+        .boxed()
+        .map(index -> functionPicker(input, index, fname))
+        .collect(Collectors.toList());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"max", "min", "sum", "sum0", "avg"})
+  void maxNoGrouping(String aggFunction) {
+    var rel =
+        b.aggregate(
+            input -> b.grouping(input), input -> functions(input, aggFunction), numericTypesTable);
+    assertFullRoundTrip(rel);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"max", "min", "sum", "sum0", "avg"})
+  void maxWithGrouping(String aggFunction) {
+    var rel =
+        b.aggregate(
+            input -> b.grouping(input, 0),
+            input -> functions(input, aggFunction),
+            numericTypesTable);
+    assertFullRoundTrip(rel);
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
@@ -16,62 +16,97 @@ public class ArithmeticFunctionTest extends PlanTestBase {
     String query =
         String.format(
             "SELECT %s + %s, %s - %s, %s * %s, %s / %s FROM numbers", c, c, c, c, c, c, c, c);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
   void abs(String column) throws Exception {
     String query = String.format("SELECT abs(%s) FROM numbers", column);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"fp32", "fp64"})
   void exponential(String column) throws Exception {
     String query = String.format("SELECT exp(%s) FROM numbers", column);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"i8", "i16", "i32", "i64"})
   void mod(String column) throws Exception {
     String query = String.format("SELECT mod(%s, %s) FROM numbers", column, column);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
   void negation(String column) throws Exception {
     String query = String.format("SELECT -%s FROM numbers", column);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"i64", "fp32", "fp64"})
   void power(String column) throws Exception {
     String query = String.format("SELECT power(%s, %s) FROM numbers", column, column);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"sin", "cos", "tan", "asin", "acos", "atan"})
   void trigonometric(String fname) throws Exception {
     String query = String.format("SELECT %s(fp32), %s(fp64) FROM numbers", fname, fname);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"fp32", "fp64"})
   void atan2(String column) throws Exception {
     String query = String.format("SELECT atan2(%s, %s) FROM numbers", column, column);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
   void sign(String column) throws Exception {
     String query = String.format("SELECT sign(%s) FROM numbers", column);
-    assertSqlSubstraitRelRoundTrip(query, CREATES);
+    assertFullRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
+  void max(String column) throws Exception {
+    String query = String.format("SELECT max(%s) FROM numbers", column);
+    assertFullRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
+  void min(String column) throws Exception {
+    String query = String.format("SELECT min(%s) FROM numbers", column);
+    assertFullRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
+  void avg(String column) throws Exception {
+    String query = String.format("SELECT avg(%s) FROM numbers", column);
+    assertFullRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
+  void sum(String column) throws Exception {
+    String query = String.format("SELECT sum(%s) FROM numbers", column);
+    assertFullRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"i8", "i16", "i32", "i64", "fp32", "fp64"})
+  void sum0(String column) throws Exception {
+    String query = String.format("SELECT sum0(%s) FROM numbers", column);
+    assertFullRoundTrip(query, CREATES);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
@@ -12,7 +12,7 @@ import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
-import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
 import java.io.IOException;
 import java.util.function.Consumer;
 import org.apache.calcite.avatica.util.TimeUnitRange;
@@ -65,7 +65,7 @@ public class CalciteCallTest extends CalciteObjs {
         func -> {
           // check that there is a cast for the incorrect argument type.
           assertEquals(
-              ExpressionCreator.cast(Type.REQUIRED.I64, ExpressionCreator.i32(false, 20)),
+              ExpressionCreator.cast(TypeCreator.REQUIRED.I64, ExpressionCreator.i32(false, 20)),
               func.arguments().get(0));
         },
         false); // TODO: implicit calcite cast

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -10,7 +10,7 @@ import io.substrait.expression.Expression;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
-import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
 import io.substrait.util.DecimalUtil;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -43,7 +43,9 @@ public class CalciteLiteralTest extends CalciteObjs {
 
   @Test
   void nullLiteral() {
-    bitest(typedNull(Type.NULLABLE.varChar(10)), rex.makeNullLiteral(tN(SqlTypeName.VARCHAR, 10)));
+    bitest(
+        typedNull(TypeCreator.NULLABLE.varChar(10)),
+        rex.makeNullLiteral(tN(SqlTypeName.VARCHAR, 10)));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.substrait.function.TypeExpression;
 import io.substrait.isthmus.utils.UserTypeFactory;
 import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -145,7 +146,7 @@ class CalciteTypeTest extends CalciteObjs {
   @ValueSource(booleans = {true, false})
   void list(boolean nullable) {
     testType(
-        Type.withNullability(nullable).list(Type.REQUIRED.I16),
+        Type.withNullability(nullable).list(TypeCreator.REQUIRED.I16),
         type.createArrayType(type.createSqlType(SqlTypeName.SMALLINT), -1),
         nullable);
   }
@@ -154,7 +155,7 @@ class CalciteTypeTest extends CalciteObjs {
   @ValueSource(booleans = {true, false})
   void map(boolean nullable) {
     testType(
-        Type.withNullability(nullable).map(Type.REQUIRED.STRING, Type.REQUIRED.I8),
+        Type.withNullability(nullable).map(TypeCreator.REQUIRED.STRING, TypeCreator.REQUIRED.I8),
         type.createMapType(
             type.createSqlType(SqlTypeName.VARCHAR), type.createSqlType(SqlTypeName.TINYINT)),
         nullable);
@@ -163,7 +164,7 @@ class CalciteTypeTest extends CalciteObjs {
   @Test
   void struct() {
     testType(
-        Type.REQUIRED.struct(Type.REQUIRED.STRING, Type.REQUIRED.I8),
+        TypeCreator.REQUIRED.struct(TypeCreator.REQUIRED.STRING, TypeCreator.REQUIRED.I8),
         type.createStructType(
             Arrays.asList(
                 type.createSqlType(SqlTypeName.VARCHAR), type.createSqlType(SqlTypeName.TINYINT)),
@@ -174,10 +175,10 @@ class CalciteTypeTest extends CalciteObjs {
   @Test
   void nestedStruct() {
     testType(
-        Type.REQUIRED.struct(
-            Type.REQUIRED.struct(Type.REQUIRED.STRING, Type.REQUIRED.I8),
-            Type.REQUIRED.struct(Type.REQUIRED.STRING, Type.REQUIRED.I8),
-            Type.REQUIRED.STRING),
+        TypeCreator.REQUIRED.struct(
+            TypeCreator.REQUIRED.struct(TypeCreator.REQUIRED.STRING, TypeCreator.REQUIRED.I8),
+            TypeCreator.REQUIRED.struct(TypeCreator.REQUIRED.STRING, TypeCreator.REQUIRED.I8),
+            TypeCreator.REQUIRED.STRING),
         type.createStructType(
             Arrays.asList(
                 type.createStructType(


### PR DESCRIPTION
fix(calcite): address type inference mismatch in arithmetic aggregate functions

feat: util methods on TypeCreator for setting type nullability
feat: builder utils for arithmetic aggregate functions
feat(calcite): support sum0 sql function
test: static fields in Type interface caused NPEs in tests 

BREAKING CHANGE: Isthmus no longer uses Calcite built-in MAX, MIN, SUM, SUM0 and AVG functions
BREAKING CHANGE: removed REQUIRED and NULLABLE fields from Type interface