### PR TITLE
Added support for char_length

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -60,6 +60,7 @@ public class FunctionMappings {
                 s(SqlStdOperatorTable.LIKE),
                 s(SqlStdOperatorTable.SUBSTRING, "substring"),
                 s(SqlStdOperatorTable.CONCAT, "concat"),
+                s(SqlStdOperatorTable.CHAR_LENGTH, "char_length"),
                 s(SqlStdOperatorTable.LOWER, "lower"),
                 s(SqlStdOperatorTable.UPPER, "upper"),
                 s(SqlStdOperatorTable.BETWEEN),

--- a/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
@@ -10,7 +10,7 @@ public class StringFunctionTest extends PlanTestBase {
 
   @ParameterizedTest
   @ValueSource(strings = {"c16", "vc32"})
-  void char_length(String column) throws Exception {
+  void charLength(String column) throws Exception {
     String query = String.format("SELECT char_length(%s) FROM strings", column);
     assertSqlSubstraitRelRoundTrip(query, CREATES);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
@@ -1,0 +1,66 @@
+package io.substrait.isthmus;
+
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class StringFunctionTest extends PlanTestBase {
+
+  static List<String> CREATES = List.of("CREATE TABLE strings (c16 CHAR(16), vc32 VARCHAR(32))");
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void char_length(String column) throws Exception {
+    String query = String.format("SELECT char_length(%s) FROM strings", column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"vc32"})
+  void concat(String column) throws Exception {
+    String query = String.format("SELECT %s || %s FROM strings", column, column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void lower(String column) throws Exception {
+    String query = String.format("SELECT lower(%s) FROM strings", column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void upper(String column) throws Exception {
+    String query = String.format("SELECT upper(%s) FROM strings", column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void substringWith1Param(String column) throws Exception {
+    String query = String.format("SELECT substring(%s, 42) FROM strings", column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void substringWith2Params(String column) throws Exception {
+    String query = String.format("SELECT substring(%s, 42, 5) FROM strings", column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void substringFrom(String column) throws Exception {
+    String query = String.format("SELECT substring(%s FROM 42) FROM strings", column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void substringFromFor(String column) throws Exception {
+    String query = String.format("SELECT substring(%s FROM 42 FOR 5) FROM strings", column);
+    assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+}


### PR DESCRIPTION
This PR adds a string-related scalar function mapping in `FunctionMappings` to support generating plans for queries that use the [`char_length`](https://www.postgresql.org/docs/current/functions-string.html#id-1.5.8.10.5.2.2.6.1.1.1) function.
It also introduces very basic unit tests for string-related functions, including the newly supported `char_length` one.