### PR TITLE
Add support of ddl and dml sql statements to SqlToSubstrait

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/DdlRelBuilder.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/DdlRelBuilder.java
@@ -1,0 +1,123 @@
+package io.substrait.isthmus.expression;
+
+import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.extension.SimpleExtension;
+import io.substrait.isthmus.FeatureBoard;
+import io.substrait.isthmus.SubstraitRelVisitor;
+import io.substrait.isthmus.TypeConverter;
+import io.substrait.plan.Plan;
+import io.substrait.relation.AbstractDdlRel;
+import io.substrait.relation.AbstractWriteRel;
+import io.substrait.relation.NamedDdl;
+import io.substrait.relation.NamedWrite;
+import io.substrait.type.NamedStruct;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.ddl.SqlCreateTable;
+import org.apache.calcite.sql.ddl.SqlCreateView;
+import org.apache.calcite.sql.util.SqlBasicVisitor;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+
+public class DdlRelBuilder extends SqlBasicVisitor<Plan.Root> {
+  protected final Map<Class<? extends SqlCall>, Function<SqlCall, Plan.Root>> createHandlers =
+      new ConcurrentHashMap<>();
+
+  private final SqlToRelConverter converter;
+  private final BiFunction<SqlToRelConverter, SqlNode, RelRoot> bestExpRelRootGetter;
+  private final SimpleExtension.ExtensionCollection extensionCollection;
+  private final FeatureBoard featureBoard;
+
+  private Function<SqlCall, Plan.Root> findCreateHandler(final SqlCall call) {
+    Class<?> currentClass = call.getClass();
+    while (SqlCall.class.isAssignableFrom(currentClass)) {
+      final Function<SqlCall, Plan.Root> found = createHandlers.get(currentClass);
+      if (found != null) {
+        return found;
+      }
+      currentClass = currentClass.getSuperclass();
+    }
+    return null;
+  }
+
+  public DdlRelBuilder(
+      final SqlToRelConverter converter,
+      final BiFunction<SqlToRelConverter, SqlNode, RelRoot> bestExpRelRootGetter,
+      final SimpleExtension.ExtensionCollection extensionCollection,
+      final FeatureBoard featureBoard) {
+    super();
+    this.converter = converter;
+    this.bestExpRelRootGetter = bestExpRelRootGetter;
+    this.extensionCollection = extensionCollection;
+    this.featureBoard = featureBoard;
+
+    createHandlers.put(
+        SqlCreateTable.class, sqlCall -> handleCreateTable((SqlCreateTable) sqlCall));
+    createHandlers.put(SqlCreateView.class, sqlCall -> handleCreateView((SqlCreateView) sqlCall));
+  }
+
+  @Override
+  public Plan.Root visit(final SqlCall sqlCall) {
+    Function<SqlCall, Plan.Root> createHandler = findCreateHandler(sqlCall);
+    if (createHandler == null) {
+      return null;
+    }
+
+    return createHandler.apply(sqlCall);
+  }
+
+  private NamedStruct getSchema(final RelRoot queryRelRoot) {
+    final RelDataType rowType = queryRelRoot.rel.getRowType();
+
+    final TypeConverter typeConverter = TypeConverter.DEFAULT;
+    return typeConverter.toNamedStruct(rowType);
+  }
+
+  public Plan.Root handleCreateTable(final SqlCreateTable sqlCreateTable) {
+    if (sqlCreateTable.query == null) {
+      throw new IllegalArgumentException("Only create table as select statements are supported");
+    }
+
+    final RelRoot queryRelRoot = bestExpRelRootGetter.apply(converter, sqlCreateTable.query);
+
+    NamedStruct schema = getSchema(queryRelRoot);
+
+    var rel = SubstraitRelVisitor.convert(queryRelRoot, extensionCollection, featureBoard);
+    NamedWrite namedWrite =
+        NamedWrite.builder()
+            .input(rel.getInput())
+            .tableSchema(schema)
+            .operation(AbstractWriteRel.WriteOp.CTAS)
+            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
+            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
+            .names(sqlCreateTable.name.names)
+            .build();
+
+    return Plan.Root.builder().input(namedWrite).build();
+  }
+
+  Plan.Root handleCreateView(final SqlCreateView sqlCreateView) {
+
+    final RelRoot queryRelRoot = bestExpRelRootGetter.apply(converter, sqlCreateView.query);
+    var rel = SubstraitRelVisitor.convert(queryRelRoot, extensionCollection, featureBoard);
+    final Expression.StructLiteral defaults = ExpressionCreator.struct(false);
+
+    final NamedDdl namedDdl =
+        NamedDdl.builder()
+            .viewDefinition(rel.getInput())
+            .tableSchema(getSchema(queryRelRoot))
+            .tableDefaults(defaults)
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .names(sqlCreateView.name.names)
+            .build();
+
+    return Plan.Root.builder().input(namedDdl).build();
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/SqlToSubstraitTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SqlToSubstraitTest.java
@@ -1,0 +1,29 @@
+package io.substrait.isthmus;
+
+import io.substrait.plan.Plan;
+import java.io.IOException;
+import java.util.List;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Test;
+
+public class SqlToSubstraitTest extends PlanTestBase {
+
+  @Test
+  void testDdlDml() throws SqlParseException, IOException {
+    final String sqlStatements = asString("sqltosubstrait/sqltosubstrait.sql");
+
+    SqlToSubstrait sql2subst = new SqlToSubstrait();
+    final List<io.substrait.plan.Plan.Root> relRoots =
+        sql2subst.sqlToPlanNodes(
+            sqlStatements,
+            List.of(
+                "create table src1 (intcol int, charcol varchar(10))",
+                "create table src2 (intcol int, charcol varchar(10))"));
+    var builder = io.substrait.plan.Plan.builder();
+    for (final io.substrait.plan.Plan.Root planRoot : relRoots) {
+      builder.addRoots(planRoot);
+    }
+    final Plan plan = builder.build();
+    assertPlanRoundtrip(plan);
+  }
+}

--- a/isthmus/src/test/resources/sqltosubstrait/sqltosubstrait.sql
+++ b/isthmus/src/test/resources/sqltosubstrait/sqltosubstrait.sql
@@ -1,0 +1,6 @@
+delete from src1 where intcol=10;
+update src1 set intcol=10 where charcol='a';
+insert into src1(intcol, charcol) values (1,'a');
+insert into src1 select * from src2;
+create view dst1 as select * from src1;
+create table dst1 as select * from src1;


### PR DESCRIPTION
DDL:

For the above mentioned sql statements create the following relations:
- `NamedWrite` for `create table as`
- `NamedDdl` for `create view`
All other types of sql statements are handled as before.

DML:

The class `SubstraitRelVisitor` now supports the following operations for the `TableModify` node:
- insert
- update
- delete