### PR TITLE
fix: propagate sorts in aggregate function invocation proto->rel

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoAggregateFunctionConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoAggregateFunctionConverter.java
@@ -53,6 +53,10 @@ public class ProtoAggregateFunctionConverter {
         measure.getOptionsList().stream()
             .map(ProtoExpressionConverter::fromFunctionOption)
             .collect(Collectors.toList());
+    List<Expression.SortField> sorts =
+        measure.getSortsList().stream()
+            .map(protoExpressionConverter::fromSortField)
+            .collect(Collectors.toList());
     return AggregateFunctionInvocation.builder()
         .arguments(functionArgs)
         .declaration(aggregateFunction)
@@ -60,6 +64,7 @@ public class ProtoAggregateFunctionConverter {
         .aggregationPhase(Expression.AggregationPhase.fromProto(measure.getPhase()))
         .invocation(Expression.AggregationInvocation.fromProto(measure.getInvocation()))
         .options(options)
+        .sort(sorts)
         .build();
   }
 }

--- a/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
@@ -53,6 +53,13 @@ public class AggregateRoundtripTest extends TestBase {
                                 .name("option")
                                 .addValues("VALUE1", "VALUE2")
                                 .build()))
+                    .sort(
+                        Arrays.asList(
+                            Expression.SortField.builder()
+                                // SORT BY decimal
+                                .expr(b.fieldReference(input, 0))
+                                .direction(Expression.SortDirection.ASC_NULLS_LAST)
+                                .build()))
                     .build())
             .build();
 


### PR DESCRIPTION
When consuming a Substrait proto plan that contains sort within aggregate calls, the SortFields were being dropped in the process.

This is what I mean by sort within aggregates:
> SELECT ARRAY_AGG(genre **ORDER BY genre**) FROM book

So this is a simple addition + test case change that closes that gap.

