### PR TITLE
fix(isthmus): use explicit return type for scalar function expressions

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -321,7 +321,8 @@ public class ExpressionRexConverter extends AbstractExpressionVisitor<RexNode, R
             .mapToObj(i -> eArgs.get(i).accept(expr.declaration(), i, this))
             .collect(java.util.stream.Collectors.toList());
 
-    return rexBuilder.makeCall(operator, args);
+    RelDataType returnType = typeConverter.toCalcite(typeFactory, expr.outputType());
+    return rexBuilder.makeCall(returnType, operator, args);
   }
 
   private String callConversionFailureMessage(


### PR DESCRIPTION
When converting a Substrait plan back to Apache Calcite which contains a datetime subtract such as the one generated by SQL-to-Substrait code for TPC-H query no. 1 the mapping fails with a `java.lang.ArrayIndexOutOfBoundsException` because the Substrait-to-Calcite mapping code relies on Calcite's type inference for determining the return type of the `subtract` function call. 

Since the Substrait plan contains an explicitly return type in this case for this function call we can simply provide the return type explicitly to Calcite and avoid using the return type inference.

This PRs provides the function return type from the Substrait plan to Calcite and adds a test case for verifying that the expression conversion no longer throws an Exception and sets the function return type correctly in Calcite.