### PR TITLE
ci: cancel in-progress build on PR update

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,11 @@ name: PR Build Check
 
 on:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   editorconfig-checker:
     name: Check editorconfig


### PR DESCRIPTION
This change modifies the pull request build definition so that previous builds of a pull request are cancelled when a new change is pushed. This avoids redundant pull request builds continuing to run to completion and wasting build resources.