### PR TITLE
ci: disable task caches in gradle build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Build with Gradle
-        run: gradle build
+        run: gradle build --rerun-tasks
   isthmus-native-image-mac-linux:
     name: Build Isthmus Native Image
     needs: java


### PR DESCRIPTION
It seems that we have a lot of flakiness on the `Build and Test Java > Build with Gradle` step, and there's some suspicion that it might come from caching intermediate results and Jabel.

Adding `--rerun-tasks` seems like a good balance -- we don't disable cache completely (so we keep Maven artifacts) but we rebuild any unchanged dependencies to prevent such problems.
