### PR TITLE
fix(core): if-then expression should be nullable if any 'then' is nullable

### DIFF
--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -584,7 +584,13 @@ public interface Expression extends FunctionArg {
     public abstract Expression elseClause();
 
     public Type getType() {
-      return elseClause().getType();
+      Type elseType = elseClause().getType();
+
+      // If any of the clauses are nullable, the whole expression is also nullable.
+      if (ifClauses().stream().anyMatch(clause -> clause.then().getType().nullable())) {
+        return TypeCreator.asNullable(elseType);
+      }
+      return elseType;
     }
 
     public static ImmutableExpression.IfThen.Builder builder() {

--- a/core/src/test/java/io/substrait/type/proto/IfThenRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/IfThenRoundtripTest.java
@@ -1,0 +1,45 @@
+package io.substrait.type.proto;
+
+import static io.substrait.expression.proto.ProtoExpressionConverter.EMPTY_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.expression.proto.ExpressionProtoConverter;
+import io.substrait.expression.proto.ProtoExpressionConverter;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class IfThenRoundtripTest extends TestBase {
+
+  @Test
+  void ifThenNotNullable() {
+    final Expression.IfThen ifRel =
+        b.ifThen(
+            Arrays.asList(
+                b.ifClause(ExpressionCreator.bool(false, false), ExpressionCreator.i64(false, 1))),
+            ExpressionCreator.i64(false, 2));
+    assertFalse(ifRel.getType().nullable());
+
+    var to = new ExpressionProtoConverter(null, null);
+    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
+    assertEquals(ifRel, from.from(ifRel.accept(to)));
+  }
+
+  @Test
+  void ifThenNullable() {
+    final Expression.IfThen ifRel =
+        b.ifThen(
+            Arrays.asList(
+                b.ifClause(ExpressionCreator.bool(true, false), ExpressionCreator.i64(true, 1))),
+            ExpressionCreator.i64(false, 2));
+    assertTrue(ifRel.getType().nullable());
+
+    var to = new ExpressionProtoConverter(null, null);
+    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
+    assertEquals(ifRel, from.from(ifRel.accept(to)));
+  }
+}


### PR DESCRIPTION
Recently had some nullability issues with Calcite coming from the SQL:

```
  CASE WHEN record_type = 'abc' THEN
    field_a
  ELSE
    ''
  END
```

Because the `else` part is a literal, `nullable` was false, but it wasn't actually true, as `field_a` is in fact nullable.

Calcite would fail assertions because of this mismatch:

```
rpc error: code = Internal desc = Cannot add expression of different type to set:
set type is RecordType(VARCHAR NOT NULL $f30, VARCHAR $f10) NOT NULL
expression type is RecordType(VARCHAR $f3, VARCHAR $f1) NOT NULL
set is org.apache.calcite.plan.volcano.RelSet@6624a103
expression is LogicalSort(sort0=[$1], dir0=[DESC], fetch=[5])
...
Type mismatch:
rowtype of original rel: RecordType(VARCHAR NOT NULL $f30, VARCHAR $f10) NOT NULL
rowtype of new rel: RecordType(VARCHAR $f3, VARCHAR $f1) NOT NULL
Difference:
$f30: VARCHAR NOT NULL -> VARCHAR
```

Simply allowing the case to be nullable fixes the issues for our query, so sending that upstream since I think it makes sense and it was just overlooked before.
