### PR TITLE
fix: correct function compound names for IntervalDay and IntervalYear #240

### DIFF
--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -82,12 +82,12 @@ public class ToTypeString
 
   @Override
   public String visit(final Type.IntervalYear expr) {
-    return "year";
+    return "iyear";
   }
 
   @Override
   public String visit(final Type.IntervalDay expr) {
-    return "day";
+    return "iday";
   }
 
   @Override


### PR DESCRIPTION
According to the documentation the short types for IntervalDay and IntervalYear are iday and iyear

https://substrait.io/extensions/#function-signature-compound-names

https://github.com/substrait-io/substrait-java/issues/240