### PR TITLE
fix: set VirtualTableScan schema explicitly

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -334,12 +334,11 @@ public class ProtoRelConverter {
                       .collect(java.util.stream.Collectors.toList()))
               .build());
     }
-    var fieldNames =
-        rel.getBaseSchema().getNamesList().stream().collect(java.util.stream.Collectors.toList());
+
     var builder =
         VirtualTableScan.builder()
             .filter(Optional.ofNullable(rel.hasFilter() ? converter.from(rel.getFilter()) : null))
-            .addAllDfsNames(fieldNames)
+            .initialSchema(NamedStruct.fromProto(rel.getBaseSchema(), protoTypeConverter))
             .rows(structLiterals);
 
     builder

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -1,7 +1,6 @@
 package io.substrait.relation;
 
 import io.substrait.expression.Expression;
-import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeVisitor;
 import java.util.List;
@@ -9,8 +8,6 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 public abstract class VirtualTableScan extends AbstractReadRel {
-
-  public abstract List<String> getDfsNames();
 
   public abstract List<Expression.StructLiteral> getRows();
 
@@ -26,7 +23,7 @@ public abstract class VirtualTableScan extends AbstractReadRel {
    */
   @Value.Check
   protected void check() {
-    var names = getDfsNames();
+    var names = getInitialSchema().names();
     var rows = getRows();
 
     assert rows.size() > 0
@@ -34,11 +31,6 @@ public abstract class VirtualTableScan extends AbstractReadRel {
         && rows.stream().noneMatch(r -> r == null)
         && rows.stream()
             .allMatch(r -> r.getType().accept(new NamedFieldCountingTypeVisitor()) == names.size());
-  }
-
-  @Override
-  public final NamedStruct getInitialSchema() {
-    return NamedStruct.of(getDfsNames(), (Type.Struct) getRows().get(0).getType());
   }
 
   @Override

--- a/core/src/test/java/io/substrait/relation/VirtualTableScanTest.java
+++ b/core/src/test/java/io/substrait/relation/VirtualTableScanTest.java
@@ -6,27 +6,41 @@ import static io.substrait.expression.ExpressionCreator.string;
 import static io.substrait.expression.ExpressionCreator.struct;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import io.substrait.TestBase;
 import io.substrait.expression.Expression;
+import io.substrait.type.NamedStruct;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-class VirtualTableScanTest {
+class VirtualTableScanTest extends TestBase {
 
   @Test
   void check() {
     VirtualTableScan virtualTableScan =
         ImmutableVirtualTableScan.builder()
-            .addDfsNames(
-                "string",
-                "struct",
-                "struct_field1",
-                "struct_field2",
-                "list",
-                "list_struct_field1",
-                "map",
-                "map_key_struct_field1",
-                "map_value_struct_field1")
+            .initialSchema(
+                NamedStruct.of(
+                    Arrays.stream(
+                            new String[] {
+                              "string",
+                              "struct",
+                              "struct_field1",
+                              "struct_field2",
+                              "list",
+                              "list_struct_field1",
+                              "map",
+                              "map_key_struct_field1",
+                              "map_value_struct_field1"
+                            })
+                        .collect(Collectors.toList()),
+                    R.struct(
+                        R.STRING,
+                        R.struct(R.STRING, R.STRING),
+                        R.list(R.STRING),
+                        R.map(R.STRING, R.STRING))))
             .addRows(
                 struct(
                     false,

--- a/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
@@ -13,6 +13,7 @@ import io.substrait.relation.ImmutableAggregate;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.RelProtoConverter;
 import io.substrait.relation.VirtualTableScan;
+import io.substrait.type.NamedStruct;
 import io.substrait.type.TypeCreator;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -25,8 +26,12 @@ public class AggregateRoundtripTest extends TestBase {
   private void assertAggregateRoundtrip(Expression.AggregationInvocation invocation) {
     var expression = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
     Expression.StructLiteral literal =
-        ImmutableExpression.StructLiteral.builder().from(expression).build();
-    var input = VirtualTableScan.builder().addRows(literal).build();
+        ImmutableExpression.StructLiteral.builder().addFields(expression).build();
+    var input =
+        VirtualTableScan.builder()
+            .initialSchema(NamedStruct.of(Arrays.asList("decimal"), R.struct(R.decimal(10, 2))))
+            .addRows(literal)
+            .build();
     ExtensionCollector functionCollector = new ExtensionCollector();
     var to = new RelProtoConverter(functionCollector);
     var extensions = defaultExtensionCollection;

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -74,6 +74,7 @@ public class ExtensionRoundtripTest extends TestBase {
   void virtualTable() {
     Rel rel =
         VirtualTableScan.builder()
+            .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
             .addRows(Expression.StructLiteral.builder().fields(Collections.emptyList()).build())
             .commonExtension(commonExtension)
             .extension(relExtension)

--- a/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
@@ -44,7 +44,10 @@ public class ReadRelRoundtripTest extends TestBase {
   void virtualTable() {
     var virtTable =
         VirtualTableScan.builder()
-            .addAllDfsNames(Stream.of("column1", "column2").collect(Collectors.toList()))
+            .initialSchema(
+                NamedStruct.of(
+                    Stream.of("column1", "column2").collect(Collectors.toList()),
+                    R.struct(R.I64, R.I64)))
             .addRows(
                 ExpressionCreator.struct(
                     false, ExpressionCreator.i64(false, 1), ExpressionCreator.i64(false, 2)))

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -136,7 +136,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
                   return ExpressionCreator.struct(false, fields);
                 })
             .collect(Collectors.toUnmodifiableList());
-    return VirtualTableScan.builder().addAllDfsNames(type.names()).addAllRows(structs).build();
+    return VirtualTableScan.builder().initialSchema(type).addAllRows(structs).build();
   }
 
   @Override


### PR DESCRIPTION
VirtualTableScan in Substrait is expected to contain both a NamedSchema (field names in dfs form and types) like any other read rel, plus the actual data rows. However substrait-java was ignoring the types of the NamedSchema, instead grabbing type info from the first row of the data. This however is not always sufficient since the data can contain varying nullability row-by-row.

This also just simplifies VirtualTableScan and makes it behave more like one would expect by looking at the Substrait spec as well as other ReadRels