### PR TITLE
fix(isthmus): correct SLF4J dependency

### DIFF
--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -17,6 +17,7 @@ var IMMUTABLES_VERSION = properties.get("immutables.version")
 var JACKSON_VERSION = properties.get("jackson.version")
 var JUNIT_VERSION = properties.get("junit.version")
 var PROTOBUF_VERSION = properties.get("protobuf.version")
+var SLF4J_VERSION = properties.get("slf4j.version")
 
 dependencies {
   implementation(project(":core"))
@@ -39,6 +40,7 @@ dependencies {
   testImplementation("org.apache.calcite:calcite-plus:${CALCITE_VERSION}")
   annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
   compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
+  runtimeOnly("org.slf4j:slf4j-jdk14:${SLF4J_VERSION}")
 }
 
 var initializeAtBuildTime =

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -96,7 +96,6 @@ dependencies {
   implementation("com.github.ben-manes.caffeine:caffeine:3.0.4")
   implementation("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
   implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
-  runtimeOnly("org.slf4j:slf4j-jdk14:${SLF4J_VERSION}")
   annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
   testImplementation("org.apache.calcite:calcite-plus:${CALCITE_VERSION}")
   annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")


### PR DESCRIPTION
- Remove concrete slf4j-jdk14 provider dependency from isthmus.
- Add concrete slf4j-jdk14 provider dependency to isthmus-cli.

Library components should only depend on slf4j-api, allowing consumers to select an appropriate concrete logging provider implementation. Being a self-contained (CLI) application, isthmus-cli can depend on a specific SLF4J provider.