### PR TITLE
fix(spark): incorrect deriveRecordType() for Expand

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
+++ b/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
@@ -34,6 +34,8 @@ object SparkExtension {
   private val EXTENSION_COLLECTION: SimpleExtension.ExtensionCollection =
     SimpleExtension.loadDefaults()
 
+  val COLLECTION: SimpleExtension.ExtensionCollection = EXTENSION_COLLECTION.merge(SparkImpls)
+
   lazy val SparkScalarFunctions: Seq[SimpleExtension.ScalarFunctionVariant] = {
     val ret = new collection.mutable.ArrayBuffer[SimpleExtension.ScalarFunctionVariant]()
     ret.appendAll(EXTENSION_COLLECTION.scalarFunctions().asScala)

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -277,14 +277,13 @@ class ToLogicalPlan(spark: SparkSession) extends DefaultRelVisitor[LogicalPlan] 
         }
 
       // An output column is nullable if any of the projections can assign null to it
-      val types = projections.transpose.map(p => (p.head.dataType, p.exists(_.nullable)))
-
-      val output = types
+      val output = projections
+        .map(p => (p.head.dataType, p.exists(_.nullable)))
         .zip(names)
         .map { case (t, name) => StructField(name, t._1, t._2) }
         .map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
 
-      Expand(projections, output, child)
+      Expand(projections.transpose, output, child)
     }
   }
 

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -290,7 +290,7 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
   }
 
   override def visitExpand(p: Expand): relation.Rel = {
-    val fields = p.projections.map(
+    val fields = p.projections.transpose.map(
       proj => {
         relation.Expand.SwitchingField.builder
           .duplicates(
@@ -302,7 +302,6 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
     val names = p.output.map(_.name)
 
     relation.Expand.builder
-      .remap(relation.Rel.Remap.offset(p.child.output.size, names.size))
       .fields(fields.asJava)
       .hint(Hint.builder.addAllOutputNames(names.asJava).build())
       .input(visit(p.child))

--- a/spark/src/test/scala/io/substrait/spark/SubstraitPlanTestBase.scala
+++ b/spark/src/test/scala/io/substrait/spark/SubstraitPlanTestBase.scala
@@ -26,7 +26,7 @@ import io.substrait.debug.TreePrinter
 import io.substrait.extension.ExtensionCollector
 import io.substrait.plan.{Plan, PlanProtoConverter, ProtoPlanConverter}
 import io.substrait.proto
-import io.substrait.relation.RelProtoConverter
+import io.substrait.relation.{ProtoRelConverter, RelProtoConverter}
 import org.scalactic.Equality
 import org.scalactic.source.Position
 import org.scalatest.Succeeded
@@ -92,6 +92,10 @@ trait SubstraitPlanTestBase { self: SharedSparkSession =>
     val logicalPlan2 = pojoRel.accept(converter);
     require(logicalPlan2.resolved);
     val pojoRel2 = new ToSubstraitRel().visit(logicalPlan2)
+
+    val extensionCollector = new ExtensionCollector;
+    val proto = new RelProtoConverter(extensionCollector).toProto(pojoRel)
+    new ProtoRelConverter(extensionCollector, SparkExtension.COLLECTION).from(proto)
 
     pojoRel2.shouldEqualPlainly(pojoRel)
     logicalPlan2


### PR DESCRIPTION
In the Expand relation, the record type was being calculated incorrectly, leading to errors when round-tripping to protobuf and back.