### PR TITLE
feat(isthmus): allow WindowFunctionConverter to use a non-default TypeConverter

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
@@ -10,6 +10,7 @@ import io.substrait.expression.FunctionArg;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.AggregateFunctions;
+import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.Type;
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +38,14 @@ public class WindowFunctionConverter
   public WindowFunctionConverter(
       List<SimpleExtension.WindowFunctionVariant> functions, RelDataTypeFactory typeFactory) {
     super(functions, typeFactory);
+  }
+
+  public WindowFunctionConverter(
+      List<SimpleExtension.WindowFunctionVariant> functions,
+      List<FunctionMappings.Sig> additionalSignatures,
+      RelDataTypeFactory typeFactory,
+      TypeConverter typeConverter) {
+    super(functions, additionalSignatures, typeFactory, typeConverter);
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowRelFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowRelFunctionConverter.java
@@ -9,6 +9,7 @@ import io.substrait.expression.FunctionArg;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.AggregateFunctions;
+import io.substrait.isthmus.TypeConverter;
 import io.substrait.relation.ConsistentPartitionWindow;
 import io.substrait.type.Type;
 import java.util.List;
@@ -36,6 +37,14 @@ public class WindowRelFunctionConverter
   public WindowRelFunctionConverter(
       List<SimpleExtension.WindowFunctionVariant> functions, RelDataTypeFactory typeFactory) {
     super(functions, typeFactory);
+  }
+
+  public WindowRelFunctionConverter(
+      List<SimpleExtension.WindowFunctionVariant> functions,
+      List<FunctionMappings.Sig> additionalSignatures,
+      RelDataTypeFactory typeFactory,
+      TypeConverter typeConverter) {
+    super(functions, additionalSignatures, typeFactory, typeConverter);
   }
 
   @Override


### PR DESCRIPTION
This to fix https://github.com/substrait-io/substrait-java/issues/290