### PR TITLE
fix(isthmus): handle Subqueries/set predicates with field references outside of the subquery

### DIFF
--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -7,8 +7,18 @@ plugins {
   id("com.diffplug.spotless") version "6.19.0"
   id("com.github.johnrengelman.shadow") version "8.1.1"
   id("com.google.protobuf") version "0.9.4"
+  id("com.adarshr.test-logger") version "4.0.0"
   signing
 }
+
+// Useful test logger when debugging, will output stdout/stderr to console
+// saves time launching the HTML test reports
+testlogger {
+  showStandardStreams = true
+  showPassedStandardStreams  = false
+  showFailedStandardStreams = true
+}
+
 
 publishing {
   publications {

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -14,11 +14,10 @@ plugins {
 // Useful test logger when debugging, will output stdout/stderr to console
 // saves time launching the HTML test reports
 testlogger {
-  showStandardStreams = true
-  showPassedStandardStreams  = false
+  showStandardStreams = false
+  showPassedStandardStreams = true
   showFailedStandardStreams = true
 }
-
 
 publishing {
   publications {

--- a/isthmus/src/test/java/io/substrait/isthmus/TestExtendedTpchQuery.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TestExtendedTpchQuery.java
@@ -19,25 +19,24 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Updated TPC-H test to convert SQL to Substrait and replay those plans back to SQL Validating that
- * the conversions can operate without exceptions
+ * Additional queries based around the style and schema of the tpc-h set Validating that the
+ * conversions can operate without exceptions
  */
 @TestMethodOrder(OrderAnnotation.class)
 @TestInstance(Lifecycle.PER_CLASS)
-public class TestTpchQuery extends PlanTestBase {
+public class TestExtendedTpchQuery extends PlanTestBase {
 
   private Map<Integer, Plan> allPlans = new HashMap<>();
 
   // Keep list of the known test failures
   // The `fromSubstrait` also assumes the to substrait worked as well
-  public static final List<Integer> toSubstraitKnownFails = List.of(22);
-  public static final List<Integer> fromSubstraitKnownFails = List.of(7, 8, 9);
+  public static final List<Integer> toSubstraitKnownFails = List.of();
+  public static final List<Integer> fromSubstraitKnownFails = List.of();
 
   @ParameterizedTest
   @Order(1)
-  @ValueSource(
-      ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22})
-  public void tpchToSubstrait(int query) throws Exception {
+  @ValueSource(ints = {1})
+  public void extendedTpchToSubstrait(int query) throws Exception {
     assumeFalse(toSubstraitKnownFails.contains(query));
 
     SqlToSubstrait s = new SqlToSubstrait();
@@ -46,16 +45,15 @@ public class TestTpchQuery extends PlanTestBase {
         Arrays.stream(values)
             .filter(t -> !t.trim().isBlank())
             .collect(java.util.stream.Collectors.toList());
-    Plan protoPlan = s.execute(asString(String.format("tpch/queries/%02d.sql", query)), creates);
+    Plan protoPlan = s.execute(asString(String.format("tpch/extended/%02d.sql", query)), creates);
 
     allPlans.put(query, protoPlan);
   }
 
   @ParameterizedTest
   @Order(2)
-  @ValueSource(
-      ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22})
-  public void tpchFromSubstrait(int query) throws Exception {
+  @ValueSource(ints = {1})
+  public void extendedTpchFromSubstrait(int query) throws Exception {
     assumeFalse(fromSubstraitKnownFails.contains(query));
     assumeTrue(allPlans.containsKey(query));
 

--- a/isthmus/src/test/java/io/substrait/isthmus/TestTpcdsQuery.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TestTpcdsQuery.java
@@ -1,0 +1,99 @@
+package io.substrait.isthmus;
+
+import com.google.protobuf.util.JsonFormat;
+
+import io.substrait.plan.ProtoPlanConverter;
+import io.substrait.proto.Plan;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.calcite.adapter.tpcds.TpcdsSchema;
+import org.apache.calcite.rel.RelNode;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ *
+ *
+ * <h3>Setup of Schema and Queries</h3>
+ *
+ * <li>Schema using `org.apache.calcite.adapter.tpcds.TpcdsSchema` from
+ * `org.apache.calcite:calcite-plus:1.28.0`
+ * <li>For queries started with `net.hydromatic.tpcds.query.Query` and then
+ * fixed generation issues
+ * replacing with specific queries from Spark SQL tpcds benchmark.
+ *
+ * <h3>Generator and query parsing issues and fixes</h3>
+ *
+ * <li>`substr` instead of `substring`
+ * <li>keywords used `returns`, `at`,.... Change to `rets`, `at`, ...
+ * <li>doesn't handle may kinds of generator expressions like: `Define
+ * SDATE=date([YEAR]+"-01-01",[YEAR]+"-07-01",sales);`, `Define
+ * CATEGORY=ulist(dist(categories,1,1),3);` and `define STATE=
+ * ulist(dist(fips_county, 3, 1),
+ * 9). So replaced with constants from spark sql tpcds query.
+ * <li>Interval specified as `30 days`; changed to `interval '30' day`
+ */
+
+@TestMethodOrder(OrderAnnotation.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestTpcdsQuery extends PlanTestBase {
+
+  private List<Optional<Plan>> allPlans;
+
+  @BeforeAll
+  public void setup() {
+    allPlans = new ArrayList<Optional<Plan>>();
+    for (int i = 1; i < 101; i++) {
+      allPlans.add(Optional.empty());
+    }
+  }
+
+  @ParameterizedTest
+  @Order(1)
+  @ValueSource(ints = {
+      1, 3, 4, 6, 7, 8, 10, 11, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 29, 30,
+      31, 32, 33, 34, 35, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 52, 54, 55, 56, 58,
+      59, 60, 61, 62, 64, 65, 67, 68, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 81, 82, 83, 85, 87,
+      88, 90, 92, 93, 94, 95, 96, 97, 99, 2, 5, 9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 66, 70, 80, 84, 86, 89, 91, 98
+  })
+  public void tpcdsSuccess(int query) throws Exception {
+    SqlToSubstrait s = new SqlToSubstrait();
+    TpcdsSchema schema = new TpcdsSchema(1.0);
+    String sql = asString(String.format("tpcds/queries/%02d.sql", query));
+    Plan protoPlan = s.execute(sql, "tpcds", schema);
+    allPlans.set(query, Optional.of(protoPlan));
+
+  }
+
+  @ParameterizedTest
+  @Order(1)
+  @ValueSource(ints = {
+      1, 3, 4, 6, 7, 8, 10, 11, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 29, 30,
+      31, 32, 33, 34, 35, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 52, 54, 55, 56, 58,
+      59, 60, 61, 62, 64, 65, 67, 68, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 81, 82, 83, 85, 87,
+      88, 90, 92, 93, 94, 95, 96, 97, 99, 2, 5, 9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 66, 70, 80, 84, 86, 89, 91, 98
+  })
+  public void tpcdsFromSubstrait(int query) throws Exception {
+    Optional<Plan> possible = allPlans.get(query);
+    if (possible.isPresent()) {
+      io.substrait.plan.Plan plan = new ProtoPlanConverter().from(possible.get());
+      SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
+      RelNode relRoot = substraitToCalcite.convert(plan.getRoots().get(0)).project(true);
+      System.out.println(SubstraitToSql.toSql(relRoot));
+    } else {
+
+      fail("Unable to convert to SQL");
+    }
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/TestTpcdsQuery.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TestTpcdsQuery.java
@@ -1,16 +1,13 @@
 package io.substrait.isthmus;
 
-import com.google.protobuf.util.JsonFormat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.substrait.plan.ProtoPlanConverter;
 import io.substrait.proto.Plan;
-
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import org.apache.calcite.adapter.tpcds.TpcdsSchema;
 import org.apache.calcite.rel.RelNode;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,28 +20,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- *
- *
- * <h3>Setup of Schema and Queries</h3>
- *
- * <li>Schema using `org.apache.calcite.adapter.tpcds.TpcdsSchema` from
- * `org.apache.calcite:calcite-plus:1.28.0`
- * <li>For queries started with `net.hydromatic.tpcds.query.Query` and then
- * fixed generation issues
- * replacing with specific queries from Spark SQL tpcds benchmark.
- *
- * <h3>Generator and query parsing issues and fixes</h3>
- *
- * <li>`substr` instead of `substring`
- * <li>keywords used `returns`, `at`,.... Change to `rets`, `at`, ...
- * <li>doesn't handle may kinds of generator expressions like: `Define
- * SDATE=date([YEAR]+"-01-01",[YEAR]+"-07-01",sales);`, `Define
- * CATEGORY=ulist(dist(categories,1,1),3);` and `define STATE=
- * ulist(dist(fips_county, 3, 1),
- * 9). So replaced with constants from spark sql tpcds query.
- * <li>Interval specified as `30 days`; changed to `interval '30' day`
+ * Updated TPC-H test to convert SQL to Substrait and replay those plans back to SQL Validating that
+ * the conversions can operate without exceptions
  */
-
 @TestMethodOrder(OrderAnnotation.class)
 @TestInstance(Lifecycle.PER_CLASS)
 public class TestTpcdsQuery extends PlanTestBase {
@@ -59,41 +37,52 @@ public class TestTpcdsQuery extends PlanTestBase {
     }
   }
 
+  // Keep list of the known test failures
+  // The `fromSubstrait` also assumes the to substrait worked as well
+  public static final List<Integer> toSubstraitKnownFails =
+      List.of(5, 9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 66, 70, 80, 84, 86, 89, 91, 98);
+  public static final List<Integer> fromSubstraitKnownFails = List.of(1, 8, 30, 49, 67, 81);
+
   @ParameterizedTest
   @Order(1)
-  @ValueSource(ints = {
-      1, 3, 4, 6, 7, 8, 10, 11, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 29, 30,
-      31, 32, 33, 34, 35, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 52, 54, 55, 56, 58,
-      59, 60, 61, 62, 64, 65, 67, 68, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 81, 82, 83, 85, 87,
-      88, 90, 92, 93, 94, 95, 96, 97, 99, 2, 5, 9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 66, 70, 80, 84, 86, 89, 91, 98
-  })
+  @ValueSource(
+      ints = {
+        1, 3, 4, 6, 7, 8, 10, 11, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 29, 30,
+        31, 32, 33, 34, 35, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 52, 54, 55, 56, 58,
+        59, 60, 61, 62, 64, 65, 67, 68, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 81, 82, 83, 85, 87,
+        88, 90, 92, 93, 94, 95, 96, 97, 99, 2, 5, 9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 66, 70, 80,
+        84, 86, 89, 91, 98,
+      })
   public void tpcdsSuccess(int query) throws Exception {
+    assumeFalse(toSubstraitKnownFails.contains(query));
+
     SqlToSubstrait s = new SqlToSubstrait();
     TpcdsSchema schema = new TpcdsSchema(1.0);
     String sql = asString(String.format("tpcds/queries/%02d.sql", query));
     Plan protoPlan = s.execute(sql, "tpcds", schema);
     allPlans.set(query, Optional.of(protoPlan));
-
   }
 
   @ParameterizedTest
-  @Order(1)
-  @ValueSource(ints = {
-      1, 3, 4, 6, 7, 8, 10, 11, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 29, 30,
-      31, 32, 33, 34, 35, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 52, 54, 55, 56, 58,
-      59, 60, 61, 62, 64, 65, 67, 68, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 81, 82, 83, 85, 87,
-      88, 90, 92, 93, 94, 95, 96, 97, 99, 2, 5, 9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 66, 70, 80, 84, 86, 89, 91, 98
-  })
+  @Order(2)
+  @ValueSource(
+      ints = {
+        1, 3, 4, 6, 7, 8, 10, 11, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 26, 28, 29, 30,
+        31, 32, 33, 34, 35, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 52, 54, 55, 56, 58,
+        59, 60, 61, 62, 64, 65, 67, 68, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 81, 82, 83, 85, 87,
+        88, 90, 92, 93, 94, 95, 96, 97, 99, 2, 5, 9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 66, 70, 80,
+        84, 86, 89, 91, 98,
+      })
   public void tpcdsFromSubstrait(int query) throws Exception {
-    Optional<Plan> possible = allPlans.get(query);
-    if (possible.isPresent()) {
-      io.substrait.plan.Plan plan = new ProtoPlanConverter().from(possible.get());
-      SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
-      RelNode relRoot = substraitToCalcite.convert(plan.getRoots().get(0)).project(true);
-      System.out.println(SubstraitToSql.toSql(relRoot));
-    } else {
 
-      fail("Unable to convert to SQL");
-    }
+    assumeFalse(fromSubstraitKnownFails.contains(query));
+    assumeTrue(allPlans.get(query).isPresent());
+
+    Optional<Plan> possible = allPlans.get(query);
+
+    io.substrait.plan.Plan plan = new ProtoPlanConverter().from(possible.get());
+    SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
+    RelNode relRoot = substraitToCalcite.convert(plan.getRoots().get(0)).project(true);
+    System.out.println(SubstraitToSql.toSql(relRoot));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/TestTpchQuery.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TestTpchQuery.java
@@ -1,0 +1,69 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.calcite.rel.RelNode;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.substrait.plan.ProtoPlanConverter;
+import io.substrait.proto.Plan;
+
+@TestMethodOrder(OrderAnnotation.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestTpchQuery extends PlanTestBase {
+
+  private List<Optional<Plan>> allPlans;
+
+  @BeforeAll
+  public void setup() {
+    allPlans = new ArrayList<Optional<Plan>>();
+    for (int i = 1; i < 23; i++) {
+      allPlans.add(Optional.empty());
+    }
+  }
+
+  @ParameterizedTest
+  @Order(1)
+  @ValueSource(ints = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 })
+  public void tpchToSubstrait(int query) throws Exception {
+    SqlToSubstrait s = new SqlToSubstrait();
+    String[] values = asString("tpch/schema.sql").split(";");
+    var creates = Arrays.stream(values)
+        .filter(t -> !t.trim().isBlank())
+        .collect(java.util.stream.Collectors.toList());
+    Plan protoPlan = s.execute(asString(String.format("tpch/queries/%02d.sql", query)), creates);
+
+    allPlans.set(query, Optional.of(protoPlan));
+
+  }
+
+  @ParameterizedTest
+  @Order(2)
+  @ValueSource(ints = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 })
+  public void tpchFromSubstrait(int query) throws Exception {
+    Optional<Plan> possible = allPlans.get(query);
+    if (possible.isPresent()){
+      io.substrait.plan.Plan plan = new ProtoPlanConverter().from(possible.get());
+      SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
+      RelNode relRoot = substraitToCalcite.convert(plan.getRoots().get(0)).project(true);
+      System.out.println(SubstraitToSql.toSql(relRoot));
+    } else {
+
+      fail("Unable to convert to SQL");
+    }
+
+
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
@@ -1,10 +1,17 @@
 package io.substrait.isthmus;
 
-import com.google.protobuf.util.JsonFormat;
 import java.util.Arrays;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.google.protobuf.util.JsonFormat;
+
+import io.substrait.plan.ProtoPlanConverter;
+
+@TestMethodOrder(OrderAnnotation.class)
 public class TpchQueryNoValidation extends PlanTestBase {
 
   @ParameterizedTest
@@ -18,7 +25,12 @@ public class TpchQueryNoValidation extends PlanTestBase {
         Arrays.stream(values)
             .filter(t -> !t.trim().isBlank())
             .collect(java.util.stream.Collectors.toList());
-    var plan = s.execute(asString(String.format("tpch/queries/%02d.sql", query)), creates);
-    System.out.println(JsonFormat.printer().print(plan));
+    var protoPlan = s.execute(asString(String.format("tpch/queries/%02d.sql", query)), creates);
+    System.out.println(JsonFormat.printer().print(protoPlan));
+
+    // extend and reverse the process
+    io.substrait.plan.Plan plan = new ProtoPlanConverter().from(protoPlan);
+    SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
+    substraitToCalcite.convert(plan.getRoots().get(0));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryNoValidation.java
@@ -1,15 +1,11 @@
 package io.substrait.isthmus;
 
+import com.google.protobuf.util.JsonFormat;
 import java.util.Arrays;
-
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import com.google.protobuf.util.JsonFormat;
-
-import io.substrait.plan.ProtoPlanConverter;
 
 @TestMethodOrder(OrderAnnotation.class)
 public class TpchQueryNoValidation extends PlanTestBase {
@@ -27,10 +23,5 @@ public class TpchQueryNoValidation extends PlanTestBase {
             .collect(java.util.stream.Collectors.toList());
     var protoPlan = s.execute(asString(String.format("tpch/queries/%02d.sql", query)), creates);
     System.out.println(JsonFormat.printer().print(protoPlan));
-
-    // extend and reverse the process
-    io.substrait.plan.Plan plan = new ProtoPlanConverter().from(protoPlan);
-    SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
-    substraitToCalcite.convert(plan.getRoots().get(0));
   }
 }

--- a/isthmus/src/test/resources/tpch/extended/01.sql
+++ b/isthmus/src/test/resources/tpch/extended/01.sql
@@ -1,0 +1,27 @@
+select
+    c1.c_name,
+    o1.o_orderstatus,
+    o1.o_totalprice
+from
+    customer c1,
+    orders o1
+where
+    o1.o_custkey = c1.c_custkey
+    and o1.o_totalprice > (
+        select
+            avg(o_totalprice)
+        from
+            orders o2
+        where
+            o2.o_totalprice < c1.c_acctbal
+            and o2.o_orderpriority = c1.c_phone
+            and o2.o_totalprice > (
+                select
+                    avg(c3.c_acctbal)
+                from
+                    customer c3
+                where
+                    c1.c_custkey = o2.o_custkey
+                    and c3.c_address = o2.o_clerk
+            )
+    );


### PR DESCRIPTION
This is resolving issue #382 found with TPC-H 17, when converting back to SQL from Substrait
The subquery references fields in an outer scope, the calcite correlation variables where referenced by Subsrtrait's 'outer reference'

However when converting back to calcite from a plan with these 'outer references' they were ignored.

Notes::

- I've added two new TPC-x tests, these are similar the existing tests, but do conversions SQL to Substrait and Substrait to SQL
- Additional SQL using subqueries has been added; would like to add some more. Suggestions welcome. 
- Added these as 1xx.sql files but could move to a separate folder?


