### PR TITLE
feat: support UDT literals using bytestring/binary representation in calcite

### DIFF
--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -487,6 +487,27 @@ public interface Expression extends FunctionArg {
   }
 
   @Value.Immutable
+  abstract static class UserDefinedLiteral implements Literal {
+    public abstract ByteString value();
+
+    public abstract String uri();
+
+    public abstract String name();
+
+    public Type getType() {
+      return Type.withNullability(nullable()).userDefined(uri(), name());
+    }
+
+    public static ImmutableExpression.UserDefinedLiteral.Builder builder() {
+      return ImmutableExpression.UserDefinedLiteral.builder();
+    }
+
+    public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
   abstract static class Switch implements Expression {
     public abstract Expression match();
 

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -219,7 +219,7 @@ public class ExpressionCreator {
   }
 
   public static Expression.UserDefinedLiteral userDefinedLiteral(
-      boolean nullable, Any value, String name, String uri) {
+      boolean nullable, String uri, String name, Any value) {
     return Expression.UserDefinedLiteral.builder()
         .nullable(nullable)
         .uri(uri)

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -1,5 +1,6 @@
 package io.substrait.expression;
 
+import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.relation.ConsistentPartitionWindow;
@@ -215,6 +216,16 @@ public class ExpressionCreator {
   public static Expression.StructLiteral struct(
       boolean nullable, Iterable<? extends Expression.Literal> values) {
     return Expression.StructLiteral.builder().nullable(nullable).addAllFields(values).build();
+  }
+
+  public static Expression.UserDefinedLiteral userDefinedLiteral(
+      boolean nullable, Any value, String name, String uri) {
+    return Expression.UserDefinedLiteral.builder()
+        .nullable(nullable)
+        .uri(uri)
+        .name(name)
+        .value(value.toByteString())
+        .build();
   }
 
   public static Expression.Switch switchStatement(

--- a/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
@@ -53,6 +53,8 @@ public interface ExpressionVisitor<R, E extends Throwable> {
 
   R visit(Expression.StructLiteral expr) throws E;
 
+  R visit(Expression.UserDefinedLiteral expr) throws E;
+
   R visit(Expression.Switch expr) throws E;
 
   R visit(Expression.IfThen expr) throws E;

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -239,7 +239,6 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
 
   @Override
   public Expression visit(io.substrait.expression.Expression.UserDefinedLiteral expr) {
-
     var typeReference =
         extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.uri(), expr.name()));
     return lit(

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -7,6 +7,7 @@ import io.substrait.expression.FieldReference;
 import io.substrait.expression.FunctionArg;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.ExtensionCollector;
+import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.Expression;
 import io.substrait.proto.FunctionArgument;
 import io.substrait.proto.Rel;
@@ -239,17 +240,15 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
   @Override
   public Expression visit(io.substrait.expression.Expression.UserDefinedLiteral expr) {
 
+    var typeReference =
+        extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.uri(), expr.name()));
     return lit(
         bldr -> {
           try {
             bldr.setNullable(expr.nullable())
                 .setUserDefined(
                     Expression.Literal.UserDefined.newBuilder()
-                        .setTypeReference(
-                            expr.getType()
-                                .accept(typeProtoConverter)
-                                .getUserDefined()
-                                .getTypeReference())
+                        .setTypeReference(typeReference)
                         .setValue(Any.parseFrom(expr.value())))
                 .build();
           } catch (InvalidProtocolBufferException e) {

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -367,7 +367,7 @@ public class ProtoExpressionConverter {
         var userDefinedLiteral = literal.getUserDefined();
         var type = lookup.getType(userDefinedLiteral.getTypeReference(), extensions);
         yield ExpressionCreator.userDefinedLiteral(
-            literal.getNullable(), userDefinedLiteral.getValue(), type.name(), type.uri());
+            literal.getNullable(), type.uri(), type.name(), userDefinedLiteral.getValue());
       }
       default -> throw new IllegalStateException(
           "Unexpected value: " + literal.getLiteralTypeCase());

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -363,6 +363,12 @@ public class ProtoExpressionConverter {
         var listType = protoTypeConverter.fromList(literal.getEmptyList());
         yield ExpressionCreator.emptyList(listType.nullable(), listType.elementType());
       }
+      case USER_DEFINED -> {
+        var userDefinedLiteral = literal.getUserDefined();
+        var type = lookup.getType(userDefinedLiteral.getTypeReference(), extensions);
+        yield ExpressionCreator.userDefinedLiteral(
+            literal.getNullable(), userDefinedLiteral.getValue(), type.name(), type.uri());
+      }
       default -> throw new IllegalStateException(
           "Unexpected value: " + literal.getLiteralTypeCase());
     };

--- a/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
@@ -154,6 +154,11 @@ public class ExpressionCopyOnWriteVisitor<EXCEPTION extends Exception>
   }
 
   @Override
+  public Optional<Expression> visit(Expression.UserDefinedLiteral expr) throws EXCEPTION {
+    return visitLiteral(expr);
+  }
+
+  @Override
   public Optional<Expression> visit(Expression.Switch expr) throws EXCEPTION {
     var match = expr.match().accept(this);
     var switchClauses = transformList(expr.switchClauses(), this::visitSwitchClause);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -94,6 +94,13 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
   }
 
   @Override
+  public RexNode visit(Expression.UserDefinedLiteral expr) throws RuntimeException {
+    return rexBuilder.makeLiteral(
+        new ByteString(expr.value().toByteArray()),
+        typeConverter.toCalcite(typeFactory, expr.getType()));
+  }
+
+  @Override
   public RexNode visit(Expression.BoolLiteral expr) throws RuntimeException {
     return rexBuilder.makeLiteral(expr.value());
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -95,9 +95,9 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
 
   @Override
   public RexNode visit(Expression.UserDefinedLiteral expr) throws RuntimeException {
-    return rexBuilder.makeLiteral(
-        new ByteString(expr.value().toByteArray()),
-        typeConverter.toCalcite(typeFactory, expr.getType()));
+    var binaryLiteral = rexBuilder.makeBinaryLiteral(new ByteString(expr.value().toByteArray()));
+    return rexBuilder.makeReinterpretCast(
+        typeConverter.toCalcite(typeFactory, expr.getType()), binaryLiteral, null);
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -91,14 +91,6 @@ public class LiteralConverter {
       return typedNull(type);
     }
 
-    if (type instanceof Type.UserDefined t) {
-      return Expression.UserDefinedLiteral.builder()
-          .uri(t.uri())
-          .name(t.name())
-          .value(ByteString.copyFrom(literal.getValueAs(byte[].class)))
-          .build();
-    }
-
     return switch (literal.getType().getSqlTypeName()) {
       case TINYINT -> i8(n, i(literal).intValue());
       case SMALLINT -> i16(n, i(literal).intValue());

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -241,7 +241,7 @@ public class CustomFunctionTest extends PlanTestBase {
 
     var bldr = Expression.Literal.newBuilder();
     var anyValue = Any.pack(bldr.setI32(10).build());
-    var val = ExpressionCreator.userDefinedLiteral(false, anyValue, "a_type", NAMESPACE);
+    var val = ExpressionCreator.userDefinedLiteral(false, NAMESPACE, "a_type", anyValue);
 
     Rel rel =
         b.project(


### PR DESCRIPTION
calcite does not accept RelDatatypes with sqltypename.OTHER and has no way of representing it as of now.
It will reject it at different steps such as [RexLiteral Precondition type check](https://github.com/apache/calcite/blob/c774c313a81d01c4e3e77cf296d04839c5ab04c0/core/src/main/java/org/apache/calcite/rex/RexLiteral.java#L231) or when building using the RexBuilder.

There's a [ticket for this on Calcite's board](https://issues.apache.org/jira/browse/IGNITE-18798) but nothing as of of now.

one hacky solution would be:
1. convert the substrait Expression.UDTLiteral into a VARBINARY/ByteString type. (the issue with this is that the Userdatatype.getsqlName would have to be set to sqlname.varbinary, otherwise the type check in calcite will fail)
2. and then when converting back, just check if the RelDatatype inherits from our UserDataType and use that to do the conversion correctly.



