### PR TITLE
build: correctly declare api dependencies

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 
 plugins {
   `maven-publish`
-  id("java")
+  id("java-library")
   id("idea")
   id("antlr")
   id("com.google.protobuf") version "0.9.4"
@@ -84,7 +84,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_VERSION}")
   testImplementation("org.junit.jupiter:junit-jupiter-params:${JUNIT_VERSION}")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${JUNIT_VERSION}")
-  implementation("com.google.protobuf:protobuf-java:${PROTOBUF_VERSION}")
+  api("com.google.protobuf:protobuf-java:${PROTOBUF_VERSION}")
   implementation("com.fasterxml.jackson.core:jackson-databind:${JACKSON_VERSION}")
   implementation("com.fasterxml.jackson.core:jackson-annotations:${JACKSON_VERSION}")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${JACKSON_VERSION}")

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
   `maven-publish`
-  id("java")
+  id("java-library")
   id("idea")
   id("com.diffplug.spotless") version "6.19.0"
   id("com.github.johnrengelman.shadow") version "8.1.1"
@@ -79,8 +79,8 @@ val SLF4J_VERSION = properties.get("slf4j.version")
 val PROTOBUF_VERSION = properties.get("protobuf.version")
 
 dependencies {
-  implementation(project(":core"))
-  implementation("org.apache.calcite:calcite-core:${CALCITE_VERSION}")
+  api(project(":core"))
+  api("org.apache.calcite:calcite-core:${CALCITE_VERSION}")
   // calcite-core 1.37.0 brings in net.minidev:json-smart:2.5.0 which has a CVE associated with it.
   // See: https://osv.dev/vulnerability/GHSA-pq2g-wx69-c263
   // This causes the build to fail. Pull in the fixed version until Calcite is updated


### PR DESCRIPTION
Currently, both the `isthmus` and `core` projects are declaring all dependencies as `implementation` dependencies. Gradle has two types of dependencies `api` and `implementation` dependencies. From the Gradle documentation:

> The `api` configuration should be used to declare dependencies which are exported by the library API, whereas the `implementation` configuration should be used to declare dependencies which are internal to the component.

https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation

For the [`core`](https://github.com/substrait-io/substrait-java/tree/main/core) project some of the protobuf Java classes are part of the Substrait Java API, e.g. `com.google.protobuf.ByteString` is exposed as part of the [`io.substrait.expression.Expression`](https://github.com/substrait-io/substrait-java/blob/d8f22f71d4b22b2047f5c6c97fc360342088334b/core/src/main/java/io/substrait/expression/Expression.java#L190) interface. Which means we should declare `com.google.protobuf:protobuf-java` as an `api` dependency instead of an `implementation` dependency.

Similarly, in the [`isthmus`](https://github.com/substrait-io/substrait-java/tree/main/isthmus) project classes coming from the dependency on the `core` project are part of the isthmus API and should be reported as an `api` dependency. Additionally, the Apache Calcite classes are part of the isthmus API and so the `org.apache.calcite:calcite-core` should also be declared as an `api` dependency.

In order to correctly declare these `api` dependencies we need to switch from the `java` to the `java-library` Gradle plugin.

If such dependencies are not declared as `api` dependencies Gradle projects depending on the `core` or `isthmus` libraries are forced to repeat the dependency declaration on the respective dependencies.