### PR TITLE
build: use Central Publisher API for Maven publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macOS-latest ]
+        os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '17'
-          distribution: 'graalvm'
+          java-version: "17"
+          distribution: "graalvm"
           # helps avoid rate-limiting issues
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
@@ -65,11 +65,11 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Download isthmus-ubuntu-latest binary
@@ -86,8 +86,10 @@ jobs:
         run: ./ci/release/run.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.SIGNING_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
   id("idea")
   id("com.github.vlsi.gradle-extensions") version "1.74"
   id("com.diffplug.spotless") version "6.19.0"
-  id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+  id("org.jreleaser") version "1.18.0" apply false
 }
 
 var IMMUTABLES_VERSION = properties.get("immutables.version")
@@ -66,24 +66,6 @@ allprojects {
         removeUnusedImports()
         trimTrailingWhitespace()
       }
-    }
-  }
-}
-
-nexusPublishing {
-  repositories {
-    create("sonatype") {
-      val sonatypeUser =
-        System.getenv("SONATYPE_USER").takeUnless { it.isNullOrEmpty() }
-          ?: extra["SONATYPE_USER"].toString()
-      val sonatypePassword =
-        System.getenv("SONATYPE_PASSWORD").takeUnless { it.isNullOrEmpty() }
-          ?: extra["SONATYPE_PASSWORD"].toString()
-      nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-
-      snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-      username.set(sonatypeUser)
-      password.set(sonatypePassword)
     }
   }
 }

--- a/ci/release/README.md
+++ b/ci/release/README.md
@@ -44,14 +44,9 @@ Create these actions secrets used by release process:
 
 ## Repository Manager
 
-The artifacts are deployed to Sonatype OSSRH (Sonatype Open Source Software Repository Manager).
+The artifacts are deployed to Sonatype [Central Publishing Portal](https://central.sonatype.com/).
 
-These are the repositories availables:
-- Snapshots: https://s01.oss.sonatype.org/content/repositories/snapshots
-- Staging: https://s01.oss.sonatype.org/content/repositories/staging
-- Releases: https://s01.oss.sonatype.org/content/repositories/releases
-
-![repositories](img/repositories.png)
+Documentation: https://central.sonatype.org/register/central-portal/
 
 ## Release Process
 

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -7,4 +7,6 @@ set -euo pipefail
 git submodule foreach 'git fetch --unshallow || true'
 
 gradle wrapper
-./gradlew clean :core:publishToSonatype :isthmus:publishToSonatype :spark:publishToSonatype closeAndReleaseSonatypeStagingRepository
+./gradlew clean
+./gradlew publishAllPublicationsToStagingRepository
+./gradlew jreleaserDeploy

--- a/ci/release/sanity.sh
+++ b/ci/release/sanity.sh
@@ -4,12 +4,13 @@
 set -euo pipefail
 export GPG_TTY=$(tty)
 
-echo "Validate Sonatype OSSRH Credentials."
-CODE=$(curl -u "$SONATYPE_USER:$SONATYPE_PASSWORD" -sSL -w '%{http_code}' -o /dev/null https://s01.oss.sonatype.org/service/local/staging/profiles)
+echo "Validate Central Publisher API credentials."
+BEARER=$(printf "%s:%s" "${SONATYPE_USER}" "${SONATYPE_PASSWORD}" | base64)
+CODE=$(curl --request GET 'https://central.sonatype.com/api/v1/publisher/published?namespace=io.substrait&name=core&version=0.1.0' --header 'accept: application/json' --header "Authorization: Bearer ${BEARER}" -sSL -w '%{http_code}' -o /dev/null)
 if [[ "$CODE" =~ ^2 ]]; then
-    echo "Sonatype OSSRH Credentials configured successfully."
+    echo "Central Publisher API credentials configured successfully."
 else
-    echo "Error to validate Sonatype OSSRH Credentials. Server returned HTTP code $CODE."
+    echo "Error to validate Central Publisher API credentials. Server returned HTTP code ${CODE}."
 fi
 
 echo "Validate Signing Private/Public Key."

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -7,8 +7,10 @@ plugins {
   id("com.diffplug.spotless") version "6.19.0"
   id("com.gradleup.shadow") version "8.3.6"
   id("com.google.protobuf") version "0.9.4"
-  signing
+  id("org.jreleaser")
 }
+
+val stagingRepositoryUrl = uri(layout.buildDirectory.dir("staging-deploy"))
 
 publishing {
   publications {
@@ -29,7 +31,8 @@ publishing {
         }
         developers {
           developer {
-            // TBD Get the list of
+            id = "vbarua"
+            name = "Victor Barua"
           }
         }
         scm {
@@ -47,22 +50,39 @@ publishing {
       val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
       url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
     }
+    maven {
+      name = "staging"
+      url = stagingRepositoryUrl
+    }
   }
 }
 
-signing {
-  setRequired({ gradle.taskGraph.hasTask("publishToSonatype") })
-  val signingKeyId =
-    System.getenv("SIGNING_KEY_ID").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY_ID"].toString()
-  val signingPassword =
-    System.getenv("SIGNING_PASSWORD").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_PASSWORD"].toString()
-  val signingKey =
-    System.getenv("SIGNING_KEY").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY"].toString()
-  useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-  sign(publishing.publications["maven-publish"])
+jreleaser {
+  gitRootSearch = true
+  signing {
+    active = org.jreleaser.model.Active.ALWAYS
+    armored = true
+    verify = false
+  }
+  deploy {
+    maven {
+      mavenCentral {
+        register("sonatype") {
+          active = org.jreleaser.model.Active.ALWAYS
+          url = "https://central.sonatype.com/api/v1/publisher"
+          stagingRepository(file(stagingRepositoryUrl).toString())
+          retryDelay = 60
+        }
+      }
+    }
+  }
+  release {
+    github {
+      skipRelease = true
+      skipTag = true
+      token = "EMPTY"
+    }
+  }
 }
 
 java {

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -4,8 +4,10 @@ plugins {
   id("scala")
   id("idea")
   id("com.diffplug.spotless") version "6.19.0"
-  signing
+  id("org.jreleaser")
 }
+
+val stagingRepositoryUrl = uri(layout.buildDirectory.dir("staging-deploy"))
 
 publishing {
   publications {
@@ -26,7 +28,8 @@ publishing {
         }
         developers {
           developer {
-            // TBD Get the list of
+            id = "vbarua"
+            name = "Victor Barua"
           }
         }
         scm {
@@ -44,22 +47,39 @@ publishing {
       val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
       url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
     }
+    maven {
+      name = "staging"
+      url = stagingRepositoryUrl
+    }
   }
 }
 
-signing {
-  setRequired({ gradle.taskGraph.hasTask("publishToSonatype") })
-  val signingKeyId =
-    System.getenv("SIGNING_KEY_ID").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY_ID"].toString()
-  val signingPassword =
-    System.getenv("SIGNING_PASSWORD").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_PASSWORD"].toString()
-  val signingKey =
-    System.getenv("SIGNING_KEY").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY"].toString()
-  useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-  sign(publishing.publications["maven-publish"])
+jreleaser {
+  gitRootSearch = true
+  signing {
+    active = org.jreleaser.model.Active.ALWAYS
+    armored = true
+    verify = false
+  }
+  deploy {
+    maven {
+      mavenCentral {
+        register("sonatype") {
+          active = org.jreleaser.model.Active.ALWAYS
+          url = "https://central.sonatype.com/api/v1/publisher"
+          stagingRepository(file(stagingRepositoryUrl).toString())
+          retryDelay = 60
+        }
+      }
+    }
+  }
+  release {
+    github {
+      skipRelease = true
+      skipTag = true
+      token = "EMPTY"
+    }
+  }
 }
 
 configurations.all {


### PR DESCRIPTION
Publishing to Maven Central using OSSRH is deprecated and is sunset on 2025-06-30. The Maven namespace has been migrated to the Central Publishing Portal. There is currently no support for publishing using the Central Publisher API in Gradle's own publishing capability, and no official Sonatype Gradle publishing plugin. JReleaser is currently recommended by Sonatype for Gradle publishing to Maven Central.

Closes #407