### PR TITLE
feat(isthmus): add support for scalar subqueries

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -21,6 +21,7 @@ import io.substrait.plan.ImmutableRoot;
 import io.substrait.plan.Plan;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.Cross;
+import io.substrait.relation.EmptyScan;
 import io.substrait.relation.Expand;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
@@ -38,6 +39,7 @@ import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -295,6 +297,12 @@ public class SubstraitBuilder {
     var struct = Type.Struct.builder().addAllFields(types).nullable(false).build();
     var namedStruct = NamedStruct.of(columnNames, struct);
     return NamedScan.builder().names(tableName).initialSchema(namedStruct).remap(remap).build();
+  }
+
+  public EmptyScan emptyScan() {
+    return EmptyScan.builder()
+        .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
+        .build();
   }
 
   public Project project(Function<Rel, Iterable<? extends Expression>> expressionsFn, Rel input) {

--- a/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
@@ -2,12 +2,10 @@ package io.substrait.type.proto;
 
 import io.substrait.TestBase;
 import io.substrait.expression.ExpressionCreator;
-import io.substrait.relation.EmptyScan;
 import io.substrait.relation.NamedScan;
 import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -35,10 +33,7 @@ public class ReadRelRoundtripTest extends TestBase {
 
   @Test
   void emptyScan() {
-    var emptyScan =
-        EmptyScan.builder()
-            .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
-            .build();
+    var emptyScan = b.emptyScan();
     verifyRoundTrip(emptyScan);
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -5,6 +5,7 @@ import io.substrait.expression.AbstractExpressionVisitor;
 import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.FailureBehavior;
+import io.substrait.expression.Expression.ScalarSubquery;
 import io.substrait.expression.Expression.SingleOrList;
 import io.substrait.expression.Expression.Switch;
 import io.substrait.expression.FieldReference;
@@ -537,5 +538,11 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
                     String.format(
                         "EnumArg(value=%s) not handled by visitor type %s.",
                         e.value(), this.getClass().getCanonicalName())));
+  }
+
+  @Override
+  public RexNode visit(ScalarSubquery expr) throws RuntimeException {
+    RelNode inputRelnode = expr.input().accept(relNodeConverter);
+    return RexSubQuery.scalar(inputRelnode);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
@@ -9,7 +9,6 @@ import io.substrait.expression.proto.ProtoExpressionConverter;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.ExtensionLookup;
 import io.substrait.extension.SimpleExtension;
-import io.substrait.relation.EmptyScan;
 import io.substrait.relation.Extension;
 import io.substrait.relation.ExtensionLeaf;
 import io.substrait.relation.ExtensionMulti;
@@ -17,7 +16,6 @@ import io.substrait.relation.ExtensionSingle;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelProtoConverter;
-import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,12 +35,6 @@ import org.apache.calcite.tools.RelBuilder;
 import org.junit.jupiter.api.Test;
 
 public class RelExtensionRoundtripTest extends PlanTestBase {
-
-  static final EmptyScan EMPTY_TABLE =
-      EmptyScan.builder()
-          .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
-          .build();
-
   @Test
   void extensionLeafRelDetailTest() {
     var detail = new ColumnAppendDetail(substraitBuilder.i32(1));
@@ -53,14 +45,16 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
   @Test
   void extensionSingleRelDetailTest() {
     var detail = new ColumnAppendDetail(substraitBuilder.i32(2));
-    var rel = ExtensionSingle.from(detail, EMPTY_TABLE).build();
+    var rel = ExtensionSingle.from(detail, substraitBuilder.emptyScan()).build();
     roundtrip(rel);
   }
 
   @Test
   void extensionMultiRelDetailTest() {
     var detail = new ColumnAppendDetail(substraitBuilder.i32(3));
-    var rel = ExtensionMulti.from(detail, EMPTY_TABLE, EMPTY_TABLE).build();
+    var rel =
+        ExtensionMulti.from(detail, substraitBuilder.emptyScan(), substraitBuilder.emptyScan())
+            .build();
     roundtrip(rel);
   }
 


### PR DESCRIPTION
Currently, the Substrait to Calcite mappings to not support scalar subqueries like the follow SQL example:

```sql
select 
  n_name 
from 
  tpch.tiny.nation 
where 
  n_regionkey = (
    select r_regionkey from tpch.tiny.region where r_name = 'EUROPE')
```

This PR adds support for mapping scalar subqueries from Substrait into Calcite and adds a test case showing that it works now.

Additionally:
- it changes `RelCreator` to be created with a list of CREATE SQL statements to initialize the schema of the `RelBuilder`
- the previous change requires `RelCreator` to extend `SqlConverterBase` so that we can reuse the `registerCreateTables()` method
- in `SubstraitExpressionConverterTest` it gets the `ExpressionRexConverter` from `SubstraitRelNodeConverter` in order to make sure the `ExpressionRexConverter` is properly set up to parse sub queries using `SubstraitRelNodeConverter`