### PR TITLE
feat(isthmus): add up-converting signature matchers, and coerce types to match 

### DIFF
--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -178,4 +178,20 @@ public class ToTypeString
       return super.visit(expr);
     }
   }
+
+  /**
+   * Subclass of ToTypeString that doesn't lose the context on the wildcard being used (for example,
+   * that can return any1, any2, etc, instead of only any, any).
+   */
+  public static class ToTypeLiteralStringLossless extends ToTypeString {
+
+    public static final ToTypeLiteralStringLossless INSTANCE = new ToTypeLiteralStringLossless();
+
+    private ToTypeLiteralStringLossless() {}
+
+    @Override
+    public String visit(ParameterizedType.StringLiteral expr) throws RuntimeException {
+      return expr.value().toLowerCase();
+    }
+  }
 }

--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -180,8 +180,11 @@ public class ToTypeString
   }
 
   /**
-   * Subclass of ToTypeString that doesn't lose the context on the wildcard being used (for example,
-   * that can return any1, any2, etc, instead of only any, any).
+   * {@link ToTypeString} emits the string `any` for all wildcard any types, even if they have
+   * numeric suffixes (i.e. `any1`, `any2`, etc).
+   *
+   * <p>These suffixes are needed to correctly perform function matching based on arguments. This
+   * subclass retains the numerics suffixes when emitting type strings for this.
    */
   public static class ToTypeLiteralStringLossless extends ToTypeString {
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus.expression;
 
+import com.github.bsideup.jabel.Desugar;
 import com.google.common.collect.*;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
@@ -13,11 +14,14 @@ import io.substrait.type.Type;
 import io.substrait.util.Util;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -170,8 +174,52 @@ public abstract class FunctionConverter<
 
     private static <F extends SimpleExtension.Function> SignatureMatcher<F> getSignatureMatcher(
         SqlOperator operator, List<F> functions) {
-      // TODO: define up-converting matchers.
-      return (a, b) -> Optional.empty();
+      return (inputTypes, outputType) -> {
+        for (F function : functions) {
+          List<SimpleExtension.Argument> args = function.requiredArguments();
+
+          var bounds = ArgumentBounds.parse(function);
+
+          // Make sure that arguments & return are within bounds and match the types
+          if (function.returnType() instanceof ParameterizedType
+              && isMatch(outputType, (ParameterizedType) function.returnType())
+              && bounds.within(inputTypes.size())
+              && argumentsMatchType(inputTypes, args)) {
+            return Optional.of(function);
+          }
+        }
+
+        return Optional.empty();
+      };
+    }
+
+    private static boolean argumentsMatchType(
+        List<Type> inputTypes, List<SimpleExtension.Argument> args) {
+
+      Map<String, Set<Type>> wildcardToType = new HashMap<>();
+      for (int i = 0; i < inputTypes.size(); i++) {
+        Type givenType = inputTypes.get(i);
+        // Variadic arguments should match the last argument's type
+        SimpleExtension.ValueArgument wantType =
+            (SimpleExtension.ValueArgument) args.get(Integer.min(i, args.size() - 1));
+
+        if (!isMatch(givenType, wantType.value())) {
+          return false;
+        }
+
+        // Register the wildcard to type
+        if (wantType.value().isWildcard()) {
+          wildcardToType
+              .computeIfAbsent(
+                  wantType.value().accept(ToTypeString.ToTypeLiteralStringLossless.INSTANCE),
+                  k -> new HashSet<>())
+              .add(givenType);
+        }
+      }
+
+      // If all the types match, check if the wildcard types are compatible.
+      // Note: We could ignore the "any" key here if we decide to not match non-enumerated types.
+      return wildcardToType.values().stream().allMatch(s -> s.size() == 1);
     }
 
     /**
@@ -289,12 +337,10 @@ public abstract class FunctionConverter<
       var outputType = typeConverter.toSubstrait(call.getType());
 
       // try to do a direct match
+      var typeStrings =
+          opTypes.stream().map(t -> t.accept(ToTypeString.INSTANCE)).collect(Collectors.toList());
       var possibleKeys =
-          matchKeys(
-              call.getOperands().collect(java.util.stream.Collectors.toList()),
-              opTypes.stream()
-                  .map(t -> t.accept(ToTypeString.INSTANCE))
-                  .collect(java.util.stream.Collectors.toList()));
+          matchKeys(call.getOperands().collect(java.util.stream.Collectors.toList()), typeStrings);
 
       var directMatchKey =
           possibleKeys
@@ -327,31 +373,74 @@ public abstract class FunctionConverter<
       }
 
       if (singularInputType.isPresent()) {
-        RelDataType leastRestrictive =
-            typeFactory.leastRestrictive(
-                call.getOperands()
-                    .map(RexNode::getType)
-                    .collect(java.util.stream.Collectors.toList()));
-        if (leastRestrictive == null) {
-          return Optional.empty();
+        Optional<T> leastRestrictive = matchByLeastRestrictive(call, outputType, operands);
+        if (leastRestrictive.isPresent()) {
+          return leastRestrictive;
         }
-        Type type = typeConverter.toSubstrait(leastRestrictive);
-        var out = singularInputType.get().tryMatch(type, outputType);
 
-        if (out.isPresent()) {
-          var declaration = out.get();
-          var coercedArgs = coerceArguments(operands, type);
-          declaration.validateOutputType(coercedArgs, outputType);
-          return Optional.of(
-              generateBinding(
-                  call,
-                  out.get(),
-                  coercedArgs.stream()
-                      .map(FunctionArg.class::cast)
-                      .collect(java.util.stream.Collectors.toList()),
-                  outputType));
+        Optional<T> coerced = matchCoerced(call, outputType, operands);
+        if (coerced.isPresent()) {
+          return coerced;
         }
       }
+      return Optional.empty();
+    }
+
+    private Optional<T> matchByLeastRestrictive(
+        C call, Type outputType, List<Expression> operands) {
+      RelDataType leastRestrictive =
+          typeFactory.leastRestrictive(
+              call.getOperands().map(RexNode::getType).collect(Collectors.toList()));
+      if (leastRestrictive == null) {
+        return Optional.empty();
+      }
+      Type type = typeConverter.toSubstrait(leastRestrictive);
+      var out = singularInputType.get().tryMatch(type, outputType);
+
+      if (out.isPresent()) {
+        var declaration = out.get();
+        var coercedArgs = coerceArguments(operands, type);
+        declaration.validateOutputType(coercedArgs, outputType);
+        return Optional.of(
+            generateBinding(
+                call,
+                out.get(),
+                coercedArgs.stream().map(FunctionArg.class::cast).collect(Collectors.toList()),
+                outputType));
+      }
+      return Optional.empty();
+    }
+
+    private Optional<T> matchCoerced(C call, Type outputType, List<Expression> operands) {
+
+      // Convert the operands to the proper Substrait type
+      List<Type> allTypes =
+          call.getOperands()
+              .map(RexNode::getType)
+              .map(typeConverter::toSubstrait)
+              .collect(Collectors.toList());
+
+      // See if all the input types match the function
+      Optional<F> matchFunction = this.matcher.tryMatch(allTypes, outputType);
+      if (matchFunction.isPresent()) {
+        List<Expression> coerced =
+            Streams.zip(
+                    operands.stream(),
+                    call.getOperands(),
+                    (a, b) -> {
+                      Type type = typeConverter.toSubstrait(b.getType());
+                      return coerceArgument(a, type);
+                    })
+                .collect(Collectors.toList());
+
+        return Optional.of(
+            generateBinding(
+                call,
+                matchFunction.get(),
+                coerced.stream().map(FunctionArg.class::cast).collect(Collectors.toList()),
+                outputType));
+      }
+
       return Optional.empty();
     }
 
@@ -374,18 +463,16 @@ public abstract class FunctionConverter<
    * Coerced types according to an expected output type. Coercion is only done for type mismatches,
    * not for nullability or parameter mismatches.
    */
-  private List<Expression> coerceArguments(List<Expression> arguments, Type type) {
+  private static List<Expression> coerceArguments(List<Expression> arguments, Type type) {
+    return arguments.stream().map(a -> coerceArgument(a, type)).collect(Collectors.toList());
+  }
 
-    return arguments.stream()
-        .map(
-            a -> {
-              var typeMatches = isMatch(type, a.getType());
-              if (!typeMatches) {
-                return ExpressionCreator.cast(type, a);
-              }
-              return a;
-            })
-        .collect(java.util.stream.Collectors.toList());
+  private static Expression coerceArgument(Expression argument, Type type) {
+    var typeMatches = isMatch(type, argument.getType());
+    if (!typeMatches) {
+      return ExpressionCreator.cast(type, argument);
+    }
+    return argument;
   }
 
   protected abstract T generateBinding(
@@ -427,5 +514,34 @@ public abstract class FunctionConverter<
       return true;
     }
     return inputType.accept(new IgnoreNullableAndParameters(type));
+  }
+
+  @Desugar
+  record ArgumentBounds(int lower, int upper) {
+
+    static ArgumentBounds parse(SimpleExtension.Function function) {
+      List<SimpleExtension.Argument> args = function.requiredArguments();
+
+      int lowerBoundRequiredArgs = args.size();
+      int upperBoundRequiredArgs = args.size();
+
+      if (function.variadic().isPresent()) {
+        SimpleExtension.VariadicBehavior variadicBehavior = function.variadic().get();
+        // Do not count variadic as a required argument, use the behavior.
+        lowerBoundRequiredArgs += 1 - variadicBehavior.getMin();
+
+        if (variadicBehavior.getMax().isEmpty()) {
+          upperBoundRequiredArgs = Integer.MAX_VALUE;
+        } else {
+          upperBoundRequiredArgs += variadicBehavior.getMax().getAsInt();
+        }
+      }
+
+      return new ArgumentBounds(lowerBoundRequiredArgs, upperBoundRequiredArgs);
+    }
+
+    boolean within(int count) {
+      return count >= lower && count <= upper;
+    }
   }
 }

--- a/isthmus/src/test/resources/extensions/functions_custom.yaml
+++ b/isthmus/src/test/resources/extensions/functions_custom.yaml
@@ -44,13 +44,6 @@ scalar_functions:
         - name: another_arg
           value: any2
       return: any2
-  - name: "to_b_type"
-    description: "converts a nullable a_type to a b_type"
-    impls:
-      - args:
-          - name: arg1
-            value: u!a_type?
-        return: u!b_type
   - name: "custom_scalar_listany_to_listany"
     description: "custom function that takes list of any"
     impls:
@@ -105,6 +98,13 @@ scalar_functions:
         variadic:
           min: 1
         return: LIST<string>
+  - name: "to_b_type"
+    description: "converts a nullable a_type to a b_type"
+    impls:
+      - args:
+          - name: arg1
+            value: u!a_type?
+        return: u!b_type
 
 aggregate_functions:
   - name: "custom_aggregate"

--- a/isthmus/src/test/resources/extensions/functions_custom.yaml
+++ b/isthmus/src/test/resources/extensions/functions_custom.yaml
@@ -6,12 +6,44 @@ types:
 
 scalar_functions:
   - name: "custom_scalar"
-    description: "a custom scalar functions"
+    description: "a custom scalar function"
     impls:
     - args:
         - name: some_arg
           value: string
       return: string
+  - name: "custom_scalar_any"
+    description: "a custom scalar function that takes any argument input"
+    impls:
+    - args:
+        - name: some_arg
+          value: any1
+      return: string
+  - name: "custom_scalar_any_to_any"
+    description: "a custom scalar function that takes any argument input and returns the same type"
+    impls:
+    - args:
+        - name: some_arg
+          value: any1
+      return: any1
+  - name: "custom_scalar_any1any1_to_any1"
+    description: "a custom scalar function that takes two any1 inputs and returns the same type"
+    impls:
+    - args:
+        - name: some_arg
+          value: any1
+        - name: another_arg
+          value: any1
+      return: any1
+  - name: "custom_scalar_any1any2_to_any2"
+    description: "a custom scalar function that takes any1 and any2 inputs and returns any2"
+    impls:
+    - args:
+        - name: some_arg
+          value: any1
+        - name: another_arg
+          value: any2
+      return: any2
   - name: "to_b_type"
     description: "converts a nullable a_type to a b_type"
     impls:
@@ -19,6 +51,49 @@ scalar_functions:
           - name: arg1
             value: u!a_type?
         return: u!b_type
+  - name: "custom_scalar_listany_to_listany"
+    description: "custom function that takes list of any"
+    impls:
+      - args:
+          - name: list
+            value: LIST<any1>
+        return: LIST<any1>
+  - name: "custom_scalar_listany_any_to_listany"
+    description: "custom function that takes list of any and an any scalar"
+    impls:
+      - args:
+          - name: list
+            value: LIST<any1>
+          - name: val
+            value: any1
+        return: LIST<any1>
+  - name: "custom_scalar_liststring_to_liststring"
+    description: "custom function that takes list of string"
+    impls:
+      - args:
+          - name: list
+            value: LIST<string>
+        return: LIST<string>
+  - name: "custom_scalar_liststring_any_to_liststring"
+    description: "custom function that takes list of string and an any scalar"
+    impls:
+      - args:
+          - name: list
+            value: LIST<string>
+          - name: val
+            value: any1
+        return: LIST<string>
+  - name: "custom_scalar_liststring_anyvariadic_to_liststring"
+    description: "custom function that takes list of string and an any scalar"
+    impls:
+      - args:
+          - name: list
+            value: LIST<string>
+          - name: val
+            value: any1
+        variadic:
+          min: 1
+        return: LIST<string>
 
 aggregate_functions:
   - name: "custom_aggregate"

--- a/isthmus/src/test/resources/extensions/functions_custom.yaml
+++ b/isthmus/src/test/resources/extensions/functions_custom.yaml
@@ -83,8 +83,19 @@ scalar_functions:
           - name: val
             value: any1
         return: LIST<string>
-  - name: "custom_scalar_liststring_anyvariadic_to_liststring"
-    description: "custom function that takes list of string and an any scalar"
+  - name: "custom_scalar_liststring_anyvariadic0_to_liststring"
+    description: "custom function that takes list of string and an any scalar (variadic with min 0)"
+    impls:
+      - args:
+          - name: list
+            value: LIST<string>
+          - name: val
+            value: any1
+        variadic:
+          min: 0
+        return: LIST<string>
+  - name: "custom_scalar_liststring_anyvariadic1_to_liststring"
+    description: "custom function that takes list of string and an any scalar (variadic with min 1)"
     impls:
       - args:
           - name: list


### PR DESCRIPTION
My attempt to take a stab at the `TODO` in the code:

```
  // TODO: define up-converting matchers.
```

We've got here since we noticed that functions that have `list<any1>, any1` arguments wouldn't match `list<string>, string` without implementing a proper `CallConverter` as adapter:

- The `FunctionConverter` was not matching using `directMatchKey` since `list_any` != `list_str`.

- When falling back to the `leastRestrictive` logic, `list<string>` + `string` would also not agree, so no functions were returned.

I've kept the `leastRestrictive` logic intact, but added another fallback matcher that checks if all arguments will match (using the existent `isMatch` logic, which relies on [IgnoreNullableAndParameters](https://github.com/substrait-io/substrait-java/blob/main/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java) internally).

--

Let me know if there are any concerns or thoughts on how to make this better.
