### PR TITLE
ci: stop pinning conventionalcommits

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -29,7 +29,7 @@ npx --yes \
   -p "@semantic-release/changelog" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "conventional-changelog-conventionalcommits@6.1.0" \
+  -p "conventional-changelog-conventionalcommits" \
   semantic-release \
   --ci false \
   --dry-run \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -11,6 +11,5 @@ npx --yes \
   -p "@semantic-release/github" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "conventional-changelog-conventionalcommits@6.1.0" \
+  -p "conventional-changelog-conventionalcommits" \
   semantic-release --ci
-


### PR DESCRIPTION
Basically reverts https://github.com/substrait-io/substrait-java/pull/175/files.

That pin causes an issue, see e.g. https://github.com/semantic-release/release-notes-generator/issues/655#issuecomment-2143737739

Confirmed locally that before this change `./ci/release/dry-run.sh` fails with the same error as seen [here](https://github.com/substrait-io/substrait-java/actions/runs/9334990717/job/25694163852), after it works:
```
[4:25:06 PM] [semantic-release] › ✔  Published release 1.0.0 on default channel
[4:25:06 PM] [semantic-release] › ℹ  Release note for version 1.0.0:
## 1.0.0 (https:/var/folders/s6/cfz9m6jn3td5t3wfhxhb22xj082ytf/T/tmp.g55tfWF1QA/compare/v0.31.0...v1.0.0) (2024-06-04)

### ⚠ BREAKING CHANGES

    * Substrait FP32 is now mapped to Calcite REAL instead of FLOAT
    * Calcite FLOAT is now mapped to Substrait FP64 instead of FP32

In Calcite, the Sql Type Names DOUBLE and FLOAT correspond to FP64, and REAL corresponds to FP32
...
```
It does however seem to want to release 1.x. But maybe that's just still the same dry-run issue as in https://github.com/substrait-io/substrait-java/pull/175#issuecomment-1708804062?
