### PR TITLE
feat(spark): make SparkSession optional

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -53,7 +53,8 @@ import scala.collection.mutable.ArrayBuffer
  * RelVisitor to convert Substrait Rel plan to [[LogicalPlan]]. Unsupported Rel node will call
  * visitFallback and throw UnsupportedOperationException.
  */
-class ToLogicalPlan(spark: SparkSession) extends DefaultRelVisitor[LogicalPlan] {
+class ToLogicalPlan(spark: SparkSession = SparkSession.builder().getOrCreate())
+  extends DefaultRelVisitor[LogicalPlan] {
 
   private val expressionConverter =
     new ToSparkExpression(ToScalarFunction(SparkExtension.SparkScalarFunctions), Some(this))

--- a/spark/src/test/scala/io/substrait/spark/LocalFiles.scala
+++ b/spark/src/test/scala/io/substrait/spark/LocalFiles.scala
@@ -53,7 +53,7 @@ class LocalFiles extends SharedSparkSession {
       .parseFrom(bytes)
     val substraitPlan2 = new ProtoPlanConverter().from(protoPlan)
 
-    val sparkPlan2 = new ToLogicalPlan(spark).convert(substraitPlan2)
+    val sparkPlan2 = new ToLogicalPlan().convert(substraitPlan2)
     val result = DatasetUtil.fromLogicalPlan(spark, sparkPlan2)
 
     assertResult(data.columns)(result.columns)


### PR DESCRIPTION
The `ToLogicalPlan` class constructor takes a SparkSession argument which must be supplied by the caller.
We can simplify the API by making this parameter optional, and defaulting to `SparkSession.builder().getOrCreate()`. The `LocalFiles.scala` test has been modified so that both usages get tested.
The need for this was triggered by invoking this API from Python code (pyspark).  Passing the SparkSession object from python involves accessing internal handles, which doesn’t make for a good user experience.