### PR TITLE
build: use Gradle signing instead of JReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,5 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          JRELEASER_GPG_SECRET_KEY: ${{ secrets.SIGNING_KEY }}
-          JRELEASER_GPG_PASSPHRASE: ${{ secrets.SIGNING_PASSWORD }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_KEY }}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory
 
 plugins {
   `maven-publish`
+  signing
   id("java-library")
   id("idea")
   id("antlr")
@@ -63,32 +64,38 @@ publishing {
   }
 }
 
+signing {
+  setRequired({
+    gradle.taskGraph.hasTask(":${project.name}:publishMaven-publishPublicationToStagingRepository")
+  })
+  val signingKeyId =
+    System.getenv("SIGNING_KEY_ID").takeUnless { it.isNullOrEmpty() }
+      ?: extra["SIGNING_KEY_ID"].toString()
+  val signingPassword =
+    System.getenv("SIGNING_PASSWORD").takeUnless { it.isNullOrEmpty() }
+      ?: extra["SIGNING_PASSWORD"].toString()
+  val signingKey =
+    System.getenv("SIGNING_KEY").takeUnless { it.isNullOrEmpty() }
+      ?: extra["SIGNING_KEY"].toString()
+  useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+  sign(publishing.publications["maven-publish"])
+}
+
 jreleaser {
   gitRootSearch = true
-  signing {
-    active = org.jreleaser.model.Active.ALWAYS
-    armored = true
-    verify = false
-  }
   deploy {
     maven {
       mavenCentral {
         register("sonatype") {
           active = org.jreleaser.model.Active.ALWAYS
           url = "https://central.sonatype.com/api/v1/publisher"
+          sign = false
           stagingRepository(file(stagingRepositoryUrl).toString())
-          retryDelay = 60
         }
       }
     }
   }
-  release {
-    github {
-      skipRelease = true
-      skipTag = true
-      token = "EMPTY"
-    }
-  }
+  release { github { enabled = false } }
 }
 
 val ANTLR_VERSION = properties.get("antlr.version")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   `maven-publish`
+  signing
   id("java")
   id("scala")
   id("idea")
@@ -54,32 +55,38 @@ publishing {
   }
 }
 
+signing {
+  setRequired({
+    gradle.taskGraph.hasTask(":${project.name}:publishMaven-publishPublicationToStagingRepository")
+  })
+  val signingKeyId =
+    System.getenv("SIGNING_KEY_ID").takeUnless { it.isNullOrEmpty() }
+      ?: extra["SIGNING_KEY_ID"].toString()
+  val signingPassword =
+    System.getenv("SIGNING_PASSWORD").takeUnless { it.isNullOrEmpty() }
+      ?: extra["SIGNING_PASSWORD"].toString()
+  val signingKey =
+    System.getenv("SIGNING_KEY").takeUnless { it.isNullOrEmpty() }
+      ?: extra["SIGNING_KEY"].toString()
+  useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+  sign(publishing.publications["maven-publish"])
+}
+
 jreleaser {
   gitRootSearch = true
-  signing {
-    active = org.jreleaser.model.Active.ALWAYS
-    armored = true
-    verify = false
-  }
   deploy {
     maven {
       mavenCentral {
         register("sonatype") {
           active = org.jreleaser.model.Active.ALWAYS
           url = "https://central.sonatype.com/api/v1/publisher"
+          sign = false
           stagingRepository(file(stagingRepositoryUrl).toString())
-          retryDelay = 60
         }
       }
     }
   }
-  release {
-    github {
-      skipRelease = true
-      skipTag = true
-      token = "EMPTY"
-    }
-  }
+  release { github { enabled = false } }
 }
 
 configurations.all {


### PR DESCRIPTION
JReleaser expects to have the corresponding public key available when signing artifacts so that it can verify that the public key is published to known key registries. While publishing works without the public key, it outputs a warning message, which can cause confusion when viewing build logs.

This change disables JReleaser artifact signing and reverts to using Gradle's own signing plugin. This also provides a smoother migration path to an official Sonatype Gradle publishing plugin, if/when one becomes available in the future.

Gradle wrapper is also updated to the latest patch release.

Relates to #419