### PR TITLE
feat: allow for more ergonomic conversion of Extension relations

### DIFF
--- a/core/src/main/java/io/substrait/extension/AdvancedExtension.java
+++ b/core/src/main/java/io/substrait/extension/AdvancedExtension.java
@@ -1,6 +1,7 @@
 package io.substrait.extension;
 
 import io.substrait.relation.Extension;
+import io.substrait.relation.RelProtoConverter;
 import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -12,10 +13,10 @@ public abstract class AdvancedExtension {
 
   public abstract Optional<Extension.Enhancement> getEnhancement();
 
-  public io.substrait.proto.AdvancedExtension toProto() {
+  public io.substrait.proto.AdvancedExtension toProto(RelProtoConverter relProtoConverter) {
     var builder = io.substrait.proto.AdvancedExtension.newBuilder();
-    getEnhancement().ifPresent(e -> builder.setEnhancement(e.toProto()));
-    getOptimizations().forEach(e -> builder.addOptimization(e.toProto()));
+    getEnhancement().ifPresent(e -> builder.setEnhancement(e.toProto(relProtoConverter)));
+    getOptimizations().forEach(e -> builder.addOptimization(e.toProto(relProtoConverter)));
     return builder.build();
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -50,7 +50,7 @@ public class RelProtoConverter implements RelVisitor<Rel, RuntimeException> {
     this.typeProtoConverter = new TypeProtoConverter(functionCollector);
   }
 
-  public List<io.substrait.proto.Expression> toProto(Collection<Expression> expressions) {
+  public List<io.substrait.proto.Expression> toProto(List<Expression> expressions) {
     return expressions.stream().map(this::toProto).collect(Collectors.toList());
   }
 

--- a/core/src/main/java/io/substrait/relation/ToProto.java
+++ b/core/src/main/java/io/substrait/relation/ToProto.java
@@ -3,5 +3,5 @@ package io.substrait.relation;
 import com.google.protobuf.Message;
 
 public interface ToProto<T extends Message> {
-  T toProto();
+  T toProto(RelProtoConverter converter);
 }

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyDetail.java
@@ -3,6 +3,7 @@ package io.substrait.relation.extensions;
 import com.google.protobuf.Any;
 import io.substrait.relation.Extension;
 import io.substrait.relation.Rel;
+import io.substrait.relation.RelProtoConverter;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -20,7 +21,7 @@ public class EmptyDetail
         Extension.ExtensionTableDetail {
 
   @Override
-  public Any toProto() {
+  public Any toProto(RelProtoConverter converter) {
     return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
   }
 

--- a/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
+++ b/core/src/main/java/io/substrait/relation/extensions/EmptyOptimization.java
@@ -3,6 +3,7 @@ package io.substrait.relation.extensions;
 import com.google.protobuf.Any;
 import io.substrait.proto.AdvancedExtension;
 import io.substrait.relation.Extension;
+import io.substrait.relation.RelProtoConverter;
 
 /**
  * Default type to which {@link AdvancedExtension#getOptimizationList()} data is converted to by the
@@ -10,7 +11,7 @@ import io.substrait.relation.Extension;
  */
 public class EmptyOptimization implements Extension.Optimization {
   @Override
-  public Any toProto() {
+  public Any toProto(RelProtoConverter converter) {
     return com.google.protobuf.Any.pack(com.google.protobuf.Empty.getDefaultInstance());
   }
 }

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -5,11 +5,13 @@ import io.substrait.proto.Type;
 
 /** Convert from {@link io.substrait.type.Type} to {@link io.substrait.proto.Type} */
 public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
-  static final org.slf4j.Logger logger =
-      org.slf4j.LoggerFactory.getLogger(TypeProtoConverter.class);
 
   public TypeProtoConverter(ExtensionCollector extensionCollector) {
     super(extensionCollector, "Type literals cannot contain parameters or expressions.");
+  }
+
+  public io.substrait.proto.Type toProto(io.substrait.type.Type type) {
+    return type.accept(this);
   }
 
   private static final BaseProtoTypes<Type, Integer> NULLABLE =

--- a/core/src/test/java/io/substrait/relation/utils/StringHolder.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolder.java
@@ -3,6 +3,7 @@ package io.substrait.relation.utils;
 import com.google.protobuf.Any;
 import io.substrait.relation.Extension;
 import io.substrait.relation.Rel;
+import io.substrait.relation.RelProtoConverter;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -31,7 +32,7 @@ public class StringHolder
   }
 
   @Override
-  public Any toProto() {
+  public Any toProto(RelProtoConverter relProtoConverter) {
     return com.google.protobuf.Any.pack(com.google.protobuf.StringValue.of(this.value));
   }
 

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   id("idea")
   id("com.diffplug.spotless") version "6.19.0"
   id("com.github.johnrengelman.shadow") version "8.1.1"
+  id("com.google.protobuf") version "0.9.4"
   signing
 }
 
@@ -104,6 +105,7 @@ dependencies {
   testImplementation("org.apache.calcite:calcite-plus:${CALCITE_VERSION}")
   annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
   compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
+  testImplementation("com.google.protobuf:protobuf-java:${PROTOBUF_VERSION}")
 }
 
 tasks {
@@ -116,3 +118,7 @@ tasks {
 }
 
 tasks { build { dependsOn(shadowJar) } }
+
+sourceSets { test { proto.srcDirs("src/test/resources/extensions") } }
+
+protobuf { protoc { artifact = "com.google.protobuf:protoc:${PROTOBUF_VERSION}" } }

--- a/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
@@ -1,0 +1,305 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.substrait.expression.Expression;
+import io.substrait.expression.proto.ProtoExpressionConverter;
+import io.substrait.extension.ExtensionCollector;
+import io.substrait.extension.ExtensionLookup;
+import io.substrait.extension.SimpleExtension;
+import io.substrait.relation.EmptyScan;
+import io.substrait.relation.Extension;
+import io.substrait.relation.ExtensionLeaf;
+import io.substrait.relation.ExtensionMulti;
+import io.substrait.relation.ExtensionSingle;
+import io.substrait.relation.ProtoRelConverter;
+import io.substrait.relation.Rel;
+import io.substrait.relation.RelProtoConverter;
+import io.substrait.type.NamedStruct;
+import io.substrait.type.Type;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.tools.RelBuilder;
+import org.junit.jupiter.api.Test;
+
+public class RelExtensionRoundtripTest extends PlanTestBase {
+
+  static final EmptyScan EMPTY_TABLE =
+      EmptyScan.builder()
+          .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
+          .build();
+
+  @Test
+  void extensionLeafRelDetailTest() throws IOException {
+    var detail = new ColumnAppendDetail(substraitBuilder.i32(1));
+    var rel = ExtensionLeaf.from(detail).build();
+    roundtrip(rel);
+  }
+
+  @Test
+  void extensionSingleRelDetailTest() throws IOException {
+    var detail = new ColumnAppendDetail(substraitBuilder.i32(2));
+    var rel = ExtensionSingle.from(detail, EMPTY_TABLE).build();
+    roundtrip(rel);
+  }
+
+  @Test
+  void extensionMultiRelDetailTest() throws IOException {
+    var detail = new ColumnAppendDetail(substraitBuilder.i32(3));
+    var rel = ExtensionMulti.from(detail, EMPTY_TABLE, EMPTY_TABLE).build();
+    roundtrip(rel);
+  }
+
+  void roundtrip(Rel pojo1) throws IOException {
+    var extensionCollector = new ExtensionCollector();
+
+    // Substrait POJO 1 -> Substrait Proto
+    io.substrait.proto.Rel proto = pojo1.accept(new RelProtoConverter(extensionCollector));
+
+    // Substrait Proto -> Substrait POJO 2
+    var pojo2 = (new CustomProtoRelConverter(extensionCollector)).from(proto);
+    assertEquals(pojo1, pojo2);
+
+    // Substrait POJO 2 -> Calcite
+    var calcite =
+        pojo2.accept(new CustomSubstraitRelNodeConverter(extensions, typeFactory, builder));
+
+    // Calcite -> Substrait POJO 3
+    var pojo3 = (new CustomSubstraitRelVisitor(typeFactory, extensions)).apply(calcite);
+    assertEquals(pojo1, pojo3);
+  }
+
+  static class ColumnAppendDetail
+      implements Extension.LeafRelDetail, Extension.SingleRelDetail, Extension.MultiRelDetail {
+    Expression.Literal literal;
+
+    ColumnAppendDetail(Expression.Literal literal) {
+      this.literal = literal;
+    }
+
+    @Override
+    // LeafRelDetail
+    public Type.Struct deriveRecordType() {
+      return Type.Struct.builder().nullable(false).addFields(literal.getType()).build();
+    }
+
+    @Override
+    // SingleRelDetail
+    public Type.Struct deriveRecordType(Rel input) {
+      return Type.Struct.builder()
+          .nullable(false)
+          .addAllFields(input.getRecordType().fields())
+          .addFields(literal.getType())
+          .build();
+    }
+
+    @Override
+    // MultiRelDetail
+    public Type.Struct deriveRecordType(List<Rel> inputs) {
+      var builder = Type.Struct.builder().nullable(false);
+      for (Rel input : inputs) {
+        builder.addAllFields(input.getRecordType().fields());
+      }
+      return builder.addFields(literal.getType()).build();
+    }
+
+    @Override
+    public Any toProto(RelProtoConverter converter) {
+      io.substrait.proto.Expression lit = converter.toProto(this.literal);
+      var inner =
+          io.substrait.isthmus.extensions.test.protobuf.ColumnAppendDetail.newBuilder()
+              .setLiteral(lit.getLiteral())
+              .build();
+      return Any.pack(inner);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == null || getClass() != o.getClass()) return false;
+      ColumnAppendDetail that = (ColumnAppendDetail) o;
+      return Objects.equals(literal, that.literal);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(literal);
+    }
+
+    @Override
+    public String toString() {
+      return "ColumnAppendDetail{" + "literal=" + literal + '}';
+    }
+  }
+
+  /**
+   * Extends the standard {@link ProtoRelConverter} to be able to handle {link
+   * io.substrait.isthmus.extensions.test.protobuf.ColumnAppendDetail} messages
+   */
+  static class CustomProtoRelConverter extends ProtoRelConverter {
+
+    public CustomProtoRelConverter(ExtensionLookup lookup) throws IOException {
+      super(lookup);
+    }
+
+    ColumnAppendDetail unpack(Any any) {
+      try {
+        var proto =
+            any.unpack(io.substrait.isthmus.extensions.test.protobuf.ColumnAppendDetail.class);
+        var literal =
+            (new ProtoExpressionConverter(
+                    lookup, extensions, Type.Struct.builder().nullable(false).build(), this)
+                .from(proto.getLiteral()));
+        return new ColumnAppendDetail(literal);
+      } catch (InvalidProtocolBufferException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    protected Extension.LeafRelDetail detailFromExtensionLeafRel(Any any) {
+      return unpack(any);
+    }
+
+    @Override
+    protected Extension.SingleRelDetail detailFromExtensionSingleRel(Any any) {
+      return unpack(any);
+    }
+
+    @Override
+    protected Extension.MultiRelDetail detailFromExtensionMultiRel(Any any) {
+      return unpack(any);
+    }
+  }
+
+  /**
+   * Extends the standard {@link SubstraitRelNodeConverter} to handle Extension relations containing
+   * {@link ColumnAppendDetail}
+   */
+  static class CustomSubstraitRelNodeConverter extends SubstraitRelNodeConverter {
+
+    public CustomSubstraitRelNodeConverter(
+        SimpleExtension.ExtensionCollection extensions,
+        RelDataTypeFactory typeFactory,
+        RelBuilder relBuilder) {
+      super(extensions, typeFactory, relBuilder);
+    }
+
+    public RelNode visit(ExtensionLeaf extensionLeaf) {
+      if (extensionLeaf.getDetail() instanceof ColumnAppendDetail) {
+        ColumnAppendDetail cad = (ColumnAppendDetail) extensionLeaf.getDetail();
+        RexLiteral literal = (RexLiteral) cad.literal.accept(this.expressionRexConverter);
+        RelOptCluster cluster = relBuilder.getCluster();
+        RelTraitSet traits = cluster.traitSet();
+        return new ColumnAppenderRel(
+            relBuilder.getCluster(), traits, literal, Collections.emptyList());
+      }
+      throw new RuntimeException("detail was not ColumnAppendDetail");
+    }
+
+    @Override
+    public RelNode visit(ExtensionSingle extensionSingle) throws RuntimeException {
+      if (extensionSingle.getDetail() instanceof ColumnAppendDetail) {
+        ColumnAppendDetail cad = (ColumnAppendDetail) extensionSingle.getDetail();
+        RelNode input = extensionSingle.getInput().accept(this);
+        RexLiteral literal = (RexLiteral) cad.literal.accept(this.expressionRexConverter);
+        return new ColumnAppenderRel(
+            input.getCluster(), input.getTraitSet(), literal, List.of(input));
+      }
+      throw new RuntimeException("detail was not ColumnAppendDetail");
+    }
+
+    @Override
+    public RelNode visit(ExtensionMulti extensionMulti) throws RuntimeException {
+      if (extensionMulti.getDetail() instanceof ColumnAppendDetail) {
+        ColumnAppendDetail cad = (ColumnAppendDetail) extensionMulti.getDetail();
+        List<RelNode> inputs =
+            extensionMulti.getInputs().stream()
+                .map(input -> input.accept(this))
+                .collect(Collectors.toList());
+        RexLiteral literal = (RexLiteral) cad.literal.accept(this.expressionRexConverter);
+        return new ColumnAppenderRel(
+            inputs.get(0).getCluster(), inputs.get(0).getTraitSet(), literal, inputs);
+      }
+      throw new RuntimeException("detail was not ColumnAppendDetail");
+    }
+  }
+
+  /** Extends the standard {@link SubstraitRelVisitor} to handle the {@link ColumnAppenderRel} */
+  static class CustomSubstraitRelVisitor extends SubstraitRelVisitor {
+
+    public CustomSubstraitRelVisitor(
+        RelDataTypeFactory typeFactory, SimpleExtension.ExtensionCollection extensions) {
+      super(typeFactory, extensions);
+    }
+
+    @Override
+    public Rel visitOther(RelNode other) {
+      if (other instanceof ColumnAppenderRel) {
+        ColumnAppenderRel car = (ColumnAppenderRel) other;
+        Expression.Literal literal = (Expression.Literal) toExpression(car.literal);
+        ColumnAppendDetail detail = new ColumnAppendDetail(literal);
+        List<Rel> inputs = apply(car.getInputs());
+
+        if (inputs.isEmpty()) {
+          return ExtensionLeaf.from(detail).build();
+        } else if (inputs.size() == 1) {
+          return ExtensionSingle.from(detail, inputs.get(0)).build();
+        } else {
+          return ExtensionMulti.from(detail, inputs).build();
+        }
+      }
+      return super.visitOther(other);
+    }
+  }
+
+  /** Maps to a Substrait Extension {@link Rel} with the {@link ColumnAppendDetail} message set */
+  static class ColumnAppenderRel extends AbstractRelNode {
+
+    final RexLiteral literal;
+    final List<RelNode> inputs;
+
+    public ColumnAppenderRel(
+        RelOptCluster cluster, RelTraitSet traitSet, RexLiteral literal, List<RelNode> inputs) {
+      super(cluster, traitSet);
+      this.literal = literal;
+      this.inputs = inputs;
+    }
+
+    @Override
+    public List<RelNode> getInputs() {
+      return inputs;
+    }
+
+    @Override
+    protected RelDataType deriveRowType() {
+      List<RelDataTypeField> fields = new ArrayList<>();
+      for (RelNode input : getInputs()) {
+        fields.addAll(input.getRowType().getFieldList());
+      }
+      var appendedField =
+          new RelDataTypeFieldImpl("appended_column", fields.size(), literal.getType());
+      fields.add(appendedField);
+      return getCluster()
+          .getTypeFactory()
+          .createStructType(
+              fields.stream().map(RelDataTypeField::getType).collect(Collectors.toList()),
+              // a real implementation would have to check that names are unique
+              fields.stream().map(RelDataTypeField::getName).collect(Collectors.toList()));
+    }
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
@@ -119,7 +119,8 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
     @Override
     public Any toProto(RelProtoConverter converter) {
       // the conversion of the literal in the detail requires the presence of the RelProtoConverter
-      io.substrait.proto.Expression lit = converter.toProto(this.literal);
+      io.substrait.proto.Expression lit =
+          converter.getExpressionProtoConverter().toProto(this.literal);
       var inner =
           io.substrait.isthmus.extensions.test.protobuf.ColumnAppendDetail.newBuilder()
               .setLiteral(lit.getLiteral())

--- a/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
@@ -66,13 +66,11 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
   }
 
   void roundtrip(Rel pojo1) throws IOException {
-    var extensionCollector = new ExtensionCollector();
-
     // Substrait POJO 1 -> Substrait Proto
-    io.substrait.proto.Rel proto = pojo1.accept(new RelProtoConverter(extensionCollector));
+    io.substrait.proto.Rel proto = pojo1.accept(new RelProtoConverter(new ExtensionCollector()));
 
     // Substrait Proto -> Substrait POJO 2
-    var pojo2 = (new CustomProtoRelConverter(extensionCollector)).from(proto);
+    var pojo2 = (new CustomProtoRelConverter(new ExtensionCollector())).from(proto);
     assertEquals(pojo1, pojo2);
 
     // Substrait POJO 2 -> Calcite
@@ -120,6 +118,7 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
 
     @Override
     public Any toProto(RelProtoConverter converter) {
+      // the conversion of the literal in the detail requires the presence of the RelProtoConverter
       io.substrait.proto.Expression lit = converter.toProto(this.literal);
       var inner =
           io.substrait.isthmus.extensions.test.protobuf.ColumnAppendDetail.newBuilder()

--- a/isthmus/src/test/resources/extensions/substrait.proto
+++ b/isthmus/src/test/resources/extensions/substrait.proto
@@ -1,0 +1,14 @@
+syntax="proto3";
+
+package isthmus;
+
+import "substrait/algebra.proto";
+import "substrait/type.proto";
+
+option java_package = "io.substrait.isthmus.extensions.test.protobuf";
+option java_multiple_files = true;
+
+// Append the literal to the output rows of the relation
+message ColumnAppendDetail {
+  substrait.Expression.Literal literal = 1;
+}


### PR DESCRIPTION
An emergent pattern with Extension relations is for users to include
Substrait messages within the detail field.

To convert these Substrait messages, users need to access to conversion
machinery within the code for converting details. This PR enables that
by modifying the ToProto interface.

BREAKING CHANGE: interface method ToProto#toProto now consumes a RelProtoConverter
BREAKING CHANGE: constructor for ExpressionProtoConverter now requires a RelProtoConverter specifically