### PR TITLE
feat(spark): support conversion of boolean types

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
+++ b/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
@@ -44,6 +44,8 @@ private class ToSparkType
   override def visit(expr: Type.FixedChar): DataType = StringType
 
   override def visit(expr: Type.VarChar): DataType = StringType
+
+  override def visit(expr: Type.Bool): DataType = BooleanType
 }
 class ToSubstraitType {
 

--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -34,12 +34,12 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
   // "q9" failed in spark 3.3
   val successfulSQL: Set[String] = Set("q1", "q3", "q4", "q7",
     "q11", "q13", "q15", "q16", "q18", "q19",
-    "q22", "q23a", "q23b", "q25", "q26", "q28", "q29",
+    "q21", "q22", "q23a", "q23b", "q25", "q26", "q28", "q29",
     "q30", "q31", "q32", "q33", "q37",
     "q41", "q42", "q43", "q46", "q48",
     "q50", "q52", "q54", "q55", "q56", "q58", "q59",
     "q60", "q61", "q62", "q65", "q66", "q68", "q69",
-    "q71", "q76", "q79",
+    "q71", "q73", "q76", "q79",
     "q81", "q82", "q85", "q88",
     "q90", "q91", "q92", "q93", "q94", "q95", "q96", "q97", "q99")
 


### PR DESCRIPTION
Add support for converting Boolean spark to substrait type. Enables two more successful TPC-DS tests.