### PR TITLE
feat(spark): add some date functions

### DIFF
--- a/core/src/main/java/io/substrait/expression/EnumArg.java
+++ b/core/src/main/java/io/substrait/expression/EnumArg.java
@@ -26,5 +26,9 @@ public interface EnumArg extends FunctionArg {
     return ImmutableEnumArg.builder().value(Optional.of(option)).build();
   }
 
+  static EnumArg of(String value) {
+    return ImmutableEnumArg.builder().value(Optional.of(value)).build();
+  }
+
   EnumArg UNSPECIFIED_ENUM_ARG = ImmutableEnumArg.builder().value(Optional.empty()).build();
 }

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 Substrait Java is a project that makes it easier to build [Substrait](https://substrait.io/) plans through Java. The project has two main parts:
 1) **Core** is the module that supports building Substrait plans directly through Java. This is much easier than manipulating the Substrait protobuf directly. It has no direct support for going from SQL to Substrait (that's covered by the second part)
 2) **Isthmus** is the module that allows going from SQL to a Substrait plan. Both Java APIs and a top level script for conversion are present. Not all SQL is supported yet by this module, but a lot is. For example, all of the TPC-H queries and all but a few of the TPC-DS queries are translatable.
-3) **Spark** is the module that provides an API for translating a Substrait plan to and from a Spark query plan.  The most commonly used logical relations are supported, including those generated from all of the TPC-H queries, but there are currently some gaps in support that prevent all of the TPC-DS queries from being translatable.
+3) **Spark** is the module that provides an API for translating a Substrait plan to and from a Spark query plan.  The most commonly used logical relations and functions are supported, including those generated from all of the TPC-H and TCP-DS queries.
 
 ## Building
 After you've cloned the project through git, Substrait Java is built with a tool called [Gradle](https://gradle.org/). To build, execute the following:

--- a/spark/src/main/resources/spark.yml
+++ b/spark/src/main/resources/spark.yml
@@ -16,13 +16,6 @@
 ---
 scalar_functions:
   -
-    name: year
-    description: Returns the year component of the date/timestamp
-    impls:
-      - args:
-          - value: date
-        return: i32
-  -
     name: unscaled
     description:  >-
       Return the unscaled Long value of a Decimal, assuming it fits in a Long.
@@ -41,6 +34,16 @@ scalar_functions:
       - args:
           - value: i64
         return: DECIMAL<P,S>
+  - name: add
+    description: >-
+      Adds days to a date
+    impls:
+      - args:
+          - name: start_date
+            value: date
+          - name: days
+            value: i32
+        return: date
   - name: shift_right
     description: >-
       Bitwise (signed) shift right.

--- a/spark/src/main/scala/io/substrait/spark/expression/Enum.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/Enum.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.substrait.spark.expression
+
+import org.apache.spark.sql.catalyst.expressions.{LeafExpression, Unevaluable}
+import org.apache.spark.sql.types.{DataType, NullType}
+
+/**
+ * For internal use only. This represents the equivalent of a Substrait enum parameter type for use
+ * during conversion. It must not become part of a final Spark logical plan.
+ *
+ * @param value
+ *   The enum string value.
+ */
+case class Enum(value: String) extends LeafExpression with Unevaluable {
+  override def nullable: Boolean = false
+
+  override def dataType: DataType = NullType
+
+  override def equals(that: Any): Boolean = that match {
+    case Enum(other) => other == value
+    case _ => false
+  }
+}

--- a/spark/src/main/scala/io/substrait/spark/expression/ToScalarFunction.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToScalarFunction.scala
@@ -40,7 +40,7 @@ abstract class ToScalarFunction(functions: Seq[SimpleExtension.ScalarFunctionVar
       .build()
   }
 
-  def convert(expression: Expression, operands: Seq[SExpression]): Option[SExpression] = {
+  def convert(expression: Expression, operands: Seq[FunctionArg]): Option[SExpression] = {
     Option(signatures.get(expression.getClass))
       .flatMap(m => m.attemptMatch(expression, operands))
   }

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -71,8 +71,7 @@ class ToLogicalPlan(spark: SparkSession) extends DefaultRelVisitor[LogicalPlan] 
     }
 
     val aggregateFunction = SparkExtension.toAggregateFunction
-      .getSparkExpressionFromSubstraitFunc(function.declaration.key, function.outputType)
-      .map(sig => sig.makeCall(arguments))
+      .getSparkExpressionFromSubstraitFunc(function.declaration.key, arguments)
       .map(_.asInstanceOf[AggregateFunction])
       .getOrElse({
         val msg = String.format(
@@ -137,8 +136,7 @@ class ToLogicalPlan(spark: SparkSession) extends DefaultRelVisitor[LogicalPlan] 
                 arg.accept(func.declaration(), i, expressionConverter)
             }
             val windowFunction = SparkExtension.toWindowFunction
-              .getSparkExpressionFromSubstraitFunc(func.declaration.key, func.outputType)
-              .map(sig => sig.makeCall(arguments))
+              .getSparkExpressionFromSubstraitFunc(func.declaration.key, arguments)
               .map {
                 case win: WindowFunction => win
                 case agg: AggregateFunction =>

--- a/spark/src/test/scala/io/substrait/spark/DateTimeSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/DateTimeSuite.scala
@@ -1,0 +1,30 @@
+package io.substrait.spark
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DateTimeSuite extends SparkFunSuite with SharedSparkSession with SubstraitPlanTestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sparkContext.setLogLevel("WARN")
+  }
+
+  test("date_add") {
+    val qry =
+      "select cast(d AS DATE) + interval 5 days from (values ('2025-03-27'), ('2025-01-02')) as table(d)"
+    assertSqlSubstraitRelRoundTrip(qry)
+  }
+
+  test("date_sub") {
+    val qry =
+      "select cast(d AS DATE) - interval 5 days from (values ('2025-03-27'), ('2025-01-02')) as table(d)"
+    assertSqlSubstraitRelRoundTrip(qry)
+  }
+
+  test("extract_year_month") {
+    val qry = "select year(cast(d AS DATE)), month(cast(d AS DATE)) " +
+      "from (values ('2025-03-27'), ('2025-01-02')) as table(d)"
+    assertSqlSubstraitRelRoundTrip(qry)
+  }
+}

--- a/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCDSPlan.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.internal.SQLConf
 
 class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
 
-  private val runAllQueriesIncludeFailed = false
   override def beforeAll(): Unit = {
     super.beforeAll()
     sparkContext.setLogLevel("WARN")
@@ -31,22 +30,10 @@ class TPCDSPlan extends TPCDSBase with SubstraitPlanTestBase {
     spark.conf.set("spark.sql.readSideCharPadding", "false")
   }
 
-  // spotless:off
-  val failingSQL: Set[String] = Set(
-    "q72" //requires implementation of date_add()
-  )
-  // spotless:on
-
   tpcdsQueries.foreach {
     q =>
-      if (runAllQueriesIncludeFailed || !failingSQL.contains(q)) {
-        test(s"check simplified (tpcds-v1.4/$q)") {
-          testQuery("tpcds", q)
-        }
-      } else {
-        ignore(s"check simplified (tpcds-v1.4/$q)") {
-          testQuery("tpcds", q)
-        }
+      test(s"check simplified (tpcds-v1.4/$q)") {
+        testQuery("tpcds", q)
       }
   }
 

--- a/spark/src/test/scala/io/substrait/spark/expression/YamlTest.scala
+++ b/spark/src/test/scala/io/substrait/spark/expression/YamlTest.scala
@@ -22,11 +22,7 @@ import org.apache.spark.SparkFunSuite
 
 class YamlTest extends SparkFunSuite {
 
-  test("has_year_definition") {
-    assert(
-      SparkExtension.SparkScalarFunctions
-        .map(f => f.key())
-        .exists(p => p.equals("year:date")))
+  test("has_unscaled_definition") {
     assert(
       SparkExtension.SparkScalarFunctions
         .map(f => f.key())


### PR DESCRIPTION
The date/time functions in Spark don’t map directly to the Substrait eqivalents. E.g.
- `date ± interval-days` are handled by the `DateAdd` & `DateSub` functions in Spark, but as a variant of the arithmetic `add` function in substrait.
- The date/time component extraction functions are all handled by different functions in Spark, but by a single `extract` function in Substrait with an `enum` argument to specify which component.

Neither of these could be handled using the existing function mapping capabilities in the `spark` module.

This commit exends this capability so that it can now handle these two scenarios in (I hope) a generic way.

I’ve added a few variants of the `extract` function - more can follow.

Adding this will give us 100% pass rate for all the TPC-DS querues.  The README is updated accordingly.