### PR TITLE
feat: add new join types

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -207,8 +207,12 @@ public class SubstraitRelNodeConverter extends AbstractRelVisitor<RelNode, Runti
           case OUTER -> JoinRelType.FULL;
           case SEMI -> JoinRelType.SEMI;
           case ANTI -> JoinRelType.ANTI;
+          case LEFT_SEMI -> JoinRelType.SEMI;
+          case LEFT_ANTI -> JoinRelType.ANTI;
           case UNKNOWN -> throw new UnsupportedOperationException(
               "Unknown join type is not supported");
+          default -> throw new UnsupportedOperationException(
+              "Unsupported join type: " + join.getJoinType().name());
         };
     RelNode node = relBuilder.push(left).push(right).join(joinType, condition).build();
     return applyRemap(node, join.getRemap());

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -176,8 +176,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
           case LEFT -> Join.JoinType.LEFT;
           case RIGHT -> Join.JoinType.RIGHT;
           case FULL -> Join.JoinType.OUTER;
-          case SEMI -> Join.JoinType.SEMI;
-          case ANTI -> Join.JoinType.ANTI;
+          case SEMI -> Join.JoinType.LEFT_SEMI;
+          case ANTI -> Join.JoinType.LEFT_ANTI;
           default -> throw new UnsupportedOperationException(
               "Unsupported join type: " + join.getJoinType());
         };

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -186,8 +186,12 @@ class ToLogicalPlan(spark: SparkSession = SparkSession.builder().getOrCreate())
         case relation.Join.JoinType.OUTER => FullOuter
         case relation.Join.JoinType.SEMI => LeftSemi
         case relation.Join.JoinType.ANTI => LeftAnti
+        case relation.Join.JoinType.LEFT_SEMI => LeftSemi
+        case relation.Join.JoinType.LEFT_ANTI => LeftAnti
         case relation.Join.JoinType.UNKNOWN =>
           throw new UnsupportedOperationException("Unknown join type is not supported")
+        case other =>
+          throw new UnsupportedOperationException(s"Unsupported join type $other")
       }
       Join(left, right, joinType, condition, hint = JoinHint.NONE)
     }

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -290,8 +290,8 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
     case LeftOuter => relation.Join.JoinType.LEFT
     case RightOuter => relation.Join.JoinType.RIGHT
     case FullOuter => relation.Join.JoinType.OUTER
-    case LeftSemi => relation.Join.JoinType.SEMI
-    case LeftAnti => relation.Join.JoinType.ANTI
+    case LeftSemi => relation.Join.JoinType.LEFT_SEMI
+    case LeftAnti => relation.Join.JoinType.LEFT_ANTI
     case other => throw new UnsupportedOperationException(s"Unsupported join type $other")
   }
 


### PR DESCRIPTION
I noticed the Substrait specification has a couple more join types defined which were not supported yet by the substrait-java/core library. This PR adds support for these additional join types to substrait-java/core.

Additionally, it deprecates the old `JoinType` enum names `SEMI` and `ANTI` in order to be consistent with the Substrait specification names `LEFT_SEMI` and `LEFT_ANTI`.

This PR does neither add support for the new join types to the Isthmus mappings nor the Spark mappings.