### PR TITLE
Take `sorts` into account inside aggregate functions

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -411,6 +411,16 @@ public class ProtoRelConverter {
           IntStream.range(0, measure.getMeasure().getArgumentsCount())
               .mapToObj(i -> pF.convert(funcDecl, i, measure.getMeasure().getArguments(i)))
               .collect(java.util.stream.Collectors.toList());
+      var sorts =
+          IntStream.range(0, func.getSortsCount())
+              .mapToObj(
+                  i ->
+                      Expression.SortField.builder()
+                          .expr(protoExprConverter.from(func.getSorts(i).getExpr()))
+                          .direction(
+                              Expression.SortDirection.fromProto(func.getSorts(i).getDirection()))
+                          .build())
+              .collect(java.util.stream.Collectors.toList());
       measures.add(
           Aggregate.Measure.builder()
               .function(
@@ -420,6 +430,7 @@ public class ProtoRelConverter {
                       .outputType(protoTypeConverter.from(func.getOutputType()))
                       .aggregationPhase(Expression.AggregationPhase.fromProto(func.getPhase()))
                       .invocation(Expression.AggregationInvocation.fromProto(func.getInvocation()))
+                      .sort(sorts)
                       .build())
               .preMeasureFilter(
                   Optional.ofNullable(

--- a/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
@@ -32,6 +32,11 @@ public class AggregateRoundtripTest extends TestBase {
             .initialSchema(NamedStruct.of(Arrays.asList("decimal"), R.struct(R.decimal(10, 2))))
             .addRows(literal)
             .build();
+    var sort =
+        ImmutableExpression.SortField.builder()
+            .expr(ExpressionCreator.bool(true, true))
+            .direction(Expression.SortDirection.DESC_NULLS_LAST)
+            .build();
     ExtensionCollector functionCollector = new ExtensionCollector();
     var to = new RelProtoConverter(functionCollector);
     var extensions = defaultExtensionCollection;
@@ -45,6 +50,7 @@ public class AggregateRoundtripTest extends TestBase {
                     .declaration(extensions.aggregateFunctions().get(0))
                     .outputType(TypeCreator.of(false).I64)
                     .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                    .sort(Arrays.asList(sort))
                     .invocation(invocation)
                     .build())
             .build();


### PR DESCRIPTION
Aggregate functions can take inner ORDER BY statements that will sort the underlaying data before the aggregation, for example:
```sql
SELECT string_agg("foo", ', ' ORDER BY "foo" DESC) FROM "tbl"
```
In substrait this is reflected as a `sorts` field inside an aggregate function's measure. This PR adds support for loading that field in `ProtoTypeConverter`