### PR TITLE
fix(isthmus): allow for conversion of plans containing Calcite aggregate functions

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -24,19 +24,29 @@ public class AggregateFunctions {
   public static SqlAggFunction SUM0 = new SubstraitSumEmptyIsZeroAggFunction();
 
   /**
-   * Utility class to possibly convert the SqlAggFunction from the native Calcite implementation to
-   * the Substrait subclasses present here, in case they have definitions.
+   * Some Calcite rules, like {@link
+   * org.apache.calcite.rel.rules.AggregateExpandDistinctAggregatesRule}, introduce the default
+   * Calcite aggregate functions into plans.
+   *
+   * <p>When converting these Calcite plans to Substrait, we need to convert the default Calcite
+   * aggregate calls to the Substrait specific variants.
+   *
+   * <p>This function attempts to convert the given {@code aggFunction} to its Substrait equivalent
+   *
+   * @param aggFunction the {@link SqlAggFunction} to convert to a Substrait specific variant
+   * @return an optional containing the Substrait equivalent of the given {@code aggFunction} if
+   *     conversion was needed, empty otherwise.
    */
-  public static Optional<SqlAggFunction> getSubstraitAggVariant(SqlAggFunction aggFunction) {
-    if (aggFunction instanceof SqlSumEmptyIsZeroAggFunction) {
-      return Optional.of(AggregateFunctions.SUM0);
-    } else if (aggFunction instanceof SqlMinMaxAggFunction fun) {
+  public static Optional<SqlAggFunction> toSubstraitAggVariant(SqlAggFunction aggFunction) {
+    if (aggFunction instanceof SqlMinMaxAggFunction fun) {
       return Optional.of(
           fun.getKind() == SqlKind.MIN ? AggregateFunctions.MIN : AggregateFunctions.MAX);
     } else if (aggFunction instanceof SqlAvgAggFunction) {
       return Optional.of(AggregateFunctions.AVG);
     } else if (aggFunction instanceof SqlSumAggFunction) {
       return Optional.of(AggregateFunctions.SUM);
+    } else if (aggFunction instanceof SqlSumEmptyIsZeroAggFunction) {
+      return Optional.of(AggregateFunctions.SUM0);
     } else {
       return Optional.empty();
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -358,6 +358,10 @@ public abstract class FunctionConverter<
     protected String getName() {
       return name;
     }
+
+    public SqlOperator getOperator() {
+      return operator;
+    }
   }
 
   public interface GenericCall {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -354,6 +354,10 @@ public abstract class FunctionConverter<
       }
       return Optional.empty();
     }
+
+    protected String getName() {
+      return name;
+    }
   }
 
   public interface GenericCall {

--- a/isthmus/src/test/java/io/substrait/isthmus/OptimizerIntegrationTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OptimizerIntegrationTest.java
@@ -1,0 +1,51 @@
+package io.substrait.isthmus;
+
+import static io.substrait.isthmus.SqlConverterBase.EXTENSION_COLLECTION;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Test;
+
+public class OptimizerIntegrationTest extends PlanTestBase {
+
+  @Test
+  void conversionHandlesBuiltInSum0CallAddedByRule() throws SqlParseException, IOException {
+    var query =
+        "select O_CUSTKEY, count(distinct O_ORDERKEY), count(*) from orders group by O_CUSTKEY";
+    // verify that the query works generally
+    assertFullRoundTrip(query);
+
+    SqlToSubstrait sqlConverter = new SqlToSubstrait();
+    List<RelRoot> relRoots = sqlConverter.sqlToRelNode(query, tpchSchemaCreateStatements());
+    assertEquals(1, relRoots.size());
+    RelRoot planRoot = relRoots.get(0);
+    RelNode originalPlan = planRoot.rel;
+
+    // Create a program to apply the AGGREGATE_EXPAND_DISTINCT_AGGREGATES_TO_JOIN rule.
+    // This will introduce a SqlSumEmptyIsZeroAggFunction to the plan.
+    // This function does not have a mapping to Substrait.
+    // SubstraitSumEmptyIsZeroAggFunction is the variant which has a mapping.
+    // See io.substrait.isthmus.AggregateFunctions for details
+    HepProgram program =
+        new HepProgramBuilder()
+            .addRuleInstance(CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES_TO_JOIN)
+            .build();
+    HepPlanner planner = new HepPlanner(program);
+    planner.setRoot(originalPlan);
+    var newPlan = planner.findBestExp();
+
+    assertDoesNotThrow(
+        () ->
+            // Conversion of the new plan should succeed
+            SubstraitRelVisitor.convert(RelRoot.of(newPlan, planRoot.kind), EXTENSION_COLLECTION));
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -32,7 +32,7 @@ import org.apache.calcite.tools.RelBuilder;
 import org.junit.jupiter.api.Assertions;
 
 public class PlanTestBase {
-  final SimpleExtension.ExtensionCollection extensions;
+  protected final SimpleExtension.ExtensionCollection extensions;
 
   {
     try {

--- a/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
@@ -1,0 +1,59 @@
+package io.substrait.isthmus.expression;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.extension.SimpleExtension;
+import io.substrait.isthmus.RelCreator;
+import io.substrait.isthmus.TypeConverter;
+import java.io.IOException;
+import java.util.List;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+
+public class AggregateFunctionConverterTest {
+
+  protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION;
+
+  static {
+    SimpleExtension.ExtensionCollection defaults;
+    try {
+      defaults = SimpleExtension.loadDefaults();
+    } catch (IOException e) {
+      throw new RuntimeException("Failure while loading defaults.", e);
+    }
+
+    EXTENSION_COLLECTION = defaults;
+  }
+
+  final SubstraitBuilder b = new SubstraitBuilder(EXTENSION_COLLECTION);
+
+  @Test
+  public void testFunctionFinderMatch() {
+
+    RelCreator relCreator = new RelCreator();
+    RelDataTypeFactory typeFactory = relCreator.typeFactory();
+
+    AggregateFunctionConverter converter =
+        new AggregateFunctionConverter(
+            EXTENSION_COLLECTION.aggregateFunctions(),
+            List.of(),
+            typeFactory,
+            TypeConverter.DEFAULT);
+
+    var functionFinder =
+        converter.getFunctionFinder(
+            AggregateCall.create(
+                new SqlSumEmptyIsZeroAggFunction(),
+                true,
+                List.of(1),
+                0,
+                typeFactory.createSqlType(SqlTypeName.VARCHAR),
+                null));
+    assertNotNull(functionFinder);
+    assertEquals("sum0", functionFinder.getName());
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
@@ -2,47 +2,22 @@ package io.substrait.isthmus.expression;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.substrait.dsl.SubstraitBuilder;
-import io.substrait.extension.SimpleExtension;
-import io.substrait.isthmus.RelCreator;
+import io.substrait.isthmus.AggregateFunctions;
+import io.substrait.isthmus.PlanTestBase;
 import io.substrait.isthmus.TypeConverter;
-import java.io.IOException;
 import java.util.List;
 import org.apache.calcite.rel.core.AggregateCall;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
-public class AggregateFunctionConverterTest {
-
-  protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION;
-
-  static {
-    SimpleExtension.ExtensionCollection defaults;
-    try {
-      defaults = SimpleExtension.loadDefaults();
-    } catch (IOException e) {
-      throw new RuntimeException("Failure while loading defaults.", e);
-    }
-
-    EXTENSION_COLLECTION = defaults;
-  }
-
-  final SubstraitBuilder b = new SubstraitBuilder(EXTENSION_COLLECTION);
+public class AggregateFunctionConverterTest extends PlanTestBase {
 
   @Test
-  public void testFunctionFinderMatch() {
-
-    RelCreator relCreator = new RelCreator();
-    RelDataTypeFactory typeFactory = relCreator.typeFactory();
-
+  void testFunctionFinderMatch() {
     AggregateFunctionConverter converter =
         new AggregateFunctionConverter(
-            EXTENSION_COLLECTION.aggregateFunctions(),
-            List.of(),
-            typeFactory,
-            TypeConverter.DEFAULT);
+            extensions.aggregateFunctions(), List.of(), typeFactory, TypeConverter.DEFAULT);
 
     var functionFinder =
         converter.getFunctionFinder(
@@ -55,5 +30,6 @@ public class AggregateFunctionConverterTest {
                 null));
     assertNotNull(functionFinder);
     assertEquals("sum0", functionFinder.getName());
+    assertEquals(AggregateFunctions.SUM0, functionFinder.getOperator());
   }
 }


### PR DESCRIPTION
Some of the Calcite CoreRules might bring their own functions at a late stage, so I've decided to make the converter flexible enough and handle the superclass types correctly (since we already do a similar conversion to `APPROX_COUNT_DISTINCT` in the same spot).

Another alternative would be to improve the matchers and check if names match or if it's an `instanceof` the passing call -- today `signatures` is an `IdentityHashMap`, so it's really strict.
