### PR TITLE
fix(spark): output columns of expand relation

### DIFF
--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -33,7 +33,7 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
 
   // spotless:off
   val successfulSQL: Set[String] = Set("q1", "q3", "q4", "q7",
-    "q11", "q13", "q14b", "q15", "q16", "q18", "q19",
+    "q11", "q13", "q14a", "q14b", "q15", "q16", "q18", "q19",
     "q21", "q22", "q23a", "q23b", "q24a", "q24b", "q25", "q26", "q28", "q29",
     "q30", "q31", "q32", "q33", "q37", "q38",
     "q40", "q41", "q42", "q43", "q46", "q48",


### PR DESCRIPTION
Fix the logic for deriving whether each output column of the expand relation is nullable or not.
If one or more of the projections can assign null to the column, then it must be defined as nullable.