### PR TITLE
build: make spotless run more reliably

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out/**
 .pmdCache
 
 */bin
+.metals

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,10 +62,10 @@ allprojects {
     configure<SpotlessExtension> {
       kotlinGradle { ktfmt().googleStyle() }
       java {
+        target("src/*/java/**/*.java")
         googleJavaFormat()
         removeUnusedImports()
         trimTrailingWhitespace()
-        targetExclude("**/build/**")
       }
     }
   }


### PR DESCRIPTION
When I run `./gradlew clean build` on my local clone I constantly see Spotless tripping up on files in the `build` folder no longer existing which means I have to run the command multiple times. This suggests to me that the `targetExclude` configuration does not work as expected.

Instead this PRs configures the `target` to format every `*.java` file within any of the `src/*/java/**` directories which works more reliably and achieves the same goal as the current configuration.

This PR also adds `.metals` to the `.gitignore` for the VS Code users among us which uses metals for the Scala code.