### PR TITLE
chore: avoid Java version mismatch (alternative)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,16 +43,17 @@ allprojects {
   tasks.configureEach<Test> {
     val javaToolchains = project.extensions.getByType<JavaToolchainService>()
     useJUnitPlatform()
-    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
+    // run tests on Java 8
+    // toolchain resolver plugin will download Java 8 if not installed
+    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(8)) })
     testLogging { exceptionFormat = TestExceptionFormat.FULL }
   }
   tasks.withType<JavaCompile> {
     sourceCompatibility = "17"
-    if (project.name != "core") {
-      options.release.set(11)
-    } else {
-      options.release.set(8)
-    }
+    // compile for Java 8 release level
+    options.release = 8
+    // use a Java 17 to compile code, will download Java 17 if not installed
+    javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(17) }
     dependsOn(submodulesUpdate)
   }
 

--- a/examples/substrait-spark/build.gradle.kts
+++ b/examples/substrait-spark/build.gradle.kts
@@ -38,3 +38,9 @@ tasks.named<Test>("test") {
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
+
+// dependency io.substrait:spark:0.36.0 above has been compiled for Java 11, setting release to 11
+tasks.withType<JavaCompile> {
+  sourceCompatibility = "17"
+  options.release = 11
+}

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
@@ -17,6 +17,7 @@ import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
 import io.substrait.proto.ExtendedExpression;
 import io.substrait.proto.Plan;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.apache.calcite.avatica.util.Casing;
@@ -42,7 +43,7 @@ public class IsthmusEntryPoint implements Callable<Integer> {
       names = {"-c", "--create"},
       description =
           "One or multiple create table statements e.g. CREATE TABLE T1(foo int, bar bigint)")
-  private List<String> createStatements = List.of();
+  private List<String> createStatements = Collections.emptyList();
 
   @Option(
       names = {"--outputformat"},
@@ -94,7 +95,7 @@ public class IsthmusEntryPoint implements Callable<Integer> {
       SqlToSubstrait converter = new SqlToSubstrait(featureBoard);
       Prepare.CatalogReader catalog =
           SubstraitCreateStatementParser.processCreateStatementsToCatalog(
-              createStatements.toArray(String[]::new));
+              createStatements.toArray(new String[0]));
       Plan plan = converter.execute(sql, catalog);
       printMessage(plan);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
@@ -12,6 +12,7 @@ import io.substrait.isthmus.sql.SubstraitSqlValidator;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -141,7 +142,7 @@ public class SqlExpressionToSubstrait extends SqlConverterBase {
     Map<String, RexNode> nameToNodeMap = new HashMap<>();
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
     CalciteCatalogReader catalogReader =
-        new CalciteCatalogReader(rootSchema, List.of(), factory, config);
+        new CalciteCatalogReader(rootSchema, Collections.emptyList(), factory, config);
     if (tables != null) {
       for (String tableDef : tables) {
         List<SubstraitTable> tList =

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -131,10 +131,10 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
                   var fields =
                       list.stream()
                           .map(l -> literalConverter.convert(l))
-                          .collect(Collectors.toUnmodifiableList());
+                          .collect(Collectors.toList());
                   return ExpressionCreator.struct(false, fields);
                 })
-            .collect(Collectors.toUnmodifiableList());
+            .collect(Collectors.toList());
     return VirtualTableScan.builder().initialSchema(type).addAllRows(structs).build();
   }
 
@@ -266,7 +266,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     var invocation =
         aggregateFunctionConverter.convert(
             input, inputType, call, t -> t.accept(rexExpressionConverter));
-    if (invocation.isEmpty()) {
+    if (!invocation.isPresent()) {
       throw new UnsupportedOperationException("Unable to find binding for call " + call);
     }
     var builder = Aggregate.Measure.builder().function(invocation.get());

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus.calcite;
 
 import io.substrait.isthmus.AggregateFunctions;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +30,7 @@ public class SubstraitOperatorTable implements SqlOperatorTable {
 
   private static final SqlOperatorTable SUBSTRAIT_OPERATOR_TABLE =
       SqlOperatorTables.of(
-          List.of(
+          Arrays.asList(
               AggregateFunctions.MAX,
               AggregateFunctions.MIN,
               AggregateFunctions.AVG,
@@ -51,7 +52,7 @@ public class SubstraitOperatorTable implements SqlOperatorTable {
               // filter out the kinds that have been overriden from the standard operator table
               STANDARD_OPERATOR_TABLE.getOperatorList().stream()
                   .filter(op -> !OVERRIDE_KINDS.contains(op.kind)))
-          .collect(Collectors.toUnmodifiableList());
+          .collect(Collectors.toList());
 
   @Override
   public void lookupOperatorOverloads(

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.substrait.expression.AbstractExpressionVisitor;
 import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
@@ -426,10 +427,12 @@ public class ExpressionRexConverter
                 sf -> {
                   Set<SqlKind> direction =
                       switch (sf.direction()) {
-                        case ASC_NULLS_FIRST -> Set.of(SqlKind.NULLS_FIRST);
-                        case ASC_NULLS_LAST -> Set.of(SqlKind.NULLS_LAST);
-                        case DESC_NULLS_FIRST -> Set.of(SqlKind.DESCENDING, SqlKind.NULLS_FIRST);
-                        case DESC_NULLS_LAST -> Set.of(SqlKind.DESCENDING, SqlKind.NULLS_LAST);
+                        case ASC_NULLS_FIRST -> ImmutableSet.of(SqlKind.NULLS_FIRST);
+                        case ASC_NULLS_LAST -> ImmutableSet.of(SqlKind.NULLS_LAST);
+                        case DESC_NULLS_FIRST -> ImmutableSet.of(
+                            SqlKind.DESCENDING, SqlKind.NULLS_FIRST);
+                        case DESC_NULLS_LAST -> ImmutableSet.of(
+                            SqlKind.DESCENDING, SqlKind.NULLS_LAST);
                         case CLUSTERED -> throw new IllegalArgumentException(
                             "SORT_DIRECTION_CLUSTERED is not supported");
                       };

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
@@ -49,7 +49,7 @@ public class FieldSelectionConverter implements CallConverter {
       case ROW:
         {
           var index = toInt(literal);
-          if (index.isEmpty()) {
+          if (!index.isPresent()) {
             return Optional.empty();
           }
           if (input instanceof FieldReference) {
@@ -61,7 +61,7 @@ public class FieldSelectionConverter implements CallConverter {
       case ARRAY:
         {
           var index = toInt(literal);
-          if (index.isEmpty()) {
+          if (!index.isPresent()) {
             return Optional.empty();
           }
 
@@ -75,7 +75,7 @@ public class FieldSelectionConverter implements CallConverter {
       case MAP:
         {
           var mapKey = toString(literal);
-          if (mapKey.isEmpty()) {
+          if (!mapKey.isPresent()) {
             return Optional.empty();
           }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -1,6 +1,8 @@
 package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.substrait.isthmus.AggregateFunctions;
 import java.util.Locale;
 import java.util.Map;
@@ -98,17 +100,21 @@ public class FunctionMappings {
 
   // contains return-type based resolver for both scalar and aggregator operator
   public static final Map<SqlOperator, TypeBasedResolver> OPERATOR_RESOLVER =
-      Map.of(
+      ImmutableMap.of(
           SqlStdOperatorTable.PLUS,
           resolver(
-              SqlStdOperatorTable.PLUS, Set.of("i8", "i16", "i32", "i64", "fp32", "fp64", "dec")),
+              SqlStdOperatorTable.PLUS,
+              ImmutableSet.of("i8", "i16", "i32", "i64", "fp32", "fp64", "dec")),
           SqlStdOperatorTable.DATETIME_PLUS,
-          resolver(SqlStdOperatorTable.PLUS, Set.of("date", "time", "timestamp")),
+          resolver(SqlStdOperatorTable.PLUS, ImmutableSet.of("date", "time", "timestamp")),
           SqlStdOperatorTable.MINUS,
           resolver(
-              SqlStdOperatorTable.MINUS, Set.of("i8", "i16", "i32", "i64", "fp32", "fp64", "dec")),
+              SqlStdOperatorTable.MINUS,
+              ImmutableSet.of("i8", "i16", "i32", "i64", "fp32", "fp64", "dec")),
           SqlStdOperatorTable.MINUS_DATE,
-          resolver(SqlStdOperatorTable.MINUS_DATE, Set.of("date", "timestamp_tz", "timestamp")));
+          resolver(
+              SqlStdOperatorTable.MINUS_DATE,
+              ImmutableSet.of("date", "timestamp_tz", "timestamp")));
 
   public static void main(String[] args) {
     SCALAR_SIGS.forEach(System.out::println);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -174,8 +174,8 @@ public class LiteralConverter {
         var interval = Duration.ofMillis(totalMillis);
 
         var days = interval.toDays();
-        var seconds = interval.minusDays(days).toSeconds();
-        var micros = interval.toMillisPart() * 1000;
+        var seconds = interval.minusDays(days).getSeconds();
+        var micros = interval.getNano() / 1000;
 
         yield intervalDay(n, (int) days, (int) seconds, micros, 6);
       }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -7,6 +7,7 @@ import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.CallConverter;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.Type;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -43,7 +44,7 @@ public class ScalarFunctionConverter
       TypeConverter typeConverter) {
     super(functions, additionalSignatures, typeFactory, typeConverter);
 
-    mappers = List.of(new TrimFunctionMapper(functions));
+    mappers = Arrays.asList(new TrimFunctionMapper(functions));
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/TrimFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/TrimFunctionMapper.java
@@ -77,9 +77,7 @@ final class TrimFunctionMapper implements ScalarFunctionMapper {
 
   private List<ScalarFunctionVariant> findFunction(
       String name, Collection<ScalarFunctionVariant> functions) {
-    return functions.stream()
-        .filter(f -> name.equals(f.name()))
-        .collect(Collectors.toUnmodifiableList());
+    return functions.stream().filter(f -> name.equals(f.name())).collect(Collectors.toList());
   }
 
   @Override
@@ -92,14 +90,13 @@ final class TrimFunctionMapper implements ScalarFunctionMapper {
 
     return trimType.map(
         trim -> {
-          var functions = trimFunctions.getOrDefault(trim, List.of());
+          var functions = trimFunctions.getOrDefault(trim, Collections.emptyList());
           if (functions.isEmpty()) {
             return null;
           }
 
           var name = trim.substraitName();
-          var operands =
-              call.getOperands().stream().skip(1).collect(Collectors.toUnmodifiableList());
+          var operands = call.getOperands().stream().skip(1).collect(Collectors.toList());
           return new SubstraitFunctionMapping(name, operands, functions);
         });
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -45,7 +45,10 @@ public class SubstraitCreateStatementParser {
 
   private static final CalciteCatalogReader EMPTY_CATALOG =
       new CalciteCatalogReader(
-          CalciteSchema.createRootSchema(false), List.of(), TYPE_FACTORY, CONNECTION_CONFIG);
+          CalciteSchema.createRootSchema(false),
+          Collections.emptyList(),
+          TYPE_FACTORY,
+          CONNECTION_CONFIG);
 
   // A validator is needed to convert the types in column declarations to Calcite types
   private static final SqlValidator VALIDATOR =

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -7,6 +7,7 @@ import io.substrait.relation.NamedScan;
 import io.substrait.relation.Rel;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -22,8 +23,8 @@ public class AggregationFunctionsTest extends PlanTestBase {
   static final TypeCreator N = TypeCreator.of(true);
 
   // Create a table with that has a column of every numeric type, both NOT NULL and NULL
-  private List<Type> numericTypesR = List.of(R.I8, R.I16, R.I32, R.I64, R.FP32, R.FP64);
-  private List<Type> numericTypesN = List.of(N.I8, N.I16, N.I32, N.I64, N.FP32, N.FP64);
+  private List<Type> numericTypesR = Arrays.asList(R.I8, R.I16, R.I32, R.I64, R.FP32, R.FP64);
+  private List<Type> numericTypesN = Arrays.asList(N.I8, N.I16, N.I32, N.I64, N.FP32, N.FP64);
   private List<Type> numericTypes =
       Stream.concat(numericTypesR.stream(), numericTypesN.stream()).collect(Collectors.toList());
 
@@ -37,7 +38,8 @@ public class AggregationFunctionsTest extends PlanTestBase {
   private List<String> columnNames =
       Streams.mapWithIndex(tableTypes.stream(), (t, index) -> String.valueOf(index))
           .collect(Collectors.toList());
-  private NamedScan numericTypesTable = b.namedScan(List.of("example"), columnNames, tableTypes);
+  private NamedScan numericTypesTable =
+      b.namedScan(Arrays.asList("example"), columnNames, tableTypes);
 
   // Create the given function call on the given field of the input
   private Aggregate.Measure functionPicker(Rel input, int field, String fname) {

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -307,7 +307,7 @@ public class CalciteLiteralTest extends CalciteObjs {
   @Test
   void tDecimalLiteral() {
     List<BigDecimal> decimalList =
-        List.of(
+        Arrays.asList(
             new BigDecimal("-123.457890"),
             new BigDecimal("123.457890"),
             new BigDecimal("123.450000"),
@@ -320,7 +320,7 @@ public class CalciteLiteralTest extends CalciteObjs {
   @Test
   void tDecimalLiteral2() {
     List<BigDecimal> decimalList =
-        List.of(
+        Arrays.asList(
             new BigDecimal("-99.123456789123456789123456789123456789"), // scale = 36, precision =38
             new BigDecimal("99.123456789123456789123456789123456789") // scale = 36, precision = 38
             );

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
@@ -11,6 +11,8 @@ import io.substrait.relation.NamedScan;
 import io.substrait.relation.Rel;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -51,9 +53,9 @@ public class ComplexAggregateTest extends PlanTestBase {
     new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory).convert(pojo);
   }
 
-  private List<Type> columnTypes = List.of(R.I32, R.I32, R.I32, R.I32);
-  private List<String> columnNames = List.of("a", "b", "c", "d");
-  private NamedScan table = b.namedScan(List.of("example"), columnNames, columnTypes);
+  private List<Type> columnTypes = Arrays.asList(R.I32, R.I32, R.I32, R.I32);
+  private List<String> columnNames = Arrays.asList("a", "b", "c", "d");
+  private NamedScan table = b.namedScan(Arrays.asList("example"), columnNames, columnTypes);
 
   private Aggregate.Grouping emptyGrouping = Aggregate.Grouping.builder().build();
 
@@ -63,17 +65,17 @@ public class ComplexAggregateTest extends PlanTestBase {
     var rel =
         b.aggregate(
             input -> emptyGrouping,
-            input -> List.of(b.sum(b.add(b.fieldReference(input, 2), b.i32(7)))),
+            input -> Arrays.asList(b.sum(b.add(b.fieldReference(input, 2), b.i32(7)))),
             table);
 
     var expectedFinal =
         b.aggregate(
             input -> emptyGrouping,
             // sum call references input field
-            input -> List.of(b.sum(input, 4)),
+            input -> Arrays.asList(b.sum(input, 4)),
             b.project(
                 // add call is moved to child project
-                input -> List.of(b.add(b.fieldReference(input, 2), b.i32(7))),
+                input -> Arrays.asList(b.add(b.fieldReference(input, 2), b.i32(7))),
                 table));
 
     validateAggregateTransformation(rel, expectedFinal);
@@ -86,7 +88,7 @@ public class ComplexAggregateTest extends PlanTestBase {
         b.aggregate(
             input -> emptyGrouping,
             input ->
-                List.of(
+                Arrays.asList(
                     withPreMeasureFilter(
                         b.sum(input, 0), b.equal(b.fieldReference(input, 1), b.i32(42)))),
             table);
@@ -94,8 +96,10 @@ public class ComplexAggregateTest extends PlanTestBase {
     var expectedFinal =
         b.aggregate(
             input -> emptyGrouping,
-            input -> List.of(withPreMeasureFilter(b.sum(input, 0), b.fieldReference(input, 4))),
-            b.project(input -> List.of(b.equal(b.fieldReference(input, 1), b.i32(42))), table));
+            input ->
+                Arrays.asList(withPreMeasureFilter(b.sum(input, 0), b.fieldReference(input, 4))),
+            b.project(
+                input -> Arrays.asList(b.equal(b.fieldReference(input, 1), b.i32(42))), table));
 
     validateAggregateTransformation(rel, expectedFinal);
   }
@@ -107,10 +111,10 @@ public class ComplexAggregateTest extends PlanTestBase {
         b.aggregate(
             input -> emptyGrouping,
             input ->
-                List.of(
+                Arrays.asList(
                     withSort(
                         b.sum(input, 3),
-                        List.of(
+                        Arrays.asList(
                             b.sortField(
                                 b.negate(b.fieldReference(input, 1)),
                                 Expression.SortDirection.ASC_NULLS_FIRST)))),
@@ -120,16 +124,16 @@ public class ComplexAggregateTest extends PlanTestBase {
         b.aggregate(
             input -> emptyGrouping,
             input ->
-                List.of(
+                Arrays.asList(
                     withSort(
                         b.sum(input, 3),
-                        List.of(
+                        Arrays.asList(
                             b.sortField(
                                 b.fieldReference(input, 4),
                                 Expression.SortDirection.ASC_NULLS_FIRST)))),
             b.project(
                 // negate call is moved to child project
-                input -> List.of(b.negate(b.fieldReference(input, 1))),
+                input -> Arrays.asList(b.negate(b.fieldReference(input, 1))),
                 table));
 
     validateAggregateTransformation(rel, expectedFinal);
@@ -142,17 +146,17 @@ public class ComplexAggregateTest extends PlanTestBase {
             input ->
                 b.grouping(
                     b.fieldReference(input, 2), b.add(b.fieldReference(input, 1), b.i32(42))),
-            input -> List.of(),
+            input -> Collections.emptyList(),
             table);
 
     var expectedFinal =
         b.aggregate(
             // grouping exprs are now field references to input
             input -> b.grouping(input, 4, 5),
-            input -> List.of(),
+            input -> Collections.emptyList(),
             b.project(
                 input ->
-                    List.of(
+                    Arrays.asList(
                         b.fieldReference(input, 2), b.add(b.fieldReference(input, 1), b.i32(42))),
                 table));
 
@@ -161,17 +165,18 @@ public class ComplexAggregateTest extends PlanTestBase {
 
   @Test
   void handleOutOfOrderGroupingArguments() {
-    var rel = b.aggregate(input -> b.grouping(input, 1, 0, 2), input -> List.of(), table);
+    var rel =
+        b.aggregate(input -> b.grouping(input, 1, 0, 2), input -> Collections.emptyList(), table);
 
     var expectedFinal =
         b.aggregate(
             // grouping exprs are now field references to input
             input -> b.grouping(input, 4, 5, 6),
-            input -> List.of(),
+            input -> Collections.emptyList(),
             b.project(
                 // ALL grouping exprs are added to the child projects (including field references)
                 input ->
-                    List.of(
+                    Arrays.asList(
                         b.fieldReference(input, 1),
                         b.fieldReference(input, 0),
                         b.fieldReference(input, 2)),
@@ -185,8 +190,11 @@ public class ComplexAggregateTest extends PlanTestBase {
     Rel rel =
         b.aggregate(
             input -> b.grouping(input, 2, 0),
-            input -> List.of(),
-            b.namedScan(List.of("foo"), List.of("a", "b", "c"), List.of(R.I64, R.I64, R.STRING)));
+            input -> Collections.emptyList(),
+            b.namedScan(
+                Arrays.asList("foo"),
+                Arrays.asList("a", "b", "c"),
+                Arrays.asList(R.I64, R.I64, R.STRING)));
     var relNode = new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory).convert(rel);
     assertRowMatch(relNode.getRowType(), R.STRING, R.I64);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
@@ -9,6 +9,7 @@ import io.substrait.relation.Rel;
 import io.substrait.type.TypeCreator;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
@@ -59,10 +60,11 @@ public class ComplexSortTest extends PlanTestBase {
             b.remap(1),
             b.sort(
                 input ->
-                    List.of(
+                    Arrays.asList(
                         b.sortField(
                             b.fieldReference(input, 0), Expression.SortDirection.ASC_NULLS_LAST)),
-                b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
+                b.namedScan(
+                    Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.STRING))));
 
     String expected =
         """
@@ -88,11 +90,12 @@ public class ComplexSortTest extends PlanTestBase {
             b.remap(1),
             b.sort(
                 input ->
-                    List.of(
+                    Arrays.asList(
                         b.sortField(
                             b.cast(b.fieldReference(input, 0), R.I32),
                             Expression.SortDirection.ASC_NULLS_LAST)),
-                b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
+                b.namedScan(
+                    Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.STRING))));
 
     String expected =
         """
@@ -116,15 +119,16 @@ public class ComplexSortTest extends PlanTestBase {
 
     Rel rel =
         b.project(
-            input -> List.of(b.cast(b.fieldReference(input, 0), R.I32)),
+            input -> Arrays.asList(b.cast(b.fieldReference(input, 0), R.I32)),
             b.remap(1),
             b.sort(
                 input ->
-                    List.of(
+                    Arrays.asList(
                         b.sortField(
                             b.cast(b.fieldReference(input, 0), R.I32),
                             Expression.SortDirection.DESC_NULLS_LAST)),
-                b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
+                b.namedScan(
+                    Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.STRING))));
 
     String expected =
         """
@@ -148,15 +152,16 @@ public class ComplexSortTest extends PlanTestBase {
 
     Rel rel =
         b.project(
-            input -> List.of(b.fieldReference(input, 0)),
+            input -> Arrays.asList(b.fieldReference(input, 0)),
             b.remap(1),
             b.sort(
                 input ->
-                    List.of(
+                    Arrays.asList(
                         b.sortField(
                             b.cast(b.fieldReference(input, 0), R.STRING),
                             Expression.SortDirection.DESC_NULLS_LAST)),
-                b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING))));
+                b.namedScan(
+                    Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.STRING))));
 
     String expected =
         """
@@ -180,18 +185,21 @@ public class ComplexSortTest extends PlanTestBase {
 
     Rel rel =
         b.project(
-            input -> List.of(b.fieldReference(input, 0), b.fieldReference(input, 1)),
+            input -> Arrays.asList(b.fieldReference(input, 0), b.fieldReference(input, 1)),
             b.remap(2, 3),
             b.sort(
                 input ->
-                    List.of(
+                    Arrays.asList(
                         b.sortField(
                             b.cast(b.fieldReference(input, 0), R.I32),
                             Expression.SortDirection.DESC_NULLS_FIRST),
                         b.sortField(
                             b.add(b.negate(b.fieldReference(input, 1)), b.i32(42)),
                             Expression.SortDirection.ASC_NULLS_LAST)),
-                b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.STRING, R.I32))));
+                b.namedScan(
+                    Arrays.asList("example"),
+                    Arrays.asList("a", "b"),
+                    Arrays.asList(R.STRING, R.I32))));
 
     String expected =
         """

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -20,6 +20,7 @@ import io.substrait.relation.RelProtoConverter;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelNode;
@@ -100,7 +101,7 @@ public class CustomFunctionTest extends PlanTestBase {
 
   // Define additional mapping signatures for the custom scalar functions
   final List<FunctionMappings.Sig> additionalScalarSignatures =
-      List.of(
+      Arrays.asList(
           FunctionMappings.s(customScalarFn),
           FunctionMappings.s(customScalarAnyFn),
           FunctionMappings.s(customScalarAnyToAnyFn),
@@ -220,7 +221,7 @@ public class CustomFunctionTest extends PlanTestBase {
 
   // Define additional mapping signatures for the custom aggregate functions
   final List<FunctionMappings.Sig> additionalAggregateSignatures =
-      List.of(FunctionMappings.s(customAggregateFn));
+      Arrays.asList(FunctionMappings.s(customAggregateFn));
 
   static final SqlAggFunction customAggregateFn =
       new SqlAggFunction(
@@ -291,11 +292,11 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE, "custom_scalar:str", R.STRING, b.fieldReference(input, 0))),
             b.remap(1),
-            b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING)));
+            b.namedScan(Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -307,11 +308,11 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE, "custom_scalar_any:any", R.STRING, b.fieldReference(input, 0))),
             b.remap(1),
-            b.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
+            b.namedScan(Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.I64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -323,14 +324,14 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_any_to_any:any",
                         R.FP64,
                         b.fieldReference(input, 0))),
             b.remap(1),
-            b.namedScan(List.of("example"), List.of("a"), List.of(R.FP64)));
+            b.namedScan(Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.FP64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -342,7 +343,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_any1any1_to_any1:any_any",
@@ -350,7 +351,8 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 0),
                         b.fieldReference(input, 1))),
             b.remap(2),
-            b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.FP64, R.FP64)));
+            b.namedScan(
+                Arrays.asList("example"), Arrays.asList("a", "b"), Arrays.asList(R.FP64, R.FP64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -362,7 +364,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_any1any1_to_any1:any_any",
@@ -370,7 +372,10 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 0),
                         b.fieldReference(input, 1))),
             b.remap(2),
-            b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.FP64, R.STRING)));
+            b.namedScan(
+                Arrays.asList("example"),
+                Arrays.asList("a", "b"),
+                Arrays.asList(R.FP64, R.STRING)));
 
     assertThrows(
         IllegalArgumentException.class,
@@ -386,7 +391,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_any1any2_to_any2:any_any",
@@ -394,7 +399,10 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 0),
                         b.fieldReference(input, 1))),
             b.remap(2),
-            b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.FP64, R.STRING)));
+            b.namedScan(
+                Arrays.asList("example"),
+                Arrays.asList("a", "b"),
+                Arrays.asList(R.FP64, R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -406,14 +414,15 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_listany_to_listany:list",
                         R.list(R.I64),
                         b.fieldReference(input, 0))),
             b.remap(1),
-            b.namedScan(List.of("example"), List.of("a"), List.of(R.list(R.I64))));
+            b.namedScan(
+                Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.list(R.I64))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -425,7 +434,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_listany_any_to_listany:list_any",
@@ -434,7 +443,9 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 1))),
             b.remap(2),
             b.namedScan(
-                List.of("example"), List.of("a", "b"), List.of(R.list(R.STRING), R.STRING)));
+                Arrays.asList("example"),
+                Arrays.asList("a", "b"),
+                Arrays.asList(R.list(R.STRING), R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -446,14 +457,15 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_liststring_to_liststring:list",
                         R.list(R.STRING),
                         b.fieldReference(input, 0))),
             b.remap(1),
-            b.namedScan(List.of("example"), List.of("a"), List.of(R.list(R.STRING))));
+            b.namedScan(
+                Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.list(R.STRING))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -465,7 +477,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_liststring_any_to_liststring:list_any",
@@ -474,7 +486,9 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 1))),
             b.remap(2),
             b.namedScan(
-                List.of("example"), List.of("a", "b"), List.of(R.list(R.STRING), R.STRING)));
+                Arrays.asList("example"),
+                Arrays.asList("a", "b"),
+                Arrays.asList(R.list(R.STRING), R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -486,7 +500,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_liststring_anyvariadic0_to_liststring:list_any",
@@ -497,9 +511,9 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 3))),
             b.remap(4),
             b.namedScan(
-                List.of("example"),
-                List.of("a", "b", "c", "d"),
-                List.of(R.list(R.STRING), R.STRING, R.STRING, R.STRING)));
+                Arrays.asList("example"),
+                Arrays.asList("a", "b", "c", "d"),
+                Arrays.asList(R.list(R.STRING), R.STRING, R.STRING, R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -511,14 +525,15 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_liststring_anyvariadic0_to_liststring:list_any",
                         R.list(R.STRING),
                         b.fieldReference(input, 0))),
             b.remap(1),
-            b.namedScan(List.of("example"), List.of("a"), List.of(R.list(R.STRING))));
+            b.namedScan(
+                Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.list(R.STRING))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -530,7 +545,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "custom_scalar_liststring_anyvariadic1_to_liststring:list_any",
@@ -539,7 +554,9 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 1))),
             b.remap(2),
             b.namedScan(
-                List.of("example"), List.of("a", "b"), List.of(R.list(R.STRING), R.STRING)));
+                Arrays.asList("example"),
+                Arrays.asList("a", "b"),
+                Arrays.asList(R.list(R.STRING), R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -554,11 +571,11 @@ public class CustomFunctionTest extends PlanTestBase {
         b.aggregate(
             input -> b.grouping(input, 0),
             input ->
-                List.of(
+                Arrays.asList(
                     b.measure(
                         b.aggregateFn(
                             NAMESPACE, "custom_aggregate:i64", R.I64, b.fieldReference(input, 0)))),
-            b.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
+            b.namedScan(Arrays.asList("example"), Arrays.asList("a"), Arrays.asList(R.I64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -572,7 +589,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE,
                         "to_b_type:u!a_type",
@@ -580,7 +597,9 @@ public class CustomFunctionTest extends PlanTestBase {
                         b.fieldReference(input, 0))),
             b.remap(1),
             b.namedScan(
-                List.of("example"), List.of("a"), List.of(N.userDefined(NAMESPACE, "a_type"))));
+                Arrays.asList("example"),
+                Arrays.asList("a"),
+                Arrays.asList(N.userDefined(NAMESPACE, "a_type"))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     var relReturned = calciteToSubstrait.apply(calciteRel);
@@ -596,12 +615,14 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel1 =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     b.scalarFn(
                         NAMESPACE, "to_b_type:u!a_type", R.userDefined(NAMESPACE, "b_type"), val)),
             b.remap(1),
             b.namedScan(
-                List.of("example"), List.of("a"), List.of(N.userDefined(NAMESPACE, "a_type"))));
+                Arrays.asList("example"),
+                Arrays.asList("a"),
+                Arrays.asList(N.userDefined(NAMESPACE, "a_type"))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel1);
     Rel rel2 = calciteToSubstrait.apply(calciteRel);

--- a/isthmus/src/test/java/io/substrait/isthmus/EmptyArrayLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/EmptyArrayLiteralTest.java
@@ -4,7 +4,7 @@ import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.relation.Rel;
 import io.substrait.type.TypeCreator;
-import java.util.List;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class EmptyArrayLiteralTest extends PlanTestBase {
@@ -18,9 +18,9 @@ public class EmptyArrayLiteralTest extends PlanTestBase {
     var emptyListLiteral = ExpressionCreator.emptyList(false, N.I8);
     var rel =
         b.project(
-            input -> List.of(emptyListLiteral),
+            input -> Arrays.asList(emptyListLiteral),
             Rel.Remap.offset(1, 1),
-            b.namedScan(List.of("t"), List.of("col"), List.of(colType)));
+            b.namedScan(Arrays.asList("t"), Arrays.asList("col"), Arrays.asList(colType)));
     assertFullRoundTrip(rel);
   }
 
@@ -30,9 +30,9 @@ public class EmptyArrayLiteralTest extends PlanTestBase {
     var emptyListLiteral = ExpressionCreator.emptyList(true, N.I8);
     var rel =
         b.project(
-            input -> List.of(emptyListLiteral),
+            input -> Arrays.asList(emptyListLiteral),
             Rel.Remap.offset(1, 1),
-            b.namedScan(List.of("t"), List.of("col"), List.of(colType)));
+            b.namedScan(Arrays.asList("t"), Arrays.asList("col"), Arrays.asList(colType)));
     assertFullRoundTrip(rel);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
@@ -21,6 +21,7 @@ import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import io.substrait.util.EmptyVisitationContext;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexLiteral;
@@ -49,9 +50,9 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
   final RexBuilder rexBuilder = new RexBuilder(typeFactory);
 
   // Define a shared table (i.e. a NamedScan) for use in tests.
-  final List<Type> commonTableType = List.of(R.I32, R.FP32, N.STRING, N.BOOLEAN);
+  final List<Type> commonTableType = Arrays.asList(R.I32, R.FP32, N.STRING, N.BOOLEAN);
   final Rel commonTable =
-      b.namedScan(List.of("example"), List.of("a", "b", "c", "d"), commonTableType);
+      b.namedScan(Arrays.asList("example"), Arrays.asList("a", "b", "c", "d"), commonTableType);
 
   @Test
   public void listLiteral() throws IOException, SqlParseException {
@@ -93,7 +94,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
     Expression switchExpression =
         b.switchExpression(
             b.fieldReference(commonTable, 0),
-            List.of(b.switchClause(b.i32(5), b.i32(1)), b.switchClause(b.i32(10), b.i32(2))),
+            Arrays.asList(b.switchClause(b.i32(5), b.i32(1)), b.switchClause(b.i32(10), b.i32(2))),
             b.i32(3));
     RexNode rexNode = switchExpression.accept(converter, Context.newContext());
     Expression expression =
@@ -104,7 +105,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
     // cannot roundtrip test switchExpression because Calcite simplifies the representation
     assertExpressionEquality(
         b.ifThen(
-            List.of(
+            Arrays.asList(
                 b.ifClause(b.equal(b.fieldReference(commonTable, 0), b.i32(5)), b.i32(1)),
                 b.ifClause(b.equal(b.fieldReference(commonTable, 0), b.i32(10)), b.i32(2))),
             b.i32(3)),
@@ -116,7 +117,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
+                Arrays.asList(
                     ExpressionCreator.cast(
                         R.I64,
                         b.fieldReference(input, 0),
@@ -124,7 +125,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
                     ExpressionCreator.cast(
                         R.I32, b.fieldReference(input, 0), Expression.FailureBehavior.RETURN_NULL)),
             b.remap(1, 2),
-            b.namedScan(List.of("test"), List.of("col1"), List.of(R.STRING)));
+            b.namedScan(Arrays.asList("test"), Arrays.asList("col1"), Arrays.asList(R.STRING)));
 
     assertFullRoundTrip(rel);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/ExtendedExpressionTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ExtendedExpressionTestBase.java
@@ -18,7 +18,7 @@ public class ExtendedExpressionTestBase {
   public static List<String> tpchSchemaCreateStatements(String schemaToLoad) throws IOException {
     String[] values = asString(schemaToLoad).split(";");
     return Arrays.stream(values)
-        .filter(t -> !t.trim().isBlank())
+        .filter(t -> !t.trim().matches("^\\s*$"))
         .collect(java.util.stream.Collectors.toList());
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
@@ -3,7 +3,7 @@ package io.substrait.isthmus;
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.relation.Rel;
 import io.substrait.type.TypeCreator;
-import java.util.List;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class FetchTest extends PlanTestBase {
@@ -12,7 +12,8 @@ public class FetchTest extends PlanTestBase {
 
   final SubstraitBuilder b = new SubstraitBuilder(extensions);
 
-  final Rel TABLE = b.namedScan(List.of("test"), List.of("col1"), List.of(R.STRING));
+  final Rel TABLE =
+      b.namedScan(Arrays.asList("test"), Arrays.asList("col1"), Arrays.asList(R.STRING));
 
   @Test
   void limitOnly() {

--- a/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
 import io.substrait.plan.Plan;
 import io.substrait.relation.NamedScan;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ public class NameRoundtripTest extends PlanTestBase {
     String query = """
       SELECT "a", "B" FROM foo GROUP BY a, b
       """;
-    List<String> expectedNames = List.of("a", "B");
+    List<String> expectedNames = Arrays.asList("a", "B");
 
     List<org.apache.calcite.rel.RelRoot> calciteRelRoots = s.sqlToRelNode(query, catalogReader);
     assertEquals(1, calciteRelRoots.size());
@@ -44,12 +45,12 @@ public class NameRoundtripTest extends PlanTestBase {
   void preserveNamesFromSubstrait() {
     NamedScan rel =
         substraitBuilder.namedScan(
-            List.of("foo"),
-            List.of("i64", "struct", "struct0", "struct1"),
-            List.of(R.I64, R.struct(R.FP64, R.STRING)));
+            Arrays.asList("foo"),
+            Arrays.asList("i64", "struct", "struct0", "struct1"),
+            Arrays.asList(R.I64, R.struct(R.FP64, R.STRING)));
 
     Plan.Root planRoot =
-        Plan.Root.builder().input(rel).names(List.of("i", "s", "s0", "s1")).build();
+        Plan.Root.builder().input(rel).names(Arrays.asList("i", "s", "s0", "s1")).build();
     assertFullRoundTrip(planRoot);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.TextFormat;
 import io.substrait.isthmus.calcite.SubstraitSchema;
 import io.substrait.plan.ProtoPlanConverter;
@@ -9,7 +10,6 @@ import io.substrait.proto.Expression;
 import io.substrait.proto.Plan;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Map;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -57,7 +57,7 @@ public class NestedStructQueryTest extends PlanTestBase {
 
   private void test(Table table, String query, String expectedExpressionText)
       throws SqlParseException, IOException {
-    final Schema schema = new SubstraitSchema(Map.of("my_table", table));
+    final Schema schema = new SubstraitSchema(ImmutableMap.of("my_table", table));
     final CalciteCatalogReader catalog = schemaToCatalog("nested", schema);
     final SqlToSubstrait sqlToSubstrait = new SqlToSubstrait();
     Plan plan = sqlToSubstrait.execute(query, catalog);

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -305,7 +305,7 @@ public class PlanTestBase {
   protected static CalciteCatalogReader schemaToCatalog(String schemaName, Schema schema) {
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
     rootSchema.add(schemaName, schema);
-    List<String> defaultSchema = List.of(schemaName);
+    List<String> defaultSchema = Arrays.asList(schemaName);
     return new CalciteCatalogReader(
         rootSchema,
         defaultSchema,

--- a/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
@@ -20,6 +20,7 @@ import io.substrait.relation.RelProtoConverter;
 import io.substrait.type.Type;
 import io.substrait.util.EmptyVisitationContext;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -218,7 +219,7 @@ public class RelExtensionRoundtripTest extends PlanTestBase {
         RelNode input = extensionSingle.getInput().accept(this, context);
         RexLiteral literal = (RexLiteral) cad.literal.accept(this.expressionRexConverter, context);
         return new ColumnAppenderRel(
-            input.getCluster(), input.getTraitSet(), literal, List.of(input));
+            input.getCluster(), input.getTraitSet(), literal, Arrays.asList(input));
       }
       throw new RuntimeException("detail was not ColumnAppendDetail");
     }

--- a/isthmus/src/test/java/io/substrait/isthmus/SchemaCollectorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SchemaCollectorTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.relation.Rel;
-import java.util.List;
+import java.util.Arrays;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.junit.jupiter.api.Test;
 
@@ -26,10 +26,13 @@ public class SchemaCollectorTest extends PlanTestBase {
     Rel rel =
         b.cross(
             b.namedScan(
-                List.of("table1"),
-                List.of("col1", "col2", "col3"),
-                List.of(N.I64, R.FP64, N.STRING)),
-            b.namedScan(List.of("table2"), List.of("col4", "col5"), List.of(N.BOOLEAN, N.I32)));
+                Arrays.asList("table1"),
+                Arrays.asList("col1", "col2", "col3"),
+                Arrays.asList(N.I64, R.FP64, N.STRING)),
+            b.namedScan(
+                Arrays.asList("table2"),
+                Arrays.asList("col4", "col5"),
+                Arrays.asList(N.BOOLEAN, N.I32)));
     CalciteSchema calciteSchema = schemaCollector.toSchema(rel);
 
     hasTable(
@@ -45,14 +48,15 @@ public class SchemaCollectorTest extends PlanTestBase {
         b.cross(
             b.cross(
                 b.namedScan(
-                    List.of("schema1", "table1"),
-                    List.of("col1", "col2", "col3"),
-                    List.of(N.I64, N.FP64, N.STRING)),
+                    Arrays.asList("schema1", "table1"),
+                    Arrays.asList("col1", "col2", "col3"),
+                    Arrays.asList(N.I64, N.FP64, N.STRING)),
                 b.namedScan(
-                    List.of("schema1", "table2"),
-                    List.of("col4", "col5"),
-                    List.of(N.BOOLEAN, N.I32))),
-            b.namedScan(List.of("schema2", "table3"), List.of("col6"), List.of(N.I64)));
+                    Arrays.asList("schema1", "table2"),
+                    Arrays.asList("col4", "col5"),
+                    Arrays.asList(N.BOOLEAN, N.I32))),
+            b.namedScan(
+                Arrays.asList("schema2", "table3"), Arrays.asList("col6"), Arrays.asList(N.I64)));
     CalciteSchema calciteSchema = schemaCollector.toSchema(rel);
 
     CalciteSchema schema1 = calciteSchema.getSubSchema("schema1", false);
@@ -68,8 +72,13 @@ public class SchemaCollectorTest extends PlanTestBase {
     Rel rel =
         b.cross(
             b.namedScan(
-                List.of("level1", "level2a", "level3", "t1"), List.of("col1"), List.of(N.I64)),
-            b.namedScan(List.of("level1", "level2b", "t2"), List.of("col2"), List.of(N.I32)));
+                Arrays.asList("level1", "level2a", "level3", "t1"),
+                Arrays.asList("col1"),
+                Arrays.asList(N.I64)),
+            b.namedScan(
+                Arrays.asList("level1", "level2b", "t2"),
+                Arrays.asList("col2"),
+                Arrays.asList(N.I32)));
 
     var rootSchema = schemaCollector.toSchema(rel);
     CalciteSchema level1 = rootSchema.getSubSchema("level1", false);
@@ -84,7 +93,8 @@ public class SchemaCollectorTest extends PlanTestBase {
 
   @Test
   void canHandleDuplicateNamedScans() {
-    Rel table = b.namedScan(List.of("table"), List.of("col1"), List.of(N.BOOLEAN));
+    Rel table =
+        b.namedScan(Arrays.asList("table"), Arrays.asList("col1"), Arrays.asList(N.BOOLEAN));
     Rel rel = b.cross(table, table);
 
     CalciteSchema calciteSchema = schemaCollector.toSchema(rel);
@@ -95,8 +105,8 @@ public class SchemaCollectorTest extends PlanTestBase {
   void validatesSchemasForDuplicateNamedScans() {
     Rel rel =
         b.cross(
-            b.namedScan(List.of("t"), List.of("col1"), List.of(N.BOOLEAN)),
-            b.namedScan(List.of("t"), List.of("col1"), List.of(R.BOOLEAN)));
+            b.namedScan(Arrays.asList("t"), Arrays.asList("col1"), Arrays.asList(N.BOOLEAN)),
+            b.namedScan(Arrays.asList("t"), Arrays.asList("col1"), Arrays.asList(R.BOOLEAN)));
 
     IllegalArgumentException exception =
         assertThrows(IllegalArgumentException.class, () -> schemaCollector.toSchema(rel));
@@ -109,8 +119,8 @@ public class SchemaCollectorTest extends PlanTestBase {
   void validatesSchemasForNestedDuplicateNamedScans() {
     Rel rel =
         b.cross(
-            b.namedScan(List.of("s", "t"), List.of("col1"), List.of(N.BOOLEAN)),
-            b.namedScan(List.of("s", "t"), List.of("col1"), List.of(R.BOOLEAN)));
+            b.namedScan(Arrays.asList("s", "t"), Arrays.asList("col1"), Arrays.asList(N.BOOLEAN)),
+            b.namedScan(Arrays.asList("s", "t"), Arrays.asList("col1"), Arrays.asList(R.BOOLEAN)));
 
     IllegalArgumentException exception =
         assertThrows(IllegalArgumentException.class, () -> schemaCollector.toSchema(rel));

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -17,6 +17,7 @@ import io.substrait.relation.Rel;
 import io.substrait.relation.Rel.Remap;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -34,9 +35,9 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
 
   final ExpressionRexConverter converter;
 
-  final List<Type> commonTableType = List.of(R.I32, R.FP32, N.STRING, N.BOOLEAN);
+  final List<Type> commonTableType = Arrays.asList(R.I32, R.FP32, N.STRING, N.BOOLEAN);
   final Rel commonTable =
-      b.namedScan(List.of("example"), List.of("a", "b", "c", "d"), commonTableType);
+      b.namedScan(Arrays.asList("example"), Arrays.asList("a", "b", "c", "d"), commonTableType);
 
   final SubstraitRelNodeConverter relNodeConverter =
       new SubstraitRelNodeConverter(extensions, typeFactory, builder);
@@ -50,7 +51,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
     var expr =
         b.switchExpression(
             b.fieldReference(commonTable, 0),
-            List.of(b.switchClause(b.i32(0), b.fieldReference(commonTable, 3))),
+            Arrays.asList(b.switchClause(b.i32(0), b.fieldReference(commonTable, 3))),
             b.bool(false));
     var calciteExpr = expr.accept(converter, Context.newContext());
 
@@ -64,7 +65,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
     Expression.ScalarSubquery expr =
         Expression.ScalarSubquery.builder().type(R.I64).input(subQueryRel).build();
 
-    Project query = b.project(input -> List.of(expr), b.emptyScan());
+    Project query = b.project(input -> Arrays.asList(expr), b.emptyScan());
 
     SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
     RelNode calciteRel = substraitToCalcite.convert(query);
@@ -85,7 +86,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
             .tuples(subQueryRel)
             .build();
 
-    Project query = b.project(input -> List.of(expr), b.emptyScan());
+    Project query = b.project(input -> Arrays.asList(expr), b.emptyScan());
 
     SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
     RelNode calciteRel = substraitToCalcite.convert(query);
@@ -106,7 +107,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
             .tuples(subQueryRel)
             .build();
 
-    Project query = b.project(input -> List.of(expr), b.emptyScan());
+    Project query = b.project(input -> Arrays.asList(expr), b.emptyScan());
 
     SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
     RelNode calciteRel = substraitToCalcite.convert(query);
@@ -127,7 +128,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
             .tuples(subQueryRel)
             .build();
 
-    Project query = b.project(input -> List.of(expr), b.emptyScan());
+    Project query = b.project(input -> Arrays.asList(expr), b.emptyScan());
 
     SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
     Exception exception =
@@ -151,8 +152,8 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
    */
   Rel createSubQueryRel() {
     return b.project(
-        input -> List.of(b.fieldReference(input, 0)),
-        Remap.of(List.of(3)),
+        input -> Arrays.asList(b.fieldReference(input, 0)),
+        Remap.of(Arrays.asList(3)),
         b.filter(input -> b.equal(b.fieldReference(input, 2), b.str("EUROPE")), commonTable));
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -8,6 +8,7 @@ import io.substrait.relation.Set.SetOp;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,12 +24,12 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   final SubstraitBuilder b = new SubstraitBuilder(extensions);
 
   // Define a shared table (i.e. a NamedScan) for use in tests.
-  final List<Type> commonTableType = List.of(R.I32, R.FP32, N.STRING, N.BOOLEAN);
+  final List<Type> commonTableType = Arrays.asList(R.I32, R.FP32, N.STRING, N.BOOLEAN);
   final List<Type> commonTableTypeTwice =
       Stream.concat(commonTableType.stream(), commonTableType.stream())
           .collect(Collectors.toList());
   final Rel commonTable =
-      b.namedScan(List.of("example"), List.of("a", "b", "c", "d"), commonTableType);
+      b.namedScan(Arrays.asList("example"), Arrays.asList("a", "b", "c", "d"), commonTableType);
 
   final SubstraitToCalcite converter = new SubstraitToCalcite(extensions, typeFactory);
 
@@ -40,7 +41,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
           b.root(
               b.aggregate(
                   input -> b.grouping(input, 0, 2),
-                  input -> List.of(b.count(input, 0)),
+                  input -> Arrays.asList(b.count(input, 0)),
                   commonTable));
 
       var relNode = converter.convert(root.getInput());
@@ -53,7 +54,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
           b.root(
               b.aggregate(
                   input -> b.grouping(input, 0, 2),
-                  input -> List.of(b.count(input, 0)),
+                  input -> Arrays.asList(b.count(input, 0)),
                   b.remap(1, 2),
                   commonTable));
 
@@ -140,8 +141,9 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
 
     @Test
     public void leftJoin() {
-      final List<Type> joinTableType = List.of(R.STRING, R.FP64, R.BINARY);
-      final Rel joinTable = b.namedScan(List.of("join"), List.of("a", "b", "c"), joinTableType);
+      final List<Type> joinTableType = Arrays.asList(R.STRING, R.FP64, R.BINARY);
+      final Rel joinTable =
+          b.namedScan(Arrays.asList("join"), Arrays.asList("a", "b", "c"), joinTableType);
 
       Plan.Root root =
           b.root(
@@ -156,8 +158,9 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
 
     @Test
     public void rightJoin() {
-      final List<Type> joinTableType = List.of(R.STRING, R.FP64, R.BINARY);
-      final Rel joinTable = b.namedScan(List.of("join"), List.of("a", "b", "c"), joinTableType);
+      final List<Type> joinTableType = Arrays.asList(R.STRING, R.FP64, R.BINARY);
+      final Rel joinTable =
+          b.namedScan(Arrays.asList("join"), Arrays.asList("a", "b", "c"), joinTableType);
 
       Plan.Root root =
           b.root(
@@ -172,8 +175,9 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
 
     @Test
     public void outerJoin() {
-      final List<Type> joinTableType = List.of(R.STRING, R.FP64, R.BINARY);
-      final Rel joinTable = b.namedScan(List.of("join"), List.of("a", "b", "c"), joinTableType);
+      final List<Type> joinTableType = Arrays.asList(R.STRING, R.FP64, R.BINARY);
+      final Rel joinTable =
+          b.namedScan(Arrays.asList("join"), Arrays.asList("a", "b", "c"), joinTableType);
 
       Plan.Root root =
           b.root(
@@ -192,7 +196,9 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     @Test
     public void direct() {
       Plan.Root root =
-          b.root(b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.I32, R.FP32)));
+          b.root(
+              b.namedScan(
+                  Arrays.asList("example"), Arrays.asList("a", "b"), Arrays.asList(R.I32, R.FP32)));
 
       var relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, R.FP32);
@@ -203,7 +209,10 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       Plan.Root root =
           b.root(
               b.namedScan(
-                  List.of("example"), List.of("a", "b"), List.of(R.I32, R.FP32), b.remap(1)));
+                  Arrays.asList("example"),
+                  Arrays.asList("a", "b"),
+                  Arrays.asList(R.I32, R.FP32),
+                  b.remap(1)));
 
       var relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.FP32);
@@ -284,7 +293,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
 
       Plan.Root root = b.root(emptyScan);
       var relNode = converter.convert(root.getInput());
-      assertRowMatch(relNode.getRowType(), List.of(R.I32, N.STRING));
+      assertRowMatch(relNode.getRowType(), Arrays.asList(R.I32, N.STRING));
     }
 
     @Test
@@ -292,7 +301,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       Rel emptyScanWithRemap =
           io.substrait.relation.EmptyScan.builder()
               .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct(R.I32, N.STRING)))
-              .remap(Rel.Remap.of(List.of(0)))
+              .remap(Rel.Remap.of(Arrays.asList(0)))
               .build();
 
       Plan.Root root = b.root(emptyScanWithRemap);

--- a/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.google.common.collect.ImmutableSet;
 import io.substrait.proto.Plan;
 import java.io.IOException;
 import java.util.Set;
@@ -12,8 +13,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /** TPC-DS test to convert SQL to Substrait and then convert those plans back to SQL. */
 public class TpcdsQueryTest extends PlanTestBase {
-  private static final Set<Integer> toSubstraitExclusions = Set.of(9, 27, 36, 70, 86);
-  private static final Set<Integer> fromSubstraitExclusions = Set.of(6, 8, 67);
+  private static final Set<Integer> toSubstraitExclusions = ImmutableSet.of(9, 27, 36, 70, 86);
+  private static final Set<Integer> fromSubstraitExclusions = ImmutableSet.of(6, 8, 67);
 
   static IntStream testCases() {
     return IntStream.rangeClosed(1, 99).filter(n -> !toSubstraitExclusions.contains(n));

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.google.common.collect.ImmutableSet;
 import io.substrait.proto.Plan;
 import java.io.IOException;
 import java.util.Set;
@@ -12,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /** TPC-H test to convert SQL to Substrait and then convert those plans back to SQL. */
 public class TpchQueryTest extends PlanTestBase {
-  private static final Set<Integer> fromSubstraitExclusions = Set.of(17);
+  private static final Set<Integer> fromSubstraitExclusions = ImmutableSet.of(17);
 
   static IntStream testCases() {
     return IntStream.rangeClosed(1, 22);

--- a/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
@@ -7,7 +7,7 @@ import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.relation.Rel;
 import java.io.IOException;
-import java.util.List;
+import java.util.Arrays;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -192,7 +192,7 @@ public class WindowFunctionTest extends PlanTestBase {
     Rel rel =
         substraitBuilder.project(
             input ->
-                List.of(
+                Arrays.asList(
                     substraitBuilder.windowFn(
                         DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
                         String.format("%s:any", function),
@@ -204,7 +204,8 @@ public class WindowFunctionTest extends PlanTestBase {
                         WindowBound.Following.CURRENT_ROW,
                         substraitBuilder.fieldReference(input, 0))),
             substraitBuilder.remap(1),
-            substraitBuilder.namedScan(List.of("window_test"), List.of("a"), List.of(R.FP64)));
+            substraitBuilder.namedScan(
+                Arrays.asList("window_test"), Arrays.asList("a"), Arrays.asList(R.FP64)));
 
     assertFullRoundTrip(rel);
   }
@@ -215,7 +216,7 @@ public class WindowFunctionTest extends PlanTestBase {
     Rel rel =
         substraitBuilder.project(
             input ->
-                List.of(
+                Arrays.asList(
                     substraitBuilder.windowFn(
                         DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
                         String.format("%s:any_i32", function),
@@ -228,7 +229,8 @@ public class WindowFunctionTest extends PlanTestBase {
                         substraitBuilder.fieldReference(input, 0),
                         substraitBuilder.i32(1))),
             substraitBuilder.remap(1),
-            substraitBuilder.namedScan(List.of("window_test"), List.of("a"), List.of(R.FP64)));
+            substraitBuilder.namedScan(
+                Arrays.asList("window_test"), Arrays.asList("a"), Arrays.asList(R.FP64)));
 
     assertFullRoundTrip(rel);
   }
@@ -239,7 +241,7 @@ public class WindowFunctionTest extends PlanTestBase {
     Rel rel =
         substraitBuilder.project(
             input ->
-                List.of(
+                Arrays.asList(
                     substraitBuilder.windowFn(
                         DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
                         String.format("%s:any_i32_any", function),
@@ -253,7 +255,8 @@ public class WindowFunctionTest extends PlanTestBase {
                         substraitBuilder.i32(1),
                         substraitBuilder.fp64(100.0))),
             substraitBuilder.remap(1),
-            substraitBuilder.namedScan(List.of("window_test"), List.of("a"), List.of(R.FP64)));
+            substraitBuilder.namedScan(
+                Arrays.asList("window_test"), Arrays.asList("a"), Arrays.asList(R.FP64)));
 
     assertFullRoundTrip(rel);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
@@ -5,7 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.substrait.isthmus.AggregateFunctions;
 import io.substrait.isthmus.PlanTestBase;
 import io.substrait.isthmus.TypeConverter;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -17,14 +18,17 @@ public class AggregateFunctionConverterTest extends PlanTestBase {
   void testFunctionFinderMatch() {
     AggregateFunctionConverter converter =
         new AggregateFunctionConverter(
-            extensions.aggregateFunctions(), List.of(), typeFactory, TypeConverter.DEFAULT);
+            extensions.aggregateFunctions(),
+            Collections.emptyList(),
+            typeFactory,
+            TypeConverter.DEFAULT);
 
     var functionFinder =
         converter.getFunctionFinder(
             AggregateCall.create(
                 new SqlSumEmptyIsZeroAggFunction(),
                 true,
-                List.of(1),
+                Arrays.asList(1),
                 0,
                 typeFactory.createSqlType(SqlTypeName.VARCHAR),
                 null));

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,3 +12,8 @@ pluginManagement {
     kotlin("jvm") version "kotlin".v()
   }
 }
+
+plugins {
+  // Apply the foojay-resolver plugin to allow automatic download of JDKs
+  id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -103,7 +103,7 @@ java {
 
 tasks.withType<ScalaCompile>() {
   targetCompatibility = ""
-  scalaCompileOptions.additionalParameters = listOf("-release:17")
+  scalaCompileOptions.additionalParameters = listOf("-release:8")
 }
 
 var SLF4J_VERSION = properties.get("slf4j.version")


### PR DESCRIPTION
Here's an alternative to #433 which requires less changes.

Mainly:
- the Jabel plugin handles some of the differences between Java 17 and Java 8
- some APIs are not available in Java 8 and Jabel does not handle them (we don't have to change anything if we would use release level 11)
- configures both the Java and the Scala compiler to compile to release level 8
- configures the compiler version to be Java 17
- configures the JVM used for test execution to be Java 8

Downside of the approach is that we are still relying on Jabel to enable a subset of the newer Java syntax to be compiled by the Java compiler to Java 8 compatible bytecode while especially for Java API changes like `List.of()`, `Set.of()`, `Map.of()` and a couple others we need to write code that only uses the APIs available in Java 8.