### PR TITLE
fix: map switch expression to a Calcite CASE statement

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -46,6 +46,7 @@ public class SubstraitBuilder {
 
   private static final String FUNCTIONS_AGGREGATE_GENERIC = "/functions_aggregate_generic.yaml";
   private static final String FUNCTIONS_ARITHMETIC = "/functions_arithmetic.yaml";
+  private static final String FUNCTIONS_BOOLEAN = "/functions_boolean.yaml";
   private static final String FUNCTIONS_COMPARISON = "/functions_comparison.yaml";
 
   private final SimpleExtension.ExtensionCollection extensions;
@@ -459,6 +460,14 @@ public class SubstraitBuilder {
 
   public Expression.ScalarFunctionInvocation equal(Expression left, Expression right) {
     return scalarFn(FUNCTIONS_COMPARISON, "equal:any_any", R.BOOLEAN, left, right);
+  }
+
+  public Expression.ScalarFunctionInvocation or(Expression... args) {
+    // If any arg is nullable, the output of or is potentially nullable
+    // For example: false or null = null
+    var isOutputNullable = Arrays.stream(args).anyMatch(a -> a.getType().nullable());
+    var outputType = isOutputNullable ? N.BOOLEAN : R.BOOLEAN;
+    return scalarFn(FUNCTIONS_BOOLEAN, "or:bool", outputType, args);
   }
 
   public Expression.ScalarFunctionInvocation scalarFn(

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -4,9 +4,13 @@ import com.github.bsideup.jabel.Desugar;
 import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.FailureBehavior;
+import io.substrait.expression.Expression.IfClause;
+import io.substrait.expression.Expression.IfThen;
+import io.substrait.expression.Expression.SwitchClause;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.ImmutableExpression.Cast;
 import io.substrait.expression.ImmutableExpression.SingleOrList;
+import io.substrait.expression.ImmutableExpression.Switch;
 import io.substrait.expression.ImmutableFieldReference;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.function.ToTypeString;
@@ -301,6 +305,14 @@ public class SubstraitBuilder {
     return Expression.I32Literal.builder().value(v).build();
   }
 
+  public Expression cast(Expression input, Type type) {
+    return Cast.builder()
+        .input(input)
+        .type(type)
+        .failureBehavior(FailureBehavior.UNSPECIFIED)
+        .build();
+  }
+
   public FieldReference fieldReference(Rel input, int index) {
     return ImmutableFieldReference.newInputRelReference(index, input);
   }
@@ -321,12 +333,16 @@ public class SubstraitBuilder {
         .collect(java.util.stream.Collectors.toList());
   }
 
-  public Expression cast(Expression input, Type type) {
-    return Cast.builder()
-        .input(input)
-        .type(type)
-        .failureBehavior(FailureBehavior.UNSPECIFIED)
-        .build();
+  public IfThen ifThen(Iterable<? extends IfClause> ifClauses, Expression elseClause) {
+    return IfThen.builder().addAllIfClauses(ifClauses).elseClause(elseClause).build();
+  }
+
+  public IfClause ifClause(Expression condition, Expression then) {
+    return IfClause.builder().condition(condition).then(then).build();
+  }
+
+  public Expression singleOrList(Expression condition, Expression... options) {
+    return SingleOrList.builder().condition(condition).addOptions(options).build();
   }
 
   public List<Expression.SortField> sortFields(Rel input, int... indexes) {
@@ -340,8 +356,17 @@ public class SubstraitBuilder {
         .collect(java.util.stream.Collectors.toList());
   }
 
-  public Expression singleOrList(Expression condition, Expression... options) {
-    return SingleOrList.builder().condition(condition).addOptions(options).build();
+  public SwitchClause switchClause(Expression.Literal condition, Expression then) {
+    return SwitchClause.builder().condition(condition).then(then).build();
+  }
+
+  public Switch switchExpression(
+      Expression match, Iterable<? extends SwitchClause> clauses, Expression defaultClause) {
+    return Switch.builder()
+        .match(match)
+        .addAllSwitchClauses(clauses)
+        .defaultClause(defaultClause)
+        .build();
   }
 
   // Aggregate Functions

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -469,6 +469,8 @@ public interface Expression extends FunctionArg {
 
   @Value.Immutable
   abstract static class Switch implements Expression {
+    public abstract Expression match();
+
     public abstract List<SwitchClause> switchClauses();
 
     public abstract Expression defaultClause();

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -210,16 +210,20 @@ public class ExpressionCreator {
   }
 
   public static Expression.Switch switchStatement(
-      Expression defaultExpression, Expression.SwitchClause... conditionClauses) {
+      Expression match, Expression defaultExpression, Expression.SwitchClause... conditionClauses) {
     return Expression.Switch.builder()
+        .match(match)
         .defaultClause(defaultExpression)
         .addSwitchClauses(conditionClauses)
         .build();
   }
 
   public static Expression.Switch switchStatement(
-      Expression defaultExpression, Iterable<? extends Expression.SwitchClause> conditionClauses) {
+      Expression match,
+      Expression defaultExpression,
+      Iterable<? extends Expression.SwitchClause> conditionClauses) {
     return Expression.Switch.builder()
+        .match(match)
         .defaultClause(defaultExpression)
         .addAllSwitchClauses(conditionClauses)
         .build();

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -237,6 +237,7 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
     return Expression.newBuilder()
         .setSwitchExpression(
             Expression.SwitchExpression.newBuilder()
+                .setMatch(expr.match().accept(this))
                 .addAllIfs(clauses)
                 .setElse(expr.defaultClause().accept(this)))
         .build();

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
  * Converts from {@link io.substrait.proto.Expression} to {@link io.substrait.expression.Expression}
  */
 public class ProtoExpressionConverter {
+
   static final org.slf4j.Logger logger =
       org.slf4j.LoggerFactory.getLogger(ProtoExpressionConverter.class);
 
@@ -168,7 +169,8 @@ public class ProtoExpressionConverter {
             switchExpr.getIfsList().stream()
                 .map(t -> ExpressionCreator.switchClause(from(t.getIf()), from(t.getThen())))
                 .collect(java.util.stream.Collectors.toList());
-        yield ExpressionCreator.switchStatement(from(switchExpr.getElse()), clauses);
+        yield ExpressionCreator.switchStatement(
+            from(switchExpr.getMatch()), from(switchExpr.getElse()), clauses);
       }
       case SINGULAR_OR_LIST -> {
         var orList = expr.getSingularOrList();

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -220,6 +220,7 @@ public class RelCopyOnWriteVisitor extends AbstractRelVisitor<Optional<Rel>, Run
 
           @Override
           public Optional<Expression> visit(Expression.Switch expr) throws RuntimeException {
+            var matchExpr = expr.match().accept(this);
             var defaultClause = expr.defaultClause().accept(this);
             var switchClauses =
                 transformList(
@@ -234,6 +235,7 @@ public class RelCopyOnWriteVisitor extends AbstractRelVisitor<Optional<Rel>, Run
             return Optional.of(
                 Expression.Switch.builder()
                     .from(expr)
+                    .match(matchExpr.orElse(expr.match()))
                     .defaultClause(defaultClause.orElse(expr.defaultClause()))
                     .switchClauses(switchClauses.orElse(expr.switchClauses()))
                     .build());

--- a/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
@@ -88,8 +88,8 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
             new RexExpressionConverter(
                 CASE, new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory)));
 
-      // cannot roundtrip test switchExpression because Calcite simplifies the representation
-      assertExpressionEquality(
+    // cannot roundtrip test switchExpression because Calcite simplifies the representation
+    assertExpressionEquality(
         b.ifThen(
             List.of(
                 b.ifClause(b.equal(b.fieldReference(commonTable, 0), b.i32(5)), b.i32(1)),

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -1,0 +1,50 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.isthmus.expression.ExpressionRexConverter;
+import io.substrait.isthmus.expression.ScalarFunctionConverter;
+import io.substrait.isthmus.expression.WindowFunctionConverter;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.List;
+import org.apache.calcite.rel.type.RelDataType;
+import org.junit.jupiter.api.Test;
+
+public class SubstraitExpressionConverterTest extends PlanTestBase {
+
+  static final TypeCreator R = TypeCreator.of(false);
+  static final TypeCreator N = TypeCreator.of(true);
+
+  final SubstraitBuilder b = new SubstraitBuilder(extensions);
+
+  final ExpressionRexConverter converter =
+      new ExpressionRexConverter(
+          typeFactory,
+          new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory),
+          new WindowFunctionConverter(extensions.windowFunctions(), typeFactory),
+          TypeConverter.DEFAULT);
+
+  final List<Type> commonTableType = List.of(R.I32, R.FP32, N.STRING, N.BOOLEAN);
+  final Rel commonTable =
+      b.namedScan(List.of("example"), List.of("a", "b", "c", "d"), commonTableType);
+
+  @Test
+  public void switchExpression() {
+    var expr =
+        b.switchExpression(
+            b.fieldReference(commonTable, 0),
+            List.of(b.switchClause(b.i32(0), b.fieldReference(commonTable, 3))),
+            b.bool(false));
+    var calciteExpr = expr.accept(converter);
+
+    assertTypeMatch(calciteExpr.getType(), N.BOOLEAN);
+  }
+
+  void assertTypeMatch(RelDataType actual, Type expected) {
+    Type type = TypeConverter.DEFAULT.toSubstrait(actual);
+    assertEquals(expected, type);
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -285,24 +285,4 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
     }
   }
-
-  @Nested
-  class Switch {
-    @Test
-    public void simple() {
-      Plan.Root root =
-          b.root(
-              b.project(
-                  input ->
-                      List.of(
-                          b.switchExpression(
-                              b.fieldReference(input, 0),
-                              List.of(b.switchClause(b.i32(0), b.fieldReference(input, 3))),
-                              b.bool(false))),
-                  b.remap(4),
-                  commonTable));
-      var relNode = converter.convert(root.getInput());
-      assertRowMatch(relNode.getRowType(), N.BOOLEAN);
-    }
-  }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -285,4 +285,24 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
     }
   }
+
+  @Nested
+  class Switch {
+    @Test
+    public void simple() {
+      Plan.Root root =
+          b.root(
+              b.project(
+                  input ->
+                      List.of(
+                          b.switchExpression(
+                              b.fieldReference(input, 0),
+                              List.of(b.switchClause(b.i32(0), b.fieldReference(input, 3))),
+                              b.bool(false))),
+                  b.remap(4),
+                  commonTable));
+      var relNode = converter.convert(root.getInput());
+      assertRowMatch(relNode.getRowType(), N.BOOLEAN);
+    }
+  }
 }


### PR DESCRIPTION
The switch expression POJO in substrait-java doesn't contain the match expression, so I've updated the definition to include that.

To map into Calcite, I construct a CASE statement. This ends up being translated into an IfThen expression when round-tripping Substrait into Calcite.