### PR TITLE
fix(core): start with functionAnchor one instead of zero

### DIFF
--- a/core/src/main/java/io/substrait/extension/ExtensionCollector.java
+++ b/core/src/main/java/io/substrait/extension/ExtensionCollector.java
@@ -23,7 +23,8 @@ public class ExtensionCollector extends AbstractExtensionLookup {
   private final BidiMap<Integer, SimpleExtension.TypeAnchor> typeMap;
   private final BidiMap<Integer, String> uriMap;
 
-  private int counter = -1;
+  // start at 0 to make sure functionAnchors start with 1 according to spec
+  private int counter = 0;
 
   public ExtensionCollector() {
     super(new HashMap<>(), new HashMap<>());


### PR DESCRIPTION
When validating Substrait plans generated by substrait-java with the current substrait-validator (which is pretty out of date) the validator gives the following warning for all plans:

```
Warning (code 3005):
at plan.extensions[0].mapping_type<extension_function>.function_anchor:
use of anchor zero is discouraged, as references set to zero may be confused with "unspecified". (code 3005)
```

This can be easily fixed by assigning functionAnchor values starting from one instead of zero.