### PR TITLE
chore: avoid Java version mismatch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
   implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
   annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
   compileOnly("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
-  annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
-  compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
 val submodulesUpdate by
@@ -41,20 +39,10 @@ allprojects {
   repositories { mavenCentral() }
 
   tasks.configureEach<Test> {
-    val javaToolchains = project.extensions.getByType<JavaToolchainService>()
     useJUnitPlatform()
-    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
     testLogging { exceptionFormat = TestExceptionFormat.FULL }
   }
-  tasks.withType<JavaCompile> {
-    sourceCompatibility = "17"
-    if (project.name != "core") {
-      options.release.set(11)
-    } else {
-      options.release.set(8)
-    }
-    dependsOn(submodulesUpdate)
-  }
+  tasks.withType<JavaCompile> { dependsOn(submodulesUpdate) }
 
   group = "io.substrait"
   version = "${version}"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -128,8 +128,6 @@ dependencies {
   implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
   annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
   compileOnly("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
-  annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
-  compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
 }
 
 configurations[JavaPlugin.API_CONFIGURATION_NAME].let { apiConfiguration ->
@@ -233,12 +231,12 @@ tasks {
   jar { manifest { from("build/generated/sources/manifest/META-INF/MANIFEST.MF") } }
 }
 
+// Set the release instead of using a Java 8 toolchain since ANTLR requires Java 11+ to run
+tasks.withType<JavaCompile>().configureEach { options.release = 8 }
+
 java {
-  toolchain {
-    languageVersion.set(JavaLanguageVersion.of(17))
-    withJavadocJar()
-    withSourcesJar()
-  }
+  withJavadocJar()
+  withSourcesJar()
 }
 
 configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -833,7 +833,7 @@ public interface Expression extends FunctionArg {
 
     public static WindowBoundsType fromProto(
         io.substrait.proto.Expression.WindowFunction.BoundsType proto) {
-      for (var v : values()) {
+      for (WindowBoundsType v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -984,7 +984,7 @@ public interface Expression extends FunctionArg {
 
     public static PredicateOp fromProto(
         io.substrait.proto.Expression.Subquery.SetPredicate.PredicateOp proto) {
-      for (var v : values()) {
+      for (PredicateOp v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -1010,7 +1010,7 @@ public interface Expression extends FunctionArg {
     }
 
     public static AggregationInvocation fromProto(AggregateFunction.AggregationInvocation proto) {
-      for (var v : values()) {
+      for (AggregationInvocation v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -1041,7 +1041,7 @@ public interface Expression extends FunctionArg {
     }
 
     public static AggregationPhase fromProto(io.substrait.proto.AggregationPhase proto) {
-      for (var v : values()) {
+      for (AggregationPhase v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -1069,7 +1069,7 @@ public interface Expression extends FunctionArg {
     }
 
     public static SortDirection fromProto(io.substrait.proto.SortField.SortDirection proto) {
-      for (var v : values()) {
+      for (SortDirection v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -1097,7 +1097,7 @@ public interface Expression extends FunctionArg {
 
     public static FailureBehavior fromProto(
         io.substrait.proto.Expression.Cast.FailureBehavior proto) {
-      for (var v : values()) {
+      for (FailureBehavior v : values()) {
         if (v.proto == proto) {
           return v;
         }

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -7,6 +7,7 @@ import io.substrait.relation.ConsistentPartitionWindow;
 import io.substrait.type.Type;
 import io.substrait.util.DecimalUtil;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -89,7 +90,7 @@ public class ExpressionCreator {
    */
   @Deprecated
   public static Expression.TimestampLiteral timestamp(boolean nullable, LocalDateTime value) {
-    var epochMicro =
+    long epochMicro =
         TimeUnit.SECONDS.toMicros(value.toEpochSecond(ZoneOffset.UTC))
             + TimeUnit.NANOSECONDS.toMicros(value.toLocalTime().getNano());
     return timestamp(nullable, epochMicro);
@@ -127,7 +128,7 @@ public class ExpressionCreator {
    */
   @Deprecated
   public static Expression.TimestampTZLiteral timestampTZ(boolean nullable, Instant value) {
-    var epochMicro =
+    long epochMicro =
         TimeUnit.SECONDS.toMicros(value.getEpochSecond())
             + TimeUnit.NANOSECONDS.toMicros(value.getNano());
     return timestampTZ(nullable, epochMicro);
@@ -195,7 +196,7 @@ public class ExpressionCreator {
   }
 
   public static Expression.UUIDLiteral uuid(boolean nullable, ByteString uuid) {
-    var bb = uuid.asReadOnlyByteBuffer();
+    ByteBuffer bb = uuid.asReadOnlyByteBuffer();
     return Expression.UUIDLiteral.builder()
         .nullable(nullable)
         .value(new UUID(bb.getLong(), bb.getLong()))
@@ -237,7 +238,7 @@ public class ExpressionCreator {
 
   public static Expression.DecimalLiteral decimal(
       boolean nullable, BigDecimal value, int precision, int scale) {
-    var twosComplement = DecimalUtil.encodeDecimalIntoBytes(value, scale, 16);
+    byte[] twosComplement = DecimalUtil.encodeDecimalIntoBytes(value, scale, 16);
 
     return Expression.DecimalLiteral.builder()
         .nullable(nullable)

--- a/core/src/main/java/io/substrait/expression/FieldReference.java
+++ b/core/src/main/java/io/substrait/expression/FieldReference.java
@@ -225,7 +225,7 @@ public abstract class FieldReference implements Expression {
     Collections.reverse(segments);
     for (int i = 0; i < segments.size(); i++) {
       if (i == 0) {
-        var last = segments.get(0);
+        ReferenceSegment last = segments.get(0);
         reference =
             struct == null ? last.constructOnExpression(expression) : last.constructOnRoot(struct);
       } else {

--- a/core/src/main/java/io/substrait/extendedexpression/ExtendedExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/extendedexpression/ExtendedExpressionProtoConverter.java
@@ -26,7 +26,10 @@ public class ExtendedExpressionProtoConverter {
     for (io.substrait.extendedexpression.ExtendedExpression.ExpressionReferenceBase
         expressionReference : extendedExpression.getReferredExpressions()) {
       if (expressionReference
-          instanceof io.substrait.extendedexpression.ExtendedExpression.ExpressionReference et) {
+          instanceof io.substrait.extendedexpression.ExtendedExpression.ExpressionReference) {
+        io.substrait.extendedexpression.ExtendedExpression.ExpressionReference et =
+            (io.substrait.extendedexpression.ExtendedExpression.ExpressionReference)
+                expressionReference;
         io.substrait.proto.Expression expressionProto =
             et.getExpression().accept(expressionProtoConverter, EmptyVisitationContext.INSTANCE);
         ExpressionReference.Builder expressionReferenceBuilder =
@@ -36,8 +39,10 @@ public class ExtendedExpressionProtoConverter {
         builder.addReferredExpr(expressionReferenceBuilder);
       } else if (expressionReference
           instanceof
-          io.substrait.extendedexpression.ExtendedExpression.AggregateFunctionReference
-          aft) {
+          io.substrait.extendedexpression.ExtendedExpression.AggregateFunctionReference) {
+        io.substrait.extendedexpression.ExtendedExpression.AggregateFunctionReference aft =
+            (io.substrait.extendedexpression.ExtendedExpression.AggregateFunctionReference)
+                expressionReference;
         ExpressionReference.Builder expressionReferenceBuilder =
             ExpressionReference.newBuilder()
                 .setMeasure(

--- a/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
@@ -15,7 +15,7 @@ public abstract class AbstractExtensionLookup implements ExtensionLookup {
 
   public SimpleExtension.ScalarFunctionVariant getScalarFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = functionAnchorMap.get(reference);
+    SimpleExtension.FunctionAnchor anchor = functionAnchorMap.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
@@ -26,7 +26,7 @@ public abstract class AbstractExtensionLookup implements ExtensionLookup {
 
   public SimpleExtension.WindowFunctionVariant getWindowFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = functionAnchorMap.get(reference);
+    SimpleExtension.FunctionAnchor anchor = functionAnchorMap.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
@@ -37,7 +37,7 @@ public abstract class AbstractExtensionLookup implements ExtensionLookup {
 
   public SimpleExtension.AggregateFunctionVariant getAggregateFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = functionAnchorMap.get(reference);
+    SimpleExtension.FunctionAnchor anchor = functionAnchorMap.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown function id. Make sure that the function id provided was shared in the extensions section of the plan.");
@@ -48,7 +48,7 @@ public abstract class AbstractExtensionLookup implements ExtensionLookup {
 
   public SimpleExtension.Type getType(
       int reference, SimpleExtension.ExtensionCollection extensions) {
-    var anchor = typeAnchorMap.get(reference);
+    SimpleExtension.TypeAnchor anchor = typeAnchorMap.get(reference);
     if (anchor == null) {
       throw new IllegalArgumentException(
           "Unknown type id. Make sure that the type id provided was shared in the extensions section of the plan.");

--- a/core/src/main/java/io/substrait/extension/AdvancedExtension.java
+++ b/core/src/main/java/io/substrait/extension/AdvancedExtension.java
@@ -14,7 +14,8 @@ public abstract class AdvancedExtension {
   public abstract Optional<Extension.Enhancement> getEnhancement();
 
   public io.substrait.proto.AdvancedExtension toProto(RelProtoConverter relProtoConverter) {
-    var builder = io.substrait.proto.AdvancedExtension.newBuilder();
+    io.substrait.proto.AdvancedExtension.Builder builder =
+        io.substrait.proto.AdvancedExtension.newBuilder();
     getEnhancement().ifPresent(e -> builder.setEnhancement(e.toProto(relProtoConverter)));
     getOptimizations().forEach(e -> builder.addOptimization(e.toProto(relProtoConverter)));
     return builder.build();

--- a/core/src/main/java/io/substrait/extension/ImmutableExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/ImmutableExtensionLookup.java
@@ -46,12 +46,12 @@ public class ImmutableExtensionLookup extends AbstractExtensionLookup {
         List<SimpleExtensionURI> simpleExtensionURIs,
         List<SimpleExtensionDeclaration> simpleExtensionDeclarations) {
       Map<Integer, String> namespaceMap = new HashMap<>();
-      for (var extension : simpleExtensionURIs) {
+      for (SimpleExtensionURI extension : simpleExtensionURIs) {
         namespaceMap.put(extension.getExtensionUriAnchor(), extension.getUri());
       }
 
       // Add all functions used in plan to the functionMap
-      for (var extension : simpleExtensionDeclarations) {
+      for (SimpleExtensionDeclaration extension : simpleExtensionDeclarations) {
         if (!extension.hasExtensionFunction()) {
           continue;
         }
@@ -68,7 +68,7 @@ public class ImmutableExtensionLookup extends AbstractExtensionLookup {
       }
 
       // Add all types used in plan to the typeMap
-      for (var extension : simpleExtensionDeclarations) {
+      for (SimpleExtensionDeclaration extension : simpleExtensionDeclarations) {
         if (!extension.hasExtensionType()) {
           continue;
         }

--- a/core/src/main/java/io/substrait/hint/Hint.java
+++ b/core/src/main/java/io/substrait/hint/Hint.java
@@ -12,7 +12,8 @@ public abstract class Hint {
   public abstract List<String> getOutputNames();
 
   public RelCommon.Hint toProto() {
-    var builder = RelCommon.Hint.newBuilder().addAllOutputNames(getOutputNames());
+    RelCommon.Hint.Builder builder =
+        RelCommon.Hint.newBuilder().addAllOutputNames(getOutputNames());
     getAlias().ifPresent(builder::setAlias);
     return builder.build();
   }

--- a/core/src/main/java/io/substrait/relation/AbstractDdlRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractDdlRel.java
@@ -33,7 +33,7 @@ public abstract class AbstractDdlRel extends ZeroInputRel {
     }
 
     public static DdlObject fromProto(DdlRel.DdlObject proto) {
-      for (var v : values()) {
+      for (DdlObject v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -61,7 +61,7 @@ public abstract class AbstractDdlRel extends ZeroInputRel {
     }
 
     public static DdlOp fromProto(DdlRel.DdlOp proto) {
-      for (var v : values()) {
+      for (DdlOp v : values()) {
         if (v.proto == proto) {
           return v;
         }

--- a/core/src/main/java/io/substrait/relation/AbstractWriteRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractWriteRel.java
@@ -33,7 +33,7 @@ public abstract class AbstractWriteRel extends SingleInputRel {
     }
 
     public static WriteOp fromProto(WriteRel.WriteOp proto) {
-      for (var v : values()) {
+      for (WriteOp v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -60,7 +60,7 @@ public abstract class AbstractWriteRel extends SingleInputRel {
     }
 
     public static CreateMode fromProto(WriteRel.CreateMode proto) {
-      for (var v : values()) {
+      for (CreateMode v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -85,7 +85,7 @@ public abstract class AbstractWriteRel extends SingleInputRel {
     }
 
     public static OutputMode fromProto(WriteRel.OutputMode proto) {
-      for (var v : values()) {
+      for (OutputMode v : values()) {
         if (v.proto == proto) {
           return v;
         }

--- a/core/src/main/java/io/substrait/relation/AggregateFunctionProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/AggregateFunctionProtoConverter.java
@@ -3,9 +3,13 @@ package io.substrait.relation;
 import io.substrait.expression.FunctionArg;
 import io.substrait.expression.proto.ExpressionProtoConverter;
 import io.substrait.extension.ExtensionCollector;
+import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.AggregateFunction;
+import io.substrait.proto.FunctionArgument;
 import io.substrait.type.proto.TypeProtoConverter;
 import io.substrait.util.EmptyVisitationContext;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -25,9 +29,10 @@ public class AggregateFunctionProtoConverter {
   }
 
   public AggregateFunction toProto(Aggregate.Measure measure) {
-    var argVisitor = FunctionArg.toProto(typeProtoConverter, exprProtoConverter);
-    var args = measure.getFunction().arguments();
-    var aggFuncDef = measure.getFunction().declaration();
+    FunctionArg.FuncArgVisitor<FunctionArgument, EmptyVisitationContext, RuntimeException>
+        argVisitor = FunctionArg.toProto(typeProtoConverter, exprProtoConverter);
+    List<FunctionArg> args = measure.getFunction().arguments();
+    SimpleExtension.AggregateFunctionVariant aggFuncDef = measure.getFunction().declaration();
 
     return AggregateFunction.newBuilder()
         .setPhase(measure.getFunction().aggregationPhase().toProto())
@@ -39,7 +44,7 @@ public class AggregateFunctionProtoConverter {
                     i ->
                         args.get(i)
                             .accept(aggFuncDef, i, argVisitor, EmptyVisitationContext.INSTANCE))
-                .collect(java.util.stream.Collectors.toList()))
+                .collect(Collectors.toList()))
         .setFunctionReference(
             functionCollector.getFunctionReference(measure.getFunction().declaration()))
         .build();

--- a/core/src/main/java/io/substrait/relation/Expand.java
+++ b/core/src/main/java/io/substrait/relation/Expand.java
@@ -53,8 +53,8 @@ public abstract class Expand extends SingleInputRel {
     public abstract List<Expression> getDuplicates();
 
     public Type getType() {
-      var nullable = getDuplicates().stream().anyMatch(d -> d.getType().nullable());
-      var type = getDuplicates().get(0).getType();
+      boolean nullable = getDuplicates().stream().anyMatch(d -> d.getType().nullable());
+      Type type = getDuplicates().get(0).getType();
       return nullable ? TypeCreator.asNullable(type) : TypeCreator.asNotNullable(type);
     }
 

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -76,12 +76,11 @@ public abstract class Join extends BiRel implements HasExtension {
         return getLeft().getRecordType().fields().stream().map(TypeCreator::asNullable);
       case RIGHT_SEMI:
       case RIGHT_ANTI:
-        return Stream.of(); // these are right joins which ignore left side columns
+        // these are right joins which ignore left side columns
+        return Stream.of();
       case RIGHT_MARK:
-        return Stream.of(
-            TypeCreator.REQUIRED
-                .BOOLEAN); // right mark join keeps all fields from right and adds a boolean mark
-        // field
+        // right mark join keeps all fields from right and adds a boolean mark field
+        return Stream.of(TypeCreator.REQUIRED.BOOLEAN);
       default:
         return getLeft().getRecordType().fields().stream();
     }
@@ -97,12 +96,11 @@ public abstract class Join extends BiRel implements HasExtension {
       case ANTI:
       case LEFT_SEMI:
       case LEFT_ANTI:
-        return Stream.of(); // these are left joins which ignore right side columns
+        // these are left joins which ignore right side columns
+        return Stream.of();
       case LEFT_MARK:
-        return Stream.of(
-            TypeCreator.REQUIRED
-                .BOOLEAN); // left mark join keeps all fields from left and adds a boolean mark
-        // field
+        // left mark join keeps all fields from left and adds a boolean mark field
+        return Stream.of(TypeCreator.REQUIRED.BOOLEAN);
       default:
         return getRight().getRecordType().fields().stream();
     }

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -51,7 +51,7 @@ public abstract class Join extends BiRel implements HasExtension {
     }
 
     public static JoinType fromProto(JoinRel.JoinType proto) {
-      for (var v : values()) {
+      for (JoinType v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -63,31 +63,49 @@ public abstract class Join extends BiRel implements HasExtension {
 
   @Override
   protected Type.Struct deriveRecordType() {
-    Stream<Type> leftTypes =
-        switch (getJoinType()) {
-          case RIGHT, OUTER, RIGHT_SINGLE -> getLeft().getRecordType().fields().stream()
-              .map(TypeCreator::asNullable);
-          case RIGHT_SEMI, RIGHT_ANTI -> Stream
-              .of(); // these are right joins which ignore left side columns
-          case RIGHT_MARK -> Stream.of(
-              TypeCreator.REQUIRED
-                  .BOOLEAN); // right mark join keeps all fields from right and adds a boolean mark
-            // field
-          default -> getLeft().getRecordType().fields().stream();
-        };
-    Stream<Type> rightTypes =
-        switch (getJoinType()) {
-          case LEFT, OUTER, LEFT_SINGLE -> getRight().getRecordType().fields().stream()
-              .map(TypeCreator::asNullable);
-          case SEMI, ANTI, LEFT_SEMI, LEFT_ANTI -> Stream
-              .of(); // these are left joins which ignore right side columns
-          case LEFT_MARK -> Stream.of(
-              TypeCreator.REQUIRED
-                  .BOOLEAN); // left mark join keeps all fields from left and adds a boolean mark
-            // field
-          default -> getRight().getRecordType().fields().stream();
-        };
+    Stream<Type> leftTypes = getLeftTypes();
+    Stream<Type> rightTypes = getRightTypes();
     return TypeCreator.REQUIRED.struct(Stream.concat(leftTypes, rightTypes));
+  }
+
+  private Stream<Type> getLeftTypes() {
+    switch (getJoinType()) {
+      case RIGHT:
+      case OUTER:
+      case RIGHT_SINGLE:
+        return getLeft().getRecordType().fields().stream().map(TypeCreator::asNullable);
+      case RIGHT_SEMI:
+      case RIGHT_ANTI:
+        return Stream.of(); // these are right joins which ignore left side columns
+      case RIGHT_MARK:
+        return Stream.of(
+            TypeCreator.REQUIRED
+                .BOOLEAN); // right mark join keeps all fields from right and adds a boolean mark
+        // field
+      default:
+        return getLeft().getRecordType().fields().stream();
+    }
+  }
+
+  private Stream<Type> getRightTypes() {
+    switch (getJoinType()) {
+      case LEFT:
+      case OUTER:
+      case LEFT_SINGLE:
+        return getRight().getRecordType().fields().stream().map(TypeCreator::asNullable);
+      case SEMI:
+      case ANTI:
+      case LEFT_SEMI:
+      case LEFT_ANTI:
+        return Stream.of(); // these are left joins which ignore right side columns
+      case LEFT_MARK:
+        return Stream.of(
+            TypeCreator.REQUIRED
+                .BOOLEAN); // left mark join keeps all fields from left and adds a boolean mark
+        // field
+      default:
+        return getRight().getRecordType().fields().stream();
+    }
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/Set.java
+++ b/core/src/main/java/io/substrait/relation/Set.java
@@ -35,7 +35,7 @@ public abstract class Set extends AbstractRel implements HasExtension {
     }
 
     public static SetOp fromProto(SetRel.SetOp proto) {
-      for (var v : values()) {
+      for (SetOp v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -66,14 +66,24 @@ public abstract class Set extends AbstractRel implements HasExtension {
     }
 
     // As defined in https://substrait.io/relations/logical_relations/#set-operation-types
-    return switch (getSetOp()) {
-      case UNKNOWN -> first; // alternative would be to throw an exception
-      case MINUS_PRIMARY, MINUS_PRIMARY_ALL, MINUS_MULTISET -> first;
-      case INTERSECTION_PRIMARY -> coalesceNullabilityIntersectionPrimary(first, rest);
-      case INTERSECTION_MULTISET, INTERSECTION_MULTISET_ALL -> coalesceNullabilityIntersection(
-          first, rest);
-      case UNION_DISTINCT, UNION_ALL -> coalesceNullabilityUnion(first, rest);
-    };
+    switch (getSetOp()) {
+      case UNKNOWN:
+        return first; // alternative would be to throw an exception
+      case MINUS_PRIMARY:
+      case MINUS_PRIMARY_ALL:
+      case MINUS_MULTISET:
+        return first;
+      case INTERSECTION_PRIMARY:
+        return coalesceNullabilityIntersectionPrimary(first, rest);
+      case INTERSECTION_MULTISET:
+      case INTERSECTION_MULTISET_ALL:
+        return coalesceNullabilityIntersection(first, rest);
+      case UNION_DISTINCT:
+      case UNION_ALL:
+        return coalesceNullabilityUnion(first, rest);
+      default:
+        throw new UnsupportedOperationException("Unexpected set operation: " + getSetOp());
+    }
   }
 
   /** If field is nullable in any of the inputs, it's nullable in the output */

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -24,11 +24,11 @@ public abstract class VirtualTableScan extends AbstractReadRel {
    */
   @Value.Check
   protected void check() {
-    var names = getInitialSchema().names();
+    List<String> names = getInitialSchema().names();
 
     assert names.size()
         == NamedFieldCountingTypeVisitor.countNames(this.getInitialSchema().struct());
-    var rows = getRows();
+    List<Expression.StructLiteral> rows = getRows();
 
     assert rows.size() > 0
         && names.stream().noneMatch(s -> s == null)

--- a/core/src/main/java/io/substrait/relation/files/FileFormat.java
+++ b/core/src/main/java/io/substrait/relation/files/FileFormat.java
@@ -7,35 +7,35 @@ import org.immutables.value.Value;
 public interface FileFormat {
 
   @Value.Immutable
-  abstract static class ParquetReadOptions implements FileFormat {
+  abstract class ParquetReadOptions implements FileFormat {
     public static ImmutableFileFormat.ParquetReadOptions.Builder builder() {
       return ImmutableFileFormat.ParquetReadOptions.builder();
     }
   }
 
   @Value.Immutable
-  abstract static class ArrowReadOptions implements FileFormat {
+  abstract class ArrowReadOptions implements FileFormat {
     public static ImmutableFileFormat.ArrowReadOptions.Builder builder() {
       return ImmutableFileFormat.ArrowReadOptions.builder();
     }
   }
 
   @Value.Immutable
-  abstract static class OrcReadOptions implements FileFormat {
+  abstract class OrcReadOptions implements FileFormat {
     public static ImmutableFileFormat.OrcReadOptions.Builder builder() {
       return ImmutableFileFormat.OrcReadOptions.builder();
     }
   }
 
   @Value.Immutable
-  abstract static class DwrfReadOptions implements FileFormat {
+  abstract class DwrfReadOptions implements FileFormat {
     public static ImmutableFileFormat.DwrfReadOptions.Builder builder() {
       return ImmutableFileFormat.DwrfReadOptions.builder();
     }
   }
 
   @Value.Immutable
-  abstract static class DelimiterSeparatedTextReadOptions implements FileFormat {
+  abstract class DelimiterSeparatedTextReadOptions implements FileFormat {
     public abstract String getFieldDelimiter();
 
     public abstract long getMaxLineSize();
@@ -54,7 +54,7 @@ public interface FileFormat {
   }
 
   @Value.Immutable
-  abstract static class Extension implements FileFormat {
+  abstract class Extension implements FileFormat {
     public abstract com.google.protobuf.Any getExtension();
 
     public static ImmutableFileFormat.Extension.Builder builder() {

--- a/core/src/main/java/io/substrait/relation/files/FileOrFiles.java
+++ b/core/src/main/java/io/substrait/relation/files/FileOrFiles.java
@@ -36,29 +36,33 @@ public interface FileOrFiles {
     getFileFormat()
         .ifPresent(
             fileFormat -> {
-              if (fileFormat instanceof FileFormat.ParquetReadOptions options) {
+              if (fileFormat instanceof FileFormat.ParquetReadOptions) {
                 builder.setParquet(
                     ReadRel.LocalFiles.FileOrFiles.ParquetReadOptions.newBuilder().build());
-              } else if (fileFormat instanceof FileFormat.ArrowReadOptions options) {
+              } else if (fileFormat instanceof FileFormat.ArrowReadOptions) {
                 builder.setArrow(
                     ReadRel.LocalFiles.FileOrFiles.ArrowReadOptions.newBuilder().build());
-              } else if (fileFormat instanceof FileFormat.OrcReadOptions options) {
+              } else if (fileFormat instanceof FileFormat.OrcReadOptions) {
                 builder.setOrc(ReadRel.LocalFiles.FileOrFiles.OrcReadOptions.newBuilder().build());
-              } else if (fileFormat instanceof FileFormat.DwrfReadOptions options) {
+              } else if (fileFormat instanceof FileFormat.DwrfReadOptions) {
                 builder.setDwrf(
                     ReadRel.LocalFiles.FileOrFiles.DwrfReadOptions.newBuilder().build());
-              } else if (fileFormat
-                  instanceof FileFormat.DelimiterSeparatedTextReadOptions options) {
-                var optionsBuilder =
-                    ReadRel.LocalFiles.FileOrFiles.DelimiterSeparatedTextReadOptions.newBuilder()
-                        .setFieldDelimiter(options.getFieldDelimiter())
-                        .setMaxLineSize(options.getMaxLineSize())
-                        .setQuote(options.getQuote())
-                        .setHeaderLinesToSkip(options.getHeaderLinesToSkip())
-                        .setEscape(options.getEscape());
+              } else if (fileFormat instanceof FileFormat.DelimiterSeparatedTextReadOptions) {
+                FileFormat.DelimiterSeparatedTextReadOptions options =
+                    (FileFormat.DelimiterSeparatedTextReadOptions) fileFormat;
+                ReadRel.LocalFiles.FileOrFiles.DelimiterSeparatedTextReadOptions.Builder
+                    optionsBuilder =
+                        ReadRel.LocalFiles.FileOrFiles.DelimiterSeparatedTextReadOptions
+                            .newBuilder()
+                            .setFieldDelimiter(options.getFieldDelimiter())
+                            .setMaxLineSize(options.getMaxLineSize())
+                            .setQuote(options.getQuote())
+                            .setHeaderLinesToSkip(options.getHeaderLinesToSkip())
+                            .setEscape(options.getEscape());
                 options.getValueTreatedAsNull().ifPresent(optionsBuilder::setValueTreatedAsNull);
                 builder.setText(optionsBuilder.build());
-              } else if (fileFormat instanceof FileFormat.Extension options) {
+              } else if (fileFormat instanceof FileFormat.Extension) {
+                FileFormat.Extension options = (FileFormat.Extension) fileFormat;
                 builder.setExtension(options.getExtension());
               } else {
                 throw new UnsupportedOperationException(
@@ -72,11 +76,14 @@ public interface FileOrFiles {
                 getPath()
                     .ifPresent(
                         path -> {
-                          switch (pathType) {
-                            case URI_PATH -> builder.setUriPath(path);
-                            case URI_PATH_GLOB -> builder.setUriPathGlob(path);
-                            case URI_FILE -> builder.setUriFile(path);
-                            case URI_FOLDER -> builder.setUriFolder(path);
+                          if (pathType == PathType.URI_PATH) {
+                            builder.setUriPath(path);
+                          } else if (pathType == PathType.URI_PATH_GLOB) {
+                            builder.setUriPathGlob(path);
+                          } else if (pathType == PathType.URI_FILE) {
+                            builder.setUriFile(path);
+                          } else if (pathType == PathType.URI_FOLDER) {
+                            builder.setUriFolder(path);
                           }
                         }));
 

--- a/core/src/main/java/io/substrait/relation/physical/HashJoin.java
+++ b/core/src/main/java/io/substrait/relation/physical/HashJoin.java
@@ -43,7 +43,7 @@ public abstract class HashJoin extends BiRel implements HasExtension {
     }
 
     public static JoinType fromProto(HashJoinRel.JoinType proto) {
-      for (var v : values()) {
+      for (JoinType v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -58,21 +58,35 @@ public abstract class HashJoin extends BiRel implements HasExtension {
 
   @Override
   protected Type.Struct deriveRecordType() {
-    Stream<Type> leftTypes =
-        switch (getJoinType()) {
-          case RIGHT, OUTER -> getLeft().getRecordType().fields().stream()
-              .map(TypeCreator::asNullable);
-          case RIGHT_ANTI, RIGHT_SEMI -> Stream.empty();
-          default -> getLeft().getRecordType().fields().stream();
-        };
-    Stream<Type> rightTypes =
-        switch (getJoinType()) {
-          case LEFT, OUTER -> getRight().getRecordType().fields().stream()
-              .map(TypeCreator::asNullable);
-          case LEFT_ANTI, LEFT_SEMI -> Stream.empty();
-          default -> getRight().getRecordType().fields().stream();
-        };
+    Stream<Type> leftTypes = getLeftTypes();
+    Stream<Type> rightTypes = getRightTypes();
     return TypeCreator.REQUIRED.struct(Stream.concat(leftTypes, rightTypes));
+  }
+
+  private Stream<Type> getLeftTypes() {
+    switch (getJoinType()) {
+      case RIGHT:
+      case OUTER:
+        return getLeft().getRecordType().fields().stream().map(TypeCreator::asNullable);
+      case RIGHT_ANTI:
+      case RIGHT_SEMI:
+        return Stream.empty();
+      default:
+        return getLeft().getRecordType().fields().stream();
+    }
+  }
+
+  private Stream<Type> getRightTypes() {
+    switch (getJoinType()) {
+      case LEFT:
+      case OUTER:
+        return getRight().getRecordType().fields().stream().map(TypeCreator::asNullable);
+      case LEFT_ANTI:
+      case LEFT_SEMI:
+        return Stream.empty();
+      default:
+        return getRight().getRecordType().fields().stream();
+    }
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/physical/NestedLoopJoin.java
+++ b/core/src/main/java/io/substrait/relation/physical/NestedLoopJoin.java
@@ -40,7 +40,7 @@ public abstract class NestedLoopJoin extends BiRel implements HasExtension {
     }
 
     public static JoinType fromProto(NestedLoopJoinRel.JoinType proto) {
-      for (var v : values()) {
+      for (JoinType v : values()) {
         if (v.proto == proto) {
           return v;
         }
@@ -52,21 +52,35 @@ public abstract class NestedLoopJoin extends BiRel implements HasExtension {
 
   @Override
   protected Type.Struct deriveRecordType() {
-    Stream<Type> leftTypes =
-        switch (getJoinType()) {
-          case RIGHT, OUTER -> getLeft().getRecordType().fields().stream()
-              .map(TypeCreator::asNullable);
-          case RIGHT_ANTI, RIGHT_SEMI -> Stream.empty();
-          default -> getLeft().getRecordType().fields().stream();
-        };
-    Stream<Type> rightTypes =
-        switch (getJoinType()) {
-          case LEFT, OUTER -> getRight().getRecordType().fields().stream()
-              .map(TypeCreator::asNullable);
-          case LEFT_ANTI, LEFT_SEMI -> Stream.empty();
-          default -> getRight().getRecordType().fields().stream();
-        };
+    Stream<Type> leftTypes = getLeftTypes();
+    Stream<Type> rightTypes = getRightTypes();
     return TypeCreator.REQUIRED.struct(Stream.concat(leftTypes, rightTypes));
+  }
+
+  private Stream<Type> getLeftTypes() {
+    switch (getJoinType()) {
+      case RIGHT:
+      case OUTER:
+        return getLeft().getRecordType().fields().stream().map(TypeCreator::asNullable);
+      case RIGHT_ANTI:
+      case RIGHT_SEMI:
+        return Stream.empty();
+      default:
+        return getLeft().getRecordType().fields().stream();
+    }
+  }
+
+  private Stream<Type> getRightTypes() {
+    switch (getJoinType()) {
+      case LEFT:
+      case OUTER:
+        return getRight().getRecordType().fields().stream().map(TypeCreator::asNullable);
+      case LEFT_ANTI:
+      case LEFT_SEMI:
+        return Stream.empty();
+      default:
+        return getRight().getRecordType().fields().stream();
+    }
   }
 
   @Override

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -42,7 +42,7 @@ public class Deserializers {
     @Override
     public T deserialize(final JsonParser p, final DeserializationContext ctxt)
         throws IOException, JsonProcessingException {
-      var typeString = p.getValueAsString();
+      String typeString = p.getValueAsString();
       try {
         String namespace =
             (String) ctxt.findInjectableValue(SimpleExtension.URI_LOCATOR_KEY, null, null);

--- a/core/src/main/java/io/substrait/type/NamedStruct.java
+++ b/core/src/main/java/io/substrait/type/NamedStruct.java
@@ -20,7 +20,7 @@ public interface NamedStruct {
   }
 
   default io.substrait.proto.NamedStruct toProto(TypeProtoConverter typeProtoConverter) {
-    var type = struct().accept(typeProtoConverter);
+    io.substrait.proto.Type type = struct().accept(typeProtoConverter);
     return io.substrait.proto.NamedStruct.newBuilder()
         .setStruct(type.getStruct())
         .addAllNames(names())
@@ -29,7 +29,7 @@ public interface NamedStruct {
 
   static io.substrait.type.NamedStruct fromProto(
       io.substrait.proto.NamedStruct namedStruct, ProtoTypeConverter protoTypeConverter) {
-    var struct = namedStruct.getStruct();
+    io.substrait.proto.Type.Struct struct = namedStruct.getStruct();
     return ImmutableNamedStruct.builder()
         .names(namedStruct.getNamesList())
         .struct(

--- a/core/src/main/java/io/substrait/type/YamlRead.java
+++ b/core/src/main/java/io/substrait/type/YamlRead.java
@@ -54,7 +54,8 @@ public class YamlRead {
           new ObjectMapper(new YAMLFactory())
               .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
               .registerModule(Deserializers.MODULE);
-      var doc = mapper.readValue(new File(name), SimpleExtension.ExtensionSignatures.class);
+      SimpleExtension.ExtensionSignatures doc =
+          mapper.readValue(new File(name), SimpleExtension.ExtensionSignatures.class);
 
       logger.atDebug().log(
           "Parsed {} functions in file {}.",

--- a/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
+++ b/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
@@ -30,11 +30,11 @@ public class TypeStringParser {
   }
 
   private static SubstraitTypeParser.StartContext parse(String str) {
-    var lexer = new SubstraitTypeLexer(CharStreams.fromString(str));
+    SubstraitTypeLexer lexer = new SubstraitTypeLexer(CharStreams.fromString(str));
     lexer.removeErrorListeners();
     lexer.addErrorListener(TypeErrorListener.INSTANCE);
-    var tokenStream = new CommonTokenStream(lexer);
-    var parser = new io.substrait.type.SubstraitTypeParser(tokenStream);
+    CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+    SubstraitTypeParser parser = new io.substrait.type.SubstraitTypeParser(tokenStream);
     parser.removeErrorListeners();
     parser.addErrorListener(TypeErrorListener.INSTANCE);
     return parser.start();

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -165,7 +165,7 @@ abstract class BaseProtoConverter<T, I>
 
   @Override
   public final T visit(final Type.UserDefined expr) {
-    var ref =
+    int ref =
         extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.uri(), expr.name()));
     return typeContainer(expr).userDefined(ref);
   }

--- a/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ParameterizedProtoConverter.java
@@ -264,59 +264,62 @@ public class ParameterizedProtoConverter
 
     @Override
     protected ParameterizedType wrap(final Object o) {
-      var bldr = ParameterizedType.newBuilder();
-      if (o instanceof Type.Boolean t) {
-        return bldr.setBool(t).build();
-      } else if (o instanceof Type.I8 t) {
-        return bldr.setI8(t).build();
-      } else if (o instanceof Type.I16 t) {
-        return bldr.setI16(t).build();
-      } else if (o instanceof Type.I32 t) {
-        return bldr.setI32(t).build();
-      } else if (o instanceof Type.I64 t) {
-        return bldr.setI64(t).build();
-      } else if (o instanceof Type.FP32 t) {
-        return bldr.setFp32(t).build();
-      } else if (o instanceof Type.FP64 t) {
-        return bldr.setFp64(t).build();
-      } else if (o instanceof Type.String t) {
-        return bldr.setString(t).build();
-      } else if (o instanceof Type.Binary t) {
-        return bldr.setBinary(t).build();
-      } else if (o instanceof Type.Timestamp t) {
-        return bldr.setTimestamp(t).build();
-      } else if (o instanceof Type.Date t) {
-        return bldr.setDate(t).build();
-      } else if (o instanceof Type.Time t) {
-        return bldr.setTime(t).build();
-      } else if (o instanceof Type.TimestampTZ t) {
-        return bldr.setTimestampTz(t).build();
-      } else if (o instanceof Type.IntervalYear t) {
-        return bldr.setIntervalYear(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedIntervalDay t) {
-        return bldr.setIntervalDay(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedIntervalCompound t) {
-        return bldr.setIntervalCompound(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedFixedChar t) {
-        return bldr.setFixedChar(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedVarChar t) {
-        return bldr.setVarchar(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedFixedBinary t) {
-        return bldr.setFixedBinary(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedDecimal t) {
-        return bldr.setDecimal(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedPrecisionTimestamp t) {
-        return bldr.setPrecisionTimestamp(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedPrecisionTimestampTZ t) {
-        return bldr.setPrecisionTimestampTz(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedStruct t) {
-        return bldr.setStruct(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedList t) {
-        return bldr.setList(t).build();
-      } else if (o instanceof ParameterizedType.ParameterizedMap t) {
-        return bldr.setMap(t).build();
-      } else if (o instanceof Type.UUID t) {
-        return bldr.setUuid(t).build();
+      ParameterizedType.Builder bldr = ParameterizedType.newBuilder();
+      if (o instanceof Type.Boolean) {
+        return bldr.setBool((Type.Boolean) o).build();
+      } else if (o instanceof Type.I8) {
+        return bldr.setI8((Type.I8) o).build();
+      } else if (o instanceof Type.I16) {
+        return bldr.setI16((Type.I16) o).build();
+      } else if (o instanceof Type.I32) {
+        return bldr.setI32((Type.I32) o).build();
+      } else if (o instanceof Type.I64) {
+        return bldr.setI64((Type.I64) o).build();
+      } else if (o instanceof Type.FP32) {
+        return bldr.setFp32((Type.FP32) o).build();
+      } else if (o instanceof Type.FP64) {
+        return bldr.setFp64((Type.FP64) o).build();
+      } else if (o instanceof Type.String) {
+        return bldr.setString((Type.String) o).build();
+      } else if (o instanceof Type.Binary) {
+        return bldr.setBinary((Type.Binary) o).build();
+      } else if (o instanceof Type.Timestamp) {
+        return bldr.setTimestamp((Type.Timestamp) o).build();
+      } else if (o instanceof Type.Date) {
+        return bldr.setDate((Type.Date) o).build();
+      } else if (o instanceof Type.Time) {
+        return bldr.setTime((Type.Time) o).build();
+      } else if (o instanceof Type.TimestampTZ) {
+        return bldr.setTimestampTz((Type.TimestampTZ) o).build();
+      } else if (o instanceof Type.IntervalYear) {
+        return bldr.setIntervalYear((Type.IntervalYear) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedIntervalDay) {
+        return bldr.setIntervalDay((ParameterizedType.ParameterizedIntervalDay) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedIntervalCompound) {
+        return bldr.setIntervalCompound((ParameterizedType.ParameterizedIntervalCompound) o)
+            .build();
+      } else if (o instanceof ParameterizedType.ParameterizedFixedChar) {
+        return bldr.setFixedChar((ParameterizedType.ParameterizedFixedChar) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedVarChar) {
+        return bldr.setVarchar((ParameterizedType.ParameterizedVarChar) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedFixedBinary) {
+        return bldr.setFixedBinary((ParameterizedType.ParameterizedFixedBinary) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedDecimal) {
+        return bldr.setDecimal((ParameterizedType.ParameterizedDecimal) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedPrecisionTimestamp) {
+        return bldr.setPrecisionTimestamp((ParameterizedType.ParameterizedPrecisionTimestamp) o)
+            .build();
+      } else if (o instanceof ParameterizedType.ParameterizedPrecisionTimestampTZ) {
+        return bldr.setPrecisionTimestampTz((ParameterizedType.ParameterizedPrecisionTimestampTZ) o)
+            .build();
+      } else if (o instanceof ParameterizedType.ParameterizedStruct) {
+        return bldr.setStruct((ParameterizedType.ParameterizedStruct) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedList) {
+        return bldr.setList((ParameterizedType.ParameterizedList) o).build();
+      } else if (o instanceof ParameterizedType.ParameterizedMap) {
+        return bldr.setMap((ParameterizedType.ParameterizedMap) o).build();
+      } else if (o instanceof Type.UUID) {
+        return bldr.setUuid((Type.UUID) o).build();
       }
       throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -18,57 +18,87 @@ public class ProtoTypeConverter {
   }
 
   public Type from(io.substrait.proto.Type type) {
-    return switch (type.getKindCase()) {
-      case BOOL -> n(type.getBool().getNullability()).BOOLEAN;
-      case I8 -> n(type.getI8().getNullability()).I8;
-      case I16 -> n(type.getI16().getNullability()).I16;
-      case I32 -> n(type.getI32().getNullability()).I32;
-      case I64 -> n(type.getI64().getNullability()).I64;
-      case FP32 -> n(type.getFp32().getNullability()).FP32;
-      case FP64 -> n(type.getFp64().getNullability()).FP64;
-      case STRING -> n(type.getString().getNullability()).STRING;
-      case BINARY -> n(type.getBinary().getNullability()).BINARY;
-      case TIMESTAMP -> n(type.getTimestamp().getNullability()).TIMESTAMP;
-      case DATE -> n(type.getDate().getNullability()).DATE;
-      case TIME -> n(type.getTime().getNullability()).TIME;
-      case INTERVAL_YEAR -> n(type.getIntervalYear().getNullability()).INTERVAL_YEAR;
-      case INTERVAL_DAY -> n(type.getIntervalDay().getNullability())
-          // precision defaults to 6 (micros) for backwards compatibility, see protobuf
-          .intervalDay(
-              type.getIntervalDay().hasPrecision() ? type.getIntervalDay().getPrecision() : 6);
-      case INTERVAL_COMPOUND -> n(type.getIntervalCompound().getNullability())
-          .intervalCompound(type.getIntervalCompound().getPrecision());
-      case TIMESTAMP_TZ -> n(type.getTimestampTz().getNullability()).TIMESTAMP_TZ;
-      case UUID -> n(type.getUuid().getNullability()).UUID;
-      case FIXED_CHAR -> n(type.getFixedChar().getNullability())
-          .fixedChar(type.getFixedChar().getLength());
-      case VARCHAR -> n(type.getVarchar().getNullability()).varChar(type.getVarchar().getLength());
-      case FIXED_BINARY -> n(type.getFixedBinary().getNullability())
-          .fixedBinary(type.getFixedBinary().getLength());
-      case DECIMAL -> n(type.getDecimal().getNullability())
-          .decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
-      case PRECISION_TIME -> n(type.getPrecisionTime().getNullability())
-          .precisionTime(type.getPrecisionTime().getPrecision());
-      case PRECISION_TIMESTAMP -> n(type.getPrecisionTimestamp().getNullability())
-          .precisionTimestamp(type.getPrecisionTimestamp().getPrecision());
-      case PRECISION_TIMESTAMP_TZ -> n(type.getPrecisionTimestampTz().getNullability())
-          .precisionTimestampTZ(type.getPrecisionTimestampTz().getPrecision());
-      case STRUCT -> n(type.getStruct().getNullability())
-          .struct(
-              type.getStruct().getTypesList().stream()
-                  .map(this::from)
-                  .collect(java.util.stream.Collectors.toList()));
-      case LIST -> fromList(type.getList());
-      case MAP -> fromMap(type.getMap());
-      case USER_DEFINED -> {
-        var userDefined = type.getUserDefined();
-        var t = lookup.getType(userDefined.getTypeReference(), extensions);
-        yield n(userDefined.getNullability()).userDefined(t.uri(), t.name());
-      }
-      case USER_DEFINED_TYPE_REFERENCE -> throw new UnsupportedOperationException(
-          "Unsupported user defined reference: " + type);
-      case KIND_NOT_SET -> throw new UnsupportedOperationException("Type is not set: " + type);
-    };
+    switch (type.getKindCase()) {
+      case BOOL:
+        return n(type.getBool().getNullability()).BOOLEAN;
+      case I8:
+        return n(type.getI8().getNullability()).I8;
+      case I16:
+        return n(type.getI16().getNullability()).I16;
+      case I32:
+        return n(type.getI32().getNullability()).I32;
+      case I64:
+        return n(type.getI64().getNullability()).I64;
+      case FP32:
+        return n(type.getFp32().getNullability()).FP32;
+      case FP64:
+        return n(type.getFp64().getNullability()).FP64;
+      case STRING:
+        return n(type.getString().getNullability()).STRING;
+      case BINARY:
+        return n(type.getBinary().getNullability()).BINARY;
+      case TIMESTAMP:
+        return n(type.getTimestamp().getNullability()).TIMESTAMP;
+      case DATE:
+        return n(type.getDate().getNullability()).DATE;
+      case TIME:
+        return n(type.getTime().getNullability()).TIME;
+      case INTERVAL_YEAR:
+        return n(type.getIntervalYear().getNullability()).INTERVAL_YEAR;
+      case INTERVAL_DAY:
+        return n(type.getIntervalDay().getNullability())
+            // precision defaults to 6 (micros) for backwards compatibility, see protobuf
+            .intervalDay(
+                type.getIntervalDay().hasPrecision() ? type.getIntervalDay().getPrecision() : 6);
+      case INTERVAL_COMPOUND:
+        return n(type.getIntervalCompound().getNullability())
+            .intervalCompound(type.getIntervalCompound().getPrecision());
+      case TIMESTAMP_TZ:
+        return n(type.getTimestampTz().getNullability()).TIMESTAMP_TZ;
+      case UUID:
+        return n(type.getUuid().getNullability()).UUID;
+      case FIXED_CHAR:
+        return n(type.getFixedChar().getNullability()).fixedChar(type.getFixedChar().getLength());
+      case VARCHAR:
+        return n(type.getVarchar().getNullability()).varChar(type.getVarchar().getLength());
+      case FIXED_BINARY:
+        return n(type.getFixedBinary().getNullability())
+            .fixedBinary(type.getFixedBinary().getLength());
+      case DECIMAL:
+        return n(type.getDecimal().getNullability())
+            .decimal(type.getDecimal().getPrecision(), type.getDecimal().getScale());
+      case PRECISION_TIME:
+        return n(type.getPrecisionTime().getNullability())
+            .precisionTime(type.getPrecisionTime().getPrecision());
+      case PRECISION_TIMESTAMP:
+        return n(type.getPrecisionTimestamp().getNullability())
+            .precisionTimestamp(type.getPrecisionTimestamp().getPrecision());
+      case PRECISION_TIMESTAMP_TZ:
+        return n(type.getPrecisionTimestampTz().getNullability())
+            .precisionTimestampTZ(type.getPrecisionTimestampTz().getPrecision());
+      case STRUCT:
+        return n(type.getStruct().getNullability())
+            .struct(
+                type.getStruct().getTypesList().stream()
+                    .map(this::from)
+                    .collect(java.util.stream.Collectors.toList()));
+      case LIST:
+        return fromList(type.getList());
+      case MAP:
+        return fromMap(type.getMap());
+      case USER_DEFINED:
+        {
+          io.substrait.proto.Type.UserDefined userDefined = type.getUserDefined();
+          SimpleExtension.Type t = lookup.getType(userDefined.getTypeReference(), extensions);
+          return n(userDefined.getNullability()).userDefined(t.uri(), t.name());
+        }
+      case USER_DEFINED_TYPE_REFERENCE:
+        throw new UnsupportedOperationException("Unsupported user defined reference: " + type);
+      case KIND_NOT_SET:
+        throw new UnsupportedOperationException("Type is not set: " + type);
+      default:
+        throw new UnsupportedOperationException("Unsupported type: " + type.getKindCase());
+    }
   }
 
   public Type.ListType fromList(io.substrait.proto.Type.List list) {

--- a/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeExpressionProtoVisitor.java
@@ -4,7 +4,9 @@ import io.substrait.extension.ExtensionCollector;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
 import io.substrait.proto.DerivationExpression;
+import io.substrait.proto.DerivationExpression.ReturnProgram.Assignment;
 import io.substrait.proto.Type;
+import java.util.List;
 
 public class TypeExpressionProtoVisitor
     extends BaseProtoConverter<DerivationExpression, DerivationExpression> {
@@ -28,21 +30,7 @@ public class TypeExpressionProtoVisitor
 
   @Override
   public DerivationExpression visit(final TypeExpression.BinaryOperation expr) {
-    var opType =
-        switch (expr.opType()) {
-          case ADD -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_PLUS;
-          case SUBTRACT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
-          case MIN -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MIN;
-          case MAX -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MAX;
-          case LT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
-            // case LTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
-          case GT -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_GREATER_THAN;
-            // case GTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
-            // case NOT_EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQ;
-          case EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQUALS;
-          case COVERS -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_COVERS;
-          default -> throw new IllegalStateException("Unexpected value: " + expr.opType());
-        };
+    DerivationExpression.BinaryOp.BinaryOpType opType = getDerivationOpType(expr.opType());
     return DerivationExpression.newBuilder()
         .setBinaryOp(
             DerivationExpression.BinaryOp.newBuilder()
@@ -51,6 +39,33 @@ public class TypeExpressionProtoVisitor
                 .setOpType(opType)
                 .build())
         .build();
+  }
+
+  private DerivationExpression.BinaryOp.BinaryOpType getDerivationOpType(
+      TypeExpression.BinaryOperation.OpType type) {
+    switch (type) {
+      case ADD:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_PLUS;
+      case SUBTRACT:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
+      case MIN:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MIN;
+      case MAX:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MAX;
+      case LT:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
+        // case LTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_LESS_THAN;
+      case GT:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_GREATER_THAN;
+        // case GTE -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_MINUS;
+        // case NOT_EQ -> DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQ;
+      case EQ:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_EQUALS;
+      case COVERS:
+        return DerivationExpression.BinaryOp.BinaryOpType.BINARY_OP_TYPE_COVERS;
+      default:
+        throw new IllegalStateException("Unexpected value: " + type);
+    }
   }
 
   @Override
@@ -82,7 +97,7 @@ public class TypeExpressionProtoVisitor
 
   @Override
   public DerivationExpression visit(final TypeExpression.ReturnProgram expr) {
-    var assignments =
+    List<Assignment> assignments =
         expr.assignments().stream()
             .map(
                 a ->
@@ -91,7 +106,7 @@ public class TypeExpressionProtoVisitor
                         .setExpression(a.expr().accept(this))
                         .build())
             .collect(java.util.stream.Collectors.toList());
-    var finalExpr = expr.finalExpression().accept(this);
+    DerivationExpression finalExpr = expr.finalExpression().accept(this);
     return DerivationExpression.newBuilder()
         .setReturnProgram(
             DerivationExpression.ReturnProgram.newBuilder()
@@ -337,59 +352,62 @@ public class TypeExpressionProtoVisitor
 
     @Override
     protected DerivationExpression wrap(final Object o) {
-      var bldr = DerivationExpression.newBuilder();
-      if (o instanceof Type.Boolean t) {
-        return bldr.setBool(t).build();
-      } else if (o instanceof Type.I8 t) {
-        return bldr.setI8(t).build();
-      } else if (o instanceof Type.I16 t) {
-        return bldr.setI16(t).build();
-      } else if (o instanceof Type.I32 t) {
-        return bldr.setI32(t).build();
-      } else if (o instanceof Type.I64 t) {
-        return bldr.setI64(t).build();
-      } else if (o instanceof Type.FP32 t) {
-        return bldr.setFp32(t).build();
-      } else if (o instanceof Type.FP64 t) {
-        return bldr.setFp64(t).build();
-      } else if (o instanceof Type.String t) {
-        return bldr.setString(t).build();
-      } else if (o instanceof Type.Binary t) {
-        return bldr.setBinary(t).build();
-      } else if (o instanceof Type.Timestamp t) {
-        return bldr.setTimestamp(t).build();
-      } else if (o instanceof Type.Date t) {
-        return bldr.setDate(t).build();
-      } else if (o instanceof Type.Time t) {
-        return bldr.setTime(t).build();
-      } else if (o instanceof Type.TimestampTZ t) {
-        return bldr.setTimestampTz(t).build();
-      } else if (o instanceof Type.IntervalYear t) {
-        return bldr.setIntervalYear(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionIntervalDay t) {
-        return bldr.setIntervalDay(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionIntervalCompound t) {
-        return bldr.setIntervalCompound(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionFixedChar t) {
-        return bldr.setFixedChar(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionVarChar t) {
-        return bldr.setVarchar(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionFixedBinary t) {
-        return bldr.setFixedBinary(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionDecimal t) {
-        return bldr.setDecimal(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionPrecisionTimestamp t) {
-        return bldr.setPrecisionTimestamp(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionPrecisionTimestampTZ t) {
-        return bldr.setPrecisionTimestampTz(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionStruct t) {
-        return bldr.setStruct(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionList t) {
-        return bldr.setList(t).build();
-      } else if (o instanceof DerivationExpression.ExpressionMap t) {
-        return bldr.setMap(t).build();
-      } else if (o instanceof Type.UUID t) {
-        return bldr.setUuid(t).build();
+      DerivationExpression.Builder bldr = DerivationExpression.newBuilder();
+      if (o instanceof Type.Boolean) {
+        return bldr.setBool((Type.Boolean) o).build();
+      } else if (o instanceof Type.I8) {
+        return bldr.setI8((Type.I8) o).build();
+      } else if (o instanceof Type.I16) {
+        return bldr.setI16((Type.I16) o).build();
+      } else if (o instanceof Type.I32) {
+        return bldr.setI32((Type.I32) o).build();
+      } else if (o instanceof Type.I64) {
+        return bldr.setI64((Type.I64) o).build();
+      } else if (o instanceof Type.FP32) {
+        return bldr.setFp32((Type.FP32) o).build();
+      } else if (o instanceof Type.FP64) {
+        return bldr.setFp64((Type.FP64) o).build();
+      } else if (o instanceof Type.String) {
+        return bldr.setString((Type.String) o).build();
+      } else if (o instanceof Type.Binary) {
+        return bldr.setBinary((Type.Binary) o).build();
+      } else if (o instanceof Type.Timestamp) {
+        return bldr.setTimestamp((Type.Timestamp) o).build();
+      } else if (o instanceof Type.Date) {
+        return bldr.setDate((Type.Date) o).build();
+      } else if (o instanceof Type.Time) {
+        return bldr.setTime((Type.Time) o).build();
+      } else if (o instanceof Type.TimestampTZ) {
+        return bldr.setTimestampTz((Type.TimestampTZ) o).build();
+      } else if (o instanceof Type.IntervalYear) {
+        return bldr.setIntervalYear((Type.IntervalYear) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionIntervalDay) {
+        return bldr.setIntervalDay((DerivationExpression.ExpressionIntervalDay) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionIntervalCompound) {
+        return bldr.setIntervalCompound((DerivationExpression.ExpressionIntervalCompound) o)
+            .build();
+      } else if (o instanceof DerivationExpression.ExpressionFixedChar) {
+        return bldr.setFixedChar((DerivationExpression.ExpressionFixedChar) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionVarChar) {
+        return bldr.setVarchar((DerivationExpression.ExpressionVarChar) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionFixedBinary) {
+        return bldr.setFixedBinary((DerivationExpression.ExpressionFixedBinary) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionDecimal) {
+        return bldr.setDecimal((DerivationExpression.ExpressionDecimal) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionPrecisionTimestamp) {
+        return bldr.setPrecisionTimestamp((DerivationExpression.ExpressionPrecisionTimestamp) o)
+            .build();
+      } else if (o instanceof DerivationExpression.ExpressionPrecisionTimestampTZ) {
+        return bldr.setPrecisionTimestampTz((DerivationExpression.ExpressionPrecisionTimestampTZ) o)
+            .build();
+      } else if (o instanceof DerivationExpression.ExpressionStruct) {
+        return bldr.setStruct((DerivationExpression.ExpressionStruct) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionList) {
+        return bldr.setList((DerivationExpression.ExpressionList) o).build();
+      } else if (o instanceof DerivationExpression.ExpressionMap) {
+        return bldr.setMap((DerivationExpression.ExpressionMap) o).build();
+      } else if (o instanceof Type.UUID) {
+        return bldr.setUuid((Type.UUID) o).build();
       }
       throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -124,61 +124,61 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
 
     @Override
     protected Type wrap(final Object o) {
-      var bldr = Type.newBuilder();
-      if (o instanceof Type.Boolean t) {
-        return bldr.setBool(t).build();
-      } else if (o instanceof Type.I8 t) {
-        return bldr.setI8(t).build();
-      } else if (o instanceof Type.I16 t) {
-        return bldr.setI16(t).build();
-      } else if (o instanceof Type.I32 t) {
-        return bldr.setI32(t).build();
-      } else if (o instanceof Type.I64 t) {
-        return bldr.setI64(t).build();
-      } else if (o instanceof Type.FP32 t) {
-        return bldr.setFp32(t).build();
-      } else if (o instanceof Type.FP64 t) {
-        return bldr.setFp64(t).build();
-      } else if (o instanceof Type.String t) {
-        return bldr.setString(t).build();
-      } else if (o instanceof Type.Binary t) {
-        return bldr.setBinary(t).build();
-      } else if (o instanceof Type.Timestamp t) {
-        return bldr.setTimestamp(t).build();
-      } else if (o instanceof Type.Date t) {
-        return bldr.setDate(t).build();
-      } else if (o instanceof Type.Time t) {
-        return bldr.setTime(t).build();
-      } else if (o instanceof Type.TimestampTZ t) {
-        return bldr.setTimestampTz(t).build();
-      } else if (o instanceof Type.IntervalYear t) {
-        return bldr.setIntervalYear(t).build();
-      } else if (o instanceof Type.IntervalDay t) {
-        return bldr.setIntervalDay(t).build();
-      } else if (o instanceof Type.IntervalCompound t) {
-        return bldr.setIntervalCompound(t).build();
-      } else if (o instanceof Type.FixedChar t) {
-        return bldr.setFixedChar(t).build();
-      } else if (o instanceof Type.VarChar t) {
-        return bldr.setVarchar(t).build();
-      } else if (o instanceof Type.FixedBinary t) {
-        return bldr.setFixedBinary(t).build();
-      } else if (o instanceof Type.Decimal t) {
-        return bldr.setDecimal(t).build();
-      } else if (o instanceof Type.PrecisionTimestamp t) {
-        return bldr.setPrecisionTimestamp(t).build();
-      } else if (o instanceof Type.PrecisionTimestampTZ t) {
-        return bldr.setPrecisionTimestampTz(t).build();
-      } else if (o instanceof Type.Struct t) {
-        return bldr.setStruct(t).build();
-      } else if (o instanceof Type.List t) {
-        return bldr.setList(t).build();
-      } else if (o instanceof Type.Map t) {
-        return bldr.setMap(t).build();
-      } else if (o instanceof Type.UUID t) {
-        return bldr.setUuid(t).build();
-      } else if (o instanceof Type.UserDefined t) {
-        return bldr.setUserDefined(t).build();
+      Type.Builder bldr = Type.newBuilder();
+      if (o instanceof Type.Boolean) {
+        return bldr.setBool((Type.Boolean) o).build();
+      } else if (o instanceof Type.I8) {
+        return bldr.setI8((Type.I8) o).build();
+      } else if (o instanceof Type.I16) {
+        return bldr.setI16((Type.I16) o).build();
+      } else if (o instanceof Type.I32) {
+        return bldr.setI32((Type.I32) o).build();
+      } else if (o instanceof Type.I64) {
+        return bldr.setI64((Type.I64) o).build();
+      } else if (o instanceof Type.FP32) {
+        return bldr.setFp32((Type.FP32) o).build();
+      } else if (o instanceof Type.FP64) {
+        return bldr.setFp64((Type.FP64) o).build();
+      } else if (o instanceof Type.String) {
+        return bldr.setString((Type.String) o).build();
+      } else if (o instanceof Type.Binary) {
+        return bldr.setBinary((Type.Binary) o).build();
+      } else if (o instanceof Type.Timestamp) {
+        return bldr.setTimestamp((Type.Timestamp) o).build();
+      } else if (o instanceof Type.Date) {
+        return bldr.setDate((Type.Date) o).build();
+      } else if (o instanceof Type.Time) {
+        return bldr.setTime((Type.Time) o).build();
+      } else if (o instanceof Type.TimestampTZ) {
+        return bldr.setTimestampTz((Type.TimestampTZ) o).build();
+      } else if (o instanceof Type.IntervalYear) {
+        return bldr.setIntervalYear((Type.IntervalYear) o).build();
+      } else if (o instanceof Type.IntervalDay) {
+        return bldr.setIntervalDay((Type.IntervalDay) o).build();
+      } else if (o instanceof Type.IntervalCompound) {
+        return bldr.setIntervalCompound((Type.IntervalCompound) o).build();
+      } else if (o instanceof Type.FixedChar) {
+        return bldr.setFixedChar((Type.FixedChar) o).build();
+      } else if (o instanceof Type.VarChar) {
+        return bldr.setVarchar((Type.VarChar) o).build();
+      } else if (o instanceof Type.FixedBinary) {
+        return bldr.setFixedBinary((Type.FixedBinary) o).build();
+      } else if (o instanceof Type.Decimal) {
+        return bldr.setDecimal((Type.Decimal) o).build();
+      } else if (o instanceof Type.PrecisionTimestamp) {
+        return bldr.setPrecisionTimestamp((Type.PrecisionTimestamp) o).build();
+      } else if (o instanceof Type.PrecisionTimestampTZ) {
+        return bldr.setPrecisionTimestampTz((Type.PrecisionTimestampTZ) o).build();
+      } else if (o instanceof Type.Struct) {
+        return bldr.setStruct((Type.Struct) o).build();
+      } else if (o instanceof Type.List) {
+        return bldr.setList((Type.List) o).build();
+      } else if (o instanceof Type.Map) {
+        return bldr.setMap((Type.Map) o).build();
+      } else if (o instanceof Type.UUID) {
+        return bldr.setUuid((Type.UUID) o).build();
+      } else if (o instanceof Type.UserDefined) {
+        return bldr.setUserDefined((Type.UserDefined) o).build();
       }
       throw new UnsupportedOperationException("Unable to wrap type of " + o.getClass());
     }

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -73,8 +73,8 @@ public class TypeExtensionTest {
                             .collect(Collectors.toList()),
                     b.namedScan(tableName, columnNames, types))));
 
-    var protoPlan = planProtoConverter.toProto(plan);
-    var planReturned = protoPlanConverter.from(protoPlan);
+    io.substrait.proto.Plan protoPlan = planProtoConverter.toProto(plan);
+    Plan planReturned = protoPlanConverter.from(protoPlan);
     assertEquals(plan, planReturned);
   }
 
@@ -99,8 +99,8 @@ public class TypeExtensionTest {
                                     b.fieldReference(input, 0)))
                             .collect(Collectors.toList()),
                     b.namedScan(tableName, columnNames, types))));
-    var protoPlan = planProtoConverter.toProto(plan);
-    var planReturned = protoPlanConverter.from(protoPlan);
+    io.substrait.proto.Plan protoPlan = planProtoConverter.toProto(plan);
+    Plan planReturned = protoPlanConverter.from(protoPlan);
     assertEquals(plan, planReturned);
   }
 }

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -25,8 +25,8 @@ public class ProtoRelConverterTest extends TestBase {
   @Nested
   class DefaultAdvancedExtensionTests {
 
-    static final StringHolder ENHANCED = new StringHolder("ENHANCED");
-    static final StringHolder OPTIMIZED = new StringHolder("OPTIMIZED");
+    final StringHolder ENHANCED = new StringHolder("ENHANCED");
+    final StringHolder OPTIMIZED = new StringHolder("OPTIMIZED");
 
     Rel relWithExtension(AdvancedExtension advancedExtension) {
       return NamedScan.builder()

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -25,8 +25,8 @@ public class ProtoRelConverterTest extends TestBase {
   @Nested
   class DefaultAdvancedExtensionTests {
 
-    final StringHolder ENHANCED = new StringHolder("ENHANCED");
-    final StringHolder OPTIMIZED = new StringHolder("OPTIMIZED");
+    final StringHolder enhanced = new StringHolder("ENHANCED");
+    final StringHolder optimized = new StringHolder("OPTIMIZED");
 
     Rel relWithExtension(AdvancedExtension advancedExtension) {
       return NamedScan.builder()
@@ -38,12 +38,12 @@ public class ProtoRelConverterTest extends TestBase {
 
     Rel emptyAdvancedExtension = relWithExtension(AdvancedExtension.builder().build());
     Rel advancedExtensionWithOptimization =
-        relWithExtension(AdvancedExtension.builder().addOptimizations(OPTIMIZED).build());
+        relWithExtension(AdvancedExtension.builder().addOptimizations(optimized).build());
     Rel advancedExtensionWithEnhancement =
-        relWithExtension(AdvancedExtension.builder().enhancement(ENHANCED).build());
+        relWithExtension(AdvancedExtension.builder().enhancement(enhanced).build());
     Rel advancedExtensionWithEnhancementAndOptimization =
         relWithExtension(
-            AdvancedExtension.builder().enhancement(ENHANCED).addOptimizations(OPTIMIZED).build());
+            AdvancedExtension.builder().enhancement(enhanced).addOptimizations(optimized).build());
 
     @Test
     void emptyAdvancedExtension() {

--- a/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
@@ -17,7 +17,7 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
 
   @Test
   void consistentPartitionWindowRoundtripSingle() {
-    var windowFunctionDeclaration =
+    SimpleExtension.WindowFunctionVariant windowFunctionDeclaration =
         defaultExtensionCollection.getWindowFunction(
             SimpleExtension.FunctionAnchor.of(
                 DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
@@ -70,11 +70,11 @@ public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
 
   @Test
   void consistentPartitionWindowRoundtripMulti() {
-    var windowFunctionLeadDeclaration =
+    SimpleExtension.WindowFunctionVariant windowFunctionLeadDeclaration =
         defaultExtensionCollection.getWindowFunction(
             SimpleExtension.FunctionAnchor.of(
                 DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
-    var windowFunctionLagDeclaration =
+    SimpleExtension.WindowFunctionVariant windowFunctionLagDeclaration =
         defaultExtensionCollection.getWindowFunction(
             SimpleExtension.FunctionAnchor.of(
                 DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -306,7 +306,7 @@ public class ExtensionRoundtripTest extends TestBase {
 
     @Test
     void scalarSubquery() {
-      var rel =
+      Project rel =
           b.project(
               input ->
                   Stream.of(
@@ -322,7 +322,7 @@ public class ExtensionRoundtripTest extends TestBase {
 
     @Test
     void inPredicate() {
-      var rel =
+      Project rel =
           b.project(
               input ->
                   Stream.of(
@@ -337,7 +337,7 @@ public class ExtensionRoundtripTest extends TestBase {
 
     @Test
     void setPredicate() {
-      var rel =
+      Project rel =
           b.project(
               input ->
                   Stream.of(

--- a/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
@@ -51,8 +51,8 @@ public class GenericRoundtripTest extends TestBase {
     // roundtrip to protobuff and back and check equality
     Expression val = (Expression) m.invoke(null, paramInst.toArray(new Object[0]));
 
-    var to = new ExpressionProtoConverter(null, null);
-    var from =
+    ExpressionProtoConverter to = new ExpressionProtoConverter(null, null);
+    ProtoExpressionConverter from =
         new ProtoExpressionConverter(
             null,
             null,

--- a/core/src/test/java/io/substrait/type/proto/IfThenRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/IfThenRoundtripTest.java
@@ -25,8 +25,9 @@ public class IfThenRoundtripTest extends TestBase {
             ExpressionCreator.i64(false, 2));
     assertFalse(ifRel.getType().nullable());
 
-    var to = new ExpressionProtoConverter(null, null);
-    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
+    ExpressionProtoConverter to = new ExpressionProtoConverter(null, null);
+    ProtoExpressionConverter from =
+        new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
     assertEquals(ifRel, from.from(ifRel.accept(to, EmptyVisitationContext.INSTANCE)));
   }
 
@@ -39,8 +40,9 @@ public class IfThenRoundtripTest extends TestBase {
             ExpressionCreator.i64(false, 2));
     assertTrue(ifRel.getType().nullable());
 
-    var to = new ExpressionProtoConverter(null, null);
-    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
+    ExpressionProtoConverter to = new ExpressionProtoConverter(null, null);
+    ProtoExpressionConverter from =
+        new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
     assertEquals(ifRel, from.from(ifRel.accept(to, EmptyVisitationContext.INSTANCE)));
   }
 }

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -15,9 +15,11 @@ public class LiteralRoundtripTest extends TestBase {
 
   @Test
   void decimal() {
-    var val = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
-    var to = new ExpressionProtoConverter(null, null);
-    var from = new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
+    io.substrait.expression.Expression.DecimalLiteral val =
+        ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);
+    ExpressionProtoConverter to = new ExpressionProtoConverter(null, null);
+    ProtoExpressionConverter from =
+        new ProtoExpressionConverter(null, null, EMPTY_TYPE, protoRelConverter);
     assertEquals(val, from.from(val.accept(to, EmptyVisitationContext.INSTANCE)));
   }
 }

--- a/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 public class LocalFilesRoundtripTest extends TestBase {
 
   private void assertLocalFilesRoundtrip(FileOrFiles file) {
-    var builder =
+    io.substrait.relation.ImmutableLocalFiles.Builder builder =
         LocalFiles.builder()
             .initialSchema(
                 NamedStruct.builder()
@@ -48,8 +48,8 @@ public class LocalFilesRoundtripTest extends TestBase {
                     ExpressionCreator.i32(false, 1)))
         .ifPresent(builder::filter);
 
-    var localFiles = builder.build();
-    var protoFileRel = relProtoConverter.toProto(localFiles);
+    io.substrait.relation.ImmutableLocalFiles localFiles = builder.build();
+    io.substrait.proto.Rel protoFileRel = relProtoConverter.toProto(localFiles);
     assertTrue(protoFileRel.getRead().hasFilter());
     assertEquals(protoFileRel, relProtoConverter.toProto(protoRelConverter.from(protoFileRel)));
   }
@@ -57,37 +57,53 @@ public class LocalFilesRoundtripTest extends TestBase {
   private ImmutableFileOrFiles.Builder setPath(
       ImmutableFileOrFiles.Builder builder,
       ReadRel.LocalFiles.FileOrFiles.PathTypeCase pathTypeCase) {
-    return switch (pathTypeCase) {
-      case URI_PATH -> builder.pathType(FileOrFiles.PathType.URI_PATH).path("path");
-      case URI_PATH_GLOB -> builder.pathType(FileOrFiles.PathType.URI_PATH_GLOB).path("path");
-      case URI_FILE -> builder.pathType(FileOrFiles.PathType.URI_FILE).path("path");
-      case URI_FOLDER -> builder.pathType(FileOrFiles.PathType.URI_FOLDER).path("path");
-      case PATHTYPE_NOT_SET -> builder;
-    };
+    switch (pathTypeCase) {
+      case URI_PATH:
+        return builder.pathType(FileOrFiles.PathType.URI_PATH).path("path");
+      case URI_PATH_GLOB:
+        return builder.pathType(FileOrFiles.PathType.URI_PATH_GLOB).path("path");
+      case URI_FILE:
+        return builder.pathType(FileOrFiles.PathType.URI_FILE).path("path");
+      case URI_FOLDER:
+        return builder.pathType(FileOrFiles.PathType.URI_FOLDER).path("path");
+      case PATHTYPE_NOT_SET:
+        return builder;
+      default:
+        throw new IllegalArgumentException("Unknown path type case: " + pathTypeCase);
+    }
   }
 
   private ImmutableFileOrFiles.Builder setFileFormat(
       ImmutableFileOrFiles.Builder builder,
       ReadRel.LocalFiles.FileOrFiles.FileFormatCase fileFormatCase) {
-    return switch (fileFormatCase) {
-      case PARQUET -> builder.fileFormat(FileFormat.ParquetReadOptions.builder().build());
-      case ARROW -> builder.fileFormat(FileFormat.ArrowReadOptions.builder().build());
-      case ORC -> builder.fileFormat(FileFormat.OrcReadOptions.builder().build());
-      case DWRF -> builder.fileFormat(FileFormat.DwrfReadOptions.builder().build());
-      case TEXT -> builder.fileFormat(
-          FileFormat.DelimiterSeparatedTextReadOptions.builder()
-              .fieldDelimiter("|")
-              .maxLineSize(1000)
-              .quote("\"")
-              .headerLinesToSkip(1)
-              .escape("\\")
-              .build());
-      case EXTENSION -> builder.fileFormat(
-          FileFormat.Extension.builder()
-              .extension(com.google.protobuf.Any.newBuilder().build())
-              .build());
-      case FILEFORMAT_NOT_SET -> builder;
-    };
+    switch (fileFormatCase) {
+      case PARQUET:
+        return builder.fileFormat(FileFormat.ParquetReadOptions.builder().build());
+      case ARROW:
+        return builder.fileFormat(FileFormat.ArrowReadOptions.builder().build());
+      case ORC:
+        return builder.fileFormat(FileFormat.OrcReadOptions.builder().build());
+      case DWRF:
+        return builder.fileFormat(FileFormat.DwrfReadOptions.builder().build());
+      case TEXT:
+        return builder.fileFormat(
+            FileFormat.DelimiterSeparatedTextReadOptions.builder()
+                .fieldDelimiter("|")
+                .maxLineSize(1000)
+                .quote("\"")
+                .headerLinesToSkip(1)
+                .escape("\\")
+                .build());
+      case EXTENSION:
+        return builder.fileFormat(
+            FileFormat.Extension.builder()
+                .extension(com.google.protobuf.Any.newBuilder().build())
+                .build());
+      case FILEFORMAT_NOT_SET:
+        return builder;
+      default:
+        throw new IllegalArgumentException("Unknown file format case: " + fileFormatCase);
+    }
   }
 
   @Test

--- a/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
@@ -15,11 +15,11 @@ public class ReadRelRoundtripTest extends TestBase {
 
   @Test
   void namedScan() {
-    var tableName = Stream.of("a_table").collect(Collectors.toList());
-    var columnNames = Stream.of("column1", "column2").collect(Collectors.toList());
+    List<String> tableName = Stream.of("a_table").collect(Collectors.toList());
+    List<String> columnNames = Stream.of("column1", "column2").collect(Collectors.toList());
     List<Type> columnTypes = Stream.of(R.I64, R.I64).collect(Collectors.toList());
 
-    var namedScan = b.namedScan(tableName, columnNames, columnTypes);
+    NamedScan namedScan = b.namedScan(tableName, columnNames, columnTypes);
     namedScan =
         NamedScan.builder()
             .from(namedScan)
@@ -33,13 +33,13 @@ public class ReadRelRoundtripTest extends TestBase {
 
   @Test
   void emptyScan() {
-    var emptyScan = b.emptyScan();
+    io.substrait.relation.EmptyScan emptyScan = b.emptyScan();
     verifyRoundTrip(emptyScan);
   }
 
   @Test
   void virtualTable() {
-    var virtTable =
+    io.substrait.relation.ImmutableVirtualTableScan virtTable =
         VirtualTableScan.builder()
             .initialSchema(
                 NamedStruct.of(

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -54,7 +54,7 @@ public class TestTypeRoundtrip {
    * @param type
    */
   private void t(Type type) {
-    var converted = type.accept(typeProtoConverter);
+    io.substrait.proto.Type converted = type.accept(typeProtoConverter);
     assertEquals(type, protoTypeConverter.from(converted));
   }
 

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
@@ -102,11 +102,12 @@ public class IsthmusEntryPoint implements Callable<Integer> {
   }
 
   private void printMessage(Message message) throws IOException {
-    switch (outputFormat) {
-      case PROTOJSON -> System.out.println(
-          JsonFormat.printer().includingDefaultValueFields().print(message));
-      case PROTOTEXT -> TextFormat.printer().print(message, System.out);
-      case BINARY -> message.writeTo(System.out);
+    if (outputFormat == OutputFormat.PROTOJSON) {
+      System.out.println(JsonFormat.printer().includingDefaultValueFields().print(message));
+    } else if (outputFormat == OutputFormat.PROTOTEXT) {
+      TextFormat.printer().print(message, System.out);
+    } else if (outputFormat == OutputFormat.BINARY) {
+      message.writeTo(System.out);
     }
   }
 

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -93,7 +93,7 @@ jreleaser {
 }
 
 java {
-  toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+  toolchain { languageVersion = JavaLanguageVersion.of(11) }
   withJavadocJar()
   withSourcesJar()
 }
@@ -149,8 +149,6 @@ dependencies {
         "calcite-core brings in commons-lang:commons-lang:2.4 which has a security vulnerability"
       )
   }
-  annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
-  compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
   testImplementation("com.google.protobuf:protobuf-java:${PROTOBUF_VERSION}")
 }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -38,7 +38,8 @@ public class AggregateFunctions {
    *     conversion was needed, empty otherwise.
    */
   public static Optional<SqlAggFunction> toSubstraitAggVariant(SqlAggFunction aggFunction) {
-    if (aggFunction instanceof SqlMinMaxAggFunction fun) {
+    if (aggFunction instanceof SqlMinMaxAggFunction) {
+      SqlMinMaxAggFunction fun = (SqlMinMaxAggFunction) aggFunction;
       return Optional.of(
           fun.getKind() == SqlKind.MIN ? AggregateFunctions.MIN : AggregateFunctions.MAX);
     } else if (aggFunction instanceof SqlAvgAggFunction) {

--- a/isthmus/src/main/java/io/substrait/isthmus/PreCalciteAggregateValidator.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/PreCalciteAggregateValidator.java
@@ -91,9 +91,12 @@ public class PreCalciteAggregateValidator {
   }
 
   private static boolean isSimpleFieldReference(FunctionArg e) {
-    return e instanceof FieldReference fr
-        && fr.segments().size() == 1
-        && fr.segments().get(0) instanceof FieldReference.StructField;
+    if (!(e instanceof FieldReference)) {
+      return false;
+    }
+
+    List<FieldReference.ReferenceSegment> segments = ((FieldReference) e).segments();
+    return segments.size() == 1 && segments.get(0) instanceof FieldReference.StructField;
   }
 
   private static int getFieldRefOffset(FieldReference fr) {
@@ -194,8 +197,8 @@ public class PreCalciteAggregateValidator {
     }
 
     private Expression projectOutNonFieldReference(FunctionArg farg) {
-      if ((farg instanceof Expression e)) {
-        return projectOutNonFieldReference(e);
+      if ((farg instanceof Expression)) {
+        return projectOutNonFieldReference((Expression) farg);
       } else {
         throw new IllegalArgumentException("cannot handle non-expression argument for aggregate");
       }

--- a/isthmus/src/main/java/io/substrait/isthmus/RelNodeVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/RelNodeVisitor.java
@@ -94,38 +94,38 @@ public abstract class RelNodeVisitor<OUTPUT, EXCEPTION extends Throwable> {
    * RelVisitor.reverseAccept(RelNode) due to the lack of ability to extend base classes.
    */
   public final OUTPUT reverseAccept(RelNode node) throws EXCEPTION {
-    if (node instanceof TableScan scan) {
-      return this.visit(scan);
-    } else if (node instanceof TableFunctionScan scan) {
-      return this.visit(scan);
-    } else if (node instanceof Values values) {
-      return this.visit(values);
-    } else if (node instanceof Filter filter) {
-      return this.visit(filter);
-    } else if (node instanceof Calc calc) {
-      return this.visit(calc);
-    } else if (node instanceof Project project) {
-      return this.visit(project);
-    } else if (node instanceof Join join) {
-      return this.visit(join);
-    } else if (node instanceof Correlate correlate) {
-      return this.visit(correlate);
-    } else if (node instanceof Union union) {
-      return this.visit(union);
-    } else if (node instanceof Intersect intersect) {
-      return this.visit(intersect);
-    } else if (node instanceof Minus minus) {
-      return this.visit(minus);
-    } else if (node instanceof Match match) {
-      return this.visit(match);
-    } else if (node instanceof Sort sort) {
-      return this.visit(sort);
-    } else if (node instanceof Exchange exchange) {
-      return this.visit(exchange);
-    } else if (node instanceof Aggregate aggregate) {
-      return this.visit(aggregate);
-    } else if (node instanceof TableModify modify) {
-      return this.visit(modify);
+    if (node instanceof TableScan) {
+      return this.visit((TableScan) node);
+    } else if (node instanceof TableFunctionScan) {
+      return this.visit((TableFunctionScan) node);
+    } else if (node instanceof Values) {
+      return this.visit((Values) node);
+    } else if (node instanceof Filter) {
+      return this.visit((Filter) node);
+    } else if (node instanceof Calc) {
+      return this.visit((Calc) node);
+    } else if (node instanceof Project) {
+      return this.visit((Project) node);
+    } else if (node instanceof Join) {
+      return this.visit((Join) node);
+    } else if (node instanceof Correlate) {
+      return this.visit((Correlate) node);
+    } else if (node instanceof Union) {
+      return this.visit((Union) node);
+    } else if (node instanceof Intersect) {
+      return this.visit((Intersect) node);
+    } else if (node instanceof Minus) {
+      return this.visit((Minus) node);
+    } else if (node instanceof Match) {
+      return this.visit((Match) node);
+    } else if (node instanceof Sort) {
+      return this.visit((Sort) node);
+    } else if (node instanceof Exchange) {
+      return this.visit((Exchange) node);
+    } else if (node instanceof Aggregate) {
+      return this.visit((Aggregate) node);
+    } else if (node instanceof TableModify) {
+      return this.visit((TableModify) node);
     } else {
       return this.visitOther(node);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
@@ -1,6 +1,5 @@
 package io.substrait.isthmus;
 
-import com.github.bsideup.jabel.Desugar;
 import io.substrait.extendedexpression.ExtendedExpression;
 import io.substrait.extendedexpression.ExtendedExpressionProtoConverter;
 import io.substrait.extension.SimpleExtension;
@@ -45,12 +44,23 @@ public class SqlExpressionToSubstrait extends SqlConverterBase {
     this.rexConverter = new RexExpressionConverter(scalarFunctionConverter);
   }
 
-  @Desugar
-  private record Result(
-      SqlValidator validator,
-      CalciteCatalogReader catalogReader,
-      Map<String, RelDataType> nameToTypeMap,
-      Map<String, RexNode> nameToNodeMap) {}
+  private static final class Result {
+    final SqlValidator validator;
+    final CalciteCatalogReader catalogReader;
+    final Map<String, RelDataType> nameToTypeMap;
+    final Map<String, RexNode> nameToNodeMap;
+
+    Result(
+        SqlValidator validator,
+        CalciteCatalogReader catalogReader,
+        Map<String, RelDataType> nameToTypeMap,
+        Map<String, RexNode> nameToNodeMap) {
+      this.validator = validator;
+      this.catalogReader = catalogReader;
+      this.nameToTypeMap = nameToTypeMap;
+      this.nameToNodeMap = nameToNodeMap;
+    }
+  }
 
   /**
    * Converts the given SQL expression to an {@link io.substrait.proto.ExtendedExpression }
@@ -78,10 +88,10 @@ public class SqlExpressionToSubstrait extends SqlConverterBase {
     var result = registerCreateTablesForExtendedExpression(createStatements);
     return executeInnerSQLExpressions(
         sqlExpressions,
-        result.validator(),
-        result.catalogReader(),
-        result.nameToTypeMap(),
-        result.nameToNodeMap());
+        result.validator,
+        result.catalogReader,
+        result.nameToTypeMap,
+        result.nameToNodeMap);
   }
 
   private io.substrait.proto.ExtendedExpression executeInnerSQLExpressions(

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
@@ -108,7 +108,7 @@ public class AggregateFunctionConverter
     return signatures.get(lookupFunction);
   }
 
-  static class WrappedAggregateCall implements GenericCall {
+  static class WrappedAggregateCall implements FunctionConverter.GenericCall {
     private final AggregateCall call;
     private final RelNode input;
     private final RexBuilder rexBuilder;

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -66,8 +66,11 @@ public class CallConverters {
 
             // For now, we only support handling of SqlKind.REINTEPRETET for the case of stored
             // user-defined literals
-            if (operand instanceof Expression.FixedBinaryLiteral literal
-                && type instanceof Type.UserDefined t) {
+            if (operand instanceof Expression.FixedBinaryLiteral
+                && type instanceof Type.UserDefined) {
+              Expression.FixedBinaryLiteral literal = (Expression.FixedBinaryLiteral) operand;
+              Type.UserDefined t = (Type.UserDefined) type;
+
               return Expression.UserDefinedLiteral.builder()
                   .uri(t.uri())
                   .name(t.name())

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/EnumConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/EnumConverter.java
@@ -117,8 +117,8 @@ public class EnumConverter {
         return Optional.empty();
       }
       Argument arg = args.get(enumAnchor.argIdx);
-      if (arg instanceof SimpleExtension.EnumArgument ea) {
-        return Optional.of(ea);
+      if (arg instanceof SimpleExtension.EnumArgument) {
+        return Optional.of((SimpleExtension.EnumArgument) arg);
       } else {
         return Optional.empty();
       }
@@ -127,19 +127,21 @@ public class EnumConverter {
 
   static Optional<EnumArg> fromRex(
       SimpleExtension.Function function, RexLiteral literal, int argIdx) {
-    return switch (literal.getType().getSqlTypeName()) {
-      case SYMBOL -> {
-        Object v = literal.getValue();
-        if (!literal.isNull() && (v instanceof Enum)) {
-          Enum<?> value = (Enum<?>) v;
-          ArgAnchor enumAnchor = argAnchor(function, argIdx);
-          yield findEnumArg(function, enumAnchor).map(ea -> EnumArg.of(ea, value.name()));
-        } else {
-          yield Optional.empty();
+    switch (literal.getType().getSqlTypeName()) {
+      case SYMBOL:
+        {
+          Object v = literal.getValue();
+          if (!literal.isNull() && (v instanceof Enum)) {
+            Enum<?> value = (Enum<?>) v;
+            ArgAnchor enumAnchor = argAnchor(function, argIdx);
+            return findEnumArg(function, enumAnchor).map(ea -> EnumArg.of(ea, value.name()));
+          }
+
+          return Optional.empty();
         }
-      }
-      default -> Optional.empty();
-    };
+      default:
+        return Optional.empty();
+    }
   }
 
   static boolean canConvert(Enum<?> value) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
@@ -92,14 +92,14 @@ public class FieldSelectionConverter implements CallConverter {
   }
 
   private Optional<Integer> toInt(Expression.Literal l) {
-    if (l instanceof Expression.I8Literal i8) {
-      return Optional.of(i8.value());
-    } else if (l instanceof Expression.I16Literal i16) {
-      return Optional.of(i16.value());
-    } else if (l instanceof Expression.I32Literal i32) {
-      return Optional.of(i32.value());
-    } else if (l instanceof Expression.I64Literal i64) {
-      return Optional.of((int) i64.value());
+    if (l instanceof Expression.I8Literal) {
+      return Optional.of(((Expression.I8Literal) l).value());
+    } else if (l instanceof Expression.I16Literal) {
+      return Optional.of(((Expression.I16Literal) l).value());
+    } else if (l instanceof Expression.I32Literal) {
+      return Optional.of(((Expression.I32Literal) l).value());
+    } else if (l instanceof Expression.I64Literal) {
+      return Optional.of((int) ((Expression.I64Literal) l).value());
     }
     logger.atWarn().log("Literal expected to be int type but was not. {}.", l);
     return Optional.empty();

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -203,7 +203,7 @@ public abstract class FunctionConverter<
      * @param args expected arguments as defined in a {@link SimpleExtension.Function}
      * @return true if the {@code inputTypes} satisfy the {@code args}, false otherwise
      */
-    private static boolean inputTypesMatchDefinedArguments(
+    private boolean inputTypesMatchDefinedArguments(
         List<Type> inputTypes, List<SimpleExtension.Argument> args) {
 
       Map<String, Set<Type>> wildcardToType = new HashMap<>();
@@ -242,9 +242,8 @@ public abstract class FunctionConverter<
      * <p>If this exists, the function finder will attempt to find a least-restrictive match using
      * these.
      */
-    private static <F extends SimpleExtension.Function>
-        Optional<SingularArgumentMatcher<F>> getSingularInputType(List<F> functions) {
-      List<SingularArgumentMatcher> matchers = new ArrayList<>();
+    private Optional<SingularArgumentMatcher<F>> getSingularInputType(List<F> functions) {
+      List<SingularArgumentMatcher<F>> matchers = new ArrayList<>();
       for (var f : functions) {
 
         ParameterizedType firstType = null;
@@ -274,15 +273,17 @@ public abstract class FunctionConverter<
         }
       }
 
-      return switch (matchers.size()) {
-        case 0 -> Optional.empty();
-        case 1 -> Optional.of(matchers.get(0));
-        default -> Optional.of(chained(matchers));
-      };
+      switch (matchers.size()) {
+        case 0:
+          return Optional.empty();
+        case 1:
+          return Optional.of(matchers.get(0));
+        default:
+          return Optional.of(chained(matchers));
+      }
     }
 
-    public static <F extends SimpleExtension.Function> SingularArgumentMatcher<F> singular(
-        F function, ParameterizedType type) {
+    private SingularArgumentMatcher<F> singular(F function, ParameterizedType type) {
       return (inputType, outputType) -> {
         var check = isMatch(inputType, type);
         if (check) {
@@ -292,7 +293,7 @@ public abstract class FunctionConverter<
       };
     }
 
-    public static SingularArgumentMatcher chained(List<SingularArgumentMatcher> matchers) {
+    private SingularArgumentMatcher<F> chained(List<SingularArgumentMatcher<F>> matchers) {
       return (inputType, outputType) -> {
         for (var s : matchers) {
           var outcome = s.tryMatch(inputType, outputType);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -129,25 +129,30 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
   public Expression visitFieldAccess(RexFieldAccess fieldAccess) {
     SqlKind kind = fieldAccess.getReferenceExpr().getKind();
     switch (kind) {
-      case CORREL_VARIABLE -> {
-        int stepsOut = relVisitor.getFieldAccessDepth(fieldAccess);
+      case CORREL_VARIABLE:
+        {
+          int stepsOut = relVisitor.getFieldAccessDepth(fieldAccess);
 
-        return FieldReference.newRootStructOuterReference(
-            fieldAccess.getField().getIndex(),
-            typeConverter.toSubstrait(fieldAccess.getType()),
-            stepsOut);
-      }
-      case ITEM, INPUT_REF, FIELD_ACCESS -> {
-        Expression expression = fieldAccess.getReferenceExpr().accept(this);
-        if (expression instanceof FieldReference) {
-          FieldReference nestedReference = (FieldReference) expression;
-          return nestedReference.dereferenceStruct(fieldAccess.getField().getIndex());
-        } else {
-          return FieldReference.newStructReference(fieldAccess.getField().getIndex(), expression);
+          return FieldReference.newRootStructOuterReference(
+              fieldAccess.getField().getIndex(),
+              typeConverter.toSubstrait(fieldAccess.getType()),
+              stepsOut);
         }
-      }
-      default -> throw new UnsupportedOperationException(
-          String.format("RexFieldAccess for SqlKind %s not supported", kind));
+      case ITEM:
+      case INPUT_REF:
+      case FIELD_ACCESS:
+        {
+          Expression expression = fieldAccess.getReferenceExpr().accept(this);
+          if (expression instanceof FieldReference) {
+            FieldReference nestedReference = (FieldReference) expression;
+            return nestedReference.dereferenceStruct(fieldAccess.getField().getIndex());
+          } else {
+            return FieldReference.newStructReference(fieldAccess.getField().getIndex(), expression);
+          }
+        }
+      default:
+        throw new UnsupportedOperationException(
+            String.format("RexFieldAccess for SqlKind %s not supported", kind));
     }
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -135,7 +135,7 @@ public class ScalarFunctionConverter
         .orElse(Optional.empty());
   }
 
-  protected static class WrappedScalarCall implements GenericCall {
+  protected static class WrappedScalarCall implements FunctionConverter.GenericCall {
 
     private final RexCall delegate;
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/SortFieldConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/SortFieldConverter.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus.expression;
 
 import io.substrait.expression.Expression;
 import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rex.RexFieldCollation;
 
 public class SortFieldConverter {
@@ -10,23 +11,27 @@ public class SortFieldConverter {
   public static Expression.SortField toSortField(
       RexFieldCollation rexFieldCollation, RexExpressionConverter rexExpressionConverter) {
     var expr = rexFieldCollation.left.accept(rexExpressionConverter);
-    var rexDirection = rexFieldCollation.getDirection();
-    Expression.SortDirection direction =
-        switch (rexDirection) {
-          case ASCENDING -> rexFieldCollation.getNullDirection()
-                  == RelFieldCollation.NullDirection.LAST
-              ? Expression.SortDirection.ASC_NULLS_LAST
-              : Expression.SortDirection.ASC_NULLS_FIRST;
-          case DESCENDING -> rexFieldCollation.getNullDirection()
-                  == RelFieldCollation.NullDirection.LAST
-              ? Expression.SortDirection.DESC_NULLS_LAST
-              : Expression.SortDirection.DESC_NULLS_FIRST;
-          default -> throw new IllegalArgumentException(
-              String.format(
-                  "Unexpected RelFieldCollation.Direction:%s enum at the RexFieldCollation!",
-                  rexDirection));
-        };
+    Expression.SortDirection direction = asSortDirection(rexFieldCollation);
 
     return Expression.SortField.builder().expr(expr).direction(direction).build();
+  }
+
+  private static Expression.SortDirection asSortDirection(RexFieldCollation collation) {
+    RelFieldCollation.Direction direction = collation.getDirection();
+
+    if (direction == Direction.ASCENDING) {
+      return collation.getNullDirection() == RelFieldCollation.NullDirection.LAST
+          ? Expression.SortDirection.ASC_NULLS_LAST
+          : Expression.SortDirection.ASC_NULLS_FIRST;
+    }
+    if (direction == Direction.DESCENDING) {
+      return collation.getNullDirection() == RelFieldCollation.NullDirection.LAST
+          ? Expression.SortDirection.DESC_NULLS_LAST
+          : Expression.SortDirection.DESC_NULLS_FIRST;
+    }
+
+    throw new IllegalArgumentException(
+        String.format(
+            "Unexpected RelFieldCollation.Direction:%s enum at the RexFieldCollation!", direction));
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowRelFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowRelFunctionConverter.java
@@ -99,7 +99,7 @@ public class WindowRelFunctionConverter
     return m.attemptMatch(wrapped, topLevelConverter);
   }
 
-  static class WrappedWindowRelCall implements GenericCall {
+  static class WrappedWindowRelCall implements FunctionConverter.GenericCall {
     private final Window.RexWinAggCall winAggCall;
     private final RexWindowBound lowerBound;
     private final RexWindowBound upperBound;

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -67,9 +67,11 @@ public class SubstraitCreateStatementParser {
 
     SqlNodeList sqlNode = parser.parseStmtList();
     for (SqlNode parsed : sqlNode) {
-      if (!(parsed instanceof SqlCreateTable create)) {
+      if (!(parsed instanceof SqlCreateTable)) {
         throw fail("Not a valid CREATE TABLE statement.");
       }
+
+      SqlCreateTable create = (SqlCreateTable) parsed;
 
       if (create.name.names.size() > 1) {
         throw fail("Only simple table names are allowed.", create.name.getParserPosition());
@@ -83,7 +85,7 @@ public class SubstraitCreateStatementParser {
       List<RelDataType> columnTypes = new ArrayList<>();
 
       for (SqlNode node : create.columnList) {
-        if (!(node instanceof SqlColumnDeclaration col)) {
+        if (!(node instanceof SqlColumnDeclaration)) {
           if (node instanceof SqlKeyConstraint) {
             // key constraints declarations, like primary key declaration, are valid and should not
             // result in parse exceptions. Ignore the constraint declaration.
@@ -92,6 +94,8 @@ public class SubstraitCreateStatementParser {
 
           throw fail("Unexpected column list construction.", node.getParserPosition());
         }
+
+        SqlColumnDeclaration col = (SqlColumnDeclaration) node;
 
         if (col.name.names.size() != 1) {
           throw fail("Expected simple column names.", col.name.getParserPosition());

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -41,15 +41,20 @@ public class AggregationFunctionsTest extends PlanTestBase {
 
   // Create the given function call on the given field of the input
   private Aggregate.Measure functionPicker(Rel input, int field, String fname) {
-    return switch (fname) {
-      case "min" -> b.min(input, field);
-      case "max" -> b.max(input, field);
-      case "sum" -> b.sum(input, field);
-      case "sum0" -> b.sum0(input, field);
-      case "avg" -> b.avg(input, field);
-      default -> throw new RuntimeException(
-          String.format("no function is associated with %s", fname));
-    };
+    switch (fname) {
+      case "min":
+        return b.min(input, field);
+      case "max":
+        return b.max(input, field);
+      case "sum":
+        return b.sum(input, field);
+      case "sum0":
+        return b.sum0(input, field);
+      case "avg":
+        return b.avg(input, field);
+      default:
+        throw new RuntimeException(String.format("no function is associated with %s", fname));
+    }
   }
 
   // Create one function call per numeric type column

--- a/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
@@ -37,10 +37,9 @@ public class ApplyJoinPlanTest extends PlanTestBase {
   public void lateralJoinQuery() throws SqlParseException {
     String sql;
     sql =
-        """
-            SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
-            FROM store_sales CROSS JOIN LATERAL
-              (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+        "SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk\n"
+            + "FROM store_sales CROSS JOIN LATERAL\n"
+            + "  (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)";
 
     /* the calcite plan for the above query is:
       LogicalProject(SS_SOLD_DATE_SK=[$0], SS_ITEM_SK=[$2], SS_CUSTOMER_SK=[$3])
@@ -69,11 +68,9 @@ public class ApplyJoinPlanTest extends PlanTestBase {
   public void outerApplyQuery() throws SqlParseException {
     String sql;
     sql =
-        """
-       SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
-        FROM store_sales OUTER APPLY
-          (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)
-       """;
+        "SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk\n"
+            + "FROM store_sales OUTER APPLY\n"
+            + "  (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)";
 
     RelRoot root = getCalcitePlan(sql);
 
@@ -92,15 +89,14 @@ public class ApplyJoinPlanTest extends PlanTestBase {
   public void nestedApplyJoinQuery() throws SqlParseException {
     String sql;
     sql =
-        """
-            SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
-            FROM store_sales CROSS APPLY
-              ( SELECT i_item_sk
-                FROM item CROSS APPLY
-                  ( SELECT p_promo_sk
-                    FROM promotion
-                    WHERE p_item_sk = i_item_sk AND p_item_sk = ss_item_sk )
-                WHERE item.i_item_sk = store_sales.ss_item_sk )""";
+        "SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk\n"
+            + "FROM store_sales CROSS APPLY\n"
+            + "  ( SELECT i_item_sk\n"
+            + "    FROM item CROSS APPLY\n"
+            + "      ( SELECT p_promo_sk\n"
+            + "        FROM promotion\n"
+            + "        WHERE p_item_sk = i_item_sk AND p_item_sk = ss_item_sk )\n"
+            + "    WHERE item.i_item_sk = store_sales.ss_item_sk )";
 
     /* the calcite plan for the above query is:
     LogicalProject(SS_SOLD_DATE_SK=[$0], SS_ITEM_SK=[$2], SS_CUSTOMER_SK=[$3])
@@ -135,10 +131,9 @@ public class ApplyJoinPlanTest extends PlanTestBase {
   public void crossApplyQuery() throws SqlParseException {
     String sql;
     sql =
-        """
-            SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk
-            FROM store_sales CROSS APPLY
-              (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)""";
+        "SELECT ss_sold_date_sk, ss_item_sk, ss_customer_sk\n"
+            + "FROM store_sales CROSS APPLY\n"
+            + "  (select i_item_sk from item where item.i_item_sk = store_sales.ss_item_sk)";
 
     FeatureBoard featureBoard = ImmutableFeatureBoard.builder().build();
     SqlToSubstrait s = new SqlToSubstrait(featureBoard);

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteObjs.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteObjs.java
@@ -14,12 +14,16 @@ public abstract class CalciteObjs {
   final RexBuilder rex = new RexBuilder(type);
 
   RelDataType t(SqlTypeName typeName, int... vals) {
-    return switch (vals.length) {
-      case 0 -> type.createSqlType(typeName);
-      case 1 -> type.createSqlType(typeName, vals[0]);
-      case 2 -> type.createSqlType(typeName, vals[0], vals[1]);
-      default -> throw new IllegalArgumentException();
-    };
+    switch (vals.length) {
+      case 0:
+        return type.createSqlType(typeName);
+      case 1:
+        return type.createSqlType(typeName, vals[0]);
+      case 2:
+        return type.createSqlType(typeName, vals[0], vals[1]);
+      default:
+        throw new IllegalArgumentException();
+    }
   }
 
   RelDataType tN(SqlTypeName typeName, int... vals) {

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
@@ -65,11 +65,9 @@ public class ComplexSortTest extends PlanTestBase {
                 b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
 
     String expected =
-        """
-        Collation: [0]
-        LogicalSort(sort0=[$0], dir0=[ASC])
-          LogicalTableScan(table=[[example]])
-        """;
+        "Collation: [0]\n"
+            + "LogicalSort(sort0=[$0], dir0=[ASC])\n"
+            + "  LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
     var sw = new StringWriter();
@@ -95,13 +93,11 @@ public class ComplexSortTest extends PlanTestBase {
                 b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
 
     String expected =
-        """
-         LogicalProject(a0=[$0])
-           Collation: [1]
-           LogicalSort(sort0=[$1], dir0=[ASC])
-             LogicalProject(a=[$0], a0=[CAST($0):INTEGER NOT NULL])
-               LogicalTableScan(table=[[example]])
-         """;
+        "LogicalProject(a0=[$0])\n"
+            + "  Collation: [1]\n"
+            + "  LogicalSort(sort0=[$1], dir0=[ASC])\n"
+            + "    LogicalProject(a=[$0], a0=[CAST($0):INTEGER NOT NULL])\n"
+            + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
     var sw = new StringWriter();
@@ -127,13 +123,11 @@ public class ComplexSortTest extends PlanTestBase {
                 b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
 
     String expected =
-        """
-        LogicalProject(a0=[CAST($0):INTEGER NOT NULL])
-          Collation: [1 DESC-nulls-last]
-          LogicalSort(sort0=[$1], dir0=[DESC-nulls-last])
-            LogicalProject(a=[$0], a0=[CAST($0):INTEGER NOT NULL])
-              LogicalTableScan(table=[[example]])
-         """;
+        "LogicalProject(a0=[CAST($0):INTEGER NOT NULL])\n"
+            + "  Collation: [1 DESC-nulls-last]\n"
+            + "  LogicalSort(sort0=[$1], dir0=[DESC-nulls-last])\n"
+            + "    LogicalProject(a=[$0], a0=[CAST($0):INTEGER NOT NULL])\n"
+            + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
     var sw = new StringWriter();
@@ -159,13 +153,11 @@ public class ComplexSortTest extends PlanTestBase {
                 b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
 
     String expected =
-        """
-        LogicalProject(a0=[$0])
-          Collation: [1 DESC-nulls-last]
-          LogicalSort(sort0=[$1], dir0=[DESC-nulls-last])
-            LogicalProject(a=[$0], a0=[$0])
-              LogicalTableScan(table=[[example]])
-        """;
+        "LogicalProject(a0=[$0])\n"
+            + "  Collation: [1 DESC-nulls-last]\n"
+            + "  LogicalSort(sort0=[$1], dir0=[DESC-nulls-last])\n"
+            + "    LogicalProject(a=[$0], a0=[$0])\n"
+            + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
     var sw = new StringWriter();
@@ -194,13 +186,11 @@ public class ComplexSortTest extends PlanTestBase {
                 b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.STRING, R.I32))));
 
     String expected =
-        """
-        LogicalProject(a0=[$0], b0=[$1])
-          Collation: [2 DESC, 3]
-          LogicalSort(sort0=[$2], sort1=[$3], dir0=[DESC], dir1=[ASC])
-            LogicalProject(a=[$0], b=[$1], a0=[CAST($0):INTEGER NOT NULL], $f3=[+(-($1), 42)])
-              LogicalTableScan(table=[[example]])
-        """;
+        "LogicalProject(a0=[$0], b0=[$1])\n"
+            + "  Collation: [2 DESC, 3]\n"
+            + "  LogicalSort(sort0=[$2], sort1=[$3], dir0=[DESC], dir1=[ASC])\n"
+            + "    LogicalProject(a=[$0], b=[$1], a0=[CAST($0):INTEGER NOT NULL], $f3=[+(-($1), 42)])\n"
+            + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
     var sw = new StringWriter();

--- a/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
@@ -21,9 +21,7 @@ public class NameRoundtripTest extends PlanTestBase {
     SqlToSubstrait s = new SqlToSubstrait();
     var substraitToCalcite = new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory);
 
-    String query = """
-      SELECT "a", "B" FROM foo GROUP BY a, b
-      """;
+    String query = "SELECT \"a\", \"B\" FROM foo GROUP BY a, b";
     List<String> expectedNames = List.of("a", "B");
 
     List<org.apache.calcite.rel.RelRoot> calciteRelRoots = s.sqlToRelNode(query, catalogReader);

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
@@ -85,24 +85,17 @@ public class NestedStructQueryTest extends PlanTestBase {
         };
 
     String query =
-        """
-           SELECT
-             "nested"."my_table"."a"
-           FROM
-             "nested"."my_table";
-           """;
+        "SELECT\n" + "  \"nested\".\"my_table\".\"a\"\n" + "FROM\n" + "  \"nested\".\"my_table\";";
 
     String expectedExpressionText =
-        """
-          selection {
-            direct_reference {
-              struct_field {
-                field: 1 # a
-              }
-            }
-            root_reference: {}
-          }
-        """;
+        "selection {\n"
+            + "  direct_reference {\n"
+            + "    struct_field {\n"
+            + "      field: 1 # a\n"
+            + "    }\n"
+            + "  }\n"
+            + "  root_reference: {}\n"
+            + "}";
 
     test(table, query, expectedExpressionText);
   }
@@ -121,29 +114,25 @@ public class NestedStructQueryTest extends PlanTestBase {
         };
 
     String query =
-        """
-           SELECT
-             "nested"."my_table"."a"."b"
-           FROM
-             "nested"."my_table";
-           """;
+        "SELECT\n"
+            + "   \"nested\".\"my_table\".\"a\".\"b\"\n"
+            + "FROM\n"
+            + "  \"nested\".\"my_table\";";
 
     String expectedExpressionText =
-        """
-          selection {
-            direct_reference {
-              struct_field {
-                field: 1 # a
-                child {
-                  struct_field {
-                    field: 0 # b
-                  }
-                }
-              }
-            }
-            root_reference: {}
-          }
-        """;
+        "selection {\n"
+            + "  direct_reference {\n"
+            + "    struct_field {\n"
+            + "      field: 1 # a\n"
+            + "      child {\n"
+            + "        struct_field {\n"
+            + "          field: 0 # b\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "  root_reference: {}\n"
+            + "}";
 
     test(table, query, expectedExpressionText);
   }
@@ -162,34 +151,30 @@ public class NestedStructQueryTest extends PlanTestBase {
         };
 
     String query =
-        """
-           SELECT
-             "nested"."my_table"."a"."b"."c"
-           FROM
-             "nested"."my_table";
-           """;
+        "SELECT\n"
+            + "  \"nested\".\"my_table\".\"a\".\"b\".\"c\"\n"
+            + "FROM\n"
+            + "   \"nested\".\"my_table\";";
 
     String expectedExpressionText =
-        """
-          selection {
-            direct_reference {
-              struct_field {
-                field: 1 # a
-                child {
-                  struct_field {
-                    field: 0 # b
-                    child: {
-                      struct_field {
-                        field: 0 # c
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            root_reference: {}
-          }
-        """;
+        "selection {\n"
+            + "  direct_reference {\n"
+            + "    struct_field {\n"
+            + "      field: 1 # a\n"
+            + "      child {\n"
+            + "        struct_field {\n"
+            + "          field: 0 # b\n"
+            + "          child: {\n"
+            + "            struct_field {\n"
+            + "              field: 0 # c\n"
+            + "            }\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "  root_reference: {}\n"
+            + "}";
 
     test(table, query, expectedExpressionText);
   }
@@ -207,29 +192,25 @@ public class NestedStructQueryTest extends PlanTestBase {
         };
 
     String query =
-        """
-           SELECT
-             "nested"."my_table"."a"[1]
-           FROM
-             "nested"."my_table";
-           """;
+        "SELECT\n"
+            + "  \"nested\".\"my_table\".\"a\"[1]\n"
+            + "FROM\n"
+            + "  \"nested\".\"my_table\";";
 
     String expectedExpressionText =
-        """
-            selection {
-              direct_reference {
-                struct_field {
-                  field: 1 # a
-                  child {
-                    list_element {
-                      offset: 1
-                    }
-                  }
-                }
-              }
-              root_reference: {}
-            }
-        """;
+        "selection {\n"
+            + "  direct_reference {\n"
+            + "    struct_field {\n"
+            + "      field: 1 # a\n"
+            + "      child {\n"
+            + "        list_element {\n"
+            + "          offset: 1\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "  root_reference: {}\n"
+            + "}";
 
     test(table, query, expectedExpressionText);
   }
@@ -251,39 +232,35 @@ public class NestedStructQueryTest extends PlanTestBase {
         };
 
     String query =
-        """
-           SELECT
-             "nested"."my_table"."a"[1][2][3]
-           FROM
-             "nested"."my_table";
-           """;
+        "SELECT\n"
+            + "  \"nested\".\"my_table\".\"a\"[1][2][3]\n"
+            + "FROM\n"
+            + "  \"nested\".\"my_table\";";
 
     String expectedExpressionText =
-        """
-        selection {
-          direct_reference {
-            struct_field {
-              field: 1 # a
-              child {
-                list_element {
-                  offset: 1
-                  child {
-                    list_element {
-                      offset: 2
-                      child {
-                        list_element {
-                          offset: 3
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-          root_reference: {}
-        }
-        """;
+        "selection {\n"
+            + "  direct_reference {\n"
+            + "    struct_field {\n"
+            + "      field: 1 # a\n"
+            + "      child {\n"
+            + "        list_element {\n"
+            + "          offset: 1\n"
+            + "          child {\n"
+            + "            list_element {\n"
+            + "              offset: 2\n"
+            + "              child {\n"
+            + "                list_element {\n"
+            + "                  offset: 3\n"
+            + "                }\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "  root_reference: {}\n"
+            + "}";
 
     test(table, query, expectedExpressionText);
   }
@@ -308,51 +285,47 @@ public class NestedStructQueryTest extends PlanTestBase {
         };
 
     String query =
-        """
-           SELECT
-             "nested"."my_table".a.b[2].c['my_map_key'].x
-           FROM
-             "nested"."my_table";
-           """;
+        "SELECT\n"
+            + "  \"nested\".\"my_table\".a.b[2].c['my_map_key'].x\n"
+            + "FROM\n"
+            + "  \"nested\".\"my_table\";";
 
     String expectedExpressionText =
-        """
-          selection {
-            direct_reference {
-              struct_field {
-                field: 0 # .a
-                child {
-                  struct_field {
-                    field: 0 # .b
-                    child {
-                      list_element {
-                        offset: 2
-                        child {
-                          struct_field {
-                            field: 0 # .c
-                            child {
-                              map_key {
-                                map_key {
-                                  string: "my_map_key" # ['my_map_key']
-                                }
-                                child {
-                                  struct_field {
-                                    field: 0 # .x
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-            root_reference {}
-          }
-        """;
+        "  selection {\n"
+            + "  direct_reference {\n"
+            + "    struct_field {\n"
+            + "      field: 0 # .a\n"
+            + "      child {\n"
+            + "        struct_field {\n"
+            + "          field: 0 # .b\n"
+            + "          child {\n"
+            + "            list_element {\n"
+            + "              offset: 2\n"
+            + "              child {\n"
+            + "                struct_field {\n"
+            + "                  field: 0 # .c\n"
+            + "                  child {\n"
+            + "                    map_key {\n"
+            + "                      map_key {\n"
+            + "                        string: \"my_map_key\" # ['my_map_key']\n"
+            + "                      }\n"
+            + "                      child {\n"
+            + "                        struct_field {\n"
+            + "                          field: 0 # .x\n"
+            + "                        }\n"
+            + "                      }\n"
+            + "                    }\n"
+            + "                  }\n"
+            + "                }\n"
+            + "              }\n"
+            + "            }\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "  root_reference {}\n"
+            + "}\n";
     test(table, query, expectedExpressionText);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
@@ -76,34 +76,28 @@ public class ProtoPlanConverterTest extends PlanTestBase {
         };
     var featureBoard = ImmutableFeatureBoard.builder().build();
 
-    Plan plan1 =
-        assertProtoPlanRoundrip(
-            """
-            select
-              c.c_custKey,
-              o.o_custkey
-            from
-              "customer" c cross join
-              "orders" o
-            """,
-            new SqlToSubstrait(featureBoard));
+    String query1 =
+        "select\n"
+            + "  c.c_custKey,\n"
+            + "  o.o_custkey\n"
+            + "from\n"
+            + "  \"customer\" c cross join\n"
+            + "  \"orders\" o";
+    Plan plan1 = assertProtoPlanRoundrip(query1, new SqlToSubstrait(featureBoard));
     plan1
         .getRoots()
         .forEach(
             t -> t.getInput().accept(crossJoinCountingVisitor, EmptyVisitationContext.INSTANCE));
     assertEquals(1, counter[0]);
 
-    Plan plan2 =
-        assertProtoPlanRoundrip(
-            """
-            select
-              c.c_custKey,
-              o.o_custkey
-            from
-              "customer" c,
-              "orders" o
-            """,
-            new SqlToSubstrait(featureBoard));
+    String query2 =
+        "select\n"
+            + "  c.c_custKey,\n"
+            + "  o.o_custkey\n"
+            + "from\n"
+            + "  \"customer\" c,\n"
+            + "  \"orders\" o";
+    Plan plan2 = assertProtoPlanRoundrip(query2, new SqlToSubstrait(featureBoard));
     plan2
         .getRoots()
         .forEach(

--- a/isthmus/src/test/java/io/substrait/isthmus/utils/SetUtils.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/utils/SetUtils.java
@@ -18,17 +18,7 @@ public class SetUtils {
    * @return a sql query
    */
   public static String getSetQuery(Set.SetOp op, boolean multi) {
-    String opString =
-        switch (op) {
-          case MINUS_PRIMARY -> "EXCEPT";
-          case MINUS_PRIMARY_ALL -> "EXCEPT ALL";
-          case INTERSECTION_MULTISET -> "INTERSECT";
-          case INTERSECTION_MULTISET_ALL -> "INTERSECT ALL";
-          case UNION_DISTINCT -> "UNION";
-          case UNION_ALL -> "UNION ALL";
-          default -> throw new UnsupportedOperationException(
-              "Unknown set operation is not supported");
-        };
+    String opString = asString(op);
 
     StringBuilder query = new StringBuilder();
     query.append(
@@ -46,6 +36,25 @@ public class SetUtils {
       query.append(
           "select ps_partkey as partkey, ps_comment as str, (ps_partkey + ps_partkey) as expr from partsupp");
       return query.toString();
+    }
+  }
+
+  private static String asString(Set.SetOp op) {
+    switch (op) {
+      case MINUS_PRIMARY:
+        return "EXCEPT";
+      case MINUS_PRIMARY_ALL:
+        return "EXCEPT ALL";
+      case INTERSECTION_MULTISET:
+        return "INTERSECT";
+      case INTERSECTION_MULTISET_ALL:
+        return "INTERSECT ALL";
+      case UNION_DISTINCT:
+        return "UNION";
+      case UNION_ALL:
+        return "UNION ALL";
+      default:
+        throw new UnsupportedOperationException("Unknown set operation is not supported");
     }
   }
 

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -96,7 +96,7 @@ configurations.all {
 }
 
 java {
-  toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+  toolchain { languageVersion = JavaLanguageVersion.of(17) }
   withJavadocJar()
   withSourcesJar()
 }
@@ -150,5 +150,6 @@ tasks {
   test {
     dependsOn(":core:shadowJar")
     useJUnitPlatform { includeEngines("scalatest") }
+    jvmArgs("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED")
   }
 }

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -101,10 +101,7 @@ java {
   withSourcesJar()
 }
 
-tasks.withType<ScalaCompile>() {
-  targetCompatibility = ""
-  scalaCompileOptions.additionalParameters = listOf("-release:17")
-}
+tasks.withType<ScalaCompile>() { scalaCompileOptions.additionalParameters = listOf("-release:17") }
 
 var SLF4J_VERSION = properties.get("slf4j.version")
 var SPARKBUNDLE_VERSION = properties.get("sparkbundle.version")


### PR DESCRIPTION
When developing, the build (both on the command-line and in the IDE) frequently fails due to usage of unsupported Java language features for the target Java runtime. This is due to the the Java source version being set to a newer version than the target Java version. While this sometimes works, this combination is explicitly disallowed by the Java compiler. Source version must be equal to or less than the target version.

This change uses the correct Java toolchain version for each sub-project. The exception being the core sub-project, since it targets Java 8 whereas ANTLR requires Java 11+ to run. Instead, the Java compiler release option is set to Java 8, ensuring that Java 8 bytecode is produced and that no APIs not present in Java 8 are used.

While numerous code changes are required to adhere to the target Java language version, there are no functional changes.