### PR TITLE
feat(spark): enable some missing string functions

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
@@ -48,7 +48,6 @@ class FunctionMappings {
     s[GreaterThanOrEqual]("gte"),
     s[EqualTo]("equal"),
     s[EqualNullSafe]("is_not_distinct_from"),
-    // s[BitwiseXor]("xor"),
     s[IsNull]("is_null"),
     s[IsNotNull]("is_not_null"),
     s[EndsWith]("ends_with"),
@@ -56,6 +55,10 @@ class FunctionMappings {
     s[Contains]("contains"),
     s[StartsWith]("starts_with"),
     s[Substring]("substring"),
+    s[Upper]("upper"),
+    s[Lower]("lower"),
+    s[Concat]("concat"),
+    s[Coalesce]("coalesce"),
     s[Year]("year"),
 
     // internal

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
@@ -35,6 +35,8 @@ abstract class ToSubstraitExpression extends HasOutputStack[Seq[Attribute]] {
       case BinaryExpression(left, right) => Some(Seq(left, right))
       case UnaryExpression(child) => Some(Seq(child))
       case t: TernaryExpression => Some(Seq(t.first, t.second, t.third))
+      case Coalesce(children) => Some(children.toList)
+      case Concat(children) => Some(children.toList)
       case _ => None
     }
   }

--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -34,9 +34,9 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
   // spotless:off
   val successfulSQL: Set[String] = Set("q1", "q3", "q4", "q7",
     "q11", "q13", "q14b", "q15", "q16", "q18", "q19",
-    "q21", "q22", "q23a", "q23b", "q25", "q26", "q28", "q29",
+    "q21", "q22", "q23a", "q23b", "q24a", "q24b", "q25", "q26", "q28", "q29",
     "q30", "q31", "q32", "q33", "q37", "q38",
-    "q41", "q42", "q43", "q46", "q48",
+    "q40", "q41", "q42", "q43", "q46", "q48",
     "q50", "q52", "q54", "q55", "q56", "q58", "q59",
     "q60", "q61", "q62", "q65", "q66", "q68", "q69",
     "q71", "q73", "q76", "q79",


### PR DESCRIPTION
Add mappings for upper/lower/concat/coalesce