### PR TITLE
fix(spark): casting date/time requires timezone

### DIFF
--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -36,7 +36,7 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
     "q2", // because round() isn't defined in substrait to work with Decimal. https://github.com/substrait-io/substrait/pull/713
     "q9", // requires implementation of named_struct()
     "q10", "q35", "q45", // Unsupported join type ExistenceJoin (this is an internal spark type)
-    "q51", "q83", "q84", // TBD
+    "q51", "q84", // TBD
     "q72" //requires implementation of date_add()
   )
   // spotless:on


### PR DESCRIPTION
When casting a date type to a string, Spark requires that a timezone is specified, otherwise it will not resolve the logical plan.
The timezone is ignored for non-date/time values.