### PR TITLE
fix(isthmus): more standard SQL for TPCDS query 72

### DIFF
--- a/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryNoValidation.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryNoValidation.java
@@ -44,8 +44,8 @@ public class TpcdsQueryNoValidation extends PlanTestBase {
       ints = {
         1, 3, 4, 6, 7, 8, 10, 11, 13, 14, 15, 16, 18, 19, 21, 22, 23, 25, 26, 28, 29, 30, 31, 32,
         33, 34, 35, 37, 38, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 52, 54, 55, 56, 58, 59, 60, 61,
-        62, 64, 65, 67, 68, 69, 71, 73, 74, 75, 76, 77, 79, 81, 82, 83, 85, 87, 88, 90, 92, 93, 94,
-        95, 96, 97, 99
+        62, 64, 65, 67, 68, 69, 71, 72, 73, 74, 75, 76, 77, 79, 81, 82, 83, 85, 87, 88, 90, 92, 93,
+        94, 95, 96, 97, 99
       })
   public void tpcdsSuccess(int query) throws Exception {
     testQuery(query);
@@ -54,8 +54,7 @@ public class TpcdsQueryNoValidation extends PlanTestBase {
   @ParameterizedTest
   @ValueSource(
       ints = {
-        2, 5, 9, 12, 17, 20, 24, 27, 36, 39, 47, 51, 53, 57, 63, 66, 70, 72, 78, 80, 84, 86, 89, 91,
-        98
+        2, 5, 9, 12, 17, 20, 24, 27, 36, 39, 47, 51, 53, 57, 63, 66, 70, 78, 80, 84, 86, 89, 91, 98
       })
   public void tpcdsFailure(int query) throws Exception {
     // testQuery(query);

--- a/isthmus/src/test/resources/tpcds/queries/72.sql
+++ b/isthmus/src/test/resources/tpcds/queries/72.sql
@@ -17,7 +17,7 @@ left outer join promotion on (cs_promo_sk=p_promo_sk)
 left outer join catalog_returns on (cr_item_sk = cs_item_sk and cr_order_number = cs_order_number)
 where d1.d_week_seq = d2.d_week_seq
   and inv_quantity_on_hand < cs_quantity 
-  and d3.d_date > d1.d_date + 5
+  and d3.d_date > d1.d_date + interval '5' day
   and hd_buy_potential = '1001-5000'
   and d1.d_year = 1998
   and hd_buy_potential = '1001-5000'


### PR DESCRIPTION
According to a related [Calcite issue](https://issues.apache.org/jira/browse/CALCITE-304), TPCDS query 72 uses Oracle-specific syntax for date addition, which defaults to days as the time unit when a numeric value is added to a date. A more standards-compliant form is to explicitly specify the time unit as an interval.