### PR TITLE
fix(core): create and use SubstraitVersion Java class

### DIFF
--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -1,12 +1,10 @@
 package io.substrait.plan;
 
+import io.substrait.SubstraitVersion;
 import io.substrait.proto.AdvancedExtension;
 import io.substrait.relation.Rel;
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.jar.Attributes.Name;
-import java.util.jar.Manifest;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -32,14 +30,7 @@ public abstract class Plan {
     public static final Version DEFAULT_VERSION;
 
     static {
-      final String[] versionComponents = loadVersion();
-      DEFAULT_VERSION =
-          ImmutableVersion.builder()
-              .major(Integer.parseInt(versionComponents[0]))
-              .minor(Integer.parseInt(versionComponents[1]))
-              .patch(Integer.parseInt(versionComponents[2]))
-              .producer(Optional.of("substrait-java"))
-              .build();
+      DEFAULT_VERSION = loadVersion();
     }
 
     public abstract int getMajor();
@@ -52,28 +43,15 @@ public abstract class Plan {
 
     public abstract Optional<String> getProducer();
 
-    private static String[] loadVersion() {
-      // load the specification version from the JAR manifest
-      String specificationVersion = Version.class.getPackage().getSpecificationVersion();
+    private static Version loadVersion() {
+      final String[] versionComponents = SubstraitVersion.VERSION.split("\\.");
 
-      // load the manifest directly from the classpath if the specification version is null which is
-      // the case if the Version class is not in a JAR, e.g. during the Gradle build
-      if (specificationVersion == null) {
-        try {
-          Manifest manifest =
-              new Manifest(
-                  Version.class.getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF"));
-          specificationVersion = manifest.getMainAttributes().getValue(Name.SPECIFICATION_VERSION);
-        } catch (IOException e) {
-          throw new IllegalStateException("Could not load version from manifest", e);
-        }
-      }
-
-      if (specificationVersion == null) {
-        specificationVersion = "0.0.0";
-      }
-
-      return specificationVersion.split("\\.");
+      return ImmutableVersion.builder()
+          .major(Integer.parseInt(versionComponents[0]))
+          .minor(Integer.parseInt(versionComponents[1]))
+          .patch(Integer.parseInt(versionComponents[2]))
+          .producer(Optional.of("substrait-java"))
+          .build();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/substrait-io/substrait-java/issues/411

This PR keeps the manifest files since they are still a good practice to keep around. But instead of relying on the specification version from the manifest for populating the Substrait plan version this PR adds Gradle code which generates a simple Java class `SubstraitVersion` with a constant `VERSION` containing the version number from git describe.

From #411 it looks like at least in some cases when calling the isthmus Java code from Python via JPype there is an issue accessing the manifest file or any other file packaged as a resource into the isthmus shadow JAR. Using a generated Java class avoids this issue since JPype seems to have no issues accessing Java classes.