### PR TITLE
feat(core): shade ANTLR runtime into substrait-core

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = unset
 insert_final_newline = unset
 indent_style = unset
 trim_trailing_whitespace = unset
+
+[*.gradle.kts]
+indent_size = 2

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   id("antlr")
   id("com.google.protobuf") version "0.8.17"
   id("com.diffplug.spotless") version "6.11.0"
+  id("com.github.johnrengelman.shadow") version "7.1.2"
   signing
 }
 
@@ -85,7 +86,7 @@ dependencies {
   implementation("com.google.code.findbugs:jsr305:3.0.2")
 
   antlr("org.antlr:antlr4:${ANTLR_VERSION}")
-  implementation("org.antlr:antlr4-runtime:${ANTLR_VERSION}")
+  shadow("org.antlr:antlr4-runtime:${ANTLR_VERSION}")
   implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
   annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
   compileOnly("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
@@ -138,3 +139,16 @@ tasks.named<AntlrTask>("generateGrammarSource") {
 }
 
 protobuf { protoc { artifact = "com.google.protobuf:protoc:3.17.3" } }
+
+tasks {
+  shadowJar {
+    archiveClassifier.set("")
+    relocate("org.antlr.v4.runtime", "io.substrait.shadow.org.antlr.v4.runtime")
+    dependencies { include(dependency("org.antlr:antlr4-runtime:.*")) }
+    exclude("META-INF/maven/org.antlr/")
+  }
+  jar {
+    enabled = false
+    dependsOn(shadowJar)
+  }
+}


### PR DESCRIPTION
An external dependency on a specific ANTLR runtime version can cause version conflicts for consuming projects that also make use of ANTLR. This change shades the ANTLR runtime into the substrait core JAR file, renaming the ANTLR runtime packages to avoid conflicts with any ANTLR dependency in consuming projects.

Closes #259