### PR TITLE
fix: semantic release requires Node version 20.8.1 or higher

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "19"
+          node-version: "20"
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
   security:
     name: Security validation
@@ -91,6 +91,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "19"
+          node-version: "20"
       - name: Check current status before next release
         run: ./ci/release/dry_run.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "19"
       - run: npx commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
   security:
     name: Security validation
@@ -91,6 +91,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "19"
       - name: Check current status before next release
         run: ./ci/release/dry_run.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           distribution: 'adopt'
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '19'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Download isthmus-ubuntu-latest binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           distribution: 'adopt'
       - uses: actions/setup-node@v4
         with:
-          node-version: '19'
+          node-version: '20'
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Download isthmus-ubuntu-latest binary


### PR DESCRIPTION
To closes: https://github.com/substrait-io/substrait-java/issues/219