### PR TITLE
fix(isthmus): support more datetime extract variants

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -8,6 +8,7 @@ import io.substrait.expression.Expression.IfClause;
 import io.substrait.expression.Expression.IfThen;
 import io.substrait.expression.Expression.SwitchClause;
 import io.substrait.expression.FieldReference;
+import io.substrait.expression.FunctionArg;
 import io.substrait.expression.ImmutableExpression.Cast;
 import io.substrait.expression.ImmutableExpression.SingleOrList;
 import io.substrait.expression.ImmutableExpression.Switch;
@@ -640,7 +641,7 @@ public class SubstraitBuilder {
   }
 
   public Expression.ScalarFunctionInvocation scalarFn(
-      String namespace, String key, Type outputType, Expression... args) {
+      String namespace, String key, Type outputType, FunctionArg... args) {
     var declaration =
         extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(namespace, key));
     return Expression.ScalarFunctionInvocation.builder()

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -1,11 +1,14 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.Expression;
+import io.substrait.expression.Expression.ScalarFunctionInvocation;
 import io.substrait.expression.ExpressionCreator;
+import io.substrait.expression.ImmutableEnumArg;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.isthmus.expression.CallConverters;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
@@ -13,6 +16,9 @@ import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
 import io.substrait.type.TypeCreator;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -60,5 +66,196 @@ public class FunctionConversionTest extends PlanTestBase {
 
     // TODO: remove once this can be converted back to Substrait
     assertThrows(IllegalArgumentException.class, () -> calciteExpr.accept(rexExpressionConverter));
+  }
+
+  @Test
+  public void extractTimestampTzScalarFunction() {
+    ScalarFunctionInvocation reqTstzFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_tstz_str",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            Expression.TimestampTZLiteral.builder().value(0).build(),
+            Expression.StrLiteral.builder().value("GMT").build());
+
+    RexNode calciteExpr = reqTstzFn.accept(expressionRexConverter);
+    assertEquals(SqlKind.EXTRACT, calciteExpr.getKind());
+    assertInstanceOf(RexCall.class, calciteExpr);
+
+    RexCall extract = (RexCall) calciteExpr;
+    assertEquals(
+        "EXTRACT(FLAG(MONTH), 1970-01-01 00:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(6), 'GMT':VARCHAR)",
+        extract.toString());
+  }
+
+  @Test
+  public void extractPrecisionTimestampTzScalarFunction() {
+    ScalarFunctionInvocation reqPtstzFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_ptstz_str",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            Expression.PrecisionTimestampTZLiteral.builder().value(0).precision(6).build(),
+            Expression.StrLiteral.builder().value("GMT").build());
+
+    RexNode calciteExpr = reqPtstzFn.accept(expressionRexConverter);
+    assertEquals(SqlKind.EXTRACT, calciteExpr.getKind());
+    assertInstanceOf(RexCall.class, calciteExpr);
+
+    RexCall extract = (RexCall) calciteExpr;
+    assertEquals(
+        "EXTRACT(FLAG(MONTH), 1970-01-01 00:00:00:TIMESTAMP_WITH_LOCAL_TIME_ZONE(6), 'GMT':VARCHAR)",
+        extract.toString());
+  }
+
+  @Test
+  public void extractTimestampScalarFunction() {
+    ScalarFunctionInvocation reqTsFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_ts",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            Expression.TimestampLiteral.builder().value(0).build());
+
+    RexNode calciteExpr = reqTsFn.accept(expressionRexConverter);
+    assertEquals(SqlKind.EXTRACT, calciteExpr.getKind());
+    assertInstanceOf(RexCall.class, calciteExpr);
+
+    RexCall extract = (RexCall) calciteExpr;
+    assertEquals("EXTRACT(FLAG(MONTH), 1970-01-01 00:00:00:TIMESTAMP(6))", extract.toString());
+  }
+
+  @Test
+  public void extractPrecisionTimestampScalarFunction() {
+    ScalarFunctionInvocation reqPtsFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_pts",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            Expression.PrecisionTimestampLiteral.builder().value(0).precision(6).build());
+
+    RexNode calciteExpr = reqPtsFn.accept(expressionRexConverter);
+    assertEquals(SqlKind.EXTRACT, calciteExpr.getKind());
+    assertInstanceOf(RexCall.class, calciteExpr);
+
+    RexCall extract = (RexCall) calciteExpr;
+    assertEquals("EXTRACT(FLAG(MONTH), 1970-01-01 00:00:00:TIMESTAMP(6))", extract.toString());
+  }
+
+  @Test
+  public void extractDateScalarFunction() {
+    ScalarFunctionInvocation reqDateFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_date",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            Expression.DateLiteral.builder().value(0).build());
+
+    RexNode calciteExpr = reqDateFn.accept(expressionRexConverter);
+    assertEquals(SqlKind.EXTRACT, calciteExpr.getKind());
+    assertInstanceOf(RexCall.class, calciteExpr);
+
+    RexCall extract = (RexCall) calciteExpr;
+    assertEquals("EXTRACT(FLAG(MONTH), 1970-01-01)", extract.toString());
+  }
+
+  @Test
+  public void extractTimeScalarFunction() {
+    ScalarFunctionInvocation reqTimeFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_time",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MINUTE").build(),
+            Expression.TimeLiteral.builder().value(0).build());
+
+    RexNode calciteExpr = reqTimeFn.accept(expressionRexConverter);
+    assertEquals(SqlKind.EXTRACT, calciteExpr.getKind());
+    assertInstanceOf(RexCall.class, calciteExpr);
+
+    RexCall extract = (RexCall) calciteExpr;
+    assertEquals("EXTRACT(FLAG(MINUTE), 00:00:00:TIME(6))", extract.toString());
+  }
+
+  @Test
+  public void unsupportedExtractTimestampTzWithIndexing() {
+    ScalarFunctionInvocation reqReqTstzFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_req_tstz_str",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            ImmutableEnumArg.builder().value("ONE").build(),
+            Expression.TimestampTZLiteral.builder().value(0).build(),
+            Expression.StrLiteral.builder().value("GMT").build());
+
+    assertThrows(
+        UnsupportedOperationException.class, () -> reqReqTstzFn.accept(expressionRexConverter));
+  }
+
+  @Test
+  public void unsupportedExtractPrecisionTimestampTzWithIndexing() {
+    ScalarFunctionInvocation reqReqPtstzFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_req_ptstz_str",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            ImmutableEnumArg.builder().value("ONE").build(),
+            Expression.PrecisionTimestampTZLiteral.builder().value(0).precision(6).build(),
+            Expression.StrLiteral.builder().value("GMT").build());
+
+    assertThrows(
+        UnsupportedOperationException.class, () -> reqReqPtstzFn.accept(expressionRexConverter));
+  }
+
+  @Test
+  public void unsupportedExtractTimestampWithIndexing() {
+    ScalarFunctionInvocation reqReqTsFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_req_ts",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            ImmutableEnumArg.builder().value("ONE").build(),
+            Expression.TimestampLiteral.builder().value(0).build());
+
+    assertThrows(
+        UnsupportedOperationException.class, () -> reqReqTsFn.accept(expressionRexConverter));
+  }
+
+  @Test
+  public void unsupportedExtractPrecisionTimestampWithIndexing() {
+    ScalarFunctionInvocation reqReqPtsFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_req_pts",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            ImmutableEnumArg.builder().value("ONE").build(),
+            Expression.PrecisionTimestampLiteral.builder().value(0).precision(6).build());
+
+    assertThrows(
+        UnsupportedOperationException.class, () -> reqReqPtsFn.accept(expressionRexConverter));
+  }
+
+  @Test
+  public void unsupportedExtractDateWithIndexing() {
+    ScalarFunctionInvocation reqReqDateFn =
+        b.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "extract:req_req_date",
+            TypeCreator.REQUIRED.I64,
+            ImmutableEnumArg.builder().value("MONTH").build(),
+            ImmutableEnumArg.builder().value("ONE").build(),
+            Expression.DateLiteral.builder().value(0).build());
+
+    assertThrows(
+        UnsupportedOperationException.class, () -> reqReqDateFn.accept(expressionRexConverter));
   }
 }


### PR DESCRIPTION
Currently, the Substrait to Calcite mappings only support mapping scalar functions with enum arguments for the `extract:req_ts` function which means it only supports the `extract` function with an enum argument and a timestamp but none of the other datetime extract functions defined in the default datetime extension.

This PR adds basic support for all datetime extract functions which are not using the indexing argument which indicates whether e.g. months should start to be counted from 0 instead of 1.

It is still a naive mapping from the enum values defined in the datetime extension YAML to Apache Calcite's `TimeUnitRange` enum which misses some of the Substrait enum values (e.g. `US_YEAR`, `PICOSECONDS`) or has spelling differences for some of the enum values (`ISOYEAR` vs. `ISO_YEAR`).

This PR at least allows some of the TPC-H queries to be mapped back from Substrait to Calcite which currently throws an `UnsupportedOperationException` due to missing support for date extract.

I would suggest to revisit the function mapping code in a follow-up PR to create a framework which supports more sophisticated mapping logic.