### PR TITLE
chore: avoid using generated immutables

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -3,16 +3,15 @@ package io.substrait.dsl;
 import com.github.bsideup.jabel.Desugar;
 import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
+import io.substrait.expression.Expression.Cast;
 import io.substrait.expression.Expression.FailureBehavior;
 import io.substrait.expression.Expression.IfClause;
 import io.substrait.expression.Expression.IfThen;
+import io.substrait.expression.Expression.SingleOrList;
+import io.substrait.expression.Expression.Switch;
 import io.substrait.expression.Expression.SwitchClause;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.FunctionArg;
-import io.substrait.expression.ImmutableExpression.Cast;
-import io.substrait.expression.ImmutableExpression.SingleOrList;
-import io.substrait.expression.ImmutableExpression.Switch;
-import io.substrait.expression.ImmutableFieldReference;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
@@ -33,7 +32,6 @@ import io.substrait.relation.Sort;
 import io.substrait.relation.physical.HashJoin;
 import io.substrait.relation.physical.MergeJoin;
 import io.substrait.relation.physical.NestedLoopJoin;
-import io.substrait.type.ImmutableType;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -396,7 +394,7 @@ public class SubstraitBuilder {
   }
 
   public FieldReference fieldReference(Rel input, int index) {
-    return ImmutableFieldReference.newInputRelReference(index, input);
+    return FieldReference.newInputRelReference(index, input);
   }
 
   public List<FieldReference> fieldReferences(Rel input, int... indexes) {
@@ -406,7 +404,7 @@ public class SubstraitBuilder {
   }
 
   public FieldReference fieldReference(List<Rel> inputs, int index) {
-    return ImmutableFieldReference.newInputRelReference(index, inputs);
+    return FieldReference.newInputRelReference(index, inputs);
   }
 
   public List<FieldReference> fieldReferences(List<Rel> inputs, int... indexes) {
@@ -439,7 +437,7 @@ public class SubstraitBuilder {
         .mapToObj(
             index ->
                 Expression.SortField.builder()
-                    .expr(ImmutableFieldReference.newInputRelReference(index, input))
+                    .expr(FieldReference.newInputRelReference(index, input))
                     .direction(Expression.SortDirection.ASC_NULLS_LAST)
                     .build())
         .collect(java.util.stream.Collectors.toList());
@@ -678,11 +676,7 @@ public class SubstraitBuilder {
   // Types
 
   public Type.UserDefined userDefinedType(String namespace, String typeName) {
-    return ImmutableType.UserDefined.builder()
-        .uri(namespace)
-        .name(typeName)
-        .nullable(false)
-        .build();
+    return Type.UserDefined.builder().uri(namespace).name(typeName).nullable(false).build();
   }
 
   // Misc

--- a/core/src/main/java/io/substrait/expression/EnumArg.java
+++ b/core/src/main/java/io/substrait/expression/EnumArg.java
@@ -23,12 +23,16 @@ public interface EnumArg extends FunctionArg {
 
   static EnumArg of(SimpleExtension.EnumArgument enumArg, String option) {
     assert (enumArg.options().contains(option));
-    return ImmutableEnumArg.builder().value(Optional.of(option)).build();
+    return builder().value(Optional.of(option)).build();
   }
 
   static EnumArg of(String value) {
-    return ImmutableEnumArg.builder().value(Optional.of(value)).build();
+    return builder().value(Optional.of(value)).build();
   }
 
-  EnumArg UNSPECIFIED_ENUM_ARG = ImmutableEnumArg.builder().value(Optional.empty()).build();
+  EnumArg UNSPECIFIED_ENUM_ARG = builder().value(Optional.empty()).build();
+
+  static ImmutableEnumArg.Builder builder() {
+    return ImmutableEnumArg.builder();
+  }
 }

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -5,7 +5,6 @@ import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.FunctionArg;
 import io.substrait.expression.FunctionOption;
-import io.substrait.expression.ImmutableExpression;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.ExtensionLookup;
 import io.substrait.extension.SimpleExtension;
@@ -121,7 +120,7 @@ public class ProtoExpressionConverter {
             scalarFunction.getOptionsList().stream()
                 .map(ProtoExpressionConverter::fromFunctionOption)
                 .collect(Collectors.toList());
-        yield ImmutableExpression.ScalarFunctionInvocation.builder()
+        yield Expression.ScalarFunctionInvocation.builder()
             .addAllArguments(args)
             .declaration(declaration)
             .outputType(protoTypeConverter.from(scalarFunction.getOutputType()))
@@ -152,7 +151,7 @@ public class ProtoExpressionConverter {
             orList.getOptionsList().stream()
                 .map(this::from)
                 .collect(java.util.stream.Collectors.toList());
-        yield ImmutableExpression.SingleOrList.builder()
+        yield Expression.SingleOrList.builder()
             .condition(from(orList.getValue()))
             .addAllOptions(values)
             .build();
@@ -163,14 +162,14 @@ public class ProtoExpressionConverter {
             multiOrList.getOptionsList().stream()
                 .map(
                     t ->
-                        ImmutableExpression.MultiOrListRecord.builder()
+                        Expression.MultiOrListRecord.builder()
                             .addAllValues(
                                 t.getFieldsList().stream()
                                     .map(this::from)
                                     .collect(java.util.stream.Collectors.toList()))
                             .build())
                 .collect(java.util.stream.Collectors.toList());
-        yield ImmutableExpression.MultiOrList.builder()
+        yield Expression.MultiOrList.builder()
             .addAllOptionCombinations(values)
             .addAllConditions(
                 multiOrList.getValueList().stream()
@@ -186,7 +185,7 @@ public class ProtoExpressionConverter {
         switch (expr.getSubquery().getSubqueryTypeCase()) {
           case SET_PREDICATE -> {
             var rel = protoRelConverter.from(expr.getSubquery().getSetPredicate().getTuples());
-            yield ImmutableExpression.SetPredicate.builder()
+            yield Expression.SetPredicate.builder()
                 .tuples(rel)
                 .predicateOp(
                     Expression.PredicateOp.fromProto(
@@ -195,7 +194,7 @@ public class ProtoExpressionConverter {
           }
           case SCALAR -> {
             var rel = protoRelConverter.from(expr.getSubquery().getScalar().getInput());
-            yield ImmutableExpression.ScalarSubquery.builder()
+            yield Expression.ScalarSubquery.builder()
                 .input(rel)
                 .type(
                     rel.getRecordType()
@@ -220,7 +219,7 @@ public class ProtoExpressionConverter {
                 expr.getSubquery().getInPredicate().getNeedlesList().stream()
                     .map(e -> this.from(e))
                     .collect(java.util.stream.Collectors.toList());
-            yield ImmutableExpression.InPredicate.builder().haystack(rel).needles(needles).build();
+            yield Expression.InPredicate.builder().haystack(rel).needles(needles).build();
           }
           case SET_COMPARISON -> {
             throw new UnsupportedOperationException(

--- a/core/src/main/java/io/substrait/extendedexpression/ExtendedExpression.java
+++ b/core/src/main/java/io/substrait/extendedexpression/ExtendedExpression.java
@@ -20,6 +20,10 @@ public abstract class ExtendedExpression {
 
   public abstract Optional<AdvancedExtension> getAdvancedExtension();
 
+  public static ImmutableExtendedExpression.Builder builder() {
+    return ImmutableExtendedExpression.builder();
+  }
+
   public interface ExpressionReferenceBase {
     List<String> getOutputNames();
   }
@@ -27,6 +31,10 @@ public abstract class ExtendedExpression {
   @Value.Immutable
   public abstract static class ExpressionReference implements ExpressionReferenceBase {
     public abstract Expression getExpression();
+
+    public static ImmutableExpressionReference.Builder builder() {
+      return ImmutableExpressionReference.builder();
+    }
   }
 
   @Value.Immutable

--- a/core/src/main/java/io/substrait/extendedexpression/ProtoExtendedExpressionConverter.java
+++ b/core/src/main/java/io/substrait/extendedexpression/ProtoExtendedExpressionConverter.java
@@ -5,7 +5,6 @@ import io.substrait.expression.proto.ProtoExpressionConverter;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.ExtensionLookup;
 import io.substrait.extension.ImmutableExtensionLookup;
-import io.substrait.extension.ImmutableSimpleExtension;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.ExpressionReference;
 import io.substrait.proto.NamedStruct;
@@ -29,7 +28,7 @@ public class ProtoExtendedExpressionConverter {
 
   private final ProtoTypeConverter protoTypeConverter =
       new ProtoTypeConverter(
-          new ExtensionCollector(), ImmutableSimpleExtension.ExtensionCollection.builder().build());
+          new ExtensionCollector(), SimpleExtension.ExtensionCollection.builder().build());
 
   public ExtendedExpression from(io.substrait.proto.ExtendedExpression extendedExpression) {
     // fill in simple extension information through a discovery in the current proto-extended

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -570,6 +570,10 @@ public class SimpleExtension {
 
     public abstract List<WindowFunctionVariant> windowFunctions();
 
+    public static ImmutableSimpleExtension.ExtensionCollection.Builder builder() {
+      return ImmutableSimpleExtension.ExtensionCollection.builder();
+    }
+
     private final Supplier<Set<String>> namespaceSupplier =
         Util.memoize(
             () -> {

--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -43,10 +43,14 @@ public abstract class Plan {
 
     public abstract Optional<String> getProducer();
 
+    public static ImmutableVersion.Builder builder() {
+      return ImmutableVersion.builder();
+    }
+
     private static Version loadVersion() {
       final String[] versionComponents = SubstraitVersion.VERSION.split("\\.");
 
-      return ImmutableVersion.builder()
+      return builder()
           .major(Integer.parseInt(versionComponents[0]))
           .minor(Integer.parseInt(versionComponents[1]))
           .patch(Integer.parseInt(versionComponents[2]))

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -2,7 +2,6 @@ package io.substrait.relation;
 
 import io.substrait.expression.Expression;
 import io.substrait.expression.FunctionArg;
-import io.substrait.expression.ImmutableExpression;
 import io.substrait.expression.proto.ProtoExpressionConverter;
 import io.substrait.extension.AdvancedExtension;
 import io.substrait.extension.ExtensionLookup;
@@ -31,13 +30,11 @@ import io.substrait.proto.UpdateRel;
 import io.substrait.proto.WriteRel;
 import io.substrait.relation.extensions.EmptyDetail;
 import io.substrait.relation.extensions.EmptyOptimization;
+import io.substrait.relation.files.FileFormat;
 import io.substrait.relation.files.FileOrFiles;
-import io.substrait.relation.files.ImmutableFileFormat;
-import io.substrait.relation.files.ImmutableFileOrFiles;
 import io.substrait.relation.physical.HashJoin;
 import io.substrait.relation.physical.MergeJoin;
 import io.substrait.relation.physical.NestedLoopJoin;
-import io.substrait.type.ImmutableNamedStruct;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.proto.ProtoTypeConverter;
@@ -325,7 +322,7 @@ public class ProtoRelConverter {
 
   protected NamedStruct newNamedStruct(io.substrait.proto.NamedStruct namedStruct) {
     var struct = namedStruct.getStruct();
-    return ImmutableNamedStruct.builder()
+    return NamedStruct.builder()
         .names(namedStruct.getNamesList())
         .struct(
             Type.Struct.builder()
@@ -485,22 +482,22 @@ public class ProtoRelConverter {
   }
 
   protected FileOrFiles newFileOrFiles(ReadRel.LocalFiles.FileOrFiles file) {
-    ImmutableFileOrFiles.Builder builder =
-        ImmutableFileOrFiles.builder()
+    var builder =
+        FileOrFiles.builder()
             .partitionIndex(file.getPartitionIndex())
             .start(file.getStart())
             .length(file.getLength());
     if (file.hasParquet()) {
-      builder.fileFormat(ImmutableFileFormat.ParquetReadOptions.builder().build());
+      builder.fileFormat(FileFormat.ParquetReadOptions.builder().build());
     } else if (file.hasOrc()) {
-      builder.fileFormat(ImmutableFileFormat.OrcReadOptions.builder().build());
+      builder.fileFormat(FileFormat.OrcReadOptions.builder().build());
     } else if (file.hasArrow()) {
-      builder.fileFormat(ImmutableFileFormat.ArrowReadOptions.builder().build());
+      builder.fileFormat(FileFormat.ArrowReadOptions.builder().build());
     } else if (file.hasDwrf()) {
-      builder.fileFormat(ImmutableFileFormat.DwrfReadOptions.builder().build());
+      builder.fileFormat(FileFormat.DwrfReadOptions.builder().build());
     } else if (file.hasText()) {
       var ffBuilder =
-          ImmutableFileFormat.DelimiterSeparatedTextReadOptions.builder()
+          FileFormat.DelimiterSeparatedTextReadOptions.builder()
               .fieldDelimiter(file.getText().getFieldDelimiter())
               .maxLineSize(file.getText().getMaxLineSize())
               .quote(file.getText().getQuote())
@@ -511,8 +508,7 @@ public class ProtoRelConverter {
       }
       builder.fileFormat(ffBuilder.build());
     } else if (file.hasExtension()) {
-      builder.fileFormat(
-          ImmutableFileFormat.Extension.builder().extension(file.getExtension()).build());
+      builder.fileFormat(FileFormat.Extension.builder().extension(file.getExtension()).build());
     }
     if (file.hasUriFile()) {
       builder.pathType(FileOrFiles.PathType.URI_FILE).path(file.getUriFile());
@@ -534,7 +530,7 @@ public class ProtoRelConverter {
     List<Expression.StructLiteral> structLiterals = new ArrayList<>(virtualTable.getValuesCount());
     for (var struct : virtualTable.getValuesList()) {
       structLiterals.add(
-          ImmutableExpression.StructLiteral.builder()
+          Expression.StructLiteral.builder()
               .fields(
                   struct.getFieldsList().stream()
                       .map(converter::from)

--- a/core/src/main/java/io/substrait/relation/files/FileFormat.java
+++ b/core/src/main/java/io/substrait/relation/files/FileFormat.java
@@ -56,5 +56,9 @@ public interface FileFormat {
   @Value.Immutable
   abstract static class Extension implements FileFormat {
     public abstract com.google.protobuf.Any getExtension();
+
+    public static ImmutableFileFormat.Extension.Builder builder() {
+      return ImmutableFileFormat.Extension.builder();
+    }
   }
 }

--- a/core/src/main/java/io/substrait/relation/files/FileOrFiles.java
+++ b/core/src/main/java/io/substrait/relation/files/FileOrFiles.java
@@ -26,6 +26,10 @@ public interface FileOrFiles {
 
   Optional<FileFormat> getFileFormat();
 
+  static ImmutableFileOrFiles.Builder builder() {
+    return ImmutableFileOrFiles.builder();
+  }
+
   default ReadRel.LocalFiles.FileOrFiles toProto() {
     ReadRel.LocalFiles.FileOrFiles.Builder builder = ReadRel.LocalFiles.FileOrFiles.newBuilder();
 

--- a/core/src/main/java/io/substrait/type/NamedStruct.java
+++ b/core/src/main/java/io/substrait/type/NamedStruct.java
@@ -11,6 +11,10 @@ public interface NamedStruct {
 
   List<String> names();
 
+  static ImmutableNamedStruct.Builder builder() {
+    return ImmutableNamedStruct.builder();
+  }
+
   static NamedStruct of(Iterable<String> names, Type.Struct type) {
     return ImmutableNamedStruct.builder().addAllNames(names).struct(type).build();
   }

--- a/core/src/test/java/io/substrait/extendedexpression/ExtendedExpressionRoundTripTest.java
+++ b/core/src/test/java/io/substrait/extendedexpression/ExtendedExpressionRoundTripTest.java
@@ -5,7 +5,7 @@ import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.*;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.relation.Aggregate;
-import io.substrait.type.ImmutableNamedStruct;
+import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ public class ExtendedExpressionRoundTripTest extends TestBase {
   public void testRoundTrip(ExtendedExpression.ExpressionReferenceBase expressionReference) {
     List<ExtendedExpression.ExpressionReferenceBase> expressionReferences = new ArrayList<>();
     expressionReferences.add(expressionReference);
-    ImmutableNamedStruct namedStruct = getImmutableNamedStruct();
+    NamedStruct namedStruct = getImmutableNamedStruct();
     assertExtendedExpressionOperation(expressionReferences, namedStruct);
   }
 
@@ -120,8 +120,8 @@ public class ExtendedExpressionRoundTripTest extends TestBase {
         .build();
   }
 
-  private static ImmutableNamedStruct getImmutableNamedStruct() {
-    return ImmutableNamedStruct.builder()
+  private static NamedStruct getImmutableNamedStruct() {
+    return NamedStruct.builder()
         .addNames("N_NATIONKEY", "N_NAME", "N_REGIONKEY", "N_COMMENT")
         .struct(
             Type.Struct.builder()
@@ -137,7 +137,7 @@ public class ExtendedExpressionRoundTripTest extends TestBase {
 
   private static void assertExtendedExpressionOperation(
       List<ExtendedExpression.ExpressionReferenceBase> expressionReferences,
-      ImmutableNamedStruct namedStruct) {
+      NamedStruct namedStruct) {
 
     // initial pojo
     ExtendedExpression extendedExpressionPojoInitial =

--- a/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
@@ -7,10 +7,8 @@ import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FunctionOption;
-import io.substrait.expression.ImmutableExpression;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.relation.Aggregate;
-import io.substrait.relation.ImmutableAggregate;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.RelProtoConverter;
 import io.substrait.relation.VirtualTableScan;
@@ -26,7 +24,7 @@ public class AggregateRoundtripTest extends TestBase {
   private void assertAggregateRoundtrip(Expression.AggregationInvocation invocation) {
     var expression = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
     Expression.StructLiteral literal =
-        ImmutableExpression.StructLiteral.builder().addFields(expression).build();
+        Expression.StructLiteral.builder().addFields(expression).build();
     var input =
         VirtualTableScan.builder()
             .initialSchema(NamedStruct.of(Arrays.asList("decimal"), R.struct(R.decimal(10, 2))))
@@ -62,7 +60,7 @@ public class AggregateRoundtripTest extends TestBase {
                     .build())
             .build();
 
-    var aggRel = ImmutableAggregate.builder().input(input).measures(Arrays.asList(measure)).build();
+    var aggRel = Aggregate.builder().input(input).measures(Arrays.asList(measure)).build();
     var protoAggRel = to.toProto(aggRel);
     assertEquals(
         protoAggRel.getAggregate().getMeasuresList().get(0).getMeasure().getInvocation(),

--- a/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
@@ -5,11 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.substrait.TestBase;
 import io.substrait.expression.Expression;
 import io.substrait.expression.FunctionOption;
-import io.substrait.expression.ImmutableWindowBound;
+import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.relation.ConsistentPartitionWindow;
-import io.substrait.relation.ImmutableConsistentPartitionWindow;
 import io.substrait.relation.Rel;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,7 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
             Arrays.asList("a", "b", "c"),
             Arrays.asList(R.I64, R.I16, R.I32));
     Rel rel1 =
-        ImmutableConsistentPartitionWindow.builder()
+        ConsistentPartitionWindow.builder()
             .input(input)
             .windowFunctions(
                 Arrays.asList(
@@ -45,8 +44,8 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
                         .outputType(R.I64)
                         .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
                         .invocation(Expression.AggregationInvocation.ALL)
-                        .lowerBound(ImmutableWindowBound.Unbounded.UNBOUNDED)
-                        .upperBound(ImmutableWindowBound.Following.CURRENT_ROW)
+                        .lowerBound(WindowBound.Unbounded.UNBOUNDED)
+                        .upperBound(WindowBound.Following.CURRENT_ROW)
                         .boundsType(Expression.WindowBoundsType.RANGE)
                         .build()))
             // PARTITION BY b
@@ -85,7 +84,7 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
             Arrays.asList("a", "b", "c"),
             Arrays.asList(R.I64, R.I16, R.I32));
     Rel rel1 =
-        ImmutableConsistentPartitionWindow.builder()
+        ConsistentPartitionWindow.builder()
             .input(input)
             .windowFunctions(
                 Arrays.asList(
@@ -102,8 +101,8 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
                         .outputType(R.I64)
                         .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
                         .invocation(Expression.AggregationInvocation.ALL)
-                        .lowerBound(ImmutableWindowBound.Unbounded.UNBOUNDED)
-                        .upperBound(ImmutableWindowBound.Following.CURRENT_ROW)
+                        .lowerBound(WindowBound.Unbounded.UNBOUNDED)
+                        .upperBound(WindowBound.Following.CURRENT_ROW)
                         .boundsType(Expression.WindowBoundsType.RANGE)
                         .build(),
                     ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
@@ -119,8 +118,8 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
                         .outputType(R.I64)
                         .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
                         .invocation(Expression.AggregationInvocation.ALL)
-                        .lowerBound(ImmutableWindowBound.Unbounded.UNBOUNDED)
-                        .upperBound(ImmutableWindowBound.Following.CURRENT_ROW)
+                        .lowerBound(WindowBound.Unbounded.UNBOUNDED)
+                        .upperBound(WindowBound.Following.CURRENT_ROW)
                         .boundsType(Expression.WindowBoundsType.RANGE)
                         .build()))
             // PARTITION BY b

--- a/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
@@ -6,13 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.substrait.TestBase;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FieldReference;
-import io.substrait.expression.ImmutableFieldReference;
 import io.substrait.proto.ReadRel;
 import io.substrait.relation.LocalFiles;
+import io.substrait.relation.files.FileFormat;
 import io.substrait.relation.files.FileOrFiles;
-import io.substrait.relation.files.ImmutableFileFormat;
 import io.substrait.relation.files.ImmutableFileOrFiles;
-import io.substrait.type.ImmutableNamedStruct;
+import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.Arrays;
@@ -24,7 +23,7 @@ public class LocalFilesRoundtripTest extends TestBase {
     var builder =
         LocalFiles.builder()
             .initialSchema(
-                ImmutableNamedStruct.builder()
+                NamedStruct.builder()
                     .addNames("id")
                     .struct(
                         Type.Struct.builder()
@@ -42,7 +41,7 @@ public class LocalFilesRoundtripTest extends TestBase {
                 ExpressionCreator.scalarFunction(
                     declaration,
                     TypeCreator.REQUIRED.BOOLEAN,
-                    ImmutableFieldReference.builder()
+                    FieldReference.builder()
                         .addSegments(FieldReference.StructField.of(0))
                         .type(TypeCreator.REQUIRED.I32)
                         .build(),
@@ -71,12 +70,12 @@ public class LocalFilesRoundtripTest extends TestBase {
       ImmutableFileOrFiles.Builder builder,
       ReadRel.LocalFiles.FileOrFiles.FileFormatCase fileFormatCase) {
     return switch (fileFormatCase) {
-      case PARQUET -> builder.fileFormat(ImmutableFileFormat.ParquetReadOptions.builder().build());
-      case ARROW -> builder.fileFormat(ImmutableFileFormat.ArrowReadOptions.builder().build());
-      case ORC -> builder.fileFormat(ImmutableFileFormat.OrcReadOptions.builder().build());
-      case DWRF -> builder.fileFormat(ImmutableFileFormat.DwrfReadOptions.builder().build());
+      case PARQUET -> builder.fileFormat(FileFormat.ParquetReadOptions.builder().build());
+      case ARROW -> builder.fileFormat(FileFormat.ArrowReadOptions.builder().build());
+      case ORC -> builder.fileFormat(FileFormat.OrcReadOptions.builder().build());
+      case DWRF -> builder.fileFormat(FileFormat.DwrfReadOptions.builder().build());
       case TEXT -> builder.fileFormat(
-          ImmutableFileFormat.DelimiterSeparatedTextReadOptions.builder()
+          FileFormat.DelimiterSeparatedTextReadOptions.builder()
               .fieldDelimiter("|")
               .maxLineSize(1000)
               .quote("\"")
@@ -84,7 +83,7 @@ public class LocalFilesRoundtripTest extends TestBase {
               .escape("\\")
               .build());
       case EXTENSION -> builder.fileFormat(
-          ImmutableFileFormat.Extension.builder()
+          FileFormat.Extension.builder()
               .extension(com.google.protobuf.Any.newBuilder().build())
               .build());
       case FILEFORMAT_NOT_SET -> builder;
@@ -101,7 +100,7 @@ public class LocalFilesRoundtripTest extends TestBase {
                         pathTypeCase ->
                             assertLocalFilesRoundtrip(
                                 setFileFormat(
-                                        setPath(ImmutableFileOrFiles.builder(), pathTypeCase),
+                                        setPath(FileOrFiles.builder(), pathTypeCase),
                                         fileFormatCase)
                                     .partitionIndex(0)
                                     .start(2)

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -3,7 +3,7 @@ package io.substrait.type.proto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.substrait.extension.ExtensionCollector;
-import io.substrait.extension.ImmutableSimpleExtension;
+import io.substrait.extension.SimpleExtension;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,8 +46,7 @@ public class TestTypeRoundtrip {
   private TypeProtoConverter typeProtoConverter = new TypeProtoConverter(lookup);
 
   private ProtoTypeConverter protoTypeConverter =
-      new ProtoTypeConverter(
-          lookup, ImmutableSimpleExtension.ExtensionCollection.builder().build());
+      new ProtoTypeConverter(lookup, SimpleExtension.ExtensionCollection.builder().build());
 
   /*
    * Test a type pojo -> proto -> pojo roundtrip.

--- a/isthmus/src/main/java/io/substrait/isthmus/PreCalciteAggregateValidator.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/PreCalciteAggregateValidator.java
@@ -4,8 +4,6 @@ import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.FunctionArg;
-import io.substrait.expression.ImmutableExpression;
-import io.substrait.expression.ImmutableFieldReference;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.Project;
 import java.util.ArrayList;
@@ -161,7 +159,7 @@ public class PreCalciteAggregateValidator {
               .map(this::projectOutNonFieldReference)
               .collect(Collectors.toList());
 
-      List<ImmutableExpression.SortField> newSortFields =
+      List<Expression.SortField> newSortFields =
           oldAggregateFunctionInvocation.sort().stream()
               .map(
                   sf ->
@@ -217,7 +215,7 @@ public class PreCalciteAggregateValidator {
      */
     private Expression projectOut(Expression expr) {
       newExpressions.add(expr);
-      return ImmutableFieldReference.builder()
+      return FieldReference.builder()
           // create a field reference to the new expression, then update the expression offset
           .addSegments(FieldReference.StructField.of(expressionOffset++))
           .type(expr.getType())

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -1,8 +1,6 @@
 package io.substrait.isthmus;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.substrait.plan.ImmutablePlan.Builder;
-import io.substrait.plan.ImmutableVersion;
 import io.substrait.plan.Plan.Version;
 import io.substrait.plan.PlanProtoConverter;
 import io.substrait.proto.Plan;
@@ -57,9 +55,8 @@ public class SqlToSubstrait extends SqlConverterBase {
 
   private Plan executeInner(String sql, SqlValidator validator, Prepare.CatalogReader catalogReader)
       throws SqlParseException {
-    Builder builder = io.substrait.plan.Plan.builder();
-    builder.version(
-        ImmutableVersion.builder().from(Version.DEFAULT_VERSION).producer("isthmus").build());
+    var builder = io.substrait.plan.Plan.builder();
+    builder.version(Version.builder().from(Version.DEFAULT_VERSION).producer("isthmus").build());
 
     // TODO: consider case in which one sql passes conversion while others don't
     sqlToRelNode(sql, validator, catalogReader).stream()

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -3,7 +3,6 @@ package io.substrait.isthmus.expression;
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
-import io.substrait.expression.ImmutableExpression;
 import io.substrait.isthmus.*;
 import io.substrait.type.Type;
 import java.util.ArrayList;
@@ -106,7 +105,7 @@ public class CallConverters {
         var caseConditions = new ArrayList<Expression.IfClause>();
         for (int i = 0; i < last; i += 2) {
           caseConditions.add(
-              ImmutableExpression.IfClause.builder()
+              Expression.IfClause.builder()
                   .condition(caseArgs.get(i))
                   .then(caseArgs.get(i + 1))
                   .build());

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.ScalarFunctionInvocation;
 import io.substrait.expression.ExpressionCreator;
-import io.substrait.expression.ImmutableEnumArg;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.isthmus.expression.CallConverters;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
@@ -75,7 +75,7 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_tstz_str",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("MONTH").build(),
             Expression.TimestampTZLiteral.builder().value(0).build(),
             Expression.StrLiteral.builder().value("GMT").build());
 
@@ -96,7 +96,7 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_ptstz_str",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("MONTH").build(),
             Expression.PrecisionTimestampTZLiteral.builder().value(0).precision(6).build(),
             Expression.StrLiteral.builder().value("GMT").build());
 
@@ -117,7 +117,7 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_ts",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("MONTH").build(),
             Expression.TimestampLiteral.builder().value(0).build());
 
     RexNode calciteExpr = reqTsFn.accept(expressionRexConverter);
@@ -135,7 +135,7 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_pts",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("MONTH").build(),
             Expression.PrecisionTimestampLiteral.builder().value(0).precision(6).build());
 
     RexNode calciteExpr = reqPtsFn.accept(expressionRexConverter);
@@ -153,7 +153,7 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_date",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("MONTH").build(),
             Expression.DateLiteral.builder().value(0).build());
 
     RexNode calciteExpr = reqDateFn.accept(expressionRexConverter);
@@ -171,7 +171,7 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_time",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MINUTE").build(),
+            EnumArg.builder().value("MINUTE").build(),
             Expression.TimeLiteral.builder().value(0).build());
 
     RexNode calciteExpr = reqTimeFn.accept(expressionRexConverter);
@@ -189,8 +189,8 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_req_tstz_str",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
-            ImmutableEnumArg.builder().value("ONE").build(),
+            EnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("ONE").build(),
             Expression.TimestampTZLiteral.builder().value(0).build(),
             Expression.StrLiteral.builder().value("GMT").build());
 
@@ -205,8 +205,8 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_req_ptstz_str",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
-            ImmutableEnumArg.builder().value("ONE").build(),
+            EnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("ONE").build(),
             Expression.PrecisionTimestampTZLiteral.builder().value(0).precision(6).build(),
             Expression.StrLiteral.builder().value("GMT").build());
 
@@ -221,8 +221,8 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_req_ts",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
-            ImmutableEnumArg.builder().value("ONE").build(),
+            EnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("ONE").build(),
             Expression.TimestampLiteral.builder().value(0).build());
 
     assertThrows(
@@ -236,8 +236,8 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_req_pts",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
-            ImmutableEnumArg.builder().value("ONE").build(),
+            EnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("ONE").build(),
             Expression.PrecisionTimestampLiteral.builder().value(0).precision(6).build());
 
     assertThrows(
@@ -251,8 +251,8 @@ public class FunctionConversionTest extends PlanTestBase {
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "extract:req_req_date",
             TypeCreator.REQUIRED.I64,
-            ImmutableEnumArg.builder().value("MONTH").build(),
-            ImmutableEnumArg.builder().value("ONE").build(),
+            EnumArg.builder().value("MONTH").build(),
+            EnumArg.builder().value("ONE").build(),
             Expression.DateLiteral.builder().value(0).build());
 
     assertThrows(

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.substrait.SparkTypeUtil
 
-import io.substrait.expression.{EnumArg, Expression => SExpression, ExpressionCreator, FieldReference, ImmutableEnumArg, ImmutableExpression}
+import io.substrait.expression.{EnumArg, Expression => SExpression, ExpressionCreator, FieldReference}
 import io.substrait.expression.Expression.FailureBehavior
 import io.substrait.utils.Util
 
@@ -138,7 +138,7 @@ abstract class ToSubstraitExpression extends HasOutputStack[Seq[Attribute]] {
           p =>
             translateUp(trueValue).map(
               t => {
-                ImmutableExpression.IfClause.builder
+                SExpression.IfClause.builder
                   .condition(p)
                   .`then`(t)
                   .build()

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -38,10 +38,10 @@ import io.substrait.debug.TreePrinter
 import io.substrait.expression.{Expression => SExpression, ExpressionCreator}
 import io.substrait.extension.ExtensionCollector
 import io.substrait.hint.Hint
-import io.substrait.plan.{ImmutableRoot, ImmutableVersion, Plan}
+import io.substrait.plan.Plan
 import io.substrait.relation.RelProtoConverter
 import io.substrait.relation.Set.SetOp
-import io.substrait.relation.files.{FileFormat, ImmutableFileOrFiles}
+import io.substrait.relation.files.{FileFormat, FileOrFiles}
 import io.substrait.relation.files.FileOrFiles.PathType
 import io.substrait.utils.Util
 
@@ -486,7 +486,7 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
         fsRelation.location.inputFiles
           .map(
             file => {
-              ImmutableFileOrFiles
+              FileOrFiles
                 .builder()
                 .fileFormat(format)
                 .partitionIndex(0)
@@ -544,14 +544,14 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
     val rel = visit(p)
     Plan.builder
       .version(
-        ImmutableVersion
+        Plan.Version
           .builder()
           .from(Plan.Version.DEFAULT_VERSION)
           .producer("substrait-spark")
           .build())
       .roots(
         Collections.singletonList(
-          ImmutableRoot
+          Plan.Root
             .builder()
             .input(rel)
             .addAllNames(ToSubstraitType.toNamedStruct(p.schema).names())


### PR DESCRIPTION
Some of the non-core code is directly importing and invoking the object factories that are generated at build time from the immutables annotations.  This commit changes the code to (where possible) use the parent class methods.