### PR TITLE
feat(isthmus): support for replace

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -58,6 +58,7 @@ public class FunctionMappings {
                 s(SqlStdOperatorTable.FLOOR, "floor"),
                 s(SqlStdOperatorTable.ROUND, "round"),
                 s(SqlStdOperatorTable.LIKE),
+                s(SqlStdOperatorTable.REPLACE, "replace"),
                 s(SqlStdOperatorTable.SUBSTRING, "substring"),
                 s(SqlStdOperatorTable.CONCAT, "concat"),
                 s(SqlStdOperatorTable.CHAR_LENGTH, "char_length"),

--- a/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class StringFunctionTest extends PlanTestBase {
 
   static List<String> CREATES = List.of("CREATE TABLE strings (c16 CHAR(16), vc32 VARCHAR(32))");
+  static List<String> REPLACE_CREATES =
+      List.of(
+          "CREATE TABLE replace_strings (c16 CHAR(16), vc32 VARCHAR(32), replace_from VARCHAR(16), replace_to VARCHAR(16))");
 
   @ParameterizedTest
   @ValueSource(strings = {"c16", "vc32"})
@@ -34,6 +37,14 @@ public class StringFunctionTest extends PlanTestBase {
   void upper(String column) throws Exception {
     String query = String.format("SELECT upper(%s) FROM strings", column);
     assertSqlSubstraitRelRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void replace(String column) throws Exception {
+    String query =
+        String.format("SELECT replace(%s, replace_from, replace_to) FROM replace_strings", column);
+    assertSqlSubstraitRelRoundTrip(query, REPLACE_CREATES);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Function is available in [Calcite](https://github.com/apache/calcite/blob/4f5a08f5429ff905a2ebd96600b0966ba9e228ea/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java#L1581-L1583) and [Substrait's functions_string.yaml](https://github.com/substrait-io/substrait/blob/3ded94d69e7ae329f2730b7634ba34900250e84a/extensions/functions_string.yaml#L771-L790), so just registering the mapping here.
