### PR TITLE
refactor: enable Spotless for Scala code

### DIFF
--- a/spark/.scalafmt.conf
+++ b/spark/.scalafmt.conf
@@ -1,0 +1,70 @@
+runner.dialect = scala212
+
+# Version is required to make sure IntelliJ picks the right version
+version = 3.7.3
+preset = default
+
+# Max column
+maxColumn = 100
+
+# This parameter simply says the .stripMargin method was not redefined by the user to assign
+# special meaning to indentation preceding the | character. Hence, that indentation can be modified.
+assumeStandardLibraryStripMargin = true
+align.stripMargin = true
+
+# Align settings
+align.preset = none
+align.closeParenSite = false
+align.openParenCallSite = false
+danglingParentheses.defnSite = false
+danglingParentheses.callSite = false
+danglingParentheses.ctrlSite = true
+danglingParentheses.tupleSite = false
+align.openParenCallSite = false
+align.openParenDefnSite = false
+align.openParenTupleSite = false
+
+# Newlines
+newlines.alwaysBeforeElseAfterCurlyIf = false
+newlines.beforeCurlyLambdaParams = multiline # Newline before lambda params
+newlines.afterCurlyLambdaParams = squash # No newline after lambda params
+newlines.inInterpolation = "avoid"
+newlines.avoidInResultType = true
+optIn.annotationNewlines = true
+
+# Scaladoc
+docstrings.style = Asterisk # Javadoc style
+docstrings.removeEmpty = true
+docstrings.oneline = fold
+docstrings.forceBlankLineBefore = true
+
+# Indentation
+indent.extendSite = 2 # This makes sure extend is not indented as the ctor parameters
+
+# Rewrites
+rewrite.rules = [AvoidInfix, Imports, RedundantBraces, SortModifiers]
+
+# Imports
+rewrite.imports.sort = scalastyle
+rewrite.imports.groups = [
+    ["io.substrait.spark\\..*"],
+    ["org.apache.spark\\..*"],
+    [".*"],
+    ["javax\\..*"],
+    ["java\\..*"],
+    ["scala\\..*"]
+]
+rewrite.imports.contiguousGroups = no
+importSelectors = singleline # Imports in a single line, like IntelliJ
+
+# Remove redundant braces in string interpolation.
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.defnBodies = false
+rewrite.redundantBraces.generalExpressions = false
+rewrite.redundantBraces.ifElseExpressions = false
+rewrite.redundantBraces.methodBodies = false
+rewrite.redundantBraces.includeUnitMethods = false
+rewrite.redundantBraces.maxBreaks = 1
+
+# Remove trailing commas
+rewrite.trailingCommas.style = "never"

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -105,6 +105,13 @@ dependencies {
   testImplementation("org.apache.spark:spark-catalyst_2.12:${SPARK_VERSION}:tests")
 }
 
+spotless {
+  scala {
+    scalafmt().configFile(".scalafmt.conf")
+    toggleOffOn()
+  }
+}
+
 tasks {
   test {
     dependsOn(":core:shadowJar")

--- a/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
+++ b/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
@@ -16,11 +16,12 @@
  */
 package io.substrait.spark
 
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types._
+
 import io.substrait.`type`.{NamedStruct, Type, TypeVisitor}
 import io.substrait.function.TypeExpression
 import io.substrait.utils.Util
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
-import org.apache.spark.sql.types._
 
 import scala.collection.JavaConverters
 import scala.collection.JavaConverters.asScalaBufferConverter

--- a/spark/src/main/scala/io/substrait/spark/expression/FunctionConverter.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/FunctionConverter.scala
@@ -16,6 +16,8 @@
  */
 package io.substrait.spark.expression
 
+import io.substrait.spark.ToSubstraitType
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.{AnsiTypeCoercion, TypeCoercion}
@@ -29,7 +31,6 @@ import io.substrait.expression.{Expression => SExpression, ExpressionCreator, Fu
 import io.substrait.expression.Expression.FailureBehavior
 import io.substrait.extension.SimpleExtension
 import io.substrait.function.{ParameterizedType, ToTypeString}
-import io.substrait.spark.ToSubstraitType
 import io.substrait.utils.Util
 
 import java.{util => ju}

--- a/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
@@ -56,10 +56,12 @@ class IgnoreNullableAndParameters(val typeToMatch: ParameterizedType)
     typeToMatch.isInstanceOf[Type.IntervalYear]
 
   override def visit(`type`: Type.IntervalDay): Boolean =
-    typeToMatch.isInstanceOf[Type.IntervalDay] || typeToMatch.isInstanceOf[ParameterizedType.IntervalDay]
+    typeToMatch.isInstanceOf[Type.IntervalDay] || typeToMatch
+      .isInstanceOf[ParameterizedType.IntervalDay]
 
   override def visit(`type`: Type.IntervalCompound): Boolean =
-    typeToMatch.isInstanceOf[Type.IntervalCompound] || typeToMatch.isInstanceOf[ParameterizedType.IntervalCompound]
+    typeToMatch.isInstanceOf[Type.IntervalCompound] || typeToMatch
+      .isInstanceOf[ParameterizedType.IntervalCompound]
 
   override def visit(`type`: Type.UUID): Boolean = typeToMatch.isInstanceOf[Type.UUID]
 
@@ -109,11 +111,13 @@ class IgnoreNullableAndParameters(val typeToMatch: ParameterizedType)
 
   @throws[RuntimeException]
   override def visit(expr: ParameterizedType.IntervalDay): Boolean =
-    typeToMatch.isInstanceOf[Type.IntervalDay] || typeToMatch.isInstanceOf[ParameterizedType.IntervalDay]
+    typeToMatch.isInstanceOf[Type.IntervalDay] || typeToMatch
+      .isInstanceOf[ParameterizedType.IntervalDay]
 
   @throws[RuntimeException]
   override def visit(expr: ParameterizedType.IntervalCompound): Boolean =
-    typeToMatch.isInstanceOf[Type.IntervalCompound] || typeToMatch.isInstanceOf[ParameterizedType.IntervalCompound]
+    typeToMatch.isInstanceOf[Type.IntervalCompound] || typeToMatch
+      .isInstanceOf[ParameterizedType.IntervalCompound]
 
   @throws[RuntimeException]
   override def visit(expr: ParameterizedType.Struct): Boolean =

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
@@ -19,11 +19,11 @@ package io.substrait.spark.expression
 import io.substrait.spark.{HasOutputStack, ToSubstraitType}
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.substrait.SparkTypeUtil
 
 import io.substrait.expression.{Expression => SExpression, ExpressionCreator, FieldReference, ImmutableExpression}
 import io.substrait.expression.Expression.FailureBehavior
 import io.substrait.utils.Util
-import org.apache.spark.substrait.SparkTypeUtil
 
 import scala.collection.JavaConverters.asJavaIterableConverter
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
@@ -16,13 +16,14 @@
  */
 package io.substrait.spark.expression
 
+import io.substrait.spark.ToSubstraitType
+
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
 import io.substrait.expression.{Expression => SExpression}
 import io.substrait.expression.ExpressionCreator._
-import io.substrait.spark.ToSubstraitType
 
 class ToSubstraitLiteral {
 

--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -31,7 +31,7 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
     spark.conf.set("spark.sql.readSideCharPadding", "false")
   }
 
-  // "q9" failed in spark 3.3
+  // spotless:off
   val successfulSQL: Set[String] = Set("q1", "q3", "q4", "q7",
     "q11", "q13", "q15", "q16", "q18", "q19",
     "q22", "q23a", "q23b", "q25", "q26", "q28", "q29",
@@ -42,6 +42,7 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
     "q71", "q76", "q79",
     "q81", "q82", "q85", "q88",
     "q90", "q91", "q92", "q93", "q94", "q95", "q96", "q97", "q99")
+  // spotless:on
 
   tpcdsQueries.foreach {
     q =>

--- a/spark/src/test/scala/io/substrait/spark/TPCHPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCHPlan.scala
@@ -17,6 +17,7 @@
 package io.substrait.spark
 
 import io.substrait.spark.logical.{ToLogicalPlan, ToSubstraitRel}
+
 import org.apache.spark.sql.TPCHBase
 
 class TPCHPlan extends TPCHBase with SubstraitPlanTestBase {


### PR DESCRIPTION
Add lint checking to the Scala code in the Spark module.

All other changes in this commit are the formatting changes created by the linter.