### PR TITLE
feat: deprecate Timestamp and TimestampTZ visit functions

### DIFF
--- a/core/src/main/java/io/substrait/type/TypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/TypeVisitor.java
@@ -23,8 +23,10 @@ public interface TypeVisitor<R, E extends Throwable> {
 
   R visit(Type.Time type) throws E;
 
+  @Deprecated
   R visit(Type.TimestampTZ type) throws E;
 
+  @Deprecated
   R visit(Type.Timestamp type) throws E;
 
   R visit(Type.PrecisionTimestamp type) throws E;


### PR DESCRIPTION
By marking the function as @Deprecated and providing a default implementation makes users code a lot cleaner.

Directly implementations of the interface previously would need to implement these methods and cope with the Deprecation warning.

With this change if they are using it, no problems; but they are not obliged to implement it.