### PR TITLE
chore: update to substrait 0.47.0

### DIFF
--- a/core/src/main/antlr/SubstraitType.g4
+++ b/core/src/main/antlr/SubstraitType.g4
@@ -51,6 +51,8 @@ IntervalYear: I N T E R V A L '_' Y E A R;
 IntervalDay: I N T E R V A L '_' D A Y;
 UUID     : U U I D;
 Decimal  : D E C I M A L;
+PrecisionTimestamp: P R E C I S I O N '_' T I M E S T A M P;
+PrecisionTimestampTZ: P R E C I S I O N '_' T I M E S T A M P '_' T Z;
 FixedChar: F I X E D C H A R;
 VarChar  : V A R C H A R;
 FixedBinary: F I X E D B I N A R Y;
@@ -167,6 +169,8 @@ parameterizedType
 	| VarChar isnull='?'? Lt len=numericParameter Gt #varChar
 	| FixedBinary isnull='?'? Lt len=numericParameter Gt #fixedBinary
 	| Decimal isnull='?'? Lt precision=numericParameter Comma scale=numericParameter Gt #decimal
+	| PrecisionTimestamp isnull='?'? Lt precision=numericParameter Gt #precisionTimestamp
+	| PrecisionTimestampTZ isnull='?'? Lt precision=numericParameter Gt #precisionTimestampTZ
 	| Struct isnull='?'? Lt expr (Comma expr)* Gt #struct
 	| NStruct isnull='?'? Lt Identifier expr (Comma Identifier expr)* Gt #nStruct
 	| List isnull='?'? Lt expr Gt #list

--- a/core/src/main/java/io/substrait/function/ParameterizedType.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedType.java
@@ -107,6 +107,36 @@ public interface ParameterizedType extends TypeExpression {
   }
 
   @Value.Immutable
+  abstract static class PrecisionTimestamp extends BaseParameterizedType implements NullableType {
+    public abstract StringLiteral precision();
+
+    @Override
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
+      return parameterizedTypeVisitor.visit(this);
+    }
+
+    public static ImmutableParameterizedType.PrecisionTimestamp.Builder builder() {
+      return ImmutableParameterizedType.PrecisionTimestamp.builder();
+    }
+  }
+
+  @Value.Immutable
+  abstract static class PrecisionTimestampTZ extends BaseParameterizedType implements NullableType {
+    public abstract StringLiteral precision();
+
+    @Override
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
+      return parameterizedTypeVisitor.visit(this);
+    }
+
+    public static ImmutableParameterizedType.PrecisionTimestampTZ.Builder builder() {
+      return ImmutableParameterizedType.PrecisionTimestampTZ.builder();
+    }
+  }
+
+  @Value.Immutable
   abstract static class Struct extends BaseParameterizedType implements NullableType {
     public abstract java.util.List<ParameterizedType> fields();
 

--- a/core/src/main/java/io/substrait/function/ParameterizedTypeCreator.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedTypeCreator.java
@@ -49,6 +49,20 @@ public class ParameterizedTypeCreator extends TypeCreator
         .build();
   }
 
+  public ParameterizedType precisionTimestampE(String precision) {
+    return ParameterizedType.PrecisionTimestamp.builder()
+        .nullable(nullable)
+        .precision(parameter(precision, false))
+        .build();
+  }
+
+  public ParameterizedType precisionTimestampTZE(String precision) {
+    return ParameterizedType.PrecisionTimestampTZ.builder()
+        .nullable(nullable)
+        .precision(parameter(precision, false))
+        .build();
+  }
+
   public ParameterizedType structE(ParameterizedType... types) {
     return ParameterizedType.Struct.builder().nullable(nullable).addFields(types).build();
   }

--- a/core/src/main/java/io/substrait/function/ParameterizedTypeVisitor.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedTypeVisitor.java
@@ -11,6 +11,10 @@ public interface ParameterizedTypeVisitor<R, E extends Throwable> extends TypeVi
 
   R visit(ParameterizedType.Decimal expr) throws E;
 
+  R visit(ParameterizedType.PrecisionTimestamp expr) throws E;
+
+  R visit(ParameterizedType.PrecisionTimestampTZ expr) throws E;
+
   R visit(ParameterizedType.Struct expr) throws E;
 
   R visit(ParameterizedType.ListType expr) throws E;
@@ -43,6 +47,16 @@ public interface ParameterizedTypeVisitor<R, E extends Throwable> extends TypeVi
 
     @Override
     public R visit(ParameterizedType.Decimal expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(ParameterizedType.PrecisionTimestamp expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(ParameterizedType.PrecisionTimestampTZ expr) throws E {
       throw t();
     }
 

--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -116,6 +116,16 @@ public class ToTypeString
   }
 
   @Override
+  public String visit(final Type.PrecisionTimestamp expr) {
+    return "pts";
+  }
+
+  @Override
+  public String visit(final Type.PrecisionTimestampTZ expr) {
+    return "ptstz";
+  }
+
+  @Override
   public String visit(final Type.Struct expr) {
     return "struct";
   }
@@ -153,6 +163,16 @@ public class ToTypeString
   @Override
   public String visit(ParameterizedType.Decimal expr) throws RuntimeException {
     return "dec";
+  }
+
+  @Override
+  public String visit(ParameterizedType.PrecisionTimestamp expr) throws RuntimeException {
+    return "pts";
+  }
+
+  @Override
+  public String visit(ParameterizedType.PrecisionTimestampTZ expr) throws RuntimeException {
+    return "ptstz";
   }
 
   @Override

--- a/core/src/main/java/io/substrait/function/TypeExpression.java
+++ b/core/src/main/java/io/substrait/function/TypeExpression.java
@@ -85,6 +85,36 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
+  abstract static class PrecisionTimestamp extends BaseTypeExpression implements NullableType {
+
+    public abstract TypeExpression precision();
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+
+    public static ImmutableTypeExpression.PrecisionTimestamp.Builder builder() {
+      return ImmutableTypeExpression.PrecisionTimestamp.builder();
+    }
+  }
+
+  @Value.Immutable
+  abstract static class PrecisionTimestampTZ extends BaseTypeExpression implements NullableType {
+
+    public abstract TypeExpression precision();
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+
+    public static ImmutableTypeExpression.PrecisionTimestampTZ.Builder builder() {
+      return ImmutableTypeExpression.PrecisionTimestampTZ.builder();
+    }
+  }
+
+  @Value.Immutable
   abstract static class Struct extends BaseTypeExpression implements NullableType {
     public abstract java.util.List<TypeExpression> fields();
 

--- a/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
@@ -35,6 +35,20 @@ public class TypeExpressionCreator extends TypeCreator
         .build();
   }
 
+  public TypeExpression precisionTimestampE(TypeExpression precision) {
+    return TypeExpression.PrecisionTimestamp.builder()
+        .nullable(nullable)
+        .precision(precision)
+        .build();
+  }
+
+  public TypeExpression precisionTimestampTZE(TypeExpression precision) {
+    return TypeExpression.PrecisionTimestampTZ.builder()
+        .nullable(nullable)
+        .precision(precision)
+        .build();
+  }
+
   public TypeExpression structE(TypeExpression... types) {
     return TypeExpression.Struct.builder().nullable(nullable).addFields(types).build();
   }

--- a/core/src/main/java/io/substrait/function/TypeExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionVisitor.java
@@ -10,6 +10,10 @@ public interface TypeExpressionVisitor<R, E extends Throwable>
 
   R visit(TypeExpression.Decimal expr) throws E;
 
+  R visit(TypeExpression.PrecisionTimestamp expr) throws E;
+
+  R visit(TypeExpression.PrecisionTimestampTZ expr) throws E;
+
   R visit(TypeExpression.Struct expr) throws E;
 
   R visit(TypeExpression.ListType expr) throws E;
@@ -51,6 +55,16 @@ public interface TypeExpressionVisitor<R, E extends Throwable>
 
     @Override
     public R visit(TypeExpression.Decimal expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(TypeExpression.PrecisionTimestamp expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(TypeExpression.PrecisionTimestampTZ expr) throws E {
       throw t();
     }
 

--- a/core/src/main/java/io/substrait/type/StringTypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/StringTypeVisitor.java
@@ -110,6 +110,16 @@ public class StringTypeVisitor implements TypeVisitor<String, RuntimeException> 
   }
 
   @Override
+  public String visit(Type.PrecisionTimestamp type) throws RuntimeException {
+    return String.format("precision_timestamp<%d>%s", type.precision(), n(type));
+  }
+
+  @Override
+  public String visit(Type.PrecisionTimestampTZ type) throws RuntimeException {
+    return String.format("precision_timestamp_tz<%d>%s", type.precision(), n(type));
+  }
+
+  @Override
   public String visit(Type.Struct type) throws RuntimeException {
     return String.format(
         "struct<%s>%s",

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -155,8 +155,12 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** Deprecated, use {@link PrecisionTimestampTZ} instead */
   @Value.Immutable
+  @Deprecated
   abstract static class TimestampTZ implements Type {
+
+    /** Deprecated, use {@link PrecisionTimestampTZ#builder()} instead */
     public static ImmutableType.TimestampTZ.Builder builder() {
       return ImmutableType.TimestampTZ.builder();
     }
@@ -167,8 +171,13 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** Deprecated, use {@link PrecisionTimestamp} instead */
   @Value.Immutable
+  @Deprecated
   abstract static class Timestamp implements Type {
+
+    /** Deprecated, use {@link PrecisionTimestamp#builder()} instead */
+    @Deprecated
     public static ImmutableType.Timestamp.Builder builder() {
       return ImmutableType.Timestamp.builder();
     }
@@ -265,6 +274,34 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
 
     public static ImmutableType.Decimal.Builder builder() {
       return ImmutableType.Decimal.builder();
+    }
+
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract static class PrecisionTimestamp implements Type {
+    public abstract int precision();
+
+    public static ImmutableType.PrecisionTimestamp.Builder builder() {
+      return ImmutableType.PrecisionTimestamp.builder();
+    }
+
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract static class PrecisionTimestampTZ implements Type {
+    public abstract int precision();
+
+    public static ImmutableType.PrecisionTimestampTZ.Builder builder() {
+      return ImmutableType.PrecisionTimestampTZ.builder();
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -66,6 +66,14 @@ public class TypeCreator {
     return Type.Struct.builder().nullable(nullable).addFields(types).build();
   }
 
+  public final Type precisionTimestamp(int precision) {
+    return Type.PrecisionTimestamp.builder().nullable(nullable).precision(precision).build();
+  }
+
+  public final Type precisionTimestampTZ(int precision) {
+    return Type.PrecisionTimestampTZ.builder().nullable(nullable).precision(precision).build();
+  }
+
   public Type.Struct struct(Iterable<? extends Type> types) {
     return Type.Struct.builder().nullable(nullable).addAllFields(types).build();
   }
@@ -213,6 +221,16 @@ public class TypeCreator {
     @Override
     public Type visit(Type.Decimal type) throws RuntimeException {
       return Type.Decimal.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.PrecisionTimestamp type) throws RuntimeException {
+      return Type.PrecisionTimestamp.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.PrecisionTimestampTZ type) throws RuntimeException {
+      return Type.PrecisionTimestampTZ.builder().from(type).nullable(nullability).build();
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/TypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/TypeVisitor.java
@@ -27,6 +27,10 @@ public interface TypeVisitor<R, E extends Throwable> {
 
   R visit(Type.Timestamp type) throws E;
 
+  R visit(Type.PrecisionTimestamp type) throws E;
+
+  R visit(Type.PrecisionTimestampTZ type) throws E;
+
   R visit(Type.IntervalYear type) throws E;
 
   R visit(Type.IntervalDay type) throws E;
@@ -159,6 +163,16 @@ public interface TypeVisitor<R, E extends Throwable> {
 
     @Override
     public R visit(Type.Decimal type) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(Type.PrecisionTimestamp type) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(Type.PrecisionTimestampTZ type) throws E {
       throw t();
     }
 

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -237,6 +237,40 @@ public class ParseToPojo {
       return withNullE(nullable).decimalE(ctx.precision.accept(this), ctx.scale.accept(this));
     }
 
+    @Override
+    public TypeExpression visitPrecisionTimestamp(
+        final SubstraitTypeParser.PrecisionTimestampContext ctx) {
+      boolean nullable = ctx.isnull != null;
+      Object precision = i(ctx.precision);
+      if (precision instanceof Integer p) {
+        return withNull(nullable).precisionTimestamp(p);
+      }
+      if (precision instanceof String s) {
+        checkParameterizedOrExpression();
+        return withNullP(nullable).precisionTimestampE(s);
+      }
+
+      checkExpression();
+      return withNullE(nullable).precisionTimestampE(ctx.precision.accept(this));
+    }
+
+    @Override
+    public TypeExpression visitPrecisionTimestampTZ(
+        final SubstraitTypeParser.PrecisionTimestampTZContext ctx) {
+      boolean nullable = ctx.isnull != null;
+      Object precision = i(ctx.precision);
+      if (precision instanceof Integer p) {
+        return withNull(nullable).precisionTimestampTZ(p);
+      }
+      if (precision instanceof String s) {
+        checkParameterizedOrExpression();
+        return withNullP(nullable).precisionTimestampTZE(s);
+      }
+
+      checkExpression();
+      return withNullE(nullable).precisionTimestampTZE(ctx.precision.accept(this));
+    }
+
     private Object i(SubstraitTypeParser.NumericParameterContext ctx) {
       TypeExpression type = ctx.accept(this);
       if (type instanceof TypeExpression.IntegerLiteral) {

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -125,6 +125,16 @@ abstract class BaseProtoConverter<T, I>
   }
 
   @Override
+  public final T visit(final Type.PrecisionTimestamp expr) {
+    return typeContainer(expr).precisionTimestamp(expr.precision());
+  }
+
+  @Override
+  public final T visit(final Type.PrecisionTimestampTZ expr) {
+    return typeContainer(expr).precisionTimestampTZ(expr.precision());
+  }
+
+  @Override
   public final T visit(final Type.Struct expr) {
     return typeContainer(expr)
         .struct(

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
@@ -81,6 +81,14 @@ abstract class BaseProtoTypes<T, I> {
     return decimal(i(scale), precision);
   }
 
+  public final T precisionTimestamp(int precision) {
+    return precisionTimestamp(i(precision));
+  }
+
+  public final T precisionTimestampTZ(int precision) {
+    return precisionTimestampTZ(i(precision));
+  }
+
   public abstract T typeParam(String name);
 
   public abstract I integerParam(String name);
@@ -90,6 +98,10 @@ abstract class BaseProtoTypes<T, I> {
   public abstract T fixedBinary(I len);
 
   public abstract T decimal(I scale, I precision);
+
+  public abstract T precisionTimestamp(I precision);
+
+  public abstract T precisionTimestampTZ(I precision);
 
   public final T struct(T... types) {
     return struct(Arrays.asList(types));

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -55,6 +55,18 @@ public class ParameterizedProtoConverter
   }
 
   @Override
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.PrecisionTimestamp expr)
+      throws RuntimeException {
+    return typeContainer(expr).precisionTimestamp(i(expr.precision()));
+  }
+
+  @Override
+  public ParameterizedType visit(io.substrait.function.ParameterizedType.PrecisionTimestampTZ expr)
+      throws RuntimeException {
+    return typeContainer(expr).precisionTimestampTZ(i(expr.precision()));
+  }
+
+  @Override
   public ParameterizedType visit(io.substrait.function.ParameterizedType.Struct expr)
       throws RuntimeException {
     return typeContainer(expr)
@@ -174,6 +186,24 @@ public class ParameterizedProtoConverter
               .build());
     }
 
+    @Override
+    public ParameterizedType precisionTimestamp(ParameterizedType.IntegerOption precision) {
+      return wrap(
+          ParameterizedType.ParameterizedPrecisionTimestamp.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
+    @Override
+    public ParameterizedType precisionTimestampTZ(ParameterizedType.IntegerOption precision) {
+      return wrap(
+          ParameterizedType.ParameterizedPrecisionTimestampTZ.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
     public ParameterizedType struct(Iterable<ParameterizedType> types) {
       return wrap(
           ParameterizedType.ParameterizedStruct.newBuilder()
@@ -246,6 +276,10 @@ public class ParameterizedProtoConverter
         return bldr.setFixedBinary(t).build();
       } else if (o instanceof ParameterizedType.ParameterizedDecimal t) {
         return bldr.setDecimal(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedPrecisionTimestamp t) {
+        return bldr.setPrecisionTimestamp(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedPrecisionTimestampTZ t) {
+        return bldr.setPrecisionTimestampTz(t).build();
       } else if (o instanceof ParameterizedType.ParameterizedStruct t) {
         return bldr.setStruct(t).build();
       } else if (o instanceof ParameterizedType.ParameterizedList t) {

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -42,6 +42,10 @@ public class ProtoTypeConverter {
           .fixedBinary(type.getFixedBinary().getLength());
       case DECIMAL -> n(type.getDecimal().getNullability())
           .decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
+      case PRECISION_TIMESTAMP -> n(type.getPrecisionTimestamp().getNullability())
+          .precisionTimestamp(type.getPrecisionTimestamp().getPrecision());
+      case PRECISION_TIMESTAMP_TZ -> n(type.getPrecisionTimestampTz().getNullability())
+          .precisionTimestampTZ(type.getPrecisionTimestampTz().getPrecision());
       case STRUCT -> n(type.getStruct().getNullability())
           .struct(
               type.getStruct().getTypesList().stream()

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -122,6 +122,16 @@ public class TypeExpressionProtoVisitor
   }
 
   @Override
+  public DerivationExpression visit(ParameterizedType.PrecisionTimestamp expr) {
+    return typeContainer(expr).precisionTimestamp(expr.precision().accept(this));
+  }
+
+  @Override
+  public DerivationExpression visit(TypeExpression.PrecisionTimestampTZ expr) {
+    return typeContainer(expr).precisionTimestampTZ(expr.precision().accept(this));
+  }
+
+  @Override
   public DerivationExpression visit(ParameterizedType.Struct expr) {
     return typeContainer(expr)
         .struct(
@@ -235,6 +245,24 @@ public class TypeExpressionProtoVisitor
               .build());
     }
 
+    @Override
+    public DerivationExpression precisionTimestamp(DerivationExpression precision) {
+      return wrap(
+          DerivationExpression.ExpressionPrecisionTimestamp.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
+    @Override
+    public DerivationExpression precisionTimestampTZ(DerivationExpression precision) {
+      return wrap(
+          DerivationExpression.ExpressionPrecisionTimestampTZ.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
     public DerivationExpression struct(Iterable<DerivationExpression> types) {
       return wrap(
           DerivationExpression.ExpressionStruct.newBuilder()
@@ -311,6 +339,10 @@ public class TypeExpressionProtoVisitor
         return bldr.setFixedBinary(t).build();
       } else if (o instanceof DerivationExpression.ExpressionDecimal t) {
         return bldr.setDecimal(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionPrecisionTimestamp t) {
+        return bldr.setPrecisionTimestamp(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionPrecisionTimestampTZ t) {
+        return bldr.setPrecisionTimestampTz(t).build();
       } else if (o instanceof DerivationExpression.ExpressionStruct t) {
         return bldr.setStruct(t).build();
       } else if (o instanceof DerivationExpression.ExpressionList t) {

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -61,6 +61,22 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
               .build());
     }
 
+    public Type precisionTimestamp(Integer precision) {
+      return wrap(
+          Type.PrecisionTimestamp.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
+    public Type precisionTimestampTZ(Integer precision) {
+      return wrap(
+          Type.PrecisionTimestampTZ.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
     public Type struct(Iterable<Type> types) {
       return wrap(Type.Struct.newBuilder().addAllTypes(types).setNullability(nullability).build());
     }
@@ -121,6 +137,10 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
         return bldr.setFixedBinary(t).build();
       } else if (o instanceof Type.Decimal t) {
         return bldr.setDecimal(t).build();
+      } else if (o instanceof Type.PrecisionTimestamp t) {
+        return bldr.setPrecisionTimestamp(t).build();
+      } else if (o instanceof Type.PrecisionTimestampTZ t) {
+        return bldr.setPrecisionTimestampTz(t).build();
       } else if (o instanceof Type.Struct t) {
         return bldr.setStruct(t).build();
       } else if (o instanceof Type.List t) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
@@ -122,6 +122,18 @@ public class IgnoreNullableAndParameters
   }
 
   @Override
+  public Boolean visit(Type.PrecisionTimestamp type) {
+    return typeToMatch instanceof Type.PrecisionTimestamp
+        || typeToMatch instanceof ParameterizedType.PrecisionTimestamp;
+  }
+
+  @Override
+  public Boolean visit(Type.PrecisionTimestampTZ type) {
+    return typeToMatch instanceof Type.PrecisionTimestampTZ
+        || typeToMatch instanceof ParameterizedType.PrecisionTimestampTZ;
+  }
+
+  @Override
   public Boolean visit(Type.Struct type) {
     return typeToMatch instanceof Type.Struct || typeToMatch instanceof ParameterizedType.Struct;
   }
@@ -157,6 +169,18 @@ public class IgnoreNullableAndParameters
   @Override
   public Boolean visit(ParameterizedType.Decimal expr) throws RuntimeException {
     return typeToMatch instanceof Type.Decimal || typeToMatch instanceof ParameterizedType.Decimal;
+  }
+
+  @Override
+  public Boolean visit(ParameterizedType.PrecisionTimestamp expr) throws RuntimeException {
+    return typeToMatch instanceof Type.PrecisionTimestamp
+        || typeToMatch instanceof ParameterizedType.PrecisionTimestamp;
+  }
+
+  @Override
+  public Boolean visit(ParameterizedType.PrecisionTimestampTZ expr) throws RuntimeException {
+    return typeToMatch instanceof Type.PrecisionTimestampTZ
+        || typeToMatch instanceof ParameterizedType.PrecisionTimestampTZ;
   }
 
   @Override


### PR DESCRIPTION
feat(pojo): wire in PrecisionTimestamp and PrecisionTimestampTZ

BREAKING CHANGE: ParameterizedTypeVisitor has new visit methods
BREAKING CHANGE: TypeExpressionVisitor has new visit methods
BREAKING CHANGE: TypeVisitor has new visit methods
BREAKING CHANGE: BaseProtoTypes has new visit methods