### PR TITLE
chore(spark): pin osv-scanner to v.1.9.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           name: cyclonedx-sbom
       - name: Scan
-        run: docker run --rm -v "${PWD}/${{ matrix.project }}/build/reports/bom.json:/bom.json" ghcr.io/google/osv-scanner --sbom /bom.json
+        run: docker run --rm -v "${PWD}/${{ matrix.project }}/build/reports/bom.json:/bom.json" ghcr.io/google/osv-scanner:v1.9.2 --sbom /bom.json
   java:
     name: Build and Test Java
     runs-on: ubuntu-latest
@@ -130,7 +130,9 @@ jobs:
     - name: Install GraalVM native image
       run: gu install native-image
     - name: Build with Gradle
-      run: gradle nativeImage
+      run: |
+        ln -s isthmus-cli/proxies.json
+        gradle nativeImage
     - name: Smoke Test
       run: |
         ./isthmus-cli/src/test/script/smoke.sh


### PR DESCRIPTION
The `ghcr.io/google/osv-scanner:latest` docker image was updated to `v2.0.0-beta1`.
This breaks the build with the error:
`Failed to parse SBOM "/bom.json" with error: could not determine extractor suitable to this file`

This commit pins the image tag to last working release `v1.9.2`

