### PR TITLE
build: add vulnerability scan to PR build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v3
+  cyclonedx-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Generate SBOMs
+        run: ./gradlew cyclonedxBom
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: cyclonedx-sbom
+          path: |
+            core/build/reports/bom.json
+            isthmus/build/reports/bom.json
+            isthmus-cli/build/reports/bom.json
+  osv-scanner:
+    needs: cyclonedx-sbom
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - core
+          - isthmus
+          - isthmus-cli
+    steps:
+      - name: Download SBOMs
+        uses: actions/download-artifact@v4
+        with:
+          name: cyclonedx-sbom
+      - name: Scan
+        run: docker run --rm -v "${PWD}/${{ matrix.project }}/build/reports/bom.json:/bom.json" ghcr.io/google/osv-scanner --sbom /bom.json
   java:
     name: Build and Test Java
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   id("com.github.vlsi.gradle-extensions") version "1.74"
   id("com.diffplug.spotless") version "6.11.0"
   id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+  id("org.cyclonedx.bom") version "1.8.2"
 }
 
 var IMMUTABLES_VERSION = properties.get("immutables.version")
@@ -66,6 +67,21 @@ allprojects {
         trimTrailingWhitespace()
         targetExclude("**/build/**")
       }
+    }
+  }
+
+  if (listOf("core", "isthmus", "isthmus-cli").contains(project.name)) {
+    apply(plugin = "org.cyclonedx.bom")
+    tasks.cyclonedxBom {
+      setIncludeConfigs(listOf("runtimeClasspath"))
+      setSkipConfigs(listOf("compileClasspath", "testCompileClasspath"))
+      setProjectType("library")
+      setSchemaVersion("1.5")
+      setDestination(project.file("build/reports"))
+      setOutputName("bom")
+      setOutputFormat("json")
+      setIncludeBomSerialNumber(false)
+      setIncludeLicenseText(false)
     }
   }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.google.protobuf.gradle.protobuf
-import com.google.protobuf.gradle.protoc
 import org.gradle.plugins.ide.idea.model.IdeaModel
 
 plugins {
@@ -7,7 +5,7 @@ plugins {
   id("java")
   id("idea")
   id("antlr")
-  id("com.google.protobuf") version "0.8.17"
+  id("com.google.protobuf") version "0.9.4"
   id("com.diffplug.spotless") version "6.11.0"
   id("com.github.johnrengelman.shadow") version "8.1.1"
   signing
@@ -69,10 +67,11 @@ signing {
 }
 
 val ANTLR_VERSION = properties.get("antlr.version")
-var IMMUTABLES_VERSION = properties.get("immutables.version")
-var JACKSON_VERSION = properties.get("jackson.version")
-var JUNIT_VERSION = properties.get("junit.version")
-var SLF4J_VERSION = properties.get("slf4j.version")
+val IMMUTABLES_VERSION = properties.get("immutables.version")
+val JACKSON_VERSION = properties.get("jackson.version")
+val JUNIT_VERSION = properties.get("junit.version")
+val SLF4J_VERSION = properties.get("slf4j.version")
+val PROTOBUF_VERSION = properties.get("protobuf.version")
 
 // This allows specifying deps to be shadowed so that they don't get included in the POM file
 val shadowImplementation by configurations.creating
@@ -85,7 +84,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_VERSION}")
   testImplementation("org.junit.jupiter:junit-jupiter-params:${JUNIT_VERSION}")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${JUNIT_VERSION}")
-  implementation("com.google.protobuf:protobuf-java:3.17.3")
+  implementation("com.google.protobuf:protobuf-java:${PROTOBUF_VERSION}")
   implementation("com.fasterxml.jackson.core:jackson-databind:${JACKSON_VERSION}")
   implementation("com.fasterxml.jackson.core:jackson-annotations:${JACKSON_VERSION}")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${JACKSON_VERSION}")
@@ -162,4 +161,4 @@ tasks.named<AntlrTask>("generateGrammarSource") {
     layout.buildDirectory.dir("generated/sources/antlr/main/java/io/substrait/type").get().asFile
 }
 
-protobuf { protoc { artifact = "com.google.protobuf:protoc:3.17.3" } }
+protobuf { protoc { artifact = "com.google.protobuf:protoc:${PROTOBUF_VERSION}" } }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ guava.version=32.1.3-jre
 immutables.version=2.10.1
 jackson.version=2.16.1
 junit.version=5.8.1
-protobuf.version=3.17.3
+protobuf.version=3.25.3
 slf4j.version=2.0.13
 
 #version that is going to be updated automatically by releases

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -11,13 +11,13 @@ java {
   withSourcesJar()
 }
 
-var CALCITE_VERSION = properties.get("calcite.version")
-var GUAVA_VERSION = properties.get("guava.version")
-var IMMUTABLES_VERSION = properties.get("immutables.version")
-var JACKSON_VERSION = properties.get("jackson.version")
-var JUNIT_VERSION = properties.get("junit.version")
-var PROTOBUF_VERSION = properties.get("protobuf.version")
-var SLF4J_VERSION = properties.get("slf4j.version")
+val CALCITE_VERSION = properties.get("calcite.version")
+val GUAVA_VERSION = properties.get("guava.version")
+val IMMUTABLES_VERSION = properties.get("immutables.version")
+val JACKSON_VERSION = properties.get("jackson.version")
+val JUNIT_VERSION = properties.get("junit.version")
+val PROTOBUF_VERSION = properties.get("protobuf.version")
+val SLF4J_VERSION = properties.get("slf4j.version")
 
 dependencies {
   implementation(project(":core"))
@@ -43,7 +43,7 @@ dependencies {
   runtimeOnly("org.slf4j:slf4j-jdk14:${SLF4J_VERSION}")
 }
 
-var initializeAtBuildTime =
+val initializeAtBuildTime =
   listOf(
       "com.google.common.base.Platform",
       "com.google.common.base.Preconditions",

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -70,13 +70,13 @@ java {
   withSourcesJar()
 }
 
-var CALCITE_VERSION = properties.get("calcite.version")
-var GUAVA_VERSION = properties.get("guava.version")
-var IMMUTABLES_VERSION = properties.get("immutables.version")
-var JACKSON_VERSION = properties.get("jackson.version")
-var JUNIT_VERSION = properties.get("junit.version")
-var SLF4J_VERSION = properties.get("slf4j.version")
-var PROTOBUF_VERSION = properties.get("protobuf.version")
+val CALCITE_VERSION = properties.get("calcite.version")
+val GUAVA_VERSION = properties.get("guava.version")
+val IMMUTABLES_VERSION = properties.get("immutables.version")
+val JACKSON_VERSION = properties.get("jackson.version")
+val JUNIT_VERSION = properties.get("junit.version")
+val SLF4J_VERSION = properties.get("slf4j.version")
+val PROTOBUF_VERSION = properties.get("protobuf.version")
 
 dependencies {
   implementation(project(":core"))


### PR DESCRIPTION
Continue build on vulnerability detection.

Update protobuf dependency to address vulnerabilities:

- CVE-2022-25647
- CVE-2022-3509
- CVE-2022-3510
- CVE-2022-3171