### PR TITLE
fix(spark): enable aliased expressions to round-trip

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -423,7 +423,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }

--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -33,7 +33,6 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
 
   // spotless:off
   val failingSQL: Set[String] = Set(
-    "q35", "q51", "q84", // These fail when comparing the round-tripped query plans, but are actually equivalent (due to aliases being ignored by substrait)
     "q72" //requires implementation of date_add()
   )
   // spotless:on


### PR DESCRIPTION
A number of the TPC-DS tests were failing because the query contains multiple aliases to the same expression, causing a potential mismatch in the reference index.  Although the plans were equivalent, the substrait POJO comparison failed. This commit uses the `hint` field of the Rel message to store the alias names, and restore them back to the Spark plan to match the original.