### PR TITLE
feat: support MATCH_RECOGNIZE

### DIFF
--- a/core/src/main/java/io/substrait/dsl/PatternBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/PatternBuilder.java
@@ -5,7 +5,31 @@ import io.substrait.relation.MatchRecognize;
 
 public class PatternBuilder {
 
-  public MatchRecognize.Pattern.Quantifier ONCE = MatchRecognize.Pattern.ONCE;
+  public final MatchRecognize.Pattern.Quantifier ONCE =
+      ImmutableMatchRecognize.Quantifier.builder()
+          .matchingStrategy(MatchRecognize.MatchingStrategy.GREEDY)
+          .min(1)
+          .max(1)
+          .build();
+
+  public final MatchRecognize.Pattern.Quantifier ZERO_OR_MORE =
+      ImmutableMatchRecognize.Quantifier.builder()
+          .min(0)
+          .matchingStrategy(MatchRecognize.MatchingStrategy.GREEDY)
+          .build();
+
+  public final MatchRecognize.Pattern.Quantifier ZERO_OR_ONE =
+      ImmutableMatchRecognize.Quantifier.builder()
+          .min(0)
+          .max(1)
+          .matchingStrategy(MatchRecognize.MatchingStrategy.GREEDY)
+          .build();
+
+  public final MatchRecognize.Pattern.Quantifier ONE_OR_MORE =
+      ImmutableMatchRecognize.Quantifier.builder()
+          .min(1)
+          .matchingStrategy(MatchRecognize.MatchingStrategy.GREEDY)
+          .build();
 
   public io.substrait.relation.MatchRecognize.Pattern.PatternTerm leaf(
       MatchRecognize.Pattern.Quantifier quantifier, String identifier) {

--- a/core/src/main/java/io/substrait/dsl/PatternBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/PatternBuilder.java
@@ -1,0 +1,35 @@
+package io.substrait.dsl;
+
+import io.substrait.relation.ImmutableMatchRecognize;
+import io.substrait.relation.MatchRecognize;
+
+public class PatternBuilder {
+
+  public MatchRecognize.Pattern.Quantifier ONCE = MatchRecognize.Pattern.ONCE;
+
+  public io.substrait.relation.MatchRecognize.Pattern.PatternTerm leaf(
+      MatchRecognize.Pattern.Quantifier quantifier, String identifier) {
+    return ImmutableMatchRecognize.Leaf.builder()
+        .patternIdentifier(io.substrait.relation.MatchRecognize.PatternIdentifier.of(identifier))
+        .quantifier(quantifier)
+        .build();
+  }
+
+  public io.substrait.relation.MatchRecognize.Pattern.PatternTerm concatenate(
+      MatchRecognize.Pattern.Quantifier quantifier,
+      io.substrait.relation.MatchRecognize.Pattern.PatternTerm... components) {
+    return ImmutableMatchRecognize.Concatenation.builder()
+        .addComponents(components)
+        .quantifier(quantifier)
+        .build();
+  }
+
+  public io.substrait.relation.MatchRecognize.Pattern.PatternTerm alternation(
+      MatchRecognize.Pattern.Quantifier quantifier,
+      io.substrait.relation.MatchRecognize.Pattern.PatternTerm... components) {
+    return ImmutableMatchRecognize.Alternation.builder()
+        .addComponents(components)
+        .quantifier(quantifier)
+        .build();
+  }
+}

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -624,6 +624,10 @@ public class SubstraitBuilder {
     return comparisonFunction("lt", left, right);
   }
 
+  public Expression.ScalarFunctionInvocation gt(Expression left, Expression right) {
+    return comparisonFunction("gt", left, right);
+  }
+
   private Expression.ScalarFunctionInvocation comparisonFunction(
       String fname, Expression left, Expression right) {
     var key = String.format("%s:any_any", fname);
@@ -761,6 +765,10 @@ public class SubstraitBuilder {
   // Misc
 
   public Plan.Root root(Rel rel) {
+    return ImmutableRoot.builder().input(rel).build();
+  }
+
+  public Plan.Root root(Rel rel, List<String> names) {
     return ImmutableRoot.builder().input(rel).build();
   }
 

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -686,8 +686,70 @@ public class SubstraitBuilder {
         .build();
   }
 
-  // Types
+  // MATCH_RECOGNIZE Functions
 
+  public Expression.ScalarFunctionInvocation patternRef(
+      Rel input, String patternIdentifier, int colRef) {
+    var outputType = input.getRecordType().fields().get(colRef);
+    return scalarFn(
+        io.substrait.extension.DefaultExtensionCatalog.FUNCTIONS_MATCH_RECOGNIZE,
+        "pattern_ref:str_i32",
+        outputType,
+        str(patternIdentifier),
+        i32(colRef));
+  }
+
+  public Expression.ScalarFunctionInvocation classifier() {
+    return scalarFn(
+        io.substrait.extension.DefaultExtensionCatalog.FUNCTIONS_MATCH_RECOGNIZE,
+        "classifier:",
+        TypeCreator.of(false).STRING);
+  }
+
+  public Expression.ScalarFunctionInvocation matchNumber() {
+    return scalarFn(
+        io.substrait.extension.DefaultExtensionCatalog.FUNCTIONS_MATCH_RECOGNIZE,
+        "match_number:",
+        TypeCreator.of(false).I32);
+  }
+
+  public Expression.ScalarFunctionInvocation prev(Rel input, String patternIdentifier, int colRef) {
+    var outputType = input.getRecordType().fields().get(colRef);
+    return scalarFn(
+        io.substrait.extension.DefaultExtensionCatalog.FUNCTIONS_MATCH_RECOGNIZE,
+        "prev:str_i32",
+        outputType,
+        str(patternIdentifier),
+        i32(colRef));
+  }
+
+  public Expression.ScalarFunctionInvocation next(Rel input, String patternIdentifier, int colRef) {
+    var outputType = input.getRecordType().fields().get(colRef);
+    return scalarFn(
+        DefaultExtensionCatalog.FUNCTIONS_MATCH_RECOGNIZE,
+        "next:str_i32",
+        outputType,
+        str(patternIdentifier),
+        i32(colRef));
+  }
+
+  public Expression.ScalarFunctionInvocation last(Rel input, int colRef) {
+    var outputType = input.getRecordType().fields().get(colRef);
+    return scalarFn(
+        DefaultExtensionCatalog.FUNCTIONS_MATCH_RECOGNIZE, "last:i32", outputType, i32(colRef));
+  }
+
+  public Expression.ScalarFunctionInvocation last(Rel input, String patternIdentifier, int colRef) {
+    var outputType = input.getRecordType().fields().get(colRef);
+    return scalarFn(
+        DefaultExtensionCatalog.FUNCTIONS_MATCH_RECOGNIZE,
+        "last:str_i32",
+        outputType,
+        str(patternIdentifier),
+        i32(colRef));
+  }
+
+  // Types
   public Type.UserDefined userDefinedType(String namespace, String typeName) {
     return ImmutableType.UserDefined.builder()
         .uri(namespace)

--- a/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
+++ b/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
@@ -10,6 +10,7 @@ public class DefaultExtensionCatalog {
   public static final String FUNCTIONS_DATETIME = "/functions_datetime.yaml";
   public static final String FUNCTIONS_GEOMETRY = "/functions_geometry.yaml";
   public static final String FUNCTIONS_LOGARITHMIC = "/functions_logarithmic.yaml";
+  public static final String FUNCTIONS_MATCH_RECOGNIZE = "/functions_match_recognize.yaml";
   public static final String FUNCTIONS_ROUNDING = "/functions_rounding.yaml";
   public static final String FUNCTIONS_SET = "/functions_set.yaml";
   public static final String FUNCTIONS_STRING = "/functions_string.yaml";

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -703,6 +703,7 @@ public class SimpleExtension {
                 "comparison",
                 "datetime",
                 "logarithmic",
+                "match_recognize",
                 "rounding",
                 "string")
             .stream()

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -107,4 +107,9 @@ public abstract class AbstractRelVisitor<OUTPUT, EXCEPTION extends Exception>
   public OUTPUT visit(ConsistentPartitionWindow consistentPartitionWindow) throws EXCEPTION {
     return visitFallback(consistentPartitionWindow);
   }
+
+  @Override
+  public OUTPUT visit(MatchRecognize matchRecognize) throws EXCEPTION {
+    return visitFallback(matchRecognize);
+  }
 }

--- a/core/src/main/java/io/substrait/relation/MatchRecognize.java
+++ b/core/src/main/java/io/substrait/relation/MatchRecognize.java
@@ -344,6 +344,13 @@ public abstract class MatchRecognize extends SingleInputRel implements HasExtens
 
     public abstract Expression getPredicate();
 
+    public static PatternDefinition of(String identifier, Expression predicate) {
+      return builder()
+          .patternIdentifier(PatternIdentifier.of(identifier))
+          .predicate(predicate)
+          .build();
+    }
+
     public static ImmutableMatchRecognize.PatternDefinition.Builder builder() {
       return ImmutableMatchRecognize.PatternDefinition.builder();
     }

--- a/core/src/main/java/io/substrait/relation/MatchRecognize.java
+++ b/core/src/main/java/io/substrait/relation/MatchRecognize.java
@@ -1,0 +1,398 @@
+package io.substrait.relation;
+
+import io.substrait.expression.Expression;
+import io.substrait.proto.MatchRecognizeRel;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Enclosing
+public abstract class MatchRecognize extends SingleInputRel implements HasExtension {
+
+  public abstract List<Expression> getPartitionExpressions();
+
+  public abstract List<Expression.SortField> getSortExpressions();
+
+  public abstract List<Measure> getMeasures();
+
+  public abstract RowsPerMatch getRowsPerMatch();
+
+  public abstract AfterMatchSkip getAfterMatchSkip();
+
+  public abstract Pattern getPattern();
+
+  public abstract List<PatternDefinition> getPatternDefinitions();
+
+  @Override
+  protected Type.Struct deriveRecordType() {
+    Type.Struct inputType = getInput().getRecordType();
+    return TypeCreator.of(inputType.nullable())
+        .struct(
+            Stream.concat(
+                getPartitionExpressions().stream().map(Expression::getType),
+                getMeasures().stream().map(m -> m.getMeasureExpr().getType())));
+  }
+
+  @Override
+  public <O, E extends Exception> O accept(RelVisitor<O, E> visitor) throws E {
+    return visitor.visit(this);
+  }
+
+  public static ImmutableMatchRecognize.Builder builder() {
+    return ImmutableMatchRecognize.builder();
+  }
+
+  @Value.Immutable
+  public abstract static class Measure {
+    public abstract FrameSemantics getFrameSemantics();
+
+    public abstract Expression getMeasureExpr();
+
+    public static ImmutableMatchRecognize.Measure.Builder builder() {
+      return ImmutableMatchRecognize.Measure.builder();
+    }
+
+    public enum FrameSemantics {
+      UNSPECIFIED(MatchRecognizeRel.Measure.FrameSemantics.FRAME_SEMANTICS_UNSPECIFIED),
+      RUNNING(MatchRecognizeRel.Measure.FrameSemantics.FRAME_SEMANTICS_RUNNING),
+      FINAL(MatchRecognizeRel.Measure.FrameSemantics.FRAME_SEMANTICS_FINAL);
+
+      private final MatchRecognizeRel.Measure.FrameSemantics proto;
+
+      FrameSemantics(io.substrait.proto.MatchRecognizeRel.Measure.FrameSemantics proto) {
+        this.proto = proto;
+      }
+
+      public io.substrait.proto.MatchRecognizeRel.Measure.FrameSemantics toProto() {
+        return this.proto;
+      }
+
+      public static FrameSemantics fromProto(MatchRecognizeRel.Measure.FrameSemantics proto) {
+        for (var v : values()) {
+          if (v.proto == proto) {
+            return v;
+          }
+        }
+        throw new IllegalArgumentException("Unknown type: " + proto);
+      }
+    }
+  }
+
+  public enum RowsPerMatch {
+    ROWS_PER_MATCH_UNSPECIFIED(MatchRecognizeRel.RowsPerMatch.ROWS_PER_MATCH_UNSPECIFIED),
+    ROWS_PER_MATCH_ONE(MatchRecognizeRel.RowsPerMatch.ROWS_PER_MATCH_ONE),
+    ROWS_PER_MATCH_ALL(MatchRecognizeRel.RowsPerMatch.ROWS_PER_MATCH_ALL),
+    ROWS_PER_MATCH_ALL_SHOW_EMPTY_MATCHES(
+        MatchRecognizeRel.RowsPerMatch.ROWS_PER_MATCH_ALL_SHOW_EMPTY_MATCHES),
+    ROWS_PER_MATCH_ALL_OMIT_EMPTY_MATCHES(
+        MatchRecognizeRel.RowsPerMatch.ROWS_PER_MATCH_ALL_OMIT_EMPTY_MATCHES),
+    ROWS_PER_MATCH_ALL_WITH_UNMATCHED_ROWS(
+        MatchRecognizeRel.RowsPerMatch.ROWS_PER_MATCH_ALL_WITH_UNMATCHED_ROWS);
+
+    private final MatchRecognizeRel.RowsPerMatch proto;
+
+    RowsPerMatch(MatchRecognizeRel.RowsPerMatch proto) {
+      this.proto = proto;
+    }
+
+    public MatchRecognizeRel.RowsPerMatch toProto() {
+      return this.proto;
+    }
+
+    public static RowsPerMatch fromProto(MatchRecognizeRel.RowsPerMatch proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
+          return v;
+        }
+      }
+      throw new IllegalArgumentException("Unknown type: " + proto);
+    }
+  }
+
+  @Value.Immutable
+  public abstract static class AfterMatchSkip {
+
+    public static final AfterMatchSkip PAST_LAST_ROW =
+        ImmutableMatchRecognize.AfterMatchSkip.builder()
+            .afterMatch(AfterMatch.AFTER_MATCH_SKIP_PAST_LAST_ROW)
+            .build();
+    public static final AfterMatchSkip TO_NEXT_ROW =
+        ImmutableMatchRecognize.AfterMatchSkip.builder()
+            .afterMatch(AfterMatch.AFTER_MATCH_SKIP_TO_NEXT_ROW)
+            .build();
+
+    public abstract AfterMatch getAfterMatch();
+
+    public abstract Optional<PatternIdentifier> getSkipToVariable();
+
+    public MatchRecognizeRel.AfterMatchSkip toProto() {
+      return MatchRecognizeRel.AfterMatchSkip.newBuilder()
+          .setOption(getAfterMatch().toProto())
+          .build();
+    }
+  }
+
+  public enum AfterMatch {
+    AFTER_MATCH_UNSPECIFIED(MatchRecognizeRel.AfterMatchSkip.AfterMatch.AFTER_MATCH_UNSPECIFIED),
+    AFTER_MATCH_SKIP_PAST_LAST_ROW(
+        MatchRecognizeRel.AfterMatchSkip.AfterMatch.AFTER_MATCH_SKIP_PAST_LAST_ROW),
+    AFTER_MATCH_SKIP_TO_NEXT_ROW(
+        MatchRecognizeRel.AfterMatchSkip.AfterMatch.AFTER_MATCH_SKIP_TO_NEXT_ROW),
+    AFTER_MATCH_SKIP_TO_FIRST(
+        MatchRecognizeRel.AfterMatchSkip.AfterMatch.AFTER_MATCH_SKIP_TO_FIRST),
+    AFTER_MATCH_SKIP_TO_LAST(MatchRecognizeRel.AfterMatchSkip.AfterMatch.AFTER_MATCH_SKIP_TO_LAST);
+
+    private final MatchRecognizeRel.AfterMatchSkip.AfterMatch proto;
+
+    AfterMatch(MatchRecognizeRel.AfterMatchSkip.AfterMatch proto) {
+      this.proto = proto;
+    }
+
+    public MatchRecognizeRel.AfterMatchSkip.AfterMatch toProto() {
+      return proto;
+    }
+
+    public static AfterMatch fromProto(MatchRecognizeRel.AfterMatchSkip.AfterMatch proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
+          return v;
+        }
+      }
+      throw new IllegalArgumentException("Unknown type: " + proto);
+    }
+  }
+
+  @Value.Immutable
+  public abstract static class Pattern {
+    public abstract boolean getStartAnchor();
+
+    public abstract boolean getEndAnchor();
+
+    public abstract io.substrait.relation.MatchRecognize.Pattern.PatternTerm getRoot();
+
+    public static ImmutableMatchRecognize.Pattern.Builder builder() {
+      return ImmutableMatchRecognize.Pattern.builder();
+    }
+
+    public MatchRecognizeRel.Pattern toProto() {
+      return MatchRecognizeRel.Pattern.newBuilder()
+          .setStartAnchor(getStartAnchor())
+          .setEndAnchor(getEndAnchor())
+          .setRoot(getRoot().toProto())
+          .build();
+    }
+
+    public static final Quantifier ONCE =
+        ImmutableMatchRecognize.Quantifier.builder()
+            .quantifier(QuantifierBase.QUANTIFIER_BASE_ONCE)
+            .matchingStrategy(MatchingStrategy.UNSPECIFIED)
+            .build();
+
+    public static final Quantifier ZERO_OR_MORE =
+        ImmutableMatchRecognize.Quantifier.builder()
+            .quantifier(QuantifierBase.QUANTIFIER_BASE_ZERO_OR_MORE)
+            .matchingStrategy(MatchingStrategy.UNSPECIFIED)
+            .build();
+
+    public static final Quantifier ZERO_OR_ONE =
+        ImmutableMatchRecognize.Quantifier.builder()
+            .quantifier(QuantifierBase.QUANTIFIER_BASE_ZERO_OR_ONE)
+            .matchingStrategy(MatchingStrategy.UNSPECIFIED)
+            .build();
+
+    @Value.Immutable
+    public abstract static class Quantifier {
+
+      public abstract MatchingStrategy getMatchingStrategy();
+
+      // TODO: figure out a better way to model all the different kinds of quantifiers
+      public abstract QuantifierBase getQuantifier();
+
+      public MatchRecognizeRel.Pattern.Quantifier toProto() {
+        return MatchRecognizeRel.Pattern.Quantifier.newBuilder()
+            .setStrategy(getMatchingStrategy().toProto())
+            .setBase(getQuantifier().toProto())
+            .build();
+      }
+    }
+
+    public enum QuantifierBase {
+      QUANTIFIER_BASE_UNSPECIFIED(
+          MatchRecognizeRel.Pattern.Quantifier.QuantifierBase.QUANTIFIER_BASE_UNSPECIFIED),
+      QUANTIFIER_BASE_ONCE(
+          MatchRecognizeRel.Pattern.Quantifier.QuantifierBase.QUANTIFIER_BASE_ONCE), // A
+      QUANTIFIER_BASE_ZERO_OR_MORE(
+          MatchRecognizeRel.Pattern.Quantifier.QuantifierBase.QUANTIFIER_BASE_ZERO_OR_MORE), // A*
+      QUANTIFIER_BASE_ONE_OR_MORE(
+          MatchRecognizeRel.Pattern.Quantifier.QuantifierBase.QUANTIFIER_BASE_ONE_OR_MORE), // A+
+      QUANTIFIER_BASE_ZERO_OR_ONE(
+          MatchRecognizeRel.Pattern.Quantifier.QuantifierBase.QUANTIFIER_BASE_ZERO_OR_ONE); // A?
+
+      private final MatchRecognizeRel.Pattern.Quantifier.QuantifierBase proto;
+
+      QuantifierBase(MatchRecognizeRel.Pattern.Quantifier.QuantifierBase proto) {
+        this.proto = proto;
+      }
+
+      public MatchRecognizeRel.Pattern.Quantifier.QuantifierBase toProto() {
+        return proto;
+      }
+
+      public static QuantifierBase fromProto(
+          MatchRecognizeRel.Pattern.Quantifier.QuantifierBase proto) {
+        for (var v : values()) {
+          if (v.proto == proto) {
+            return v;
+          }
+        }
+        throw new IllegalArgumentException("Unknown type: " + proto);
+      }
+    }
+
+    public interface PatternTerm {
+
+      Quantifier getQuantifier();
+
+      io.substrait.proto.MatchRecognizeRel.Pattern.PatternTerm toProto();
+      // getQuantifier
+      // getGreedy()
+    }
+
+    @Value.Immutable
+    public abstract static class Leaf
+        implements io.substrait.relation.MatchRecognize.Pattern.PatternTerm {
+
+      public abstract PatternIdentifier getPatternIdentifier();
+
+      public static Leaf of(String identifier, Quantifier quantifier) {
+        return ImmutableMatchRecognize.Leaf.builder()
+            .patternIdentifier(PatternIdentifier.of(identifier))
+            .quantifier(quantifier)
+            .build();
+      }
+
+      @Override
+      public MatchRecognizeRel.Pattern.PatternTerm toProto() {
+        return MatchRecognizeRel.Pattern.PatternTerm.newBuilder()
+            .setLeaf(getPatternIdentifier().toProto())
+            .setQuantifier(getQuantifier().toProto())
+            .build();
+      }
+    }
+
+    @Value.Immutable
+    public abstract static class Concatenation
+        implements io.substrait.relation.MatchRecognize.Pattern.PatternTerm {
+      public abstract List<io.substrait.relation.MatchRecognize.Pattern.PatternTerm>
+          getComponents();
+
+      @Override
+      public io.substrait.proto.MatchRecognizeRel.Pattern.PatternTerm toProto() {
+        List<io.substrait.proto.MatchRecognizeRel.Pattern.PatternTerm> terms =
+            getComponents().stream()
+                .map(io.substrait.relation.MatchRecognize.Pattern.PatternTerm::toProto)
+                .collect(java.util.stream.Collectors.toList());
+        return MatchRecognizeRel.Pattern.PatternTerm.newBuilder()
+            .setQuantifier(getQuantifier().toProto())
+            .setGroup(
+                io.substrait.proto.MatchRecognizeRel.Pattern.PatternGroup.newBuilder()
+                    .setGrouping(
+                        io.substrait.proto.MatchRecognizeRel.Pattern.PatternGrouping
+                            .PATTERN_GROUPING_CONCATENATION)
+                    .addAllTerms(terms)
+                    .build())
+            .build();
+      }
+
+      public static ImmutableMatchRecognize.Concatenation.Builder builder() {
+        return ImmutableMatchRecognize.Concatenation.builder();
+      }
+    }
+
+    @Value.Immutable
+    public abstract static class Alternation
+        implements io.substrait.relation.MatchRecognize.Pattern.PatternTerm {
+      public abstract List<io.substrait.relation.MatchRecognize.Pattern.PatternTerm>
+          getComponents();
+
+      @Override
+      public io.substrait.proto.MatchRecognizeRel.Pattern.PatternTerm toProto() {
+        List<io.substrait.proto.MatchRecognizeRel.Pattern.PatternTerm> terms =
+            getComponents().stream()
+                .map(io.substrait.relation.MatchRecognize.Pattern.PatternTerm::toProto)
+                .collect(java.util.stream.Collectors.toList());
+        return MatchRecognizeRel.Pattern.PatternTerm.newBuilder()
+            .setQuantifier(getQuantifier().toProto())
+            .setGroup(
+                io.substrait.proto.MatchRecognizeRel.Pattern.PatternGroup.newBuilder()
+                    .setGrouping(
+                        MatchRecognizeRel.Pattern.PatternGrouping.PATTERN_GROUPING_ALTERNATION)
+                    .addAllTerms(terms)
+                    .build())
+            .build();
+      }
+
+      public static ImmutableMatchRecognize.Alternation.Builder builder() {
+        return ImmutableMatchRecognize.Alternation.builder();
+      }
+    }
+  }
+
+  @Value.Immutable
+  public abstract static class PatternDefinition {
+    public abstract PatternIdentifier getPatternIdentifier();
+
+    public abstract Expression getPredicate();
+
+    public static ImmutableMatchRecognize.PatternDefinition.Builder builder() {
+      return ImmutableMatchRecognize.PatternDefinition.builder();
+    }
+  }
+
+  @Value.Immutable
+  public abstract static class PatternIdentifier {
+    public abstract String getIdentifier();
+
+    public static io.substrait.relation.MatchRecognize.PatternIdentifier of(String identifier) {
+      return ImmutableMatchRecognize.PatternIdentifier.builder().identifier(identifier).build();
+    }
+
+    public io.substrait.proto.PatternIdentifier toProto() {
+      return io.substrait.proto.PatternIdentifier.newBuilder().setId(getIdentifier()).build();
+    }
+  }
+
+  public enum MatchingStrategy {
+    UNSPECIFIED(
+        MatchRecognizeRel.Pattern.Quantifier.MatchingStrategy.MATCHING_STRATEGY_UNSPECIFIED),
+    GREEDY(MatchRecognizeRel.Pattern.Quantifier.MatchingStrategy.MATCHING_STRATEGY_GREEDY),
+    RELUCTANT(
+        io.substrait.proto.MatchRecognizeRel.Pattern.Quantifier.MatchingStrategy
+            .MATCHING_STRATEGY_RELUCTANT);
+
+    private final io.substrait.proto.MatchRecognizeRel.Pattern.Quantifier.MatchingStrategy proto;
+
+    MatchingStrategy(
+        io.substrait.proto.MatchRecognizeRel.Pattern.Quantifier.MatchingStrategy proto) {
+      this.proto = proto;
+    }
+
+    public io.substrait.proto.MatchRecognizeRel.Pattern.Quantifier.MatchingStrategy toProto() {
+      return proto;
+    }
+
+    public static MatchingStrategy fromProto(
+        MatchRecognizeRel.Pattern.Quantifier.MatchingStrategy proto) {
+      for (var v : values()) {
+        if (v.proto == proto) {
+          return v;
+        }
+      }
+      throw new IllegalArgumentException("Unknown type: " + proto);
+    }
+  }
+}

--- a/core/src/main/java/io/substrait/relation/MatchRecognize.java
+++ b/core/src/main/java/io/substrait/relation/MatchRecognize.java
@@ -196,26 +196,6 @@ public abstract class MatchRecognize extends SingleInputRel implements HasExtens
           .build();
     }
 
-    public static final Quantifier ONCE =
-        ImmutableMatchRecognize.Quantifier.builder()
-            .matchingStrategy(MatchingStrategy.GREEDY)
-            .min(1)
-            .max(1)
-            .build();
-
-    public static final Quantifier ZERO_OR_MORE =
-        ImmutableMatchRecognize.Quantifier.builder()
-            .min(0)
-            .matchingStrategy(MatchingStrategy.GREEDY)
-            .build();
-
-    public static final Quantifier ZERO_OR_ONE =
-        ImmutableMatchRecognize.Quantifier.builder()
-            .min(0)
-            .max(1)
-            .matchingStrategy(MatchingStrategy.GREEDY)
-            .build();
-
     @Value.Immutable
     public abstract static class Quantifier {
 

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -1,5 +1,6 @@
 package io.substrait.relation;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.FunctionArg;
@@ -197,8 +198,19 @@ public class ProtoRelConverter {
     return builder.build();
   }
 
-  private ExtensionLeaf newExtensionLeaf(ExtensionLeafRel rel) {
+  private Rel newExtensionLeaf(ExtensionLeafRel rel) {
     Extension.LeafRelDetail detail = detailFromExtensionLeafRel(rel.getDetail());
+
+    // TODO: remove
+    if (rel.getDetail().getTypeUrl().equals("type.googleapis.com/substrait.MatchRecognizeRel")) {
+      try {
+        MatchRecognizeRel matchRecognizeRel = rel.getDetail().unpack(MatchRecognizeRel.class);
+        return newMatchRecognize(matchRecognizeRel);
+      } catch (InvalidProtocolBufferException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
     var builder =
         ExtensionLeaf.from(detail)
             .commonExtension(optionalAdvancedExtension(rel.getCommon()))

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -722,14 +722,8 @@ public class ProtoRelConverter {
 
   private io.substrait.relation.MatchRecognize.Pattern.PatternTerm patternTermFromProto(
       io.substrait.proto.MatchRecognizeRel.Pattern.PatternTerm term) {
-
     MatchRecognize.Pattern.Quantifier quantifier =
-        ImmutableMatchRecognize.Quantifier.builder()
-            .quantifier(
-                MatchRecognize.Pattern.QuantifierBase.fromProto(term.getQuantifier().getBase()))
-            .matchingStrategy(
-                MatchRecognize.MatchingStrategy.fromProto(term.getQuantifier().getStrategy()))
-            .build();
+        MatchRecognize.Pattern.Quantifier.fromProto(term.getQuantifier());
 
     return switch (term.getTermCase()) {
       case LEAF -> io.substrait.relation.MatchRecognize.Pattern.Leaf.of(

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -707,11 +707,9 @@ public class ProtoRelConverter {
   private MatchRecognize.PatternDefinition fromProto(
       ProtoExpressionConverter converter, MatchRecognizeRel.PatternDefinition patternDefinition) {
 
-    return MatchRecognize.PatternDefinition.builder()
-        .patternIdentifier(
-            MatchRecognize.PatternIdentifier.of(patternDefinition.getIdentifier().getId()))
-        .predicate(converter.from(patternDefinition.getCondition()))
-        .build();
+    return MatchRecognize.PatternDefinition.of(
+        patternDefinition.getIdentifier().getId(),
+        converter.from(patternDefinition.getCondition()));
   }
 
   private MatchRecognize.Measure fromProto(

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -713,11 +713,8 @@ public class ProtoRelConverter {
 
   private io.substrait.relation.MatchRecognize.Pattern fromProto(
       io.substrait.proto.MatchRecognizeRel.Pattern pattern) {
-    return io.substrait.relation.MatchRecognize.Pattern.builder()
-        .startAnchor(pattern.getStartAnchor())
-        .endAnchor(pattern.getEndAnchor())
-        .root(patternTermFromProto(pattern.getRoot()))
-        .build();
+    return io.substrait.relation.MatchRecognize.Pattern.of(
+        pattern.getStartAnchor(), pattern.getEndAnchor(), patternTermFromProto(pattern.getRoot()));
   }
 
   private io.substrait.relation.MatchRecognize.Pattern.PatternTerm patternTermFromProto(

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -366,6 +366,11 @@ public class RelCopyOnWriteVisitor<EXCEPTION extends Exception>
             .build());
   }
 
+  @Override
+  public Optional<Rel> visit(MatchRecognize matchRecognize) throws EXCEPTION {
+    throw new RuntimeException("RelCopyOnWrite not implemented for MatchRecognize yet");
+  }
+
   protected Optional<ConsistentPartitionWindow.WindowRelFunctionInvocation> visitWindowRelFunction(
       ConsistentPartitionWindow.WindowRelFunctionInvocation windowRelFunctionInvocation)
       throws EXCEPTION {

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -1,5 +1,6 @@
 package io.substrait.relation;
 
+import com.google.protobuf.Any;
 import io.substrait.expression.Expression;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.FunctionArg;
@@ -349,7 +350,13 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
 
     matchRecognize.getExtension().ifPresent(ae -> builder.setAdvancedExtension(ae.toProto()));
 
-    return Rel.newBuilder().setMatchRecognize(builder).build();
+    // TODO: Remove this wrapping
+    // Wrap the MatchRecognizeRel in an ExtensionLeafRel for other systems to use
+    // Using Leaf instead of Single to keep the input on the MatchRecognizeRel itself
+    ExtensionLeafRel extensionLeaf =
+        ExtensionLeafRel.newBuilder().setDetail(Any.pack(builder.build())).build();
+
+    return Rel.newBuilder().setExtensionLeaf(extensionLeaf).build();
   }
 
   private MatchRecognizeRel.Measure toProto(MatchRecognize.Measure measure) {

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -44,4 +44,6 @@ public interface RelVisitor<OUTPUT, EXCEPTION extends Exception> {
   OUTPUT visit(NestedLoopJoin nestedLoopJoin) throws EXCEPTION;
 
   OUTPUT visit(ConsistentPartitionWindow consistentPartitionWindow) throws EXCEPTION;
+
+  OUTPUT visit(MatchRecognize matchRecognize) throws EXCEPTION;
 }

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
@@ -67,6 +67,7 @@ public class MatchRecognizeMain {
 
   static void patternConcatenation() throws IOException {
     // Trino: TestRowPatternMatching
+    // TODO: need to figure how to compute the output columns when ALL ROWS PER MATCH is set
 
     VirtualTableScan input =
         b.virtualTableScan(
@@ -76,21 +77,26 @@ public class MatchRecognizeMain {
                 b.struct(b.i64(2), b.i64(80)),
                 b.struct(b.i64(3), b.i64(70)),
                 b.struct(b.i64(4), b.i64(70))));
-
-    // -- QUERY
     // SELECT m.id AS row_id, m.match, m.val, m.label
-    // FROM t2 MATCH_RECOGNIZE (
-    //  ORDER BY id
-    //  MEASURES
-    //    match_number() AS match,
-    //    RUNNING LAST(value) AS val,
-    //    classifier() AS label
-    //  ALL ROWS PER MATCH
-    //  AFTER MATCH SKIP PAST LAST ROW
-    //  PATTERN (A B C)
-    //  DEFINE
-    //    B AS B.value < PREV (B.value)
-    //    C AS C.value = PREV (C.value)
+    // FROM (
+    //   VALUES
+    //     (1, 90),
+    //     (2, 80),
+    //     (3, 70),
+    //     (4, 70)
+    // )  t(id, value)
+    // MATCH_RECOGNIZE (
+    //   ORDER BY id
+    //   MEASURES
+    //     match_number() AS match,
+    //     RUNNING LAST(value) AS val,
+    //     classifier() AS label
+    //   ALL ROWS PER MATCH
+    //   AFTER MATCH SKIP PAST LAST ROW
+    //   PATTERN (A B C)
+    //   DEFINE
+    //     B AS B.value < PREV (B.value),
+    //     C AS C.value = PREV (C.value)
     // ) AS m
 
     List<Expression.SortField> sortKeys =

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus.cli;
 
+import com.google.protobuf.util.JsonFormat;
 import io.substrait.dsl.PatternBuilder;
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.Expression;
@@ -118,7 +119,8 @@ public class MatchRecognizeMain {
     var planToProtoConverter = new PlanProtoConverter();
 
     var protoPlan = planToProtoConverter.toProto(plan);
-    System.out.println(protoPlan.toString());
+
+    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(protoPlan));
 
     var protoPlanConverter = new io.substrait.plan.ProtoPlanConverter();
     var plan2 = protoPlanConverter.from(protoPlan);

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
@@ -4,6 +4,7 @@ import com.google.protobuf.util.JsonFormat;
 import io.substrait.dsl.PatternBuilder;
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.Expression;
+import io.substrait.expression.WindowBound;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.Plan;
 import io.substrait.plan.PlanProtoConverter;
@@ -29,6 +30,14 @@ public class MatchRecognizeMain {
     }
   }
 
+  static final JsonFormat.TypeRegistry TYPE_REGISTRY =
+      JsonFormat.TypeRegistry.newBuilder().add(MatchRecognizeRel.getDescriptor()).build();
+
+  static final SubstraitBuilder b = new SubstraitBuilder(extensions);
+  static final PatternBuilder p = new PatternBuilder();
+
+  static TypeCreator R = TypeCreator.of(false);
+
   private static MatchRecognize.Measure measure(Expression expr) {
     return MatchRecognize.Measure.builder()
         .frameSemantics(MatchRecognize.Measure.FrameSemantics.UNSPECIFIED)
@@ -52,14 +61,13 @@ public class MatchRecognizeMain {
 
   public static void main(String[] args) throws java.io.IOException {
     //    patternConcatenation();
-    customersWith6OrMoreOrdersWithRisingPrices();
+    //    customersWith6OrMoreOrdersWithRisingPrices();
+    aggregationsInMeasures();
   }
 
   static void patternConcatenation() throws IOException {
     // Trino: TestRowPatternMatching
 
-    SubstraitBuilder b = new SubstraitBuilder(extensions);
-    PatternBuilder p = new PatternBuilder();
     VirtualTableScan input =
         b.virtualTableScan(
             List.of("id", "value"),
@@ -94,16 +102,12 @@ public class MatchRecognizeMain {
 
     MatchRecognize.Pattern.PatternTerm pattern =
         p.concatenate(p.ONCE, p.leaf(p.ONCE, "A"), p.leaf(p.ONCE, "B"), p.leaf(p.ONCE, "C"));
-    List<ImmutableMatchRecognize.PatternDefinition> patternDefinition =
+    List<MatchRecognize.PatternDefinition> patternDefinition =
         List.of(
-            MatchRecognize.PatternDefinition.builder()
-                .patternIdentifier(MatchRecognize.PatternIdentifier.of("B"))
-                .predicate(b.lt(b.patternRef(input, "B", 1), b.prev(input, "B", 1)))
-                .build(),
-            MatchRecognize.PatternDefinition.builder()
-                .patternIdentifier(MatchRecognize.PatternIdentifier.of("B"))
-                .predicate(b.equal(b.patternRef(input, "C", 1), b.prev(input, "C", 1)))
-                .build());
+            MatchRecognize.PatternDefinition.of(
+                "B", b.lt(b.patternRef(input, "B", 1), b.prev(input, "B", 1))),
+            MatchRecognize.PatternDefinition.of(
+                "B", b.equal(b.patternRef(input, "C", 1), b.prev(input, "C", 1))));
 
     MatchRecognize matchRecognize =
         MatchRecognize.builder()
@@ -134,43 +138,38 @@ public class MatchRecognizeMain {
     assert plan.equals(plan2);
   }
 
-  private static final JsonFormat.TypeRegistry TYPE_REGISTRY =
-      JsonFormat.TypeRegistry.newBuilder().add(MatchRecognizeRel.getDescriptor()).build();
+  // trino> SHOW COLUMNS FROM tiny.orders
+  //     -> ;
+  //    Column     |    Type     | Extra | Comment
+  // ---------------+-------------+-------+---------
+  //  orderkey      | bigint      |       |
+  //  custkey       | bigint      |       |
+  //  orderstatus   | varchar(1)  |       |
+  //  totalprice    | double      |       |
+  //  orderdate     | date        |       |
+  //  orderpriority | varchar(15) |       |
+  //  clerk         | varchar(15) |       |
+  //  shippriority  | integer     |       |
+  //  comment       | varchar(79) |       |
+  static NamedScan ORDERS =
+      b.namedScan(
+          List.of("orders"),
+          List.of(
+              "orderkey", // 0
+              "custkey", // 1
+              "orderstatus", // 2
+              "totalprice", // 3
+              "orderdate", // 4
+              "orderpriority", // 5
+              "clerk", // 6
+              "shippriority", // 7
+              "comment"), // 8
+          List.of(R.I64, R.I64, R.STRING, R.FP64, R.DATE, R.STRING, R.STRING, R.I64, R.STRING));
 
   static void customersWith6OrMoreOrdersWithRisingPrices() throws IOException {
     // SOURCE:
     // https://github.com/trinodb/trino/blob/f26bade5be88f5326e4bc243bff6bae27a93b2d2/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java#L5137-L5159
-    SubstraitBuilder b = new SubstraitBuilder(extensions);
-    PatternBuilder p = new PatternBuilder();
-    TypeCreator R = TypeCreator.of(false);
-
-    // trino> SHOW COLUMNS FROM tiny.orders
-    //     -> ;
-    //    Column     |    Type     | Extra | Comment
-    // ---------------+-------------+-------+---------
-    //  orderkey      | bigint      |       |
-    //  custkey       | bigint      |       |
-    //  orderstatus   | varchar(1)  |       |
-    //  totalprice    | double      |       |
-    //  orderdate     | date        |       |
-    //  orderpriority | varchar(15) |       |
-    //  clerk         | varchar(15) |       |
-    //  shippriority  | integer     |       |
-    //  comment       | varchar(79) |       |
-    NamedScan orders =
-        b.namedScan(
-            List.of("orders"),
-            List.of(
-                "orderkey", // 0
-                "custkey", // 1
-                "orderstatus", // 2
-                "totalprice", // 3
-                "orderdate", // 4
-                "orderpriority", // 5
-                "clerk", // 6
-                "shippriority", // 7
-                "comment"), // 8
-            List.of(R.I64, R.I64, R.STRING, R.FP64, R.DATE, R.STRING, R.STRING, R.I64, R.STRING));
+    //    SubstraitBuilder b = new SubstraitBuilder(extensions);
 
     // SELECT m.custkey, m.matchno, m.lowest_price, m.highest_price
     // FROM orders MATCH_RECOGNIZE (
@@ -187,14 +186,14 @@ public class MatchRecognizeMain {
 
     MatchRecognize matchRecognize =
         MatchRecognize.builder()
-            .input(orders)
-            .addPartitionExpressions(b.fieldReference(orders, 1))
-            .sortExpressions(b.sortFields(orders, 0))
+            .input(ORDERS)
+            .addPartitionExpressions(b.fieldReference(ORDERS, 1))
+            .sortExpressions(b.sortFields(ORDERS, 0))
             .addMeasures(
                 // A.totalprice AS lowest_price
-                measure(b.patternRef(orders, "A", 3)),
+                measure(b.patternRef(ORDERS, "A", 3)),
                 // FINAL LAST(R.totalprice) AS highest_price
-                finalMeasure(b.last(orders, "R", 3)),
+                finalMeasure(b.last(ORDERS, "R", 3)),
                 // MATCH_NUMBER() AS matchno
                 measure(b.matchNumber()))
             .rowsPerMatch(MatchRecognize.RowsPerMatch.ROWS_PER_MATCH_ONE)
@@ -215,16 +214,95 @@ public class MatchRecognizeMain {
                                 .build(),
                             "R"))))
             .addPatternDefinitions(
-                MatchRecognize.PatternDefinition.builder()
-                    .patternIdentifier(MatchRecognize.PatternIdentifier.of("R"))
-                    .predicate(b.gt(b.patternRef(orders, "R", 3), b.prev(orders, "R", 3)))
-                    .build())
+                MatchRecognize.PatternDefinition.of(
+                    "R", b.gt(b.patternRef(ORDERS, "R", 3), b.prev(ORDERS, "R", 3))))
             .build();
 
     Project select = b.project(input -> List.of(), b.remap(0, 3, 1, 2), matchRecognize);
 
     Plan plan =
         b.plan(b.root(select, List.of("custkey", "matchno", "lowest_price", "highest_price")));
+
+    var planToProtoConverter = new PlanProtoConverter();
+    var protoPlan = planToProtoConverter.toProto(plan);
+
+    System.out.println(
+        JsonFormat.printer()
+            .usingTypeRegistry(TYPE_REGISTRY)
+            .includingDefaultValueFields()
+            .print(protoPlan));
+
+    var protoPlanConverter = new io.substrait.plan.ProtoPlanConverter();
+    var plan2 = protoPlanConverter.from(protoPlan);
+    assert plan.equals(plan2);
+  }
+
+  static void aggregationsInMeasures() throws IOException {
+    // SELECT even_count, even_sum, odd_count, odd_sum
+    // FROM orders MATCH_RECOGNIZE (
+    //   MEASURES
+    //     count(EVEN.totalprice) AS even_count,
+    //     sum(EVEN.totalprice) AS even_sum,
+    //     count(ODD.totalprice) AS odd_count,
+    //     sum(ODD.totalprice) AS odd_sum
+    //   ONE ROW PER MATCH
+    //   PATTERN ((EVEN | ODD)*)
+    //   DEFINE EVEN AS orderkey % 2 = 0
+    // )
+
+    MatchRecognize matchRecognize =
+        MatchRecognize.builder()
+            .input(ORDERS)
+            .addMeasures(
+                // TODO / META: MATCH_RECOGNIZE allows usage of aggregates outside of aggregations
+                // As an Expression, the only way to encode this is a a WindowFunction
+                // However the bounds should be ignored as they are defined by the RUNNING / FINAL
+                // option on the measure
+                //
+                // We may wish to add AggregateFunction as a valid Expression type OR have the
+                // MatchRecognize measure
+                // be either an expression or AggregateFunctions
+                measure(
+                        b.sumWindowed(
+                            b.patternRef(ORDERS, "EVEN", 3),
+                            Expression.WindowBoundsType.UNSPECIFIED,
+                            WindowBound.UNBOUNDED,
+                            WindowBound.UNBOUNDED)),
+                    measure(
+                        b.countWindowed(
+                            b.patternRef(ORDERS, "EVEN", 3),
+                            Expression.WindowBoundsType.UNSPECIFIED,
+                            WindowBound.UNBOUNDED,
+                            WindowBound.UNBOUNDED)),
+                measure(
+                        b.sumWindowed(
+                            b.patternRef(ORDERS, "ODD", 3),
+                            Expression.WindowBoundsType.UNSPECIFIED,
+                            WindowBound.UNBOUNDED,
+                            WindowBound.UNBOUNDED)),
+                    measure(
+                        b.countWindowed(
+                            b.patternRef(ORDERS, "ODD", 3),
+                            Expression.WindowBoundsType.UNSPECIFIED,
+                            WindowBound.UNBOUNDED,
+                            WindowBound.UNBOUNDED)))
+            .rowsPerMatch(MatchRecognize.RowsPerMatch.ROWS_PER_MATCH_ONE)
+            .afterMatchSkip(MatchRecognize.AfterMatchSkip.PAST_LAST_ROW)
+            .pattern(
+                MatchRecognize.Pattern.of(
+                    false,
+                    false,
+                    p.alternation(
+                        MatchRecognize.Pattern.ZERO_OR_MORE,
+                        p.leaf(MatchRecognize.Pattern.ONCE, "EVEN"),
+                        p.leaf(MatchRecognize.Pattern.ONCE, "ODD"))))
+            .addPatternDefinitions(
+                MatchRecognize.PatternDefinition.of(
+                    "EVEN", b.equal(b.mod(b.fieldReference(ORDERS, 0), b.i64(2)), b.i64(0))))
+            .build();
+
+    Plan plan =
+        b.plan(b.root(matchRecognize, List.of("even_count", "even_sum", "odd_count", "odd_sum")));
 
     var planToProtoConverter = new PlanProtoConverter();
     var protoPlan = planToProtoConverter.toProto(plan);

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
@@ -1,0 +1,128 @@
+package io.substrait.isthmus.cli;
+
+import io.substrait.dsl.PatternBuilder;
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.Expression;
+import io.substrait.extension.SimpleExtension;
+import io.substrait.plan.PlanProtoConverter;
+import io.substrait.relation.ImmutableMatchRecognize;
+import io.substrait.relation.MatchRecognize;
+import io.substrait.relation.VirtualTableScan;
+import java.io.IOException;
+import java.util.List;
+
+public class MatchRecognizeMain {
+
+  protected static SimpleExtension.ExtensionCollection extensions = null;
+
+  static {
+    try {
+      extensions = SimpleExtension.loadDefaults();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static MatchRecognize.Measure measure(Expression expr) {
+    return MatchRecognize.Measure.builder()
+        .frameSemantics(MatchRecognize.Measure.FrameSemantics.UNSPECIFIED)
+        .measureExpr(expr)
+        .build();
+  }
+
+  private static MatchRecognize.Measure runningMeasure(Expression expr) {
+    return MatchRecognize.Measure.builder()
+        .frameSemantics(MatchRecognize.Measure.FrameSemantics.RUNNING)
+        .measureExpr(expr)
+        .build();
+  }
+
+  private static MatchRecognize.Measure finalMeasure(Expression expr) {
+    return MatchRecognize.Measure.builder()
+        .frameSemantics(MatchRecognize.Measure.FrameSemantics.FINAL)
+        .measureExpr(expr)
+        .build();
+  }
+
+  public static void main(String[] args) throws java.io.IOException {
+    patternConcatenation();
+  }
+
+  static void patternConcatenation() throws IOException {
+    // Trino: TestRowPatternMatching
+
+    SubstraitBuilder b = new SubstraitBuilder(extensions);
+    PatternBuilder p = new PatternBuilder();
+    VirtualTableScan input =
+        b.virtualTableScan(
+            List.of("id", "value"),
+            List.of(
+                b.struct(b.i64(1), b.i64(90)),
+                b.struct(b.i64(2), b.i64(80)),
+                b.struct(b.i64(3), b.i64(70)),
+                b.struct(b.i64(4), b.i64(70))));
+
+    // -- QUERY
+    // SELECT m.id AS row_id, m.match, m.val, m.label
+    // FROM t2 MATCH_RECOGNIZE (
+    //  ORDER BY id
+    //  MEASURES
+    //    match_number() AS match,
+    //    RUNNING LAST(value) AS val,
+    //    classifier() AS label
+    //  ALL ROWS PER MATCH
+    //  AFTER MATCH SKIP PAST LAST ROW
+    //  PATTERN (A B C)
+    //  DEFINE
+    //    B AS B.value < PREV (B.value)
+    //    C AS C.value = PREV (C.value)
+    // ) AS m
+
+    List<Expression.SortField> sortKeys =
+        List.of(b.sortField(b.fieldReference(input, 0), Expression.SortDirection.ASC_NULLS_FIRST));
+
+    List<MatchRecognize.Measure> measures =
+        List.of(
+            measure(b.matchNumber()), runningMeasure(b.last(input, 1)), measure(b.classifier()));
+
+    MatchRecognize.Pattern.PatternTerm pattern =
+        p.concatenate(p.ONCE, p.leaf(p.ONCE, "A"), p.leaf(p.ONCE, "B"), p.leaf(p.ONCE, "C"));
+    List<ImmutableMatchRecognize.PatternDefinition> patternDefinition =
+        List.of(
+            MatchRecognize.PatternDefinition.builder()
+                .patternIdentifier(MatchRecognize.PatternIdentifier.of("B"))
+                .predicate(b.lt(b.patternRef(input, "B", 1), b.prev(input, "B", 1)))
+                .build(),
+            MatchRecognize.PatternDefinition.builder()
+                .patternIdentifier(MatchRecognize.PatternIdentifier.of("B"))
+                .predicate(b.equal(b.patternRef(input, "C", 1), b.prev(input, "C", 1)))
+                .build());
+
+    MatchRecognize matchRecognize =
+        MatchRecognize.builder()
+            .input(input)
+            .sortExpressions(sortKeys)
+            .measures(measures)
+            .rowsPerMatch(MatchRecognize.RowsPerMatch.ROWS_PER_MATCH_ALL)
+            .afterMatchSkip(MatchRecognize.AfterMatchSkip.PAST_LAST_ROW)
+            .pattern(
+                ImmutableMatchRecognize.Pattern.builder()
+                    .startAnchor(false)
+                    .endAnchor(false)
+                    .root(pattern)
+                    .build())
+            .patternDefinitions(patternDefinition)
+            .build();
+
+    var plan = b.plan(b.root(matchRecognize));
+    var planToProtoConverter = new PlanProtoConverter();
+
+    var protoPlan = planToProtoConverter.toProto(plan);
+    System.out.println(protoPlan.toString());
+
+    var protoPlanConverter = new io.substrait.plan.ProtoPlanConverter();
+    var plan2 = protoPlanConverter.from(protoPlan);
+
+    assert plan.equals(plan2);
+  }
+}

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
@@ -5,10 +5,14 @@ import io.substrait.dsl.PatternBuilder;
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.Expression;
 import io.substrait.extension.SimpleExtension;
+import io.substrait.plan.Plan;
 import io.substrait.plan.PlanProtoConverter;
 import io.substrait.relation.ImmutableMatchRecognize;
 import io.substrait.relation.MatchRecognize;
+import io.substrait.relation.NamedScan;
+import io.substrait.relation.Project;
 import io.substrait.relation.VirtualTableScan;
+import io.substrait.type.TypeCreator;
 import java.io.IOException;
 import java.util.List;
 
@@ -46,7 +50,8 @@ public class MatchRecognizeMain {
   }
 
   public static void main(String[] args) throws java.io.IOException {
-    patternConcatenation();
+    //    patternConcatenation();
+    customersWith6OrMoreOrdersWithRisingPrices();
   }
 
   static void patternConcatenation() throws IOException {
@@ -125,6 +130,104 @@ public class MatchRecognizeMain {
     var protoPlanConverter = new io.substrait.plan.ProtoPlanConverter();
     var plan2 = protoPlanConverter.from(protoPlan);
 
+    assert plan.equals(plan2);
+  }
+
+  static void customersWith6OrMoreOrdersWithRisingPrices() throws IOException {
+    // SOURCE: https://github.com/trinodb/trino/blob/f26bade5be88f5326e4bc243bff6bae27a93b2d2/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java#L5137-L5159
+    SubstraitBuilder b = new SubstraitBuilder(extensions);
+    PatternBuilder p = new PatternBuilder();
+    TypeCreator R = TypeCreator.of(false);
+
+    // trino> SHOW COLUMNS FROM tiny.orders
+    //     -> ;
+    //    Column     |    Type     | Extra | Comment
+    // ---------------+-------------+-------+---------
+    //  orderkey      | bigint      |       |
+    //  custkey       | bigint      |       |
+    //  orderstatus   | varchar(1)  |       |
+    //  totalprice    | double      |       |
+    //  orderdate     | date        |       |
+    //  orderpriority | varchar(15) |       |
+    //  clerk         | varchar(15) |       |
+    //  shippriority  | integer     |       |
+    //  comment       | varchar(79) |       |
+    NamedScan orders =
+        b.namedScan(
+            List.of("orders"),
+            List.of(
+                "orderkey", // 0
+                "custkey", // 1
+                "orderstatus", // 2
+                "totalprice", // 3
+                "orderdate", // 4
+                "orderpriority", // 5
+                "clerk", // 6
+                "shippriority", // 7
+                "comment"), // 8
+            List.of(R.I64, R.I64, R.STRING, R.FP64, R.DATE, R.STRING, R.STRING, R.I64, R.STRING));
+
+    // SELECT m.custkey, m.matchno, m.lowest_price, m.highest_price
+    // FROM orders MATCH_RECOGNIZE (
+    //   PARTITION BY custkey
+    //   ORDER BY orderdate
+    //   MEASURES
+    //     A.totalprice AS lowest_price,
+    //     FINAL LAST(R.totalprice) AS highest_price,
+    //     MATCH_NUMBER() AS matchno
+    //   ONE ROW PER MATCH
+    //   PATTERN (A R{5,})
+    //   DEFINE R AS R.totalprice > PREV(R.totalprice)
+    // ) AS m
+
+    MatchRecognize matchRecognize =
+        MatchRecognize.builder()
+            .input(orders)
+            .addPartitionExpressions(b.fieldReference(orders, 1))
+            .sortExpressions(b.sortFields(orders, 0))
+            .addMeasures(
+                // A.totalprice AS lowest_price
+                measure(b.patternRef(orders, "A", 3)),
+                // FINAL LAST(R.totalprice) AS highest_price
+                finalMeasure(b.last(orders, "R", 3)),
+                // MATCH_NUMBER() AS matchno
+                measure(b.matchNumber()))
+            .rowsPerMatch(MatchRecognize.RowsPerMatch.ROWS_PER_MATCH_ONE)
+            .afterMatchSkip(MatchRecognize.AfterMatchSkip.PAST_LAST_ROW)
+            .pattern(
+                MatchRecognize.Pattern.of(
+                    false,
+                    false,
+                    p.concatenate(
+                        MatchRecognize.Pattern.ONCE,
+                        // A
+                        p.leaf(MatchRecognize.Pattern.ONCE, "A"),
+                        // R{5,}
+                        p.leaf(
+                            MatchRecognize.Pattern.Quantifier.builder()
+                                .matchingStrategy(MatchRecognize.MatchingStrategy.GREEDY)
+                                .min(5)
+                                .build(),
+                            "R"))))
+            .addPatternDefinitions(
+                MatchRecognize.PatternDefinition.builder()
+                    .patternIdentifier(MatchRecognize.PatternIdentifier.of("R"))
+                    .predicate(b.gt(b.patternRef(orders, "R", 3), b.prev(orders, "R", 3)))
+                    .build())
+            .build();
+
+    Project select = b.project(input -> List.of(), b.remap(0, 3, 1, 2), matchRecognize);
+
+    Plan plan =
+        b.plan(b.root(select, List.of("custkey", "matchno", "lowest_price", "highest_price")));
+
+    var planToProtoConverter = new PlanProtoConverter();
+    var protoPlan = planToProtoConverter.toProto(plan);
+
+    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(protoPlan));
+
+    var protoPlanConverter = new io.substrait.plan.ProtoPlanConverter();
+    var plan2 = protoPlanConverter.from(protoPlan);
     assert plan.equals(plan2);
   }
 }

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/MatchRecognizeMain.java
@@ -7,6 +7,7 @@ import io.substrait.expression.Expression;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.Plan;
 import io.substrait.plan.PlanProtoConverter;
+import io.substrait.proto.MatchRecognizeRel;
 import io.substrait.relation.ImmutableMatchRecognize;
 import io.substrait.relation.MatchRecognize;
 import io.substrait.relation.NamedScan;
@@ -133,8 +134,12 @@ public class MatchRecognizeMain {
     assert plan.equals(plan2);
   }
 
+  private static final JsonFormat.TypeRegistry TYPE_REGISTRY =
+      JsonFormat.TypeRegistry.newBuilder().add(MatchRecognizeRel.getDescriptor()).build();
+
   static void customersWith6OrMoreOrdersWithRisingPrices() throws IOException {
-    // SOURCE: https://github.com/trinodb/trino/blob/f26bade5be88f5326e4bc243bff6bae27a93b2d2/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java#L5137-L5159
+    // SOURCE:
+    // https://github.com/trinodb/trino/blob/f26bade5be88f5326e4bc243bff6bae27a93b2d2/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java#L5137-L5159
     SubstraitBuilder b = new SubstraitBuilder(extensions);
     PatternBuilder p = new PatternBuilder();
     TypeCreator R = TypeCreator.of(false);
@@ -224,7 +229,11 @@ public class MatchRecognizeMain {
     var planToProtoConverter = new PlanProtoConverter();
     var protoPlan = planToProtoConverter.toProto(plan);
 
-    System.out.println(JsonFormat.printer().includingDefaultValueFields().print(protoPlan));
+    System.out.println(
+        JsonFormat.printer()
+            .usingTypeRegistry(TYPE_REGISTRY)
+            .includingDefaultValueFields()
+            .print(protoPlan));
 
     var protoPlanConverter = new io.substrait.plan.ProtoPlanConverter();
     var plan2 = protoPlanConverter.from(protoPlan);


### PR DESCRIPTION
The code in this PR is me thinking out loud about modelling MATCH_RECOGNIZE in Substrait.
It builds off of the work in https://github.com/substrait-io/substrait/pull/636.

This should not be considered final. The primary reason I've wired this into substrait-java is to be able to produce example plans quickly.