### PR TITLE
build: use antlr4-runtime instead of antlr

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -80,7 +80,7 @@ dependencies {
 
   antlr("org.antlr:antlr4:4.9.2")
   implementation("org.slf4j:slf4j-jdk14:1.7.30")
-  implementation("org.antlr:antlr4:4.9.2")
+  implementation("org.antlr:antlr4-runtime:4.9.2")
   annotationProcessor("org.immutables:value:2.8.8")
   compileOnly("org.immutables:value-annotations:2.8.8")
   annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")


### PR DESCRIPTION
To avoid introducing unnecessary indirect dependencies. Resolve issue #162