### PR TITLE
fix(spark): use ImmutableFileFormat builders

### DIFF
--- a/core/src/main/java/io/substrait/relation/files/FileFormat.java
+++ b/core/src/main/java/io/substrait/relation/files/FileFormat.java
@@ -7,16 +7,32 @@ import org.immutables.value.Value;
 public interface FileFormat {
 
   @Value.Immutable
-  abstract static class ParquetReadOptions implements FileFormat {}
+  abstract static class ParquetReadOptions implements FileFormat {
+    public static ImmutableFileFormat.ParquetReadOptions.Builder builder() {
+      return ImmutableFileFormat.ParquetReadOptions.builder();
+    }
+  }
 
   @Value.Immutable
-  abstract static class ArrowReadOptions implements FileFormat {}
+  abstract static class ArrowReadOptions implements FileFormat {
+    public static ImmutableFileFormat.ArrowReadOptions.Builder builder() {
+      return ImmutableFileFormat.ArrowReadOptions.builder();
+    }
+  }
 
   @Value.Immutable
-  abstract static class OrcReadOptions implements FileFormat {}
+  abstract static class OrcReadOptions implements FileFormat {
+    public static ImmutableFileFormat.OrcReadOptions.Builder builder() {
+      return ImmutableFileFormat.OrcReadOptions.builder();
+    }
+  }
 
   @Value.Immutable
-  abstract static class DwrfReadOptions implements FileFormat {}
+  abstract static class DwrfReadOptions implements FileFormat {
+    public static ImmutableFileFormat.DwrfReadOptions.Builder builder() {
+      return ImmutableFileFormat.DwrfReadOptions.builder();
+    }
+  }
 
   @Value.Immutable
   abstract static class DelimiterSeparatedTextReadOptions implements FileFormat {
@@ -31,6 +47,10 @@ public interface FileFormat {
     public abstract String getEscape();
 
     public abstract Optional<String> getValueTreatedAsNull();
+
+    public static ImmutableFileFormat.DelimiterSeparatedTextReadOptions.Builder builder() {
+      return ImmutableFileFormat.DelimiterSeparatedTextReadOptions.builder();
+    }
   }
 
   @Value.Immutable


### PR DESCRIPTION
Round-trip testing was failing for query plans that involved reading files from the filesystem.
This was due to the conversion code instantiating objects directly rather than using the immutable builders. The round-trip object comparison was then failing. This commit fixes that by using the ImmutableFileFormat builders, and hence the generated equals() methods.