### PR TITLE
ci: update deprecated GitHub actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v3
   java:
     name: Build and Test Java
     runs-on: ubuntu-latest
@@ -42,7 +42,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'


### PR DESCRIPTION
Actions based on Node versions lower than Node 20 are deprecated. See:

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/