### PR TITLE
fix(core): convert hints in ProtoRelConverter

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -179,7 +179,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     return builder.build();
   }
 
@@ -197,7 +198,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     return builder.build();
   }
 
@@ -225,6 +227,7 @@ public class ProtoRelConverter {
         .viewDefinition(optionalViewDefinition(rel))
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()))
         .build();
   }
 
@@ -240,6 +243,7 @@ public class ProtoRelConverter {
         .viewDefinition(optionalViewDefinition(rel))
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()))
         .build();
   }
 
@@ -266,10 +270,10 @@ public class ProtoRelConverter {
             .condition(
                 new ProtoExpressionConverter(lookup, extensions, input.getRecordType(), this)
                     .from(rel.getCondition()));
-
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -317,7 +321,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -329,7 +334,8 @@ public class ProtoRelConverter {
     var builder =
         ExtensionLeaf.from(detail)
             .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-            .remap(optionalRelmap(rel.getCommon()));
+            .remap(optionalRelmap(rel.getCommon()))
+            .hint(optionalHint(rel.getCommon()));
     return builder.build();
   }
 
@@ -339,7 +345,8 @@ public class ProtoRelConverter {
     var builder =
         ExtensionSingle.from(detail, input)
             .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-            .remap(optionalRelmap(rel.getCommon()));
+            .remap(optionalRelmap(rel.getCommon()))
+            .hint(optionalHint(rel.getCommon()));
     return builder.build();
   }
 
@@ -349,7 +356,8 @@ public class ProtoRelConverter {
     var builder =
         ExtensionMulti.from(detail, inputs)
             .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-            .remap(optionalRelmap(rel.getCommon()));
+            .remap(optionalRelmap(rel.getCommon()))
+            .hint(optionalHint(rel.getCommon()));
     if (rel.hasDetail()) {
       builder.detail(detailFromExtensionMultiRel(rel.getDetail()));
     }
@@ -379,7 +387,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -393,7 +402,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -427,7 +437,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -503,7 +514,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -521,7 +533,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -619,7 +632,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -644,7 +658,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -670,7 +685,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -700,7 +716,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -729,10 +746,10 @@ public class ProtoRelConverter {
             .postJoinFilter(
                 Optional.ofNullable(
                     rel.hasPostJoinFilter() ? unionConverter.from(rel.getPostJoinFilter()) : null));
-
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -764,7 +781,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -791,7 +809,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }
@@ -827,7 +846,8 @@ public class ProtoRelConverter {
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
-        .remap(optionalRelmap(rel.getCommon()));
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(advancedExtension(rel.getAdvancedExtension()));
     }

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.TestBase;
 import io.substrait.extension.AdvancedExtension;
+import io.substrait.hint.Hint;
 import io.substrait.relation.utils.StringHolder;
+import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -121,6 +123,35 @@ public class ProtoRelConverterTest extends TestBase {
       Rel relReturned = protoRelConverter.from(protoRel);
 
       assertNotEquals(rel, relReturned);
+    }
+  }
+
+  /** Verify that hints are correctly transmitted in proto<->pojo */
+  @Nested
+  class HintsTest {
+
+    @Test
+    void relWithHint() {
+      Rel relWithHints =
+          NamedScan.builder()
+              .from(commonTable)
+              .hint(Hint.builder().addOutputNames("Test hint").build())
+              .build();
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(relWithHints);
+      Rel relReturned = protoRelConverter.from(protoRel);
+      assertEquals(relWithHints, relReturned);
+    }
+
+    @Test
+    void relWithHints() {
+      Rel relWithHints =
+          NamedScan.builder()
+              .from(commonTable)
+              .hint(Hint.builder().addAllOutputNames(Arrays.asList("Hint 1", "Hint 2")).build())
+              .build();
+      io.substrait.proto.Rel protoRel = relProtoConverter.toProto(relWithHints);
+      Rel relReturned = protoRelConverter.from(protoRel);
+      assertEquals(relWithHints, relReturned);
     }
   }
 }


### PR DESCRIPTION
Most of the mappings were missing the hints. This PR re-uses the already existing `optionalHint` method and includes the hints for relations where this was missing. No other functional changes.