### PR TITLE
feat(isthmus): improved Calcite support for Substrait Aggregate rels 

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -389,6 +389,11 @@ public class SubstraitBuilder {
         .collect(java.util.stream.Collectors.toList());
   }
 
+  public Expression.SortField sortField(
+      Expression expression, Expression.SortDirection sortDirection) {
+    return Expression.SortField.builder().expr(expression).direction(sortDirection).build();
+  }
+
   public SwitchClause switchClause(Expression.Literal condition, Expression then) {
     return SwitchClause.builder().condition(condition).then(then).build();
   }

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -530,6 +530,48 @@ public class SubstraitBuilder {
 
   // Scalar Functions
 
+  public Expression.ScalarFunctionInvocation negate(Expression expr) {
+    // output type of negate is the same as the input type
+    var outputType = expr.getType();
+    return scalarFn(
+        FUNCTIONS_ARITHMETIC,
+        String.format("negate:%s", ToTypeString.apply(outputType)),
+        outputType,
+        expr);
+  }
+
+  public Expression.ScalarFunctionInvocation add(Expression left, Expression right) {
+    return arithmeticFunction("add", left, right);
+  }
+
+  public Expression.ScalarFunctionInvocation subtract(Expression left, Expression right) {
+    return arithmeticFunction("substract", left, right);
+  }
+
+  public Expression.ScalarFunctionInvocation multiply(Expression left, Expression right) {
+    return arithmeticFunction("multiply", left, right);
+  }
+
+  public Expression.ScalarFunctionInvocation divide(Expression left, Expression right) {
+    return arithmeticFunction("divide", left, right);
+  }
+
+  private Expression.ScalarFunctionInvocation arithmeticFunction(
+      String fname, Expression left, Expression right) {
+    var leftTypeStr = ToTypeString.apply(left.getType());
+    var rightTypeStr = ToTypeString.apply(right.getType());
+    var key = String.format("%s:%s_%s", fname, leftTypeStr, rightTypeStr);
+
+    var isOutputNullable = left.getType().nullable() || right.getType().nullable();
+    var outputType = left.getType();
+    outputType =
+        isOutputNullable
+            ? TypeCreator.asNullable(outputType)
+            : TypeCreator.asNotNullable(outputType);
+
+    return scalarFn(FUNCTIONS_ARITHMETIC, key, outputType, left, right);
+  }
+
   public Expression.ScalarFunctionInvocation equal(Expression left, Expression right) {
     return scalarFn(
         DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "equal:any_any", R.BOOLEAN, left, right);

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -437,49 +437,76 @@ public class SubstraitBuilder {
   }
 
   public AggregateFunctionInvocation min(Rel input, int field) {
-    Type inputType = input.getRecordType().fields().get(field);
-    // min output is always nullable
+    return min(fieldReference(input, field));
+  }
+
+  public AggregateFunctionInvocation min(Expression expr) {
     return singleArgumentArithmeticAggregate(
-        input, field, "min", TypeCreator.asNullable(inputType));
+        expr,
+        "min",
+        // min output is always nullable
+        TypeCreator.asNullable(expr.getType()));
   }
 
   public AggregateFunctionInvocation max(Rel input, int field) {
-    Type inputType = input.getRecordType().fields().get(field);
-    // max output is always nullable
+    return max(fieldReference(input, field));
+  }
+
+  public AggregateFunctionInvocation max(Expression expr) {
+
     return singleArgumentArithmeticAggregate(
-        input, field, "max", TypeCreator.asNullable(inputType));
+        expr,
+        "max",
+        // max output is always nullable
+        TypeCreator.asNullable(expr.getType()));
   }
 
   public AggregateFunctionInvocation avg(Rel input, int field) {
-    Type inputType = input.getRecordType().fields().get(field);
-    // avg output is always nullable
+    return avg(fieldReference(input, field));
+  }
+
+  public AggregateFunctionInvocation avg(Expression expr) {
     return singleArgumentArithmeticAggregate(
-        input, field, "avg", TypeCreator.asNullable(inputType));
+        expr,
+        "avg",
+        // avg output is always nullable
+        TypeCreator.asNullable(expr.getType()));
   }
 
   public AggregateFunctionInvocation sum(Rel input, int field) {
-    Type inputType = input.getRecordType().fields().get(field);
-    // sum output is always nullable
+    return sum(fieldReference(input, field));
+  }
+
+  public AggregateFunctionInvocation sum(Expression expr) {
     return singleArgumentArithmeticAggregate(
-        input, field, "sum", TypeCreator.asNullable(inputType));
+        expr,
+        "sum",
+        // sum output is always nullable
+        TypeCreator.asNullable(expr.getType()));
   }
 
   public AggregateFunctionInvocation sum0(Rel input, int field) {
-    // sum0 output is always NOT NULL I64
-    return singleArgumentArithmeticAggregate(input, field, "sum0", R.I64);
+    return sum(fieldReference(input, field));
+  }
+
+  public AggregateFunctionInvocation sum0(Expression expr) {
+    return singleArgumentArithmeticAggregate(
+        expr,
+        "sum0",
+        // sum0 output is always NOT NULL I64
+        R.I64);
   }
 
   private AggregateFunctionInvocation singleArgumentArithmeticAggregate(
-      Rel input, int field, String functionName, Type outputType) {
-    Type inputType = input.getRecordType().fields().get(field);
-    String typeString = inputType.accept(ToTypeString.INSTANCE);
+      Expression expr, String functionName, Type outputType) {
+    String typeString = ToTypeString.apply(expr.getType());
     var declaration =
         extensions.getAggregateFunction(
             SimpleExtension.FunctionAnchor.of(
                 DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
                 String.format("%s:%s", functionName, typeString)));
     return AggregateFunctionInvocation.builder()
-        .arguments(fieldReferences(input, field))
+        .arguments(Arrays.asList(expr))
         .outputType(outputType)
         .declaration(declaration)
         // INITIAL_TO_RESULT is the most restrictive aggregation phase type,

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -427,6 +427,12 @@ public class SubstraitBuilder {
     return Aggregate.Grouping.builder().addAllExpressions(columns).build();
   }
 
+  public Aggregate.Grouping grouping(Expression... expressions) {
+    List<Expression> exprs =
+        Arrays.stream(expressions).collect(java.util.stream.Collectors.toList());
+    return Aggregate.Grouping.builder().addAllExpressions(exprs).build();
+  }
+
   public AggregateFunctionInvocation count(Rel input, int field) {
     var declaration =
         extensions.getAggregateFunction(

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -433,9 +433,7 @@ public class SubstraitBuilder {
   }
 
   public Aggregate.Grouping grouping(Expression... expressions) {
-    List<Expression> exprs =
-        Arrays.stream(expressions).collect(java.util.stream.Collectors.toList());
-    return Aggregate.Grouping.builder().addAllExpressions(exprs).build();
+    return Aggregate.Grouping.builder().addExpressions(expressions).build();
   }
 
   public Aggregate.Measure count(Rel input, int field) {

--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -5,7 +5,11 @@ import io.substrait.type.Type;
 public class ToTypeString
     extends ParameterizedTypeVisitor.ParameterizedTypeThrowsVisitor<String, RuntimeException> {
 
-  public static ToTypeString INSTANCE = new ToTypeString();
+  public static final ToTypeString INSTANCE = new ToTypeString();
+
+  public static String apply(Type type) {
+    return type.accept(INSTANCE);
+  }
 
   private ToTypeString() {
     super("Only type literals and parameterized types can be used in functions.");

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateValidator.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateValidator.java
@@ -1,0 +1,224 @@
+package io.substrait.isthmus;
+
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FieldReference;
+import io.substrait.expression.FunctionArg;
+import io.substrait.expression.ImmutableExpression;
+import io.substrait.expression.ImmutableFieldReference;
+import io.substrait.relation.Aggregate;
+import io.substrait.relation.Project;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Not all Substrait {@link Aggregate} rels are convertable to {@link
+ * org.apache.calcite.rel.core.Aggregate} rels
+ *
+ * <p>The code in this class can:
+ *
+ * <ul>
+ *   <li>Check for these cases
+ *   <li>Rewrite the Substrait {@link Aggregate} such that it can be converted to Calcite
+ * </ul>
+ */
+public class AggregateValidator {
+
+  /**
+   * Checks that the given {@link Aggregate} is valid for use in Calcite
+   *
+   * @param aggregate
+   * @return
+   */
+  public static boolean isValidCalciteAggregate(Aggregate aggregate) {
+    return aggregate.getMeasures().stream().allMatch(AggregateValidator::isValidCalciteMeasure)
+        && aggregate.getGroupings().stream().allMatch(AggregateValidator::isValidCalciteGrouping);
+  }
+
+  /**
+   * Checks that all expressions present in the given {@link Aggregate.Measure} are {@link
+   * FieldReference}s, as Calcite expects all expressions in {@link
+   * org.apache.calcite.rel.core.Aggregate}s to be field references.
+   *
+   * @return true if the {@code measure} can be converted to a Calcite equivalent without changes,
+   *     false otherwise.
+   */
+  private static boolean isValidCalciteMeasure(Aggregate.Measure measure) {
+    return
+    // all function arguments to measures must be field references
+    measure.getFunction().arguments().stream().allMatch(farg -> isSimpleFieldReference(farg))
+        &&
+        // all sort fields must be field references
+        measure.getFunction().sort().stream().allMatch(sf -> isSimpleFieldReference(sf.expr()))
+        &&
+        // pre-measure filter must be a field reference
+        measure.getPreMeasureFilter().map(f -> isSimpleFieldReference(f)).orElse(true);
+  }
+
+  /**
+   * Checks that all expressions present in the given {@link Aggregate.Grouping} are {@link
+   * FieldReference}s, as Calcite expects all expressions in {@link
+   * org.apache.calcite.rel.core.Aggregate}s to be field references.
+   *
+   * <p>Additionally, checks that all grouping fields are specified in ascending order.
+   *
+   * @return true if the {@code grouping} can be converted to a Calcite equivalent without changes,
+   *     false otherwise.
+   */
+  private static boolean isValidCalciteGrouping(Aggregate.Grouping grouping) {
+    if (!grouping.getExpressions().stream().allMatch(e -> isSimpleFieldReference(e))) {
+      // all grouping expressions must be field references
+      return false;
+    }
+
+    // Calcite stores grouping fields in an ImmutableBitSet and does not track the order of the
+    // grouping fields. The output record shape that Calcite generates ALWAYS has the groupings in
+    // ascending field order. This causes issues with Substrait in cases where the grouping fields
+    // in Substrait are not defined in ascending order.
+
+    // For example, if a grouping is defined as (0, 2, 1) in Substrait, Calcite will output it as
+    // (0, 1, 2), which means that the Calcite output will no longer line up with the expectations
+    // of the Substrait plan.
+    List<Integer> groupingFields =
+        grouping.getExpressions().stream()
+            // isSimpleFieldReference above guarantees that the expr is a FieldReference
+            .map(expr -> getFieldRefOffset((FieldReference) expr))
+            .collect(Collectors.toList());
+
+    return isOrdered(groupingFields);
+  }
+
+  private static boolean isSimpleFieldReference(FunctionArg e) {
+    return e instanceof FieldReference fr
+        && fr.segments().size() == 1
+        && fr.segments().get(0) instanceof FieldReference.StructField;
+  }
+
+  private static int getFieldRefOffset(FieldReference fr) {
+    return ((FieldReference.StructField) fr.segments().get(0)).offset();
+  }
+
+  private static boolean isOrdered(List<Integer> list) {
+    for (int i = 1; i < list.size(); i++) {
+      if (list.get(i - 1) > list.get(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static class AggregateTransformer {
+
+    // New expressions to include in the project before the aggregate
+    final List<Expression> newExpressions;
+
+    // Tracks the offset of the next expression added
+    int expressionOffset;
+
+    private AggregateTransformer(Aggregate aggregate) {
+      this.newExpressions = new ArrayList<>();
+      // The Substrait project output includes all input fields, followed by expressions
+      this.expressionOffset = aggregate.getInput().getRecordType().fields().size();
+    }
+
+    /**
+     * Transforms an {@link Aggregate} that cannot be handled by Calcite into an equivalent that can
+     * be handled by:
+     *
+     * <ul>
+     *   <li>Moving all non-field references into a project before the aggregation
+     *   <li>Adding all groupings to this project so that they are referenced in "order"
+     * </ul>
+     */
+    public static Aggregate transformToValidCalciteAggregate(Aggregate aggregate) {
+      var at = new AggregateTransformer(aggregate);
+
+      List<Aggregate.Measure> newMeasures =
+          aggregate.getMeasures().stream().map(at::updateMeasure).collect(Collectors.toList());
+      List<Aggregate.Grouping> newGroupings =
+          aggregate.getGroupings().stream().map(at::updateGrouping).collect(Collectors.toList());
+
+      Project preAggregateProject =
+          Project.builder().input(aggregate.getInput()).expressions(at.newExpressions).build();
+
+      return Aggregate.builder()
+          .from(aggregate)
+          .input(preAggregateProject)
+          .measures(newMeasures)
+          .groupings(newGroupings)
+          .build();
+    }
+
+    private Aggregate.Measure updateMeasure(Aggregate.Measure measure) {
+      AggregateFunctionInvocation oldAggregateFunctionInvocation = measure.getFunction();
+
+      List<Expression> newFunctionArgs =
+          oldAggregateFunctionInvocation.arguments().stream()
+              .map(this::projectOutNonFieldReference)
+              .collect(Collectors.toList());
+
+      List<ImmutableExpression.SortField> newSortFields =
+          oldAggregateFunctionInvocation.sort().stream()
+              .map(
+                  sf ->
+                      Expression.SortField.builder()
+                          .from(sf)
+                          .expr(projectOutNonFieldReference(sf.expr()))
+                          .build())
+              .collect(Collectors.toList());
+
+      Optional<Expression> newPreMeasureFilter =
+          measure.getPreMeasureFilter().map(this::projectOutNonFieldReference);
+
+      AggregateFunctionInvocation newAggregateFunctionInvocation =
+          AggregateFunctionInvocation.builder()
+              .from(oldAggregateFunctionInvocation)
+              .arguments(newFunctionArgs)
+              .sort(newSortFields)
+              .build();
+
+      return Aggregate.Measure.builder()
+          .function(newAggregateFunctionInvocation)
+          .preMeasureFilter(newPreMeasureFilter)
+          .build();
+    }
+
+    private Aggregate.Grouping updateGrouping(Aggregate.Grouping grouping) {
+      // project out all groupings unconditionally, even field references
+      // this ensures that out of order groupings are re-projected into in order groupings
+      List<Expression> newGroupingExpressions =
+          grouping.getExpressions().stream().map(this::projectOut).collect(Collectors.toList());
+      return Aggregate.Grouping.builder().expressions(newGroupingExpressions).build();
+    }
+
+    private Expression projectOutNonFieldReference(FunctionArg farg) {
+      if ((farg instanceof Expression e)) {
+        return projectOutNonFieldReference(e);
+      } else {
+        throw new IllegalArgumentException("cannot handle non-expression argument for aggregate");
+      }
+    }
+
+    private Expression projectOutNonFieldReference(Expression expr) {
+      if (isSimpleFieldReference(expr)) {
+        return expr;
+      }
+      return projectOut(expr);
+    }
+
+    /**
+     * Adds a new expression to the project at {@link AggregateTransformer#expressionOffset} and
+     * returns a field reference to the new expression
+     */
+    private Expression projectOut(Expression expr) {
+      newExpressions.add(expr);
+      return ImmutableFieldReference.builder()
+          // create a field reference to the new expression, then update the expression offset
+          .addSegments(FieldReference.StructField.of(expressionOffset++))
+          .type(expr.getType())
+          .build();
+    }
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateValidator.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateValidator.java
@@ -112,10 +112,10 @@ public class AggregateValidator {
   public static class AggregateTransformer {
 
     // New expressions to include in the project before the aggregate
-    final List<Expression> newExpressions;
+    private final List<Expression> newExpressions;
 
     // Tracks the offset of the next expression added
-    int expressionOffset;
+    private int expressionOffset;
 
     private AggregateTransformer(Aggregate aggregate) {
       this.newExpressions = new ArrayList<>();

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -228,9 +228,10 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
 
   @Override
   public RelNode visit(Aggregate aggregate) throws RuntimeException {
-    if (!AggregateValidator.isValidCalciteAggregate(aggregate)) {
+    if (!PreCalciteAggregateValidator.isValidCalciteAggregate(aggregate)) {
       aggregate =
-          AggregateValidator.AggregateTransformer.transformToValidCalciteAggregate(aggregate);
+          PreCalciteAggregateValidator.PreCalciteAggregateTransformer
+              .transformToValidCalciteAggregate(aggregate);
     }
 
     RelNode child = aggregate.getInput().accept(this);

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -276,7 +276,7 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
     List<Integer> argIndex = new ArrayList<>();
     for (RexNode arg : arguments) {
       // arguments are guaranteed to be RexInputRef because of the prior call to
-      // AggregateValidator.AggregateTransformer.transformToValidCalciteAggregate
+      // transformToValidCalciteAggregate
       argIndex.add(((RexInputRef) arg).getIndex());
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -271,6 +271,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     if (call.filterArg != -1) {
       builder.preMeasureFilter(FieldReference.newRootStructReference(call.filterArg, inputType));
     }
+    // TODO: handle the collation on the AggregateCall
+    //   https://github.com/substrait-io/substrait-java/issues/215
     return builder.build();
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -2,7 +2,7 @@ package io.substrait.isthmus;
 
 import com.google.common.collect.Streams;
 import io.substrait.dsl.SubstraitBuilder;
-import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.relation.Aggregate;
 import io.substrait.relation.NamedScan;
 import io.substrait.relation.Rel;
 import io.substrait.type.Type;
@@ -40,7 +40,7 @@ public class AggregationFunctionsTest extends PlanTestBase {
   private NamedScan numericTypesTable = b.namedScan(List.of("example"), columnNames, tableTypes);
 
   // Create the given function call on the given field of the input
-  private AggregateFunctionInvocation functionPicker(Rel input, int field, String fname) {
+  private Aggregate.Measure functionPicker(Rel input, int field, String fname) {
     return switch (fname) {
       case "min" -> b.min(input, field);
       case "max" -> b.max(input, field);
@@ -53,7 +53,7 @@ public class AggregationFunctionsTest extends PlanTestBase {
   }
 
   // Create one function call per numeric type column
-  private List<AggregateFunctionInvocation> functions(Rel input, String fname) {
+  private List<Aggregate.Measure> functions(Rel input, String fname) {
     // first column is for grouping, skip it
     return IntStream.range(1, tableTypes.size())
         .boxed()

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
@@ -1,0 +1,186 @@
+package io.substrait.isthmus;
+
+import static io.substrait.isthmus.SqlConverterBase.EXTENSION_COLLECTION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Aggregate;
+import io.substrait.relation.NamedScan;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ComplexAggregateTest extends PlanTestBase {
+
+  final TypeCreator R = TypeCreator.of(false);
+  SubstraitBuilder b = new SubstraitBuilder(extensions);
+
+  /**
+   * Check that:
+   *
+   * <ol>
+   *   <li>The {@code pojo} pojo given is transformed as expected by {@link
+   *       AggregateValidator.AggregateTransformer#transformToValidCalciteAggregate}
+   *   <li>The {@code} (original) pojo can be converted to Calcite without issues
+   * </ol>
+   *
+   * @param pojo a pojo that requires transformation for use in Calcite
+   * @param expectedTransform the expected transformation output
+   */
+  protected void validateAggregateTransformation(Aggregate pojo, Rel expectedTransform) {
+    var converterPojo =
+        AggregateValidator.AggregateTransformer.transformToValidCalciteAggregate(pojo);
+    assertEquals(expectedTransform, converterPojo);
+
+    // Substrait POJO -> Calcite
+    new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory).convert(pojo);
+  }
+
+  private List<Type> columnTypes = List.of(R.I32, R.I32, R.I32, R.I32);
+  private List<String> columnNames = List.of("a", "b", "c", "d");
+  private NamedScan table = b.namedScan(List.of("example"), columnNames, columnTypes);
+
+  private Aggregate.Grouping emptyGrouping = Aggregate.Grouping.builder().build();
+
+  @Test
+  void handleComplexMeasureArgument() {
+    // SELECT sum(c + 7) FROM example
+    var rel =
+        b.aggregate(
+            input -> emptyGrouping,
+            input -> List.of(b.sum(b.add(b.fieldReference(input, 2), b.i32(7)))),
+            table);
+
+    var expectedFinal =
+        b.aggregate(
+            input -> emptyGrouping,
+            // sum call references input field
+            input -> List.of(b.sum(input, 4)),
+            b.project(
+                // add call is moved to child project
+                input -> List.of(b.add(b.fieldReference(input, 2), b.i32(7))),
+                table));
+
+    validateAggregateTransformation(rel, expectedFinal);
+  }
+
+  @Test
+  void handleComplexPreMeasureFilter() {
+    // SELECT sum(a) FILTER (b = 42) FROM example
+    var rel =
+        b.aggregateM(
+            input -> emptyGrouping,
+            input ->
+                List.of(b.measure(b.sum(input, 0), b.equal(b.fieldReference(input, 1), b.i32(42)))),
+            table);
+
+    var expectedFinal =
+        b.aggregateM(
+            input -> emptyGrouping,
+            input -> List.of(b.measure(b.sum(input, 0), b.fieldReference(input, 4))),
+            b.project(input -> List.of(b.equal(b.fieldReference(input, 1), b.i32(42))), table));
+
+    validateAggregateTransformation(rel, expectedFinal);
+  }
+
+  @Test
+  void handleComplexSortingArguments() {
+    // SELECT sum(d ORDER BY -b ASC) FROM example
+    var rel =
+        b.aggregate(
+            input -> emptyGrouping,
+            input ->
+                List.of(
+                    AggregateFunctionInvocation.builder()
+                        .from(b.sum(input, 3))
+                        .sort(
+                            List.of(
+                                b.sortField(
+                                    b.negate(b.fieldReference(input, 1)),
+                                    Expression.SortDirection.ASC_NULLS_FIRST)))
+                        .build()),
+            table);
+
+    var expectedFinal =
+        b.aggregate(
+            input -> emptyGrouping,
+            input ->
+                List.of(
+                    AggregateFunctionInvocation.builder()
+                        // sum input does not need to be rewritten
+                        .from(b.sum(input, 3))
+                        .sort(
+                            List.of(
+                                b.sortField(
+                                    // sort field references input
+                                    b.fieldReference(input, 4),
+                                    Expression.SortDirection.ASC_NULLS_FIRST)))
+                        .build()),
+            b.project(
+                // negate call is moved to child project
+                input -> List.of(b.negate(b.fieldReference(input, 1))),
+                table));
+
+    validateAggregateTransformation(rel, expectedFinal);
+  }
+
+  @Test
+  void handleComplexGroupingArgument() {
+    var rel =
+        b.aggregate(
+            input ->
+                b.grouping(
+                    b.fieldReference(input, 2), b.add(b.fieldReference(input, 1), b.i32(42))),
+            input -> List.of(),
+            table);
+
+    var expectedFinal =
+        b.aggregate(
+            // grouping exprs are now field references to input
+            input -> b.grouping(input, 4, 5),
+            input -> List.of(),
+            b.project(
+                input ->
+                    List.of(
+                        b.fieldReference(input, 2), b.add(b.fieldReference(input, 1), b.i32(42))),
+                table));
+
+    validateAggregateTransformation(rel, expectedFinal);
+  }
+
+  @Test
+  void handleOutOfOrderGroupingArguments() {
+    var rel = b.aggregate(input -> b.grouping(input, 1, 0, 2), input -> List.of(), table);
+
+    var expectedFinal =
+        b.aggregate(
+            // grouping exprs are now field references to input
+            input -> b.grouping(input, 4, 5, 6),
+            input -> List.of(),
+            b.project(
+                // ALL grouping exprs are added to the child projects (including field references)
+                input ->
+                    List.of(
+                        b.fieldReference(input, 1),
+                        b.fieldReference(input, 0),
+                        b.fieldReference(input, 2)),
+                table));
+
+    validateAggregateTransformation(rel, expectedFinal);
+  }
+
+  @Test
+  void outOfOrderGroupingKeysHaveCorrectCalciteType() {
+    Rel rel =
+        b.aggregate(
+            input -> b.grouping(input, 2, 0),
+            input -> List.of(),
+            b.namedScan(List.of("foo"), List.of("a", "b", "c"), List.of(R.I64, R.I64, R.STRING)));
+    var relNode = new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory).convert(rel);
+    assertRowMatch(relNode.getRowType(), R.STRING, R.I64);
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
@@ -34,7 +34,7 @@ public class ComplexAggregateTest extends PlanTestBase {
    *
    * <ol>
    *   <li>The {@code pojo} pojo given is transformed as expected by {@link
-   *       AggregateValidator.AggregateTransformer#transformToValidCalciteAggregate}
+   *       PreCalciteAggregateValidator.PreCalciteAggregateTransformer#transformToValidCalciteAggregate}
    *   <li>The {@code} (original) pojo can be converted to Calcite without issues
    * </ol>
    *
@@ -43,7 +43,8 @@ public class ComplexAggregateTest extends PlanTestBase {
    */
   protected void validateAggregateTransformation(Aggregate pojo, Rel expectedTransform) {
     var converterPojo =
-        AggregateValidator.AggregateTransformer.transformToValidCalciteAggregate(pojo);
+        PreCalciteAggregateValidator.PreCalciteAggregateTransformer
+            .transformToValidCalciteAggregate(pojo);
     assertEquals(expectedTransform, converterPojo);
 
     // Substrait POJO -> Calcite

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -201,8 +201,9 @@ public class CustomFunctionTest extends PlanTestBase {
             input -> b.grouping(input, 0),
             input ->
                 List.of(
-                    b.aggregateFn(
-                        NAMESPACE, "custom_aggregate:i64", R.I64, b.fieldReference(input, 0))),
+                    b.measure(
+                        b.aggregateFn(
+                            NAMESPACE, "custom_aggregate:i64", R.I64, b.fieldReference(input, 0)))),
             b.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static io.substrait.isthmus.SqlConverterBase.EXTENSION_COLLECTION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.annotations.Beta;
@@ -15,12 +16,14 @@ import io.substrait.plan.ProtoPlanConverter;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelProtoConverter;
+import io.substrait.type.Type;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.sql.SqlKind;
@@ -202,5 +205,16 @@ public class PlanTestBase {
 
     // Verify that POJOs are the same
     assertEquals(pojo1, pojo3);
+  }
+
+  protected void assertRowMatch(RelDataType actual, Type... expected) {
+    assertRowMatch(actual, Arrays.asList(expected));
+  }
+
+  protected void assertRowMatch(RelDataType actual, List<Type> expected) {
+    Type type = TypeConverter.DEFAULT.toSubstrait(actual);
+    assertInstanceOf(Type.Struct.class, type);
+    Type.Struct struct = (Type.Struct) type;
+    assertEquals(expected, struct.fields());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -1,8 +1,5 @@
 package io.substrait.isthmus;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.plan.Plan;
 import io.substrait.relation.Join.JoinType;
@@ -10,11 +7,9 @@ import io.substrait.relation.Rel;
 import io.substrait.relation.Set.SetOp;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.calcite.rel.type.RelDataType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -34,17 +29,6 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       b.namedScan(List.of("example"), List.of("a", "b", "c", "d"), commonTableType);
 
   final SubstraitToCalcite converter = new SubstraitToCalcite(extensions, typeFactory);
-
-  void assertRowMatch(RelDataType actual, Type... expected) {
-    assertRowMatch(actual, Arrays.asList(expected));
-  }
-
-  void assertRowMatch(RelDataType actual, List<Type> expected) {
-    Type type = TypeConverter.DEFAULT.toSubstrait(actual);
-    assertInstanceOf(Type.Struct.class, type);
-    Type.Struct struct = (Type.Struct) type;
-    assertEquals(expected, struct.fields());
-  }
 
   @Nested
   class Aggregate {


### PR DESCRIPTION
Substrait Aggregates that contain expressions that are not field
references and/or grouping keys that are not in input order require
extra processing to be converted to Calcite Aggregates successfully AND
correctly