### PR TITLE
feat: support new IntervalCompound and IntervalDay update

### DIFF
--- a/core/src/main/antlr/SubstraitType.g4
+++ b/core/src/main/antlr/SubstraitType.g4
@@ -49,6 +49,7 @@ Date     : D A T E;
 Time     : T I M E;
 IntervalYear: I N T E R V A L '_' Y E A R;
 IntervalDay: I N T E R V A L '_' D A Y;
+IntervalCompound: I N T E R V A L '_' C O M P O U N D;
 UUID     : U U I D;
 Decimal  : D E C I M A L;
 PrecisionTimestamp: P R E C I S I O N '_' T I M E S T A M P;
@@ -158,7 +159,6 @@ scalarType
   | TimestampTZ #timestampTz
   | Date #date
   | Time #time
-  | IntervalDay #intervalDay
   | IntervalYear #intervalYear
   | UUID #uuid
   | UserDefined Identifier #userDefined
@@ -169,6 +169,8 @@ parameterizedType
   | VarChar isnull='?'? Lt len=numericParameter Gt #varChar
   | FixedBinary isnull='?'? Lt len=numericParameter Gt #fixedBinary
   | Decimal isnull='?'? Lt precision=numericParameter Comma scale=numericParameter Gt #decimal
+  | IntervalDay isnull='?'? Lt precision=numericParameter Gt #intervalDay
+  | IntervalCompound isnull='?'? Lt precision=numericParameter Gt #intervalCompound
   | PrecisionTimestamp isnull='?'? Lt precision=numericParameter Gt #precisionTimestamp
   | PrecisionTimestampTZ isnull='?'? Lt precision=numericParameter Gt #precisionTimestampTZ
   | Struct isnull='?'? Lt expr (Comma expr)* Gt #struct
@@ -205,4 +207,3 @@ expr
   | (Bang) expr #NotExpr
   | ifExpr=expr QMark thenExpr=expr Colon elseExpr=expr #Ternary
   ;
-

--- a/core/src/main/java/io/substrait/expression/AbstractExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/AbstractExpressionVisitor.java
@@ -95,6 +95,11 @@ public abstract class AbstractExpressionVisitor<OUTPUT, EXCEPTION extends Except
   }
 
   @Override
+  public OUTPUT visit(Expression.IntervalCompoundLiteral expr) throws EXCEPTION {
+    return visitFallback(expr);
+  }
+
+  @Override
   public OUTPUT visit(Expression.UUIDLiteral expr) throws EXCEPTION {
     return visitFallback(expr);
   }

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -333,14 +333,45 @@ public interface Expression extends FunctionArg {
 
     public abstract int seconds();
 
-    public abstract int microseconds();
+    public abstract long subseconds();
+
+    public abstract int precision();
 
     public Type getType() {
-      return Type.withNullability(nullable()).INTERVAL_DAY;
+      return Type.withNullability(nullable()).intervalDay(precision());
     }
 
     public static ImmutableExpression.IntervalDayLiteral.Builder builder() {
       return ImmutableExpression.IntervalDayLiteral.builder();
+    }
+
+    public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract static class IntervalCompoundLiteral implements Literal {
+    // Flattened IntervalYearLiteral
+    public abstract int years();
+
+    public abstract int months();
+
+    // Flattened IntervalDayLiteral
+    public abstract int days();
+
+    public abstract int seconds();
+
+    public abstract long subseconds();
+
+    public abstract int precision();
+
+    public Type getType() {
+      return Type.withNullability(nullable()).intervalCompound(precision());
+    }
+
+    public static ImmutableExpression.IntervalCompoundLiteral.Builder builder() {
+      return ImmutableExpression.IntervalCompoundLiteral.builder();
     }
 
     public <R, E extends Throwable> R accept(ExpressionVisitor<R, E> visitor) throws E {

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -161,16 +161,36 @@ public class ExpressionCreator {
   }
 
   public static Expression.IntervalDayLiteral intervalDay(boolean nullable, int days, int seconds) {
-    return intervalDay(nullable, days, seconds, 0);
+    return intervalDay(nullable, days, seconds, 0, 0);
   }
 
   public static Expression.IntervalDayLiteral intervalDay(
-      boolean nullable, int days, int seconds, int microseconds) {
+      boolean nullable, int days, int seconds, long subseconds, int precision) {
     return Expression.IntervalDayLiteral.builder()
         .nullable(nullable)
         .days(days)
         .seconds(seconds)
-        .microseconds(microseconds)
+        .subseconds(subseconds)
+        .precision(precision)
+        .build();
+  }
+
+  public static Expression.IntervalCompoundLiteral intervalCompound(
+      boolean nullable,
+      int years,
+      int months,
+      int days,
+      int seconds,
+      long subseconds,
+      int precision) {
+    return Expression.IntervalCompoundLiteral.builder()
+        .nullable(nullable)
+        .years(years)
+        .months(months)
+        .days(days)
+        .seconds(seconds)
+        .subseconds(subseconds)
+        .precision(precision)
         .build();
   }
 

--- a/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
@@ -39,6 +39,8 @@ public interface ExpressionVisitor<R, E extends Throwable> {
 
   R visit(Expression.IntervalDayLiteral expr) throws E;
 
+  R visit(Expression.IntervalCompoundLiteral expr) throws E;
+
   R visit(Expression.UUIDLiteral expr) throws E;
 
   R visit(Expression.FixedCharLiteral expr) throws E;

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -159,7 +159,27 @@ public class ExpressionProtoConverter implements ExpressionVisitor<Expression, R
                     Expression.Literal.IntervalDayToSecond.newBuilder()
                         .setDays(expr.days())
                         .setSeconds(expr.seconds())
-                        .setMicroseconds(expr.microseconds())));
+                        .setSubseconds(expr.subseconds())
+                        .setPrecision(expr.precision())));
+  }
+
+  @Override
+  public Expression visit(io.substrait.expression.Expression.IntervalCompoundLiteral expr) {
+    return lit(
+        bldr ->
+            bldr.setNullable(expr.nullable())
+                .setIntervalCompound(
+                    Expression.Literal.IntervalCompound.newBuilder()
+                        .setIntervalYearToMonth(
+                            Expression.Literal.IntervalYearToMonth.newBuilder()
+                                .setYears(expr.years())
+                                .setMonths(expr.months()))
+                        .setIntervalDayToSecond(
+                            Expression.Literal.IntervalDayToSecond.newBuilder()
+                                .setDays(expr.days())
+                                .setSeconds(expr.seconds())
+                                .setSubseconds(expr.subseconds())
+                                .setPrecision(expr.precision()))));
   }
 
   @Override

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -341,8 +341,8 @@ public class ProtoExpressionConverter {
           literal.getIntervalYearToMonth().getYears(),
           literal.getIntervalYearToMonth().getMonths());
       case INTERVAL_DAY_TO_SECOND -> {
-        // Handle deprecated version that doesn't provide precision and that uses microseconds instead
-        // of subseconds, for backwards compatibility
+        // Handle deprecated version that doesn't provide precision and that uses microseconds
+        // instead of subseconds, for backwards compatibility
         int precision =
             literal.getIntervalDayToSecond().hasPrecision()
                 ? literal.getIntervalDayToSecond().getPrecision()

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -340,11 +340,38 @@ public class ProtoExpressionConverter {
           literal.getNullable(),
           literal.getIntervalYearToMonth().getYears(),
           literal.getIntervalYearToMonth().getMonths());
-      case INTERVAL_DAY_TO_SECOND -> ExpressionCreator.intervalDay(
-          literal.getNullable(),
-          literal.getIntervalDayToSecond().getDays(),
-          literal.getIntervalDayToSecond().getSeconds(),
-          literal.getIntervalDayToSecond().getMicroseconds());
+      case INTERVAL_DAY_TO_SECOND -> {
+        // Handle deprecated version that doesn't provide precision and that uses microseconds instead
+        // of subseconds, for backwards compatibility
+        int precision =
+            literal.getIntervalDayToSecond().hasPrecision()
+                ? literal.getIntervalDayToSecond().getPrecision()
+                : 6; // microseconds
+        long subseconds =
+            literal.getIntervalDayToSecond().hasPrecision()
+                ? literal.getIntervalDayToSecond().getSubseconds()
+                : literal.getIntervalDayToSecond().getMicroseconds();
+        yield ExpressionCreator.intervalDay(
+            literal.getNullable(),
+            literal.getIntervalDayToSecond().getDays(),
+            literal.getIntervalDayToSecond().getSeconds(),
+            subseconds,
+            precision);
+      }
+      case INTERVAL_COMPOUND -> {
+        if (!literal.getIntervalCompound().getIntervalDayToSecond().hasPrecision()) {
+          throw new RuntimeException(
+              "Interval compound with deprecated version of interval day (ie. no precision) is not supported");
+        }
+        yield ExpressionCreator.intervalCompound(
+            literal.getNullable(),
+            literal.getIntervalCompound().getIntervalYearToMonth().getYears(),
+            literal.getIntervalCompound().getIntervalYearToMonth().getMonths(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getDays(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getSeconds(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getSubseconds(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getPrecision());
+      }
       case FIXED_CHAR -> ExpressionCreator.fixedChar(literal.getNullable(), literal.getFixedChar());
       case VAR_CHAR -> ExpressionCreator.varChar(
           literal.getNullable(), literal.getVarChar().getValue(), literal.getVarChar().getLength());

--- a/core/src/main/java/io/substrait/function/ParameterizedType.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedType.java
@@ -107,6 +107,36 @@ public interface ParameterizedType extends TypeExpression {
   }
 
   @Value.Immutable
+  abstract static class IntervalDay extends BaseParameterizedType implements NullableType {
+    public abstract StringLiteral precision();
+
+    @Override
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
+      return parameterizedTypeVisitor.visit(this);
+    }
+
+    public static ImmutableParameterizedType.IntervalDay.Builder builder() {
+      return ImmutableParameterizedType.IntervalDay.builder();
+    }
+  }
+
+  @Value.Immutable
+  abstract static class IntervalCompound extends BaseParameterizedType implements NullableType {
+    public abstract StringLiteral precision();
+
+    @Override
+    <R, E extends Throwable> R accept(final ParameterizedTypeVisitor<R, E> parameterizedTypeVisitor)
+        throws E {
+      return parameterizedTypeVisitor.visit(this);
+    }
+
+    public static ImmutableParameterizedType.IntervalCompound.Builder builder() {
+      return ImmutableParameterizedType.IntervalCompound.builder();
+    }
+  }
+
+  @Value.Immutable
   abstract static class PrecisionTimestamp extends BaseParameterizedType implements NullableType {
     public abstract StringLiteral precision();
 

--- a/core/src/main/java/io/substrait/function/ParameterizedTypeCreator.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedTypeCreator.java
@@ -49,6 +49,20 @@ public class ParameterizedTypeCreator extends TypeCreator
         .build();
   }
 
+  public ParameterizedType intervalDayE(String precision) {
+    return ParameterizedType.IntervalDay.builder()
+        .nullable(nullable)
+        .precision(parameter(precision, false))
+        .build();
+  }
+
+  public ParameterizedType intervalCompoundE(String precision) {
+    return ParameterizedType.IntervalCompound.builder()
+        .nullable(nullable)
+        .precision(parameter(precision, false))
+        .build();
+  }
+
   public ParameterizedType precisionTimestampE(String precision) {
     return ParameterizedType.PrecisionTimestamp.builder()
         .nullable(nullable)

--- a/core/src/main/java/io/substrait/function/ParameterizedTypeVisitor.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedTypeVisitor.java
@@ -11,6 +11,10 @@ public interface ParameterizedTypeVisitor<R, E extends Throwable> extends TypeVi
 
   R visit(ParameterizedType.Decimal expr) throws E;
 
+  R visit(ParameterizedType.IntervalDay expr) throws E;
+
+  R visit(ParameterizedType.IntervalCompound expr) throws E;
+
   R visit(ParameterizedType.PrecisionTimestamp expr) throws E;
 
   R visit(ParameterizedType.PrecisionTimestampTZ expr) throws E;
@@ -57,6 +61,16 @@ public interface ParameterizedTypeVisitor<R, E extends Throwable> extends TypeVi
 
     @Override
     public R visit(ParameterizedType.PrecisionTimestampTZ expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(ParameterizedType.IntervalDay expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(ParameterizedType.IntervalCompound expr) throws E {
       throw t();
     }
 

--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -91,6 +91,11 @@ public class ToTypeString
   }
 
   @Override
+  public String visit(final Type.IntervalCompound expr) {
+    return "icompound";
+  }
+
+  @Override
   public String visit(final Type.UUID expr) {
     return "uuid";
   }
@@ -163,6 +168,16 @@ public class ToTypeString
   @Override
   public String visit(ParameterizedType.Decimal expr) throws RuntimeException {
     return "dec";
+  }
+
+  @Override
+  public String visit(ParameterizedType.IntervalDay expr) throws RuntimeException {
+    return "iday";
+  }
+
+  @Override
+  public String visit(ParameterizedType.IntervalCompound expr) throws RuntimeException {
+    return "icompound";
   }
 
   @Override

--- a/core/src/main/java/io/substrait/function/TypeExpression.java
+++ b/core/src/main/java/io/substrait/function/TypeExpression.java
@@ -85,6 +85,36 @@ public interface TypeExpression {
   }
 
   @Value.Immutable
+  abstract static class IntervalDay extends BaseTypeExpression implements NullableType {
+
+    public abstract TypeExpression precision();
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+
+    public static ImmutableTypeExpression.IntervalDay.Builder builder() {
+      return ImmutableTypeExpression.IntervalDay.builder();
+    }
+  }
+
+  @Value.Immutable
+  abstract static class IntervalCompound extends BaseTypeExpression implements NullableType {
+
+    public abstract TypeExpression precision();
+
+    @Override
+    <R, E extends Throwable> R acceptE(final TypeExpressionVisitor<R, E> visitor) throws E {
+      return visitor.visit(this);
+    }
+
+    public static ImmutableTypeExpression.IntervalCompound.Builder builder() {
+      return ImmutableTypeExpression.IntervalCompound.builder();
+    }
+  }
+
+  @Value.Immutable
   abstract static class PrecisionTimestamp extends BaseTypeExpression implements NullableType {
 
     public abstract TypeExpression precision();

--- a/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
@@ -35,6 +35,17 @@ public class TypeExpressionCreator extends TypeCreator
         .build();
   }
 
+  public TypeExpression intervalDayE(TypeExpression precision) {
+    return TypeExpression.IntervalDay.builder().nullable(nullable).precision(precision).build();
+  }
+
+  public TypeExpression intervalCompoundE(TypeExpression precision) {
+    return TypeExpression.IntervalCompound.builder()
+        .nullable(nullable)
+        .precision(precision)
+        .build();
+  }
+
   public TypeExpression precisionTimestampE(TypeExpression precision) {
     return TypeExpression.PrecisionTimestamp.builder()
         .nullable(nullable)

--- a/core/src/main/java/io/substrait/function/TypeExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionVisitor.java
@@ -10,6 +10,10 @@ public interface TypeExpressionVisitor<R, E extends Throwable>
 
   R visit(TypeExpression.Decimal expr) throws E;
 
+  R visit(TypeExpression.IntervalDay expr) throws E;
+
+  R visit(TypeExpression.IntervalCompound expr) throws E;
+
   R visit(TypeExpression.PrecisionTimestamp expr) throws E;
 
   R visit(TypeExpression.PrecisionTimestampTZ expr) throws E;
@@ -65,6 +69,16 @@ public interface TypeExpressionVisitor<R, E extends Throwable>
 
     @Override
     public R visit(TypeExpression.PrecisionTimestampTZ expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(TypeExpression.IntervalDay expr) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(TypeExpression.IntervalCompound expr) throws E {
       throw t();
     }
 

--- a/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
@@ -119,6 +119,11 @@ public class ExpressionCopyOnWriteVisitor<EXCEPTION extends Exception>
   }
 
   @Override
+  public Optional<Expression> visit(Expression.IntervalCompoundLiteral expr) throws EXCEPTION {
+    return visitLiteral(expr);
+  }
+
+  @Override
   public Optional<Expression> visit(Expression.UUIDLiteral expr) throws EXCEPTION {
     return visitLiteral(expr);
   }

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -17,14 +17,14 @@ public abstract class Join extends BiRel implements HasExtension {
 
   public abstract JoinType getJoinType();
 
-  public static enum JoinType {
+  public enum JoinType {
     UNKNOWN(JoinRel.JoinType.JOIN_TYPE_UNSPECIFIED),
     INNER(JoinRel.JoinType.JOIN_TYPE_INNER),
     OUTER(JoinRel.JoinType.JOIN_TYPE_OUTER),
     LEFT(JoinRel.JoinType.JOIN_TYPE_LEFT),
     RIGHT(JoinRel.JoinType.JOIN_TYPE_RIGHT),
-    SEMI(JoinRel.JoinType.JOIN_TYPE_SEMI),
-    ANTI(JoinRel.JoinType.JOIN_TYPE_ANTI);
+    SEMI(JoinRel.JoinType.JOIN_TYPE_LEFT_SEMI),
+    ANTI(JoinRel.JoinType.JOIN_TYPE_LEFT_ANTI);
 
     private JoinRel.JoinType proto;
 

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -302,6 +302,8 @@ public class ProtoRelConverter {
       builder.fileFormat(ImmutableFileFormat.ArrowReadOptions.builder().build());
     } else if (file.hasDwrf()) {
       builder.fileFormat(ImmutableFileFormat.DwrfReadOptions.builder().build());
+    } else if (file.hasText()) {
+      throw new RuntimeException("Delimiter separated text files not supported yet"); // TODO
     } else if (file.hasExtension()) {
       builder.fileFormat(
           ImmutableFileFormat.Extension.builder().extension(file.getExtension()).build());

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -141,6 +141,11 @@ public abstract class VirtualTableScan extends AbstractReadRel {
     }
 
     @Override
+    public Integer visit(Type.IntervalCompound type) throws RuntimeException {
+      return 0;
+    }
+
+    @Override
     public Integer visit(Type.UUID type) throws RuntimeException {
       return 0;
     }

--- a/core/src/main/java/io/substrait/type/StringTypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/StringTypeVisitor.java
@@ -85,6 +85,11 @@ public class StringTypeVisitor implements TypeVisitor<String, RuntimeException> 
   }
 
   @Override
+  public String visit(Type.IntervalCompound type) throws RuntimeException {
+    return "interval_compound" + n(type);
+  }
+
+  @Override
   public String visit(Type.UUID type) throws RuntimeException {
     return "uuid" + n(type);
   }

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -202,8 +202,24 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
 
   @Value.Immutable
   abstract static class IntervalDay implements Type {
+    public abstract int precision();
+
     public static ImmutableType.IntervalDay.Builder builder() {
       return ImmutableType.IntervalDay.builder();
+    }
+
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
+  }
+
+  @Value.Immutable
+  abstract static class IntervalCompound implements Type {
+    public abstract int precision();
+
+    public static ImmutableType.IntervalCompound.Builder builder() {
+      return ImmutableType.IntervalCompound.builder();
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -22,7 +22,6 @@ public class TypeCreator {
   public final Type TIMESTAMP_TZ;
   public final Type DATE;
   public final Type TIME;
-  public final Type INTERVAL_DAY;
   public final Type INTERVAL_YEAR;
   public final Type UUID;
 
@@ -41,7 +40,6 @@ public class TypeCreator {
     TIMESTAMP_TZ = Type.TimestampTZ.builder().nullable(nullable).build();
     DATE = Type.Date.builder().nullable(nullable).build();
     TIME = Type.Time.builder().nullable(nullable).build();
-    INTERVAL_DAY = Type.IntervalDay.builder().nullable(nullable).build();
     INTERVAL_YEAR = Type.IntervalYear.builder().nullable(nullable).build();
     UUID = Type.UUID.builder().nullable(nullable).build();
   }
@@ -72,6 +70,14 @@ public class TypeCreator {
 
   public final Type precisionTimestampTZ(int precision) {
     return Type.PrecisionTimestampTZ.builder().nullable(nullable).precision(precision).build();
+  }
+
+  public final Type intervalDay(int precision) {
+    return Type.IntervalDay.builder().nullable(nullable).precision(precision).build();
+  }
+
+  public final Type intervalCompound(int precision) {
+    return Type.IntervalCompound.builder().nullable(nullable).precision(precision).build();
   }
 
   public Type.Struct struct(Iterable<? extends Type> types) {
@@ -196,6 +202,11 @@ public class TypeCreator {
     @Override
     public Type visit(Type.IntervalDay type) throws RuntimeException {
       return Type.IntervalDay.builder().from(type).nullable(nullability).build();
+    }
+
+    @Override
+    public Type visit(Type.IntervalCompound type) throws RuntimeException {
+      return Type.IntervalCompound.builder().from(type).nullable(nullability).build();
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/TypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/TypeVisitor.java
@@ -37,6 +37,8 @@ public interface TypeVisitor<R, E extends Throwable> {
 
   R visit(Type.IntervalDay type) throws E;
 
+  R visit(Type.IntervalCompound type) throws E;
+
   R visit(Type.UUID type) throws E;
 
   R visit(Type.FixedChar type) throws E;
@@ -140,6 +142,11 @@ public interface TypeVisitor<R, E extends Throwable> {
 
     @Override
     public R visit(Type.IntervalDay type) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(Type.IntervalCompound type) throws E {
       throw t();
     }
 

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -261,6 +261,16 @@ public class ParseToPojo {
         return withNullP(nullable).decimalE((String) precision, (String) scale);
       }
 
+      if (precision instanceof String && scale instanceof Integer) {
+        checkParameterizedOrExpression();
+        return withNullP(nullable).decimalE((String) precision, String.valueOf(scale));
+      }
+
+      if (precision instanceof Integer && scale instanceof String) {
+        checkParameterizedOrExpression();
+        return withNullP(nullable).decimalE(String.valueOf(precision), (String) scale);
+      }
+
       checkExpression();
       return withNullE(nullable).decimalE(ctx.precision.accept(this), ctx.scale.accept(this));
     }

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -152,13 +152,41 @@ public class ParseToPojo {
     }
 
     @Override
-    public Type visitIntervalDay(final SubstraitTypeParser.IntervalDayContext ctx) {
-      return withNull(ctx).INTERVAL_DAY;
+    public Type visitIntervalYear(final SubstraitTypeParser.IntervalYearContext ctx) {
+      return withNull(ctx).INTERVAL_YEAR;
     }
 
     @Override
-    public Type visitIntervalYear(final SubstraitTypeParser.IntervalYearContext ctx) {
-      return withNull(ctx).INTERVAL_YEAR;
+    public TypeExpression visitIntervalDay(final SubstraitTypeParser.IntervalDayContext ctx) {
+      boolean nullable = ctx.isnull != null;
+      Object precision = i(ctx.precision);
+      if (precision instanceof Integer p) {
+        return withNull(nullable).intervalDay(p);
+      }
+      if (precision instanceof String s) {
+        checkParameterizedOrExpression();
+        return withNullP(nullable).intervalDayE(s);
+      }
+
+      checkExpression();
+      return withNullE(nullable).intervalDayE(ctx.precision.accept(this));
+    }
+
+    @Override
+    public TypeExpression visitIntervalCompound(
+        final SubstraitTypeParser.IntervalCompoundContext ctx) {
+      boolean nullable = ctx.isnull != null;
+      Object precision = i(ctx.precision);
+      if (precision instanceof Integer p) {
+        return withNull(nullable).intervalCompound(p);
+      }
+      if (precision instanceof String s) {
+        checkParameterizedOrExpression();
+        return withNullP(nullable).intervalCompoundE(s);
+      }
+
+      checkExpression();
+      return withNullE(nullable).intervalCompoundE(ctx.precision.accept(this));
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -96,7 +96,12 @@ abstract class BaseProtoConverter<T, I>
 
   @Override
   public final T visit(final Type.IntervalDay expr) {
-    return typeContainer(expr).INTERVAL_DAY;
+    return typeContainer(expr).intervalDay(expr.precision());
+  }
+
+  @Override
+  public final T visit(final Type.IntervalCompound expr) {
+    return typeContainer(expr).intervalCompound(expr.precision());
   }
 
   @Override

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
@@ -19,7 +19,6 @@ abstract class BaseProtoTypes<T, I> {
   public final T TIMESTAMP_TZ;
   public final T DATE;
   public final T TIME;
-  public final T INTERVAL_DAY;
   public final T INTERVAL_YEAR;
   public final T UUID;
 
@@ -38,7 +37,6 @@ abstract class BaseProtoTypes<T, I> {
     TIMESTAMP_TZ = wrap(Type.TimestampTZ.newBuilder().setNullability(nullability).build());
     DATE = wrap(Type.Date.newBuilder().setNullability(nullability).build());
     TIME = wrap(Type.Time.newBuilder().setNullability(nullability).build());
-    INTERVAL_DAY = wrap(Type.IntervalDay.newBuilder().setNullability(nullability).build());
     INTERVAL_YEAR = wrap(Type.IntervalYear.newBuilder().setNullability(nullability).build());
     UUID = wrap(Type.UUID.newBuilder().setNullability(nullability).build());
   }
@@ -81,6 +79,14 @@ abstract class BaseProtoTypes<T, I> {
     return decimal(i(scale), precision);
   }
 
+  public final T intervalDay(int precision) {
+    return intervalDay(i(precision));
+  }
+
+  public final T intervalCompound(int precision) {
+    return intervalCompound(i(precision));
+  }
+
   public final T precisionTimestamp(int precision) {
     return precisionTimestamp(i(precision));
   }
@@ -102,6 +108,10 @@ abstract class BaseProtoTypes<T, I> {
   public abstract T precisionTimestamp(I precision);
 
   public abstract T precisionTimestampTZ(I precision);
+
+  public abstract T intervalDay(I precision);
+
+  public abstract T intervalCompound(I precision);
 
   public final T struct(T... types) {
     return struct(Arrays.asList(types));

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -187,6 +187,24 @@ public class ParameterizedProtoConverter
     }
 
     @Override
+    public ParameterizedType intervalDay(ParameterizedType.IntegerOption precision) {
+      return wrap(
+          ParameterizedType.ParameterizedIntervalDay.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
+    @Override
+    public ParameterizedType intervalCompound(ParameterizedType.IntegerOption precision) {
+      return wrap(
+          ParameterizedType.ParameterizedIntervalCompound.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
+    @Override
     public ParameterizedType precisionTimestamp(ParameterizedType.IntegerOption precision) {
       return wrap(
           ParameterizedType.ParameterizedPrecisionTimestamp.newBuilder()
@@ -266,8 +284,10 @@ public class ParameterizedProtoConverter
         return bldr.setTimestampTz(t).build();
       } else if (o instanceof Type.IntervalYear t) {
         return bldr.setIntervalYear(t).build();
-      } else if (o instanceof Type.IntervalDay t) {
+      } else if (o instanceof ParameterizedType.ParameterizedIntervalDay t) {
         return bldr.setIntervalDay(t).build();
+      } else if (o instanceof ParameterizedType.ParameterizedIntervalCompound t) {
+        return bldr.setIntervalCompound(t).build();
       } else if (o instanceof ParameterizedType.ParameterizedFixedChar t) {
         return bldr.setFixedChar(t).build();
       } else if (o instanceof ParameterizedType.ParameterizedVarChar t) {

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -32,7 +32,10 @@ public class ProtoTypeConverter {
       case DATE -> n(type.getDate().getNullability()).DATE;
       case TIME -> n(type.getTime().getNullability()).TIME;
       case INTERVAL_YEAR -> n(type.getIntervalYear().getNullability()).INTERVAL_YEAR;
-      case INTERVAL_DAY -> n(type.getIntervalDay().getNullability()).INTERVAL_DAY;
+      case INTERVAL_DAY -> n(type.getIntervalDay().getNullability())
+          .intervalDay(type.getIntervalDay().getPrecision());
+      case INTERVAL_COMPOUND -> n(type.getIntervalCompound().getNullability())
+          .intervalCompound(type.getIntervalCompound().getPrecision());
       case TIMESTAMP_TZ -> n(type.getTimestampTz().getNullability()).TIMESTAMP_TZ;
       case UUID -> n(type.getUuid().getNullability()).UUID;
       case FIXED_CHAR -> n(type.getFixedChar().getNullability())

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -33,7 +33,9 @@ public class ProtoTypeConverter {
       case TIME -> n(type.getTime().getNullability()).TIME;
       case INTERVAL_YEAR -> n(type.getIntervalYear().getNullability()).INTERVAL_YEAR;
       case INTERVAL_DAY -> n(type.getIntervalDay().getNullability())
-          .intervalDay(type.getIntervalDay().getPrecision());
+          // precision defaults to 6 (micros) for backwards compatibility, see protobuf
+          .intervalDay(
+              type.getIntervalDay().hasPrecision() ? type.getIntervalDay().getPrecision() : 6);
       case INTERVAL_COMPOUND -> n(type.getIntervalCompound().getNullability())
           .intervalCompound(type.getIntervalCompound().getPrecision());
       case TIMESTAMP_TZ -> n(type.getTimestampTz().getNullability()).TIMESTAMP_TZ;

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -122,6 +122,16 @@ public class TypeExpressionProtoVisitor
   }
 
   @Override
+  public DerivationExpression visit(ParameterizedType.IntervalDay expr) {
+    return typeContainer(expr).intervalDay(expr.precision().accept(this));
+  }
+
+  @Override
+  public DerivationExpression visit(ParameterizedType.IntervalCompound expr) {
+    return typeContainer(expr).intervalCompound(expr.precision().accept(this));
+  }
+
+  @Override
   public DerivationExpression visit(ParameterizedType.PrecisionTimestamp expr) {
     return typeContainer(expr).precisionTimestamp(expr.precision().accept(this));
   }
@@ -263,6 +273,24 @@ public class TypeExpressionProtoVisitor
               .build());
     }
 
+    @Override
+    public DerivationExpression intervalDay(DerivationExpression precision) {
+      return wrap(
+          DerivationExpression.ExpressionIntervalDay.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
+    @Override
+    public DerivationExpression intervalCompound(DerivationExpression precision) {
+      return wrap(
+          DerivationExpression.ExpressionIntervalCompound.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
     public DerivationExpression struct(Iterable<DerivationExpression> types) {
       return wrap(
           DerivationExpression.ExpressionStruct.newBuilder()
@@ -329,8 +357,10 @@ public class TypeExpressionProtoVisitor
         return bldr.setTimestampTz(t).build();
       } else if (o instanceof Type.IntervalYear t) {
         return bldr.setIntervalYear(t).build();
-      } else if (o instanceof Type.IntervalDay t) {
+      } else if (o instanceof DerivationExpression.ExpressionIntervalDay t) {
         return bldr.setIntervalDay(t).build();
+      } else if (o instanceof DerivationExpression.ExpressionIntervalCompound t) {
+        return bldr.setIntervalCompound(t).build();
       } else if (o instanceof DerivationExpression.ExpressionFixedChar t) {
         return bldr.setFixedChar(t).build();
       } else if (o instanceof DerivationExpression.ExpressionVarChar t) {

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -61,6 +61,22 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
               .build());
     }
 
+    public Type intervalDay(Integer precision) {
+      return wrap(
+          Type.IntervalDay.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
+    public Type intervalCompound(Integer precision) {
+      return wrap(
+          Type.IntervalCompound.newBuilder()
+              .setPrecision(precision)
+              .setNullability(nullability)
+              .build());
+    }
+
     public Type precisionTimestamp(Integer precision) {
       return wrap(
           Type.PrecisionTimestamp.newBuilder()
@@ -129,6 +145,8 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
         return bldr.setIntervalYear(t).build();
       } else if (o instanceof Type.IntervalDay t) {
         return bldr.setIntervalDay(t).build();
+      } else if (o instanceof Type.IntervalCompound t) {
+        return bldr.setIntervalCompound(t).build();
       } else if (o instanceof Type.FixedChar t) {
         return bldr.setFixedChar(t).build();
       } else if (o instanceof Type.VarChar t) {

--- a/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
+++ b/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
@@ -119,6 +119,9 @@ public class TestTypeParser {
     test(v, pn.listE(pr.parameter("any")), "list?<any>");
     test(v, pn.listE(pn.parameter("any")), "list?<any?>");
     test(v, pn.structE(r.I8, r.I16, n.I8, pr.parameter("K")), "STRUCT?<i8, i16, i8?, K>");
+    test(v, pr.decimalE("P", "S"), "DECIMAL<P, S>");
+    test(v, pr.decimalE("P", "0"), "DECIMAL<P, 0>");
+    test(v, pr.decimalE("14", "S"), "DECIMAL<14, S>");
   }
 
   private static void test(ParseToPojo.Visitor visitor, TypeExpression expected, String toParse) {

--- a/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
@@ -75,6 +75,7 @@ public class LocalFilesRoundtripTest extends TestBase {
       case ARROW -> builder.fileFormat(ImmutableFileFormat.ArrowReadOptions.builder().build());
       case ORC -> builder.fileFormat(ImmutableFileFormat.OrcReadOptions.builder().build());
       case DWRF -> builder.fileFormat(ImmutableFileFormat.DwrfReadOptions.builder().build());
+      case TEXT -> builder; // TODO
       case EXTENSION -> builder.fileFormat(
           ImmutableFileFormat.Extension.builder()
               .extension(com.google.protobuf.Any.newBuilder().build())

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -28,12 +28,15 @@ public class TestTypeRoundtrip {
     t(creator(n).TIMESTAMP);
     t(creator(n).TIMESTAMP_TZ);
     t(creator(n).INTERVAL_YEAR);
-    t(creator(n).INTERVAL_DAY);
     t(creator(n).UUID);
     t(creator(n).fixedChar(25));
     t(creator(n).varChar(35));
     t(creator(n).fixedBinary(45));
     t(creator(n).decimal(34, 3));
+    t(creator(n).intervalDay(6));
+    t(creator(n).intervalCompound(3));
+    t(creator(n).precisionTimestamp(1));
+    t(creator(n).precisionTimestampTZ(2));
     t(creator(n).map(creator(n).I8, creator(n).I16));
     t(creator(n).list(creator(n).TIME));
     t(creator(n).struct(creator(n).TIME, creator(n).TIMESTAMP, creator(n).TIMESTAMP_TZ));

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -102,7 +102,7 @@ public class TypeConverter {
           INTERVAL_HOUR_SECOND,
           INTERVAL_MINUTE,
           INTERVAL_MINUTE_SECOND,
-          INTERVAL_SECOND -> creator.INTERVAL_DAY;
+          INTERVAL_SECOND -> creator.intervalDay(type.getScale());
       case VARBINARY -> creator.BINARY;
       case BINARY -> creator.fixedBinary(type.getPrecision());
       case MAP -> {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -229,17 +229,17 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
         new BigDecimal(expr.years() * 12 + expr.months()), YEAR_MONTH_INTERVAL);
   }
 
-  private static final long MICROS_IN_DAY = TimeUnit.DAYS.toMicros(1);
+  private static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
 
   @Override
   public RexNode visit(Expression.IntervalDayLiteral expr) throws RuntimeException {
+    long milliseconds =
+        expr.precision() > 3
+            ? (expr.subseconds() / (int) Math.pow(10, expr.precision() - 3))
+            : (expr.subseconds() * (int) Math.pow(10, 3 - expr.precision()));
     return rexBuilder.makeIntervalLiteral(
         // Current Calcite behavior is to store milliseconds since Epoch
-        // microseconds version: new BigDecimal(expr.days() * MICROS_IN_DAY + expr.seconds() *
-        // 100000L + expr.microseconds()), DAY_SECOND_INTERVAL);
-        new BigDecimal(
-            (expr.days() * MICROS_IN_DAY + expr.seconds() * 1_000_000L + expr.microseconds())
-                / 1000L),
+        new BigDecimal((expr.days() * MILLIS_IN_DAY + expr.seconds() * 1_000L + milliseconds)),
         DAY_SECOND_INTERVAL);
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
@@ -85,7 +85,14 @@ public class IgnoreNullableAndParameters
 
   @Override
   public Boolean visit(Type.IntervalDay type) {
-    return typeToMatch instanceof Type.IntervalDay;
+    return typeToMatch instanceof Type.IntervalDay
+        || typeToMatch instanceof ParameterizedType.IntervalDay;
+  }
+
+  @Override
+  public Boolean visit(Type.IntervalCompound type) {
+    return typeToMatch instanceof Type.IntervalCompound
+        || typeToMatch instanceof ParameterizedType.IntervalCompound;
   }
 
   @Override
@@ -169,6 +176,18 @@ public class IgnoreNullableAndParameters
   @Override
   public Boolean visit(ParameterizedType.Decimal expr) throws RuntimeException {
     return typeToMatch instanceof Type.Decimal || typeToMatch instanceof ParameterizedType.Decimal;
+  }
+
+  @Override
+  public Boolean visit(ParameterizedType.IntervalDay expr) throws RuntimeException {
+    return typeToMatch instanceof Type.IntervalDay
+        || typeToMatch instanceof ParameterizedType.IntervalDay;
+  }
+
+  @Override
+  public Boolean visit(ParameterizedType.IntervalCompound expr) throws RuntimeException {
+    return typeToMatch instanceof Type.IntervalCompound
+        || typeToMatch instanceof ParameterizedType.IntervalCompound;
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -172,6 +172,7 @@ public class LiteralConverter {
           INTERVAL_MINUTE_SECOND,
           INTERVAL_SECOND -> {
         // we need to convert to microseconds.
+        // TODO: don't need to anymore
         int scale = literal.getType().getScale();
         var intervalLength = literal.getValueAs(BigDecimal.class).longValue();
         var adjustedLength =
@@ -182,7 +183,7 @@ public class LiteralConverter {
         var totalMicroseconds = adjustedLength - days * MICROS_IN_DAY;
         var seconds = totalMicroseconds / 1_000_000;
         var microseconds = totalMicroseconds - 1_000_000 * seconds;
-        yield intervalDay(n, (int) days, (int) seconds, (int) microseconds);
+        yield intervalDay(n, (int) days, (int) seconds, microseconds, 6 /* micros */);
       }
 
       case ROW -> {

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -211,7 +211,7 @@ public class CalciteLiteralTest extends CalciteObjs {
                 org.apache.calcite.avatica.util.TimeUnit.SECOND,
                 3,
                 SqlParserPos.ZERO));
-    var intervalDaySecondExpr = intervalDay(false, 3, 5 * 3600 + 7 * 60 + 9, 500_000);
+    var intervalDaySecondExpr = intervalDay(false, 3, 5 * 3600 + 7 * 60 + 9, 500_000, 6);
     bitest(intervalDaySecondExpr, intervalDaySecond);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -118,7 +118,7 @@ class CalciteTypeTest extends CalciteObjs {
   @ValueSource(booleans = {true, false})
   void intervalDay(boolean nullable) {
     testType(
-        Type.withNullability(nullable).INTERVAL_DAY,
+        Type.withNullability(nullable).intervalDay(6),
         type.createSqlIntervalType(SubstraitTypeSystem.DAY_SECOND_INTERVAL),
         nullable);
   }

--- a/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
@@ -55,7 +55,11 @@ class IgnoreNullableAndParameters(val typeToMatch: ParameterizedType)
   override def visit(`type`: Type.IntervalYear): Boolean =
     typeToMatch.isInstanceOf[Type.IntervalYear]
 
-  override def visit(`type`: Type.IntervalDay): Boolean = typeToMatch.isInstanceOf[Type.IntervalDay]
+  override def visit(`type`: Type.IntervalDay): Boolean =
+    typeToMatch.isInstanceOf[Type.IntervalDay] || typeToMatch.isInstanceOf[ParameterizedType.IntervalDay]
+
+  override def visit(`type`: Type.IntervalCompound): Boolean =
+    typeToMatch.isInstanceOf[Type.IntervalCompound] || typeToMatch.isInstanceOf[ParameterizedType.IntervalCompound]
 
   override def visit(`type`: Type.UUID): Boolean = typeToMatch.isInstanceOf[Type.UUID]
 
@@ -102,6 +106,14 @@ class IgnoreNullableAndParameters(val typeToMatch: ParameterizedType)
   @throws[RuntimeException]
   override def visit(expr: ParameterizedType.Decimal): Boolean =
     typeToMatch.isInstanceOf[Type.Decimal] || typeToMatch.isInstanceOf[ParameterizedType.Decimal]
+
+  @throws[RuntimeException]
+  override def visit(expr: ParameterizedType.IntervalDay): Boolean =
+    typeToMatch.isInstanceOf[Type.IntervalDay] || typeToMatch.isInstanceOf[ParameterizedType.IntervalDay]
+
+  @throws[RuntimeException]
+  override def visit(expr: ParameterizedType.IntervalCompound): Boolean =
+    typeToMatch.isInstanceOf[Type.IntervalCompound] || typeToMatch.isInstanceOf[ParameterizedType.IntervalCompound]
 
   @throws[RuntimeException]
   override def visit(expr: ParameterizedType.Struct): Boolean =


### PR DESCRIPTION
Bumps substrait to latest to get https://github.com/substrait-io/substrait/pull/665 and addresses the breaks, adding IntervalCompound type and literal and adapting IntervalDay type and literal to have precision. For IntervalDay, backwards-compatibility is provided for reading existing protobufs using microseconds, but not for generating new protobufs, ie new plans will always use precision and subseconds.

Requires https://github.com/substrait-io/substrait/pull/687 ✅ 

CSV support from https://github.com/substrait-io/substrait/pull/646 is not implemented yet