### PR TITLE
build: fix flaky native build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -131,7 +131,6 @@ jobs:
       run: gu install native-image
     - name: Build with Gradle
       run: |
-        ln -s isthmus-cli/proxies.json
         gradle nativeImage
     - name: Smoke Test
       run: |

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -133,7 +133,7 @@ graal {
   option("-H:IncludeResources=.*yaml")
   option("--report-unsupported-elements-at-runtime")
   option("-H:+ReportExceptionStackTraces")
-  option("-H:DynamicProxyConfigurationFiles=proxies.json")
+  option("-H:DynamicProxyConfigurationFiles=${project.file("proxies.json")}")
   option("--features=io.substrait.isthmus.cli.RegisterAtRuntime")
   option("-J--enable-preview")
 }


### PR DESCRIPTION
Fixes https://github.com/substrait-io/substrait-java/issues/331

`-H:DynamicProxyConfigurationFiles=proxies.json` is interpreted based on the _cwd_, so it ends up being environment dependent.

The current change disambiguates/makes the path absolute for the module that defines the config.


cc @andrew-coleman that came up with the symlink approach.

