### PR TITLE
chore: shadow ANTLR dependency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = unset
 insert_final_newline = unset
 indent_style = unset
 trim_trailing_whitespace = unset
+
+[*.gradle.kts]
+indent_size = 2

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -108,6 +108,8 @@ tasks {
     archiveBaseName.set("isthmus")
     manifest { attributes(mapOf("Main-Class" to "io.substrait.isthmus.PlanEntryPoint")) }
   }
+
+  classes { dependsOn(":core:shadowJar") }
 }
 
 tasks { build { dependsOn(shadowJar) } }


### PR DESCRIPTION
ANTLR had a breaking change in its serialization format between 4.9 and 4.10+, meaning libraries that depend on one are incompatible with libraries that depend on another.

Spark (until Spark 4.x) depends on ANTRL 4.9, so this project bumping ANTLR 4.10+ made it impossible to use both Spark and substrait-java in the same project.

Shadowing and relocating the ANTLR dependency removes the issues with incompatibility since substrait-spark's ANTLR is now independent of any other ANTLRs.