### PR TITLE
feat: Add `unquotedcasing` option to Isthmus CLI

### DIFF
--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
@@ -19,6 +19,7 @@ import io.substrait.proto.Plan;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Callable;
+import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import picocli.CommandLine;
 
@@ -69,6 +70,11 @@ public class IsthmusEntryPoint implements Callable<Integer> {
       names = {"--crossjoinpolicy"},
       description = "One of built-in Calcite SQL compatibility modes: ${COMPLETION-CANDIDATES}")
   private CrossJoinPolicy crossJoinPolicy = CrossJoinPolicy.KEEP_AS_CROSS_JOIN;
+
+  @Option(
+      names = {"--unquotedcasing"},
+      description = "Calcite's casing policy for unquoted identifiers: ${COMPLETION-CANDIDATES}")
+  private Casing unquotedCasing = Casing.TO_UPPER;
 
   public static void main(String... args) {
     CommandLine commandLine = new CommandLine(new IsthmusEntryPoint());
@@ -122,6 +128,7 @@ public class IsthmusEntryPoint implements Callable<Integer> {
         .allowsSqlBatch(allowMultiStatement)
         .sqlConformanceMode(sqlConformanceMode)
         .crossJoinPolicy(crossJoinPolicy)
+        .unquotedCasing(unquotedCasing)
         .build();
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/FeatureBoard.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus;
 
 import io.substrait.isthmus.SubstraitRelVisitor.CrossJoinPolicy;
+import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.immutables.value.Value;
@@ -38,5 +39,13 @@ public abstract class FeatureBoard {
   @Value.Default
   public CrossJoinPolicy crossJoinPolicy() {
     return CrossJoinPolicy.KEEP_AS_CROSS_JOIN;
+  }
+
+  /**
+   * @return Calcite's identifier casing policy for unquoted identifiers.
+   */
+  @Value.Default
+  public Casing unquotedCasing() {
+    return Casing.TO_UPPER;
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -69,6 +69,7 @@ class SqlConverterBase {
     featureBoard = features == null ? FEATURES_DEFAULT : features;
     parserConfig =
         SqlParser.Config.DEFAULT
+            .withUnquotedCasing(featureBoard.unquotedCasing())
             .withParserFactory(SqlDdlParserImpl.FACTORY)
             .withConformance(featureBoard.sqlConformanceMode());
   }


### PR DESCRIPTION
Adds a command line argument to Isthmus CLI to allow specifying Calcite's "unquoted casing" policy.

## Why?

I want to add Substrait based sqllogictests to [DataFusion](https://github.com/apache/datafusion), converting the SQL to Substrait through Isthmus.
The main blocker right now is that Isthmus generates Substrait plans with uppercase tables and columns, whereas DataFusion normalizes to lowercase by default.