### PR TITLE
feat(spark): convert VirtualTableScan to LocalRelation 

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
+++ b/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
@@ -128,7 +128,7 @@ class ToSubstraitType {
     )
   }
 
-  def toAttribute(namedStruct: NamedStruct): Seq[AttributeReference] = {
+  def toAttributeSeq(namedStruct: NamedStruct): Seq[AttributeReference] = {
     namedStruct
       .struct()
       .fields()

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -333,7 +333,8 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
                 var idx = 0
                 val buf = new ArrayBuffer[SExpression.Literal](row.numFields)
                 while (idx < row.numFields) {
-                  val l = Literal.apply(row.get(idx, localRelation.schema(idx).dataType))
+                  val dt = localRelation.schema(idx).dataType
+                  val l = Literal.apply(row.get(idx, dt), dt)
                   buf += ToSubstraitLiteral.apply(l)
                   idx += 1
                 }

--- a/spark/src/test/scala/io/substrait/spark/RelationsSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/RelationsSuite.scala
@@ -1,0 +1,25 @@
+package io.substrait.spark
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+
+class RelationsSuite extends SparkFunSuite with SharedSparkSession with SubstraitPlanTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sparkContext.setLogLevel("WARN")
+  }
+
+  test("local_relation_simple") {
+    assertSqlSubstraitRelRoundTrip(
+      "select * from (values (1, 'a'), (2, 'b') as table(col1, col2))"
+    )
+  }
+
+  test("local_relation_null") {
+    assertSqlSubstraitRelRoundTrip(
+      "select * from (values (1), (NULL) as table(col))"
+    )
+  }
+
+}


### PR DESCRIPTION
The other direction (Spark -> Substrait) was already supported, but this adds Substrait -> Spark and enables round-trip testing.

Also fixes LocalRelation -> VirtualTableScan for rows containing null values.