### PR TITLE
build: use OSV-Scanner v2 for vulnerability scan

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,27 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/actions/wrapper-validation@v3
-  cyclonedx-sbom:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Generate SBOMs
-        run: ./gradlew cyclonedxBom
-      - name: Upload SBOMs
-        uses: actions/upload-artifact@v4
-        with:
-          name: cyclonedx-sbom
-          path: |
-            core/build/reports/bom.json
-            isthmus/build/reports/bom.json
-            isthmus-cli/build/reports/bom.json
+      - uses: gradle/actions/wrapper-validation@v4
   osv-scanner:
-    needs: cyclonedx-sbom
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -64,12 +45,17 @@ jobs:
           - isthmus
           - isthmus-cli
     steps:
-      - name: Download SBOMs
-        uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          name: cyclonedx-sbom
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Create Gradle lockfile
+        run: ./gradlew :${{ matrix.project }}:dependencies --write-locks
       - name: Scan
-        run: docker run --rm -v "${PWD}/${{ matrix.project }}/build/reports/bom.json:/bom.json" ghcr.io/google/osv-scanner:v1.9.2 --sbom /bom.json
+        run: docker run --rm -v "${PWD}/${{ matrix.project }}/gradle.lockfile:/gradle.lockfile" ghcr.io/google/osv-scanner:v2.0.0 scan --lockfile /gradle.lockfile
   java:
     name: Build and Test Java
     runs-on: ubuntu-latest
@@ -83,7 +69,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
         run: gradle build --rerun-tasks
   examples:
@@ -124,7 +110,7 @@ jobs:
         # helps avoid rate-limiting issues
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v4
     - name: Report Java Version
       run: java -version
     - name: Install GraalVM native image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           # helps avoid rate-limiting issues
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Report Java Version
         run: java -version
       - name: Install GraalVM native image
@@ -67,7 +67,7 @@ jobs:
         with:
           node-version: '20'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Download isthmus-ubuntu-latest binary
         uses: actions/download-artifact@v4
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,21 +69,6 @@ allprojects {
       }
     }
   }
-
-  if (listOf("core", "isthmus", "isthmus-cli").contains(project.name)) {
-    apply(plugin = "org.cyclonedx.bom")
-    tasks.cyclonedxBom {
-      setIncludeConfigs(listOf("runtimeClasspath"))
-      setSkipConfigs(listOf("compileClasspath", "testCompileClasspath"))
-      setProjectType("library")
-      setSchemaVersion("1.5")
-      setDestination(project.file("build/reports"))
-      setOutputName("bom")
-      setOutputFormat("json")
-      setIncludeBomSerialNumber(false)
-      setIncludeLicenseText(false)
-    }
-  }
 }
 
 nexusPublishing {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -124,6 +124,8 @@ java {
   }
 }
 
+configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }
+
 tasks.named("sourcesJar") { mustRunAfter("generateGrammarSource") }
 
 sourceSets {

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -11,6 +11,8 @@ java {
   withSourcesJar()
 }
 
+configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }
+
 val CALCITE_VERSION = properties.get("calcite.version")
 val GUAVA_VERSION = properties.get("guava.version")
 val IMMUTABLES_VERSION = properties.get("immutables.version")

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -71,6 +71,8 @@ java {
   withSourcesJar()
 }
 
+configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }
+
 val CALCITE_VERSION = properties.get("calcite.version")
 val GUAVA_VERSION = properties.get("guava.version")
 val IMMUTABLES_VERSION = properties.get("immutables.version")


### PR DESCRIPTION
- Use Gradle lockfile to assemble dependencies for vulnerability scanning, and avoid requiring the additional CycloneDX plugin.
- Update versions of Gradle actions.