### PR TITLE
build: switch to Java 17 for all modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,15 +43,11 @@ allprojects {
   tasks.configureEach<Test> {
     val javaToolchains = project.extensions.getByType<JavaToolchainService>()
     useJUnitPlatform()
-    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
+    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(17)) })
   }
   tasks.withType<JavaCompile> {
     sourceCompatibility = "17"
-    if (project.name != "core") {
-      options.release.set(11)
-    } else {
-      options.release.set(8)
-    }
+    options.release.set(17)
     dependsOn(submodulesUpdate)
   }
 

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -116,5 +116,6 @@ tasks {
   test {
     dependsOn(":core:shadowJar")
     useJUnitPlatform { includeEngines("scalatest") }
+    jvmArgs(listOf("--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED"))
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: this might break consumers running older Java versions

We've been seeing occasional compilation errors where the Gradle toolchain JDK auto detection picked up a Java 11 JDK which does not work with some of the newer syntax being used especially in unit tests.

The behavior was a bit random, sometimes it picked up Java 17 and the build went through, other times it picked up Java 11 and failed to compile.

I would propose to switch all modules to Java 17. This made the compilation more reliable for me locally.

I had to configure one JVM arg for the Spark tests to run successfully since something in those tests tries to access a protected module.