### PR TITLE
feat(core,isthmus): add dml support to SqlToSubstrait

### DIFF
--- a/isthmus/src/test/java/io/substrait/isthmus/DmlRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DmlRoundtripTest.java
@@ -1,0 +1,33 @@
+package io.substrait.isthmus;
+
+import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Test;
+
+public class DmlRoundtripTest extends PlanTestBase {
+
+  final Prepare.CatalogReader catalogReader =
+      SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+          "create table src1 (intcol int, charcol varchar(10))",
+          "create table src2 (intcol int, charcol varchar(10))");
+
+  public DmlRoundtripTest() throws SqlParseException {}
+
+  @Test
+  void testDelete() throws SqlParseException {
+    assertFullRoundTrip("delete from src1 where intcol=10", catalogReader);
+  }
+
+  @Test
+  void testUpdate() throws SqlParseException {
+    assertFullRoundTrip("update src1 set intcol=10 where charcol='a'", catalogReader);
+  }
+
+  @Test
+  void testInsert() throws SqlParseException {
+    assertFullRoundTrip("insert into src1 (intcol, charcol) values (1,'a'); ", catalogReader);
+    assertFullRoundTrip(
+        "insert into src1 (intcol, charcol) select intcol,charcol from src2;", catalogReader);
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -196,7 +196,10 @@ public class PlanTestBase {
     assertEquals(pojo1, pojo2);
 
     // Substrait POJO 2 -> Calcite 2
-    RelRoot calcite2 = new SubstraitToCalcite(extensions, typeFactory).convert(pojo2);
+    final SubstraitToCalcite substraitToCalcite =
+        new SubstraitToCalcite(extensions, typeFactory, catalogReader);
+
+    RelRoot calcite2 = substraitToCalcite.convert(pojo2);
     // It would be ideal to compare calcite1 and calcite2, however there isn't a good mechanism to
     // do so
     assertNotNull(calcite2);


### PR DESCRIPTION
As discussed, splitting the PR https://github.com/substrait-io/substrait-java/pull/428 into dml and ddl parts. This PR is for dml support.

The class `SubstraitRelVisitor` now supports the following operations for the `TableModify` node:

- insert
- update
- delete