### PR TITLE
chore: avoid Java version mismatch (alternative mix of Java 8 & Java 11)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,16 +43,28 @@ allprojects {
   tasks.configureEach<Test> {
     val javaToolchains = project.extensions.getByType<JavaToolchainService>()
     useJUnitPlatform()
-    javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) })
+    // run core tests on Java 8
+    // toolchain resolver plugin will download Java 8 if not installed
+    if (project.name == "core") {
+      javaLauncher.set(
+        javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(8)) }
+      )
+    } else {
+      javaLauncher.set(
+        javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(11)) }
+      )
+    }
     testLogging { exceptionFormat = TestExceptionFormat.FULL }
   }
   tasks.withType<JavaCompile> {
     sourceCompatibility = "17"
-    if (project.name != "core") {
-      options.release.set(11)
+    if (project.name == "core") {
+      options.release = 8
     } else {
-      options.release.set(8)
+      options.release = 11
     }
+    // use a Java 17 to compile code, will download Java 17 if not installed
+    javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(17) }
     dependsOn(submodulesUpdate)
   }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,3 +12,8 @@ pluginManagement {
     kotlin("jvm") version "kotlin".v()
   }
 }
+
+plugins {
+  // Apply the foojay-resolver plugin to allow automatic download of JDKs
+  id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+}

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -103,7 +103,7 @@ java {
 
 tasks.withType<ScalaCompile>() {
   targetCompatibility = ""
-  scalaCompileOptions.additionalParameters = listOf("-release:17")
+  scalaCompileOptions.additionalParameters = listOf("-release:11")
 }
 
 var SLF4J_VERSION = properties.get("slf4j.version")


### PR DESCRIPTION
Another alternative to https://github.com/substrait-io/substrait-java/pull/433 which requires less changes.

Mainly:
- the Jabel plugin handles some of the differences between Java 17 and Java 8
- explicitly configures the compiler version to be Java 17
- runs core tests on a JVM with the corresponding release level (core = Java 8, everything else = Java 11)
- configures same Scala release level as Java release level (Java 11)

Downside of the approach is that we are still relying on Jabel to enable a subset of the newer Java syntax to be compiled by the Java compiler to Java 8 compatible bytecode while especially for Java API changes we may still need to write code that only uses the APIs available in Java 8 or Java 11 depending on the module.