### PR TITLE
fix: properly support Options for Scalar/Aggregate/Window functions

### DIFF
--- a/core/src/main/java/io/substrait/expression/AggregateFunctionInvocation.java
+++ b/core/src/main/java/io/substrait/expression/AggregateFunctionInvocation.java
@@ -3,7 +3,6 @@ package io.substrait.expression;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.type.Type;
 import java.util.List;
-import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -12,7 +11,7 @@ public abstract class AggregateFunctionInvocation {
 
   public abstract List<FunctionArg> arguments();
 
-  public abstract Map<String, FunctionOption> options();
+  public abstract List<FunctionOption> options();
 
   public abstract Expression.AggregationPhase aggregationPhase();
 

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -596,7 +596,7 @@ public interface Expression extends FunctionArg {
 
     public abstract List<FunctionArg> arguments();
 
-    public abstract Map<String, FunctionOption> options();
+    public abstract List<FunctionOption> options();
 
     public abstract Type outputType();
 
@@ -620,7 +620,7 @@ public interface Expression extends FunctionArg {
 
     public abstract List<FunctionArg> arguments();
 
-    public abstract Map<String, FunctionOption> options();
+    public abstract List<FunctionOption> options();
 
     public abstract AggregationPhase aggregationPhase();
 

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -285,7 +285,7 @@ public class ExpressionCreator {
       SimpleExtension.ScalarFunctionVariant declaration,
       Type outputType,
       FunctionArg... arguments) {
-      return scalarFunction(declaration, outputType, Arrays.asList(), Arrays.asList(arguments));
+    return scalarFunction(declaration, outputType, Arrays.asList(), Arrays.asList(arguments));
   }
 
   public static Expression.ScalarFunctionInvocation scalarFunction(

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -284,20 +285,25 @@ public class ExpressionCreator {
       SimpleExtension.ScalarFunctionVariant declaration,
       Type outputType,
       FunctionArg... arguments) {
-    return Expression.ScalarFunctionInvocation.builder()
-        .declaration(declaration)
-        .outputType(outputType)
-        .addArguments(arguments)
-        .build();
+      return scalarFunction(declaration, outputType, Arrays.asList(), Arrays.asList(arguments));
   }
 
   public static Expression.ScalarFunctionInvocation scalarFunction(
       SimpleExtension.ScalarFunctionVariant declaration,
       Type outputType,
       Iterable<? extends FunctionArg> arguments) {
+    return scalarFunction(declaration, outputType, Arrays.asList(), arguments);
+  }
+
+  public static Expression.ScalarFunctionInvocation scalarFunction(
+      SimpleExtension.ScalarFunctionVariant declaration,
+      Type outputType,
+      List<? extends FunctionOption> options,
+      Iterable<? extends FunctionArg> arguments) {
     return Expression.ScalarFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
+        .options(options)
         .addAllArguments(arguments)
         .build();
   }
@@ -309,12 +315,25 @@ public class ExpressionCreator {
       List<Expression.SortField> sort,
       Expression.AggregationInvocation invocation,
       Iterable<? extends FunctionArg> arguments) {
+    return aggregateFunction(
+        declaration, outputType, phase, sort, invocation, Arrays.asList(), arguments);
+  }
+
+  public static AggregateFunctionInvocation aggregateFunction(
+      SimpleExtension.AggregateFunctionVariant declaration,
+      Type outputType,
+      Expression.AggregationPhase phase,
+      List<Expression.SortField> sort,
+      Expression.AggregationInvocation invocation,
+      List<? extends FunctionOption> options,
+      Iterable<? extends FunctionArg> arguments) {
     return AggregateFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
         .aggregationPhase(phase)
         .sort(sort)
         .invocation(invocation)
+        .addAllOptions(options)
         .addAllArguments(arguments)
         .build();
   }
@@ -326,14 +345,8 @@ public class ExpressionCreator {
       List<Expression.SortField> sort,
       Expression.AggregationInvocation invocation,
       FunctionArg... arguments) {
-    return AggregateFunctionInvocation.builder()
-        .declaration(declaration)
-        .outputType(outputType)
-        .aggregationPhase(phase)
-        .sort(sort)
-        .invocation(invocation)
-        .addArguments(arguments)
-        .build();
+    return aggregateFunction(
+        declaration, outputType, phase, sort, invocation, Arrays.asList(arguments));
   }
 
   public static Expression.WindowFunctionInvocation windowFunction(
@@ -347,6 +360,32 @@ public class ExpressionCreator {
       WindowBound lowerBound,
       WindowBound upperBound,
       Iterable<? extends FunctionArg> arguments) {
+    return windowFunction(
+        declaration,
+        outputType,
+        phase,
+        sort,
+        invocation,
+        partitionBy,
+        boundsType,
+        lowerBound,
+        upperBound,
+        Arrays.asList(),
+        arguments);
+  }
+
+  public static Expression.WindowFunctionInvocation windowFunction(
+      SimpleExtension.WindowFunctionVariant declaration,
+      Type outputType,
+      Expression.AggregationPhase phase,
+      List<Expression.SortField> sort,
+      Expression.AggregationInvocation invocation,
+      List<Expression> partitionBy,
+      Expression.WindowBoundsType boundsType,
+      WindowBound lowerBound,
+      WindowBound upperBound,
+      List<? extends FunctionOption> options,
+      Iterable<? extends FunctionArg> arguments) {
     return Expression.WindowFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
@@ -357,6 +396,7 @@ public class ExpressionCreator {
         .lowerBound(lowerBound)
         .upperBound(upperBound)
         .invocation(invocation)
+        .addAllOptions(options)
         .addAllArguments(arguments)
         .build();
   }
@@ -370,6 +410,28 @@ public class ExpressionCreator {
       WindowBound lowerBound,
       WindowBound upperBound,
       Iterable<? extends FunctionArg> arguments) {
+    return windowRelFunction(
+        declaration,
+        outputType,
+        phase,
+        invocation,
+        boundsType,
+        lowerBound,
+        upperBound,
+        Arrays.asList(),
+        arguments);
+  }
+
+  public static ConsistentPartitionWindow.WindowRelFunctionInvocation windowRelFunction(
+      SimpleExtension.WindowFunctionVariant declaration,
+      Type outputType,
+      Expression.AggregationPhase phase,
+      Expression.AggregationInvocation invocation,
+      Expression.WindowBoundsType boundsType,
+      WindowBound lowerBound,
+      WindowBound upperBound,
+      List<? extends FunctionOption> options,
+      Iterable<? extends FunctionArg> arguments) {
     return ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
@@ -379,6 +441,7 @@ public class ExpressionCreator {
         .upperBound(upperBound)
         .invocation(invocation)
         .addAllArguments(arguments)
+        .addAllOptions(options)
         .build();
   }
 
@@ -393,18 +456,18 @@ public class ExpressionCreator {
       WindowBound lowerBound,
       WindowBound upperBound,
       FunctionArg... arguments) {
-    return Expression.WindowFunctionInvocation.builder()
-        .declaration(declaration)
-        .outputType(outputType)
-        .aggregationPhase(phase)
-        .sort(sort)
-        .invocation(invocation)
-        .partitionBy(partitionBy)
-        .boundsType(boundsType)
-        .lowerBound(lowerBound)
-        .upperBound(upperBound)
-        .addArguments(arguments)
-        .build();
+    return windowFunction(
+        declaration,
+        outputType,
+        phase,
+        sort,
+        invocation,
+        partitionBy,
+        boundsType,
+        lowerBound,
+        upperBound,
+        Arrays.asList(),
+        Arrays.asList(arguments));
   }
 
   public static Expression cast(

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -285,47 +285,34 @@ public class ExpressionCreator {
       SimpleExtension.ScalarFunctionVariant declaration,
       Type outputType,
       FunctionArg... arguments) {
-    return scalarFunction(declaration, outputType, Arrays.asList(), Arrays.asList(arguments));
+    return scalarFunction(declaration, outputType, Arrays.asList(arguments));
   }
 
+  /**
+   * Use {@link Expression.ScalarFunctionInvocation#builder()} directly to specify other parameters,
+   * e.g. options
+   */
   public static Expression.ScalarFunctionInvocation scalarFunction(
       SimpleExtension.ScalarFunctionVariant declaration,
       Type outputType,
-      Iterable<? extends FunctionArg> arguments) {
-    return scalarFunction(declaration, outputType, Arrays.asList(), arguments);
-  }
-
-  public static Expression.ScalarFunctionInvocation scalarFunction(
-      SimpleExtension.ScalarFunctionVariant declaration,
-      Type outputType,
-      List<? extends FunctionOption> options,
       Iterable<? extends FunctionArg> arguments) {
     return Expression.ScalarFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
-        .options(options)
         .addAllArguments(arguments)
         .build();
   }
 
+  /**
+   * Use {@link AggregateFunctionInvocation#builder()} directly to specify other parameters, e.g.
+   * options
+   */
   public static AggregateFunctionInvocation aggregateFunction(
       SimpleExtension.AggregateFunctionVariant declaration,
       Type outputType,
       Expression.AggregationPhase phase,
       List<Expression.SortField> sort,
       Expression.AggregationInvocation invocation,
-      Iterable<? extends FunctionArg> arguments) {
-    return aggregateFunction(
-        declaration, outputType, phase, sort, invocation, Arrays.asList(), arguments);
-  }
-
-  public static AggregateFunctionInvocation aggregateFunction(
-      SimpleExtension.AggregateFunctionVariant declaration,
-      Type outputType,
-      Expression.AggregationPhase phase,
-      List<Expression.SortField> sort,
-      Expression.AggregationInvocation invocation,
-      List<? extends FunctionOption> options,
       Iterable<? extends FunctionArg> arguments) {
     return AggregateFunctionInvocation.builder()
         .declaration(declaration)
@@ -333,7 +320,6 @@ public class ExpressionCreator {
         .aggregationPhase(phase)
         .sort(sort)
         .invocation(invocation)
-        .addAllOptions(options)
         .addAllArguments(arguments)
         .build();
   }
@@ -349,6 +335,10 @@ public class ExpressionCreator {
         declaration, outputType, phase, sort, invocation, Arrays.asList(arguments));
   }
 
+  /**
+   * Use {@link Expression.WindowFunctionInvocation#builder()} directly to specify other parameters,
+   * e.g. options
+   */
   public static Expression.WindowFunctionInvocation windowFunction(
       SimpleExtension.WindowFunctionVariant declaration,
       Type outputType,
@@ -359,32 +349,6 @@ public class ExpressionCreator {
       Expression.WindowBoundsType boundsType,
       WindowBound lowerBound,
       WindowBound upperBound,
-      Iterable<? extends FunctionArg> arguments) {
-    return windowFunction(
-        declaration,
-        outputType,
-        phase,
-        sort,
-        invocation,
-        partitionBy,
-        boundsType,
-        lowerBound,
-        upperBound,
-        Arrays.asList(),
-        arguments);
-  }
-
-  public static Expression.WindowFunctionInvocation windowFunction(
-      SimpleExtension.WindowFunctionVariant declaration,
-      Type outputType,
-      Expression.AggregationPhase phase,
-      List<Expression.SortField> sort,
-      Expression.AggregationInvocation invocation,
-      List<Expression> partitionBy,
-      Expression.WindowBoundsType boundsType,
-      WindowBound lowerBound,
-      WindowBound upperBound,
-      List<? extends FunctionOption> options,
       Iterable<? extends FunctionArg> arguments) {
     return Expression.WindowFunctionInvocation.builder()
         .declaration(declaration)
@@ -396,11 +360,14 @@ public class ExpressionCreator {
         .lowerBound(lowerBound)
         .upperBound(upperBound)
         .invocation(invocation)
-        .addAllOptions(options)
         .addAllArguments(arguments)
         .build();
   }
 
+  /**
+   * Use {@link ConsistentPartitionWindow.WindowRelFunctionInvocation#builder()} directly to specify
+   * other parameters, e.g. options
+   */
   public static ConsistentPartitionWindow.WindowRelFunctionInvocation windowRelFunction(
       SimpleExtension.WindowFunctionVariant declaration,
       Type outputType,
@@ -409,28 +376,6 @@ public class ExpressionCreator {
       Expression.WindowBoundsType boundsType,
       WindowBound lowerBound,
       WindowBound upperBound,
-      Iterable<? extends FunctionArg> arguments) {
-    return windowRelFunction(
-        declaration,
-        outputType,
-        phase,
-        invocation,
-        boundsType,
-        lowerBound,
-        upperBound,
-        Arrays.asList(),
-        arguments);
-  }
-
-  public static ConsistentPartitionWindow.WindowRelFunctionInvocation windowRelFunction(
-      SimpleExtension.WindowFunctionVariant declaration,
-      Type outputType,
-      Expression.AggregationPhase phase,
-      Expression.AggregationInvocation invocation,
-      Expression.WindowBoundsType boundsType,
-      WindowBound lowerBound,
-      WindowBound upperBound,
-      List<? extends FunctionOption> options,
       Iterable<? extends FunctionArg> arguments) {
     return ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
         .declaration(declaration)
@@ -441,7 +386,6 @@ public class ExpressionCreator {
         .upperBound(upperBound)
         .invocation(invocation)
         .addAllArguments(arguments)
-        .addAllOptions(options)
         .build();
   }
 
@@ -466,7 +410,6 @@ public class ExpressionCreator {
         boundsType,
         lowerBound,
         upperBound,
-        Arrays.asList(),
         Arrays.asList(arguments));
   }
 

--- a/core/src/main/java/io/substrait/expression/FunctionOption.java
+++ b/core/src/main/java/io/substrait/expression/FunctionOption.java
@@ -9,4 +9,8 @@ public abstract class FunctionOption {
   public abstract String getName();
 
   public abstract List<String> values();
+
+  public static ImmutableFunctionOption.Builder builder() {
+    return ImmutableFunctionOption.builder();
+  }
 }

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -10,6 +10,7 @@ import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.Expression;
 import io.substrait.proto.FunctionArgument;
+import io.substrait.proto.FunctionOption;
 import io.substrait.proto.Rel;
 import io.substrait.proto.SortField;
 import io.substrait.proto.Type;
@@ -314,7 +315,18 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
                 .addAllArguments(
                     expr.arguments().stream()
                         .map(a -> a.accept(expr.declaration(), 0, argVisitor))
+                        .collect(java.util.stream.Collectors.toList()))
+                .addAllOptions(
+                    expr.options().stream()
+                        .map(ExpressionProtoConverter::from)
                         .collect(java.util.stream.Collectors.toList())))
+        .build();
+  }
+
+  public static FunctionOption from(io.substrait.expression.FunctionOption option) {
+    return FunctionOption.newBuilder()
+        .setName(option.getName())
+        .addAllPreference(option.values())
         .build();
   }
 
@@ -495,7 +507,11 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
                 .addAllPartitions(partitionExprs)
                 .setBoundsType(expr.boundsType().toProto())
                 .setLowerBound(lowerBound)
-                .setUpperBound(upperBound))
+                .setUpperBound(upperBound)
+                .addAllOptions(
+                    expr.options().stream()
+                        .map(ExpressionProtoConverter::from)
+                        .collect(java.util.stream.Collectors.toList())))
         .build();
   }
 

--- a/core/src/main/java/io/substrait/extendedexpression/ProtoExtendedExpressionConverter.java
+++ b/core/src/main/java/io/substrait/extendedexpression/ProtoExtendedExpressionConverter.java
@@ -64,9 +64,12 @@ public class ProtoExtendedExpressionConverter {
           break;
         case MEASURE:
           io.substrait.relation.Aggregate.Measure measure =
-              new ProtoAggregateFunctionConverter(
-                      functionLookup, extensionCollection, protoExpressionConverter)
-                  .from(expressionReference.getMeasure());
+              io.substrait.relation.Aggregate.Measure.builder()
+                  .function(
+                      new ProtoAggregateFunctionConverter(
+                              functionLookup, extensionCollection, protoExpressionConverter)
+                          .from(expressionReference.getMeasure()))
+                  .build();
           ImmutableAggregateFunctionReference buildMeasure =
               ImmutableAggregateFunctionReference.builder()
                   .measure(measure)

--- a/core/src/main/java/io/substrait/relation/ConsistentPartitionWindow.java
+++ b/core/src/main/java/io/substrait/relation/ConsistentPartitionWindow.java
@@ -9,7 +9,6 @@ import io.substrait.extension.SimpleExtension;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
 
@@ -49,7 +48,7 @@ public abstract class ConsistentPartitionWindow extends SingleInputRel implement
 
     public abstract List<FunctionArg> arguments();
 
-    public abstract Map<String, FunctionOption> options();
+    public abstract List<FunctionOption> options();
 
     public abstract Type outputType();
 

--- a/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
@@ -6,6 +6,7 @@ import io.substrait.TestBase;
 import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
+import io.substrait.expression.FunctionOption;
 import io.substrait.expression.ImmutableExpression;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.relation.Aggregate;
@@ -46,6 +47,12 @@ public class AggregateRoundtripTest extends TestBase {
                     .outputType(TypeCreator.of(false).I64)
                     .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
                     .invocation(invocation)
+                    .options(
+                        Arrays.asList(
+                            FunctionOption.builder()
+                                .name("option")
+                                .addValues("VALUE1", "VALUE2")
+                                .build()))
                     .build())
             .build();
 

--- a/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.substrait.TestBase;
 import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionOption;
 import io.substrait.expression.ImmutableWindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
@@ -11,7 +12,6 @@ import io.substrait.relation.ConsistentPartitionWindow;
 import io.substrait.relation.ImmutableConsistentPartitionWindow;
 import io.substrait.relation.Rel;
 import java.util.Arrays;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
@@ -36,7 +36,12 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
                         .declaration(windowFunctionDeclaration)
                         // lead(a)
                         .arguments(Arrays.asList(b.fieldReference(input, 0)))
-                        .options(Collections.emptyMap())
+                        .options(
+                            Arrays.asList(
+                                FunctionOption.builder()
+                                    .name("option")
+                                    .addValues("VALUE1", "VALUE2")
+                                    .build()))
                         .outputType(R.I64)
                         .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
                         .invocation(Expression.AggregationInvocation.ALL)


### PR DESCRIPTION
[Options](https://substrait.io/expressions/scalar_functions/#options) were supported in the Java immutables but in most cases dropped when converting into protobuf

This
- fixes the protobuf conversion,
- adds a builder for FunctionOption
- adds a ExpressionCreator functions with options
- does some refactoring