### PR TITLE
feat(spark): support insert/append operations

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/FileHolder.scala
+++ b/spark/src/main/scala/io/substrait/spark/FileHolder.scala
@@ -1,0 +1,22 @@
+package io.substrait.spark
+
+import com.google.protobuf
+import io.substrait.extension.ExtensionLookup
+import io.substrait.relation.{ProtoRelConverter, RelProtoConverter}
+import io.substrait.relation.Extension.WriteExtensionObject
+import io.substrait.relation.files.FileOrFiles
+
+case class FileHolder(fileOrFiles: FileOrFiles) extends WriteExtensionObject {
+
+  override def toProto(converter: RelProtoConverter): protobuf.Any = {
+    protobuf.Any.pack(fileOrFiles.toProto)
+  }
+}
+
+class FileHolderHandlingProtoRelConverter(lookup: ExtensionLookup)
+  extends ProtoRelConverter(lookup) {
+  override def detailFromWriteExtensionObject(any: protobuf.Any): WriteExtensionObject = {
+    FileHolder(
+      newFileOrFiles(any.unpack(classOf[io.substrait.proto.ReadRel.LocalFiles.FileOrFiles])))
+  }
+}


### PR DESCRIPTION
Partial implementation of the substrait WriteRel relation in order to support conversion of Spark insert and append operations.

Added tests for inserting to in-memory database tables and appending to local files.

A few things to note / discuss:
- Writing to the filesystem requires information of file path, format, etc.  To do this, I used the `ExtensionWrite` relation, and embedded a `ReadRel.LocalFiles.FileOrFiles` message as the extension detail.  This then requires the use of the extension's ProtoRelConverter to unpack the proto message.
- Since this might be a common scenario, it might be cleaner to extend the `WriteRel` proto message to also support a `LocalFiles` write_type in the same way that the `ReadRel` has a `LocalFiles` read_type. What do you think?  
- Would it also make sense to make `FileOrFiles` a top-level message so that it could be re-used in this way?