### PR TITLE
fix(isthmus): sql day/time interval conversion

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -97,10 +97,8 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
   @Override
   public RexNode visit(Expression.UserDefinedLiteral expr) throws RuntimeException {
     var binaryLiteral = rexBuilder.makeBinaryLiteral(new ByteString(expr.value().toByteArray()));
-    return rexBuilder.makeReinterpretCast(
-        typeConverter.toCalcite(typeFactory, expr.getType()),
-        binaryLiteral,
-        rexBuilder.makeLiteral(false));
+    var type = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeReinterpretCast(type, binaryLiteral, rexBuilder.makeLiteral(false));
   }
 
   @Override

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -216,6 +216,29 @@ public class CalciteLiteralTest extends CalciteObjs {
   }
 
   @Test
+  void tIntervalDay() {
+    // Calcite always uses milliseconds
+    BigDecimal bd = new BigDecimal(TimeUnit.DAYS.toMillis(5));
+    RexLiteral intervalDayLiteral =
+        rex.makeIntervalLiteral(
+            bd,
+            new SqlIntervalQualifier(
+                org.apache.calcite.avatica.util.TimeUnit.DAY, -1, null, -1, SqlParserPos.ZERO));
+    var intervalDayExpr = intervalDay(false, 5, 0, 0, 6);
+
+    // rex --> expression
+    var convertedExpr = intervalDayLiteral.accept(rexExpressionConverter);
+    assertEquals(intervalDayExpr, convertedExpr);
+
+    // expression -> rex
+    RexLiteral convertedRex = (RexLiteral) intervalDayExpr.accept(expressionRexConverter);
+
+    // Compare value only. Ignore the precision in SqlIntervalQualifier in comparison.
+    assertEquals(
+        intervalDayLiteral.getValueAs(BigDecimal.class), convertedRex.getValueAs(BigDecimal.class));
+  }
+
+  @Test
   void tIntervalYear() {
     BigDecimal bd = new BigDecimal(123 * 12); // '123' year(3)
     RexLiteral intervalYear =


### PR DESCRIPTION
RexLiteral day/time intervals were converted to Substrait using their scale. Despite all day/time interval RexLiteral created from SQL by Calcite having a (default) scale of 6, their value is always in milliseconds. This resulted in intervals generated by Calcite from SQL being wrong by a factor of 1000 seconds.

This change treats day/time interval RexLiteral values as milliseconds regardless of their claimed scale.

Closes #327