### PR TITLE
style: replace RuntimeException with more specific exceptions

### DIFF
--- a/buildSrc/src/main/resources/substrait-pmd.xml
+++ b/buildSrc/src/main/resources/substrait-pmd.xml
@@ -12,4 +12,5 @@
 
   <rule ref="category/java/codestyle.xml/UnnecessaryModifier" />
   <rule ref="category/java/bestpractices.xml/MissingOverride" />
+  <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" />
 </ruleset>

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -372,7 +372,7 @@ public class ExpressionProtoConverter
                         .setValue(Any.parseFrom(expr.value())))
                 .build();
           } catch (InvalidProtocolBufferException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
           }
         });
   }

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -426,7 +426,7 @@ public class ProtoExpressionConverter {
       case INTERVAL_COMPOUND:
         {
           if (!literal.getIntervalCompound().getIntervalDayToSecond().hasPrecision()) {
-            throw new RuntimeException(
+            throw new UnsupportedOperationException(
                 "Interval compound with deprecated version of interval day (ie. no precision) is not supported");
           }
           return ExpressionCreator.intervalCompound(

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -736,7 +736,7 @@ public class SimpleExtension {
                   try (InputStream stream = ExtensionCollection.class.getResourceAsStream(path)) {
                     return load(path, stream);
                   } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    throw new IllegalStateException(e);
                   }
                 })
             .collect(Collectors.toList());
@@ -752,7 +752,7 @@ public class SimpleExtension {
       ExtensionSignatures doc = objectMapper(namespace).readValue(str, ExtensionSignatures.class);
       return buildExtensionCollection(namespace, doc);
     } catch (JsonProcessingException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 
@@ -764,7 +764,7 @@ public class SimpleExtension {
     } catch (RuntimeException ex) {
       throw ex;
     } catch (Exception ex) {
-      throw new RuntimeException("Failure while parsing " + namespace, ex);
+      throw new IllegalStateException("Failure while parsing " + namespace, ex);
     }
   }
 

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -21,6 +21,7 @@ import io.substrait.type.TypeExpressionEvaluator;
 import io.substrait.util.Util;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -736,7 +737,7 @@ public class SimpleExtension {
                   try (InputStream stream = ExtensionCollection.class.getResourceAsStream(path)) {
                     return load(path, stream);
                   } catch (IOException e) {
-                    throw new IllegalStateException(e);
+                    throw new UncheckedIOException(e);
                   }
                 })
             .collect(Collectors.toList());

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -939,7 +939,7 @@ public class ProtoRelConverter {
    * io.substrait.proto.AdvancedExtension#getEnhancement()} data
    */
   protected Extension.Enhancement enhancementFromAdvancedExtension(com.google.protobuf.Any any) {
-    throw new RuntimeException("enhancements cannot be ignored by consumers");
+    throw new IllegalStateException("enhancements cannot be ignored by consumers");
   }
 
   /** Override to provide a custom converter for {@link ExtensionLeafRel#getDetail()} data */

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -296,7 +296,7 @@ public class RelProtoConverter
     List<FieldReference> rightKeys = hashJoin.getRightKeys();
 
     if (leftKeys.size() != rightKeys.size()) {
-      throw new RuntimeException("Number of left and right keys must be equal.");
+      throw new IllegalArgumentException("Number of left and right keys must be equal.");
     }
 
     builder.addAllLeftKeys(leftKeys.stream().map(this::toProto).collect(Collectors.toList()));
@@ -321,7 +321,7 @@ public class RelProtoConverter
     List<FieldReference> rightKeys = mergeJoin.getRightKeys();
 
     if (leftKeys.size() != rightKeys.size()) {
-      throw new RuntimeException("Number of left and right keys must be equal.");
+      throw new IllegalArgumentException("Number of left and right keys must be equal.");
     }
 
     builder.addAllLeftKeys(leftKeys.stream().map(this::toProto).collect(Collectors.toList()));
@@ -535,7 +535,7 @@ public class RelProtoConverter
                                 .addAllDuplicates(toProto(sf.getDuplicates())))
                         .build());
               } else {
-                throw new RuntimeException(
+                throw new IllegalArgumentException(
                     "Consistent or Switching fields must be set for the Expand relation.");
               }
             });

--- a/core/src/main/java/io/substrait/type/YamlRead.java
+++ b/core/src/main/java/io/substrait/type/YamlRead.java
@@ -72,7 +72,7 @@ public class YamlRead {
     } catch (RuntimeException ex) {
       throw ex;
     } catch (Exception ex) {
-      throw new RuntimeException("Failure while parsing file " + name, ex);
+      throw new IllegalStateException("Failure while parsing file " + name, ex);
     }
   }
 }

--- a/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConverter.java
+++ b/core/src/test/java/io/substrait/relation/utils/StringHolderHandlingProtoRelConverter.java
@@ -24,7 +24,7 @@ public class StringHolderHandlingProtoRelConverter extends ProtoRelConverter {
     try {
       return new StringHolder(any.unpack(StringValue.class).getValue());
     } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/examples/substrait-spark/build.gradle.kts
+++ b/examples/substrait-spark/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   // Apply the application plugin to add support for building a CLI application in Java.
   id("java")
   id("com.diffplug.spotless") version "7.1.0"
+  id("substrait.java-conventions")
 }
 
 repositories {

--- a/examples/substrait-spark/build.gradle.kts
+++ b/examples/substrait-spark/build.gradle.kts
@@ -38,3 +38,5 @@ tasks.named<Test>("test") {
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
+
+tasks.pmdMain { dependsOn(":core:shadowJar") }

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/RegisterAtRuntime.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/RegisterAtRuntime.java
@@ -118,7 +118,7 @@ public class RegisterAtRuntime implements Feature {
                 if (c.method != null) RuntimeReflection.register(c.method);
               });
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus;
 
+import static io.substrait.isthmus.SqlConverterBase.EXTENSION_COLLECTION;
 import static io.substrait.isthmus.SqlToSubstrait.EXTENSION_COLLECTION;
 
 import com.google.common.collect.ImmutableList;
@@ -415,7 +416,8 @@ public class SubstraitRelNodeConverter
       return relBuilder.nullsLast(relBuilder.desc(rexNode));
     }
     if (sortDirection == Expression.SortDirection.CLUSTERED) {
-      throw new RuntimeException(String.format("Unexpected Expression.SortDirection: Clustered!"));
+      throw new UnsupportedOperationException(
+          String.format("Unexpected Expression.SortDirection: Clustered!"));
     }
 
     throw new IllegalArgumentException("Unsupported sort direction: " + sortDirection);
@@ -428,10 +430,12 @@ public class SubstraitRelNodeConverter
     long count = optCount.orElse(-1L);
     var offset = fetch.getOffset();
     if (offset > Integer.MAX_VALUE) {
-      throw new RuntimeException(String.format("offset is overflowed as an integer: %d", offset));
+      throw new IllegalArgumentException(
+          String.format("offset is overflowed as an integer: %d", offset));
     }
     if (count > Integer.MAX_VALUE) {
-      throw new RuntimeException(String.format("count is overflowed as an integer: %d", count));
+      throw new IllegalArgumentException(
+          String.format("count is overflowed as an integer: %d", count));
     }
     RelNode node = relBuilder.push(child).limit((int) offset, (int) count).build();
     return applyRemap(node, fetch.getRemap());
@@ -463,7 +467,7 @@ public class SubstraitRelNodeConverter
       fieldDirection = RelFieldCollation.Direction.CLUSTERED;
       nullDirection = RelFieldCollation.NullDirection.UNSPECIFIED;
     } else {
-      throw new RuntimeException(
+      throw new UnsupportedOperationException(
           String.format("Unexpected Expression.SortDirection enum: %s !", sortDirection));
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -1,7 +1,6 @@
 package io.substrait.isthmus;
 
 import static io.substrait.isthmus.SqlConverterBase.EXTENSION_COLLECTION;
-import static io.substrait.isthmus.SqlToSubstrait.EXTENSION_COLLECTION;
 
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -132,7 +132,7 @@ public abstract class FunctionConverter<
     if (resolvedOperators.size() == 1) {
       return Optional.of(resolvedOperators.get(0));
     } else if (resolvedOperators.size() > 1) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
           String.format(
               "Found %d SqlOperators: %s for ScalarFunction %s: ",
               resolvedOperators.size(), resolvedOperators, key));

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ListSqlOperatorFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ListSqlOperatorFunctions.java
@@ -30,7 +30,7 @@ public class ListSqlOperatorFunctions {
                     SqlOperator op = (SqlOperator) f.get(null);
                     return true;
                   } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
+                    throw new IllegalStateException(e);
                   }
                 })
             .filter(f -> Modifier.isStatic(f.getModifiers()) && Modifier.isPublic(f.getModifiers()))
@@ -44,7 +44,7 @@ public class ListSqlOperatorFunctions {
     try {
       return (SqlOperator) f.get(null);
     } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -53,7 +53,8 @@ public class AggregationFunctionsTest extends PlanTestBase {
       case "avg":
         return b.avg(input, field);
       default:
-        throw new RuntimeException(String.format("no function is associated with %s", fname));
+        throw new UnsupportedOperationException(
+            String.format("no function is associated with %s", fname));
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -1,6 +1,6 @@
 package io.substrait.isthmus;
 
-import static io.substrait.isthmus.SqlToSubstrait.EXTENSION_COLLECTION;
+import static io.substrait.isthmus.SqlConverterBase.EXTENSION_COLLECTION;
 import static io.substrait.isthmus.SubstraitTypeSystem.YEAR_MONTH_INTERVAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -20,6 +20,7 @@ import io.substrait.relation.RelProtoConverter;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
@@ -47,7 +48,7 @@ public class CustomFunctionTest extends PlanTestBase {
     try {
       FUNCTIONS_CUSTOM = asString("extensions/functions_custom.yaml");
     } catch (IOException e) {
-      throw new IllegalStateException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -47,7 +47,7 @@ public class CustomFunctionTest extends PlanTestBase {
     try {
       FUNCTIONS_CUSTOM = asString("extensions/functions_custom.yaml");
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -61,7 +61,7 @@ public class PlanTestBase {
       TPCH_CATALOG =
           SubstraitCreateStatementParser.processCreateStatementsToCatalog(tpchCreateStatements);
     } catch (IOException | SqlParseException e) {
-      throw new RuntimeException(e);
+      throw new IllegalStateException(e);
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
@@ -61,7 +61,7 @@ public class RelCreator {
       RelRoot root = converter.convertQuery(parsed, true, true);
       return root;
     } catch (SqlParseException e) {
-      throw new RuntimeException(e);
+      throw new IllegalArgumentException(e);
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
@@ -165,7 +165,7 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
                 .from(proto.getLiteral()));
         return new ColumnAppendDetail(literal);
       } catch (InvalidProtocolBufferException e) {
-        throw new RuntimeException(e);
+        throw new IllegalStateException(e);
       }
     }
 
@@ -208,7 +208,7 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
         return new ColumnAppenderRel(
             relBuilder.getCluster(), traits, literal, Collections.emptyList());
       }
-      throw new RuntimeException("detail was not ColumnAppendDetail");
+      throw new UnsupportedOperationException("detail was not ColumnAppendDetail");
     }
 
     @Override
@@ -220,7 +220,7 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
         return new ColumnAppenderRel(
             input.getCluster(), input.getTraitSet(), literal, List.of(input));
       }
-      throw new RuntimeException("detail was not ColumnAppendDetail");
+      throw new UnsupportedOperationException("detail was not ColumnAppendDetail");
     }
 
     @Override
@@ -235,7 +235,7 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
         return new ColumnAppenderRel(
             inputs.get(0).getCluster(), inputs.get(0).getTraitSet(), literal, inputs);
       }
-      throw new RuntimeException("detail was not ColumnAppendDetail");
+      throw new UnsupportedOperationException("detail was not ColumnAppendDetail");
     }
   }
 

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -220,7 +220,8 @@ class ToLogicalPlan(spark: SparkSession = SparkSession.builder().getOrCreate())
       case SExpression.SortDirection.ASC_NULLS_LAST => (Ascending, NullsLast)
       case SExpression.SortDirection.DESC_NULLS_LAST => (Descending, NullsLast)
       case other =>
-        throw new RuntimeException(s"Unexpected Expression.SortDirection enum: $other !")
+        throw new UnsupportedOperationException(
+          s"Unexpected Expression.SortDirection enum: $other !")
     }
     SortOrder(expression, direction, nullOrdering, Seq.empty)
   }


### PR DESCRIPTION
replaces throwing a generic `RuntimeException` with a more specific exception like `IllegalStateException`, `IllegalArgumentException` or `UnsupportedOperationException`