### PR TITLE
fix: add fall-back version in case everything else fails

### DIFF
--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -69,6 +69,10 @@ public abstract class Plan {
         }
       }
 
+      if (specificationVersion == null) {
+        specificationVersion = "0.0.0";
+      }
+
       return specificationVersion.split("\\.");
     }
   }


### PR DESCRIPTION
I propose to add a final fall back to version `0.0.0` in case all other look-ups fail. Arguably it is better to tag plans with that version than crashing on every possible utilisation.