### PR TITLE
fix: handle LIMIT ALL queries using sentinel value in FetchRel::count

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -39,6 +39,7 @@ import io.substrait.type.TypeCreator;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -109,14 +110,30 @@ public class SubstraitBuilder {
   }
 
   public Fetch fetch(long offset, long count, Rel input) {
-    return fetch(offset, count, Optional.empty(), input);
+    return fetch(offset, OptionalLong.of(count), Optional.empty(), input);
   }
 
   public Fetch fetch(long offset, long count, Rel.Remap remap, Rel input) {
-    return fetch(offset, count, Optional.of(remap), input);
+    return fetch(offset, OptionalLong.of(count), Optional.of(remap), input);
   }
 
-  private Fetch fetch(long offset, long count, Optional<Rel.Remap> remap, Rel input) {
+  public Fetch limit(long limit, Rel input) {
+    return fetch(0, OptionalLong.of(limit), Optional.empty(), input);
+  }
+
+  public Fetch limit(long limit, Rel.Remap remap, Rel input) {
+    return fetch(0, OptionalLong.of(limit), Optional.of(remap), input);
+  }
+
+  public Fetch offset(long offset, Rel input) {
+    return fetch(offset, OptionalLong.empty(), Optional.empty(), input);
+  }
+
+  public Fetch offset(long offset, Rel.Remap remap, Rel input) {
+    return fetch(offset, OptionalLong.empty(), Optional.of(remap), input);
+  }
+
+  private Fetch fetch(long offset, OptionalLong count, Optional<Rel.Remap> remap, Rel input) {
     return Fetch.builder().offset(offset).count(count).input(input).remap(remap).build();
   }
 

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -353,7 +353,12 @@ public class ProtoRelConverter {
 
   private Fetch newFetch(FetchRel rel) {
     var input = from(rel.getInput());
-    var builder = Fetch.builder().input(input).count(rel.getCount()).offset(rel.getOffset());
+    var builder = Fetch.builder().input(input).offset(rel.getOffset());
+    if (rel.getCount() != -1) {
+      // -1 is used as a sentinel value to signal LIMIT ALL
+      // count only needs to be set when it is not -1
+      builder.count(rel.getCount());
+    }
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -149,9 +149,9 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
         FetchRel.newBuilder()
             .setCommon(common(fetch))
             .setInput(toProto(fetch.getInput()))
-            .setOffset(fetch.getOffset());
-
-    fetch.getCount().ifPresent(f -> builder.setCount(f));
+            .setOffset(fetch.getOffset())
+            // -1 is used as a sentinel value to signal LIMIT ALL
+            .setCount(fetch.getCount().orElse(-1));
 
     fetch.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
     return Rel.newBuilder().setFetch(builder).build();

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -283,22 +284,30 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
   @Override
   public Rel visit(org.apache.calcite.rel.core.Sort sort) {
-    var input = apply(sort.getInput());
-    var fields =
-        sort.getCollation().getFieldCollations().stream()
-            .map(t -> toSortField(t, input.getRecordType()))
-            .collect(java.util.stream.Collectors.toList());
-    var convertedSort = Sort.builder().addAllSortFields(fields).input(input).build();
-    if (sort.fetch == null && sort.offset == null) {
-      return convertedSort;
-    }
-    var offset = Optional.ofNullable(sort.offset).map(r -> asLong(r)).orElse(0L);
-    var builder = Fetch.builder().input(convertedSort).offset(offset);
-    if (sort.fetch == null) {
-      return builder.build();
+    Rel input = apply(sort.getInput());
+    Rel output = input;
+
+    // SortRel is added BEFORE FetchRel, if present
+    if (!sort.getCollation().getFieldCollations().isEmpty()) {
+      List<Expression.SortField> fields =
+          sort.getCollation().getFieldCollations().stream()
+              .map(t -> toSortField(t, input.getRecordType()))
+              .collect(java.util.stream.Collectors.toList());
+      output = Sort.builder().addAllSortFields(fields).input(output).build();
     }
 
-    return builder.count(asLong(sort.fetch)).build();
+    if (sort.fetch != null || sort.offset != null) {
+      Long offset = Optional.ofNullable(sort.offset).map(this::asLong).orElse(0L);
+      OptionalLong count =
+          Optional.ofNullable(sort.fetch)
+              .map(r -> OptionalLong.of(asLong(r)))
+              .orElse(OptionalLong.empty());
+
+      var builder = Fetch.builder().input(output).offset(offset).count(count);
+      output = builder.build();
+    }
+
+    return output;
   }
 
   private long asLong(RexNode rex) {

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -287,7 +287,10 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     Rel input = apply(sort.getInput());
     Rel output = input;
 
-    // SortRel is added BEFORE FetchRel, if present
+    // The Calcite Sort relation combines sorting along with offset and fetch/limit
+    // Sorting is applied BEFORE the offset and limit is are applied
+    // Substrait splits this functionality into two different relations: SortRel, FetchRel
+    // Add the SortRel to the relation tree first to match Calcite's application order
     if (!sort.getCollation().getFieldCollations().isEmpty()) {
       List<Expression.SortField> fields =
           sort.getCollation().getFieldCollations().stream()

--- a/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
@@ -1,0 +1,34 @@
+package io.substrait.isthmus;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.relation.Rel;
+import io.substrait.type.TypeCreator;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class FetchTest extends PlanTestBase {
+
+  static final TypeCreator R = TypeCreator.of(false);
+
+  final SubstraitBuilder b = new SubstraitBuilder(extensions);
+
+  final Rel TABLE = b.namedScan(List.of("test"), List.of("col1"), List.of(R.STRING));
+
+  @Test
+  void limitOnly() {
+    Rel rel = b.limit(50, TABLE);
+    assertFullRoundTrip(rel);
+  }
+
+  @Test
+  void offsetOnly() {
+    Rel rel = b.offset(50, TABLE);
+    assertFullRoundTrip(rel);
+  }
+
+  @Test
+  void offsetAndLimit() {
+    Rel rel = b.fetch(50, 10, TABLE);
+    assertFullRoundTrip(rel);
+  }
+}


### PR DESCRIPTION
FetchRels with no count set could not be distinguished from FetchRels
with count set to 0.

To account for this, the spec now uses -1 as a sentinel value for this.

feat: new limit and offset methods on SubstraitBuilder