### PR TITLE
fix: use SubstraitTypeSystem when parsing SQL

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -54,7 +54,7 @@ class SqlConverterBase {
   final FeatureBoard featureBoard;
 
   protected SqlConverterBase(FeatureBoard features) {
-    this.factory = new JavaTypeFactoryImpl();
+    this.factory = new JavaTypeFactoryImpl(SubstraitTypeSystem.TYPE_SYSTEM);
     this.config =
         CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
     this.converterConfig = SqlToRelConverter.config().withTrimUnusedFields(true).withExpand(false);

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -10,9 +10,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
-  static final org.slf4j.Logger logger =
-      org.slf4j.LoggerFactory.getLogger(SubstraitTypeSystem.class);
-
   public static final RelDataTypeSystem TYPE_SYSTEM = new SubstraitTypeSystem();
 
   private SubstraitTypeSystem() {}


### PR DESCRIPTION
BREAKING CHANGE: SQL parsing no longer uses the default Calcite type system