### PR TITLE
feat(spark): support merged structures

### DIFF
--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -33,7 +33,6 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
 
   // spotless:off
   val failingSQL: Set[String] = Set(
-    "q9", // requires implementation of named_struct()
     "q35", "q51", "q84", // These fail when comparing the round-tripped query plans, but are actually equivalent (due to aliases being ignored by substrait)
     "q72" //requires implementation of date_add()
   )


### PR DESCRIPTION
For a certain types of queries, the spark optimiser will rewrite the plan to create structs of merged sub-queries.
These plans don’t convert directly to substrait.  This commit provides a matcher for these structures and converts them back to their original form before translating them to Substrait.