### PR TITLE
fix: match functions using coercion first instead of least restrictive

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -12,6 +12,7 @@ import io.substrait.expression.ImmutableExpression.Cast;
 import io.substrait.expression.ImmutableExpression.SingleOrList;
 import io.substrait.expression.ImmutableExpression.Switch;
 import io.substrait.expression.ImmutableFieldReference;
+import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.function.ToTypeString;
@@ -336,6 +337,10 @@ public class SubstraitBuilder {
     return Expression.I32Literal.builder().value(v).build();
   }
 
+  public Expression.FP64Literal fp64(double v) {
+    return Expression.FP64Literal.builder().value(v).build();
+  }
+
   public Expression cast(Expression input, Type type) {
     return Cast.builder()
         .input(input)
@@ -596,6 +601,30 @@ public class SubstraitBuilder {
     return Expression.ScalarFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
+        .arguments(Arrays.stream(args).collect(java.util.stream.Collectors.toList()))
+        .build();
+  }
+
+  public Expression.WindowFunctionInvocation windowFn(
+      String namespace,
+      String key,
+      Type outputType,
+      Expression.AggregationPhase aggregationPhase,
+      Expression.AggregationInvocation invocation,
+      Expression.WindowBoundsType boundsType,
+      WindowBound lowerBound,
+      WindowBound upperBound,
+      Expression... args) {
+    var declaration =
+        extensions.getWindowFunction(SimpleExtension.FunctionAnchor.of(namespace, key));
+    return Expression.WindowFunctionInvocation.builder()
+        .declaration(declaration)
+        .outputType(outputType)
+        .aggregationPhase(aggregationPhase)
+        .invocation(invocation)
+        .boundsType(boundsType)
+        .lowerBound(lowerBound)
+        .upperBound(upperBound)
         .arguments(Arrays.stream(args).collect(java.util.stream.Collectors.toList()))
         .build();
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -390,14 +390,13 @@ public abstract class FunctionConverter<
       }
 
       if (singularInputType.isPresent()) {
-        Optional<T> leastRestrictive = matchByLeastRestrictive(call, outputType, operands);
-        if (leastRestrictive.isPresent()) {
-          return leastRestrictive;
-        }
-
         Optional<T> coerced = matchCoerced(call, outputType, operands);
         if (coerced.isPresent()) {
           return coerced;
+        }
+        Optional<T> leastRestrictive = matchByLeastRestrictive(call, outputType, operands);
+        if (leastRestrictive.isPresent()) {
+          return leastRestrictive;
         }
       }
       return Optional.empty();

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Test;
 
 /** Verify that custom functions can convert from Substrait to Calcite and back. */
 public class CustomFunctionTest extends PlanTestBase {
-  static final TypeCreator R = TypeCreator.of(false);
-  static final TypeCreator N = TypeCreator.of(true);
 
   // Define custom functions in a "functions_custom.yaml" extension
   static final String NAMESPACE = "/functions_custom";

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.Plan;
@@ -17,6 +18,7 @@ import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelProtoConverter;
 import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +48,9 @@ public class PlanTestBase {
   protected final RelBuilder builder = creator.createRelBuilder();
   protected final RexBuilder rex = creator.rex();
   protected final RelDataTypeFactory typeFactory = creator.typeFactory();
+  protected final SubstraitBuilder substraitBuilder = new SubstraitBuilder(extensions);
+  protected static final TypeCreator R = TypeCreator.of(false);
+  protected static final TypeCreator N = TypeCreator.of(true);
 
   public static String asString(String resource) throws IOException {
     return Resources.toString(Resources.getResource(resource), Charsets.UTF_8);

--- a/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.expression.Expression;
 import io.substrait.expression.WindowBound;
+import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.relation.Rel;
 import java.io.IOException;
 import java.util.List;
@@ -193,7 +194,7 @@ public class WindowFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     substraitBuilder.windowFn(
-                        "/functions_arithmetic.yaml",
+                        DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
                         String.format("%s:any", function),
                         R.FP64,
                         Expression.AggregationPhase.INITIAL_TO_RESULT,
@@ -216,7 +217,7 @@ public class WindowFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     substraitBuilder.windowFn(
-                        "/functions_arithmetic.yaml",
+                        DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
                         String.format("%s:any_i32", function),
                         R.FP64,
                         Expression.AggregationPhase.INITIAL_TO_RESULT,
@@ -240,7 +241,7 @@ public class WindowFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     substraitBuilder.windowFn(
-                        "/functions_arithmetic.yaml",
+                        DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
                         String.format("%s:any_i32_any", function),
                         R.I64,
                         Expression.AggregationPhase.INITIAL_TO_RESULT,


### PR DESCRIPTION
When trying to bind a function such as `LAG(FP64, 1)`, due to LEAD/LAG having function variants that take a single input (`any`), the current matcher is using least restrictive matcher using types (FP64, I32), and ends up matching the wrong function.

The `matchCoerced` function added by https://github.com/substrait-io/substrait-java/pull/226 handles this case correctly, but because the least restrictive takes precedence, it doesn't use proper types.

Inverting the matchers didn't break any of the existing tests, and I added tests to cover the LEAD/LAG scenarios, so I think this is safe.

