### PR TITLE
feat(spark): add support for trim functions

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
@@ -70,6 +70,24 @@ object DateFunction {
   }
 }
 
+object TrimFunction {
+  def unapply(e: Expression): Option[Seq[Expression]] = e match {
+    case StringTrim(srcStr, trimStr) => Some(Seq(srcStr) ++ trimStr)
+    case StringTrimLeft(srcStr, trimStr) => Some(Seq(srcStr) ++ trimStr)
+    case StringTrimRight(srcStr, trimStr) => Some(Seq(srcStr) ++ trimStr)
+    case _ => None
+  }
+
+  def unapply(name_args: (String, Seq[Expression])): Option[Expression] = name_args match {
+    case ("trim", Seq(srcStr)) => Some(StringTrim(srcStr))
+    case ("trim", Seq(srcStr, trimStr)) => Some(StringTrim(srcStr, trimStr))
+    case ("ltrim", Seq(srcStr)) => Some(StringTrimLeft(srcStr))
+    case ("ltrim", Seq(srcStr, trimStr)) => Some(StringTrimLeft(srcStr, trimStr))
+    case ("rtrim", Seq(srcStr)) => Some(StringTrimRight(srcStr))
+    case ("rtrim", Seq(srcStr, trimStr)) => Some(StringTrimRight(srcStr, trimStr))
+  }
+}
+
 class FunctionMappings {
 
   private def s[T <: Expression: ClassTag](name: String): GenericSig = {
@@ -86,6 +104,7 @@ class FunctionMappings {
     val builder = (args: Seq[Expression]) =>
       (signature, args) match {
         case DateFunction(expr) => expr
+        case TrimFunction(expr) => expr
       }
     SpecialSig(scala.reflect.classTag[T].runtimeClass, name, key, builder)
   }
@@ -142,6 +161,11 @@ class FunctionMappings {
     s[BitwiseAnd]("bitwise_and"),
     s[BitwiseOr]("bitwise_or"),
     s[BitwiseXor]("bitwise_xor"),
+
+    // trim functions require special handling
+    ss[StringTrim]("trim"),
+    ss[StringTrimLeft]("ltrim"),
+    ss[StringTrimRight]("rtrim"),
 
     // date/time functions require special handling
     ss[DateAdd]("add:date_i32"),

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
@@ -42,6 +42,7 @@ abstract class ToSubstraitExpression extends HasOutputStack[Seq[Attribute]] {
       case t: TernaryExpression => Some(Seq(t.first, t.second, t.third))
       case Coalesce(children) => Some(children.toList)
       case Concat(children) => Some(children.toList)
+      case TrimFunction(arguments) => Some(arguments)
       case _ => None
     }
   }

--- a/spark/src/test/scala/io/substrait/spark/TPCHPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCHPlan.scala
@@ -214,6 +214,16 @@ class TPCHPlan extends TPCHBase with SubstraitPlanTestBase {
     assertSqlSubstraitRelRoundTrip(query)
   }
 
+  test("trim") {
+    assertSqlSubstraitRelRoundTrip(
+      "select trim(o_comment), ltrim(o_comment), rtrim(o_comment) from orders"
+    )
+
+    assertSqlSubstraitRelRoundTrip(
+      "select trim(both from o_comment), trim(leading '-' from o_comment), trim(trailing '~' from o_comment) from orders"
+    )
+  }
+
   test("tpch_q1_variant") {
     // difference from tpch_q1 : 1) remove order by clause; 2) remove interval date literal
     assertSqlSubstraitRelRoundTrip(


### PR DESCRIPTION
These have to be implemented using the SpecialSig
function mapping scheme that was added for the date/time functions due to the slightly unusual signatures of these functions in spark.
(The GenericSig fails to convert substrait -> spark correctly).