### PR TITLE
fix(isthmus): upgrade to Calcite 1.39.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ com.github.vlsi.vlsi-release-plugins.version=1.74
 
 # library version
 antlr.version=4.13.1
-calcite.version=1.38.0
+calcite.version=1.39.0
 guava.version=32.1.3-jre
 immutables.version=2.10.1
 jackson.version=2.16.1

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -84,10 +84,13 @@ val PROTOBUF_VERSION = properties.get("protobuf.version")
 dependencies {
   api(project(":core"))
   api("org.apache.calcite:calcite-core:${CALCITE_VERSION}")
-  // calcite-core 1.37.0 brings in net.minidev:json-smart:2.5.0 which has a CVE associated with it.
-  // See: https://osv.dev/vulnerability/GHSA-pq2g-wx69-c263
-  // This causes the build to fail. Pull in the fixed version until Calcite is updated
-  implementation("net.minidev:json-smart:2.5.2")
+  constraints {
+    // calcite-core:1.39.0 has dependencies that contain vulnerabilities:
+    // - CVE-2025-27820 (org.apache.httpcomponents.client5:httpclient5 < 5.4.3)
+    // - CVE-2024-57699 (net.minidev:json-smart < 2.5.2)
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.4.4")
+    implementation("net.minidev:json-smart:2.5.2")
+  }
   implementation("org.apache.calcite:calcite-server:${CALCITE_VERSION}")
   testImplementation("org.junit.jupiter:junit-jupiter:${JUNIT_VERSION}")
   implementation("org.reflections:reflections:0.9.12")

--- a/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryNoValidation.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryNoValidation.java
@@ -29,8 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class TpcdsQueryNoValidation extends PlanTestBase {
 
-  static final Set<Integer> EXCLUDED =
-      Set.of(9, 12, 20, 27, 36, 47, 51, 53, 57, 63, 70, 86, 89, 98);
+  static final Set<Integer> EXCLUDED = Set.of(9, 27, 36, 70, 86, 98);
 
   static IntStream testCases() {
     return IntStream.rangeClosed(1, 99).filter(n -> !EXCLUDED.contains(n));


### PR DESCRIPTION
This version of Calcite improves support for nested window aggregation, which allows Isthmus to support several TPC-DS queries that were previously failing.