### PR TITLE
chore: update spark example to use latest substrait-spark

### DIFF
--- a/examples/substrait-spark/build.gradle.kts
+++ b/examples/substrait-spark/build.gradle.kts
@@ -10,10 +10,7 @@ repositories {
 }
 
 dependencies {
-  implementation("org.apache.spark:spark-core_2.12:3.5.1")
-  implementation("io.substrait:spark:0.36.0")
-  implementation("io.substrait:core:0.36.0")
-  implementation("org.apache.spark:spark-sql_2.12:3.5.1")
+  implementation(project(":spark"))
 
   // For a real Spark application, these would not be required since they would be in the Spark
   // server classpath
@@ -22,6 +19,8 @@ dependencies {
 }
 
 tasks.jar {
+  dependsOn(":spark:jar", ":core:jar", ":core:shadowJar")
+
   isZip64 = true
   exclude("META-INF/*.RSA")
   exclude("META-INF/*.SF")

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
@@ -6,6 +6,7 @@ import io.substrait.expression.Expression.Cast;
 import io.substrait.expression.Expression.DateLiteral;
 import io.substrait.expression.Expression.DecimalLiteral;
 import io.substrait.expression.Expression.EmptyListLiteral;
+import io.substrait.expression.Expression.EmptyMapLiteral;
 import io.substrait.expression.Expression.FP32Literal;
 import io.substrait.expression.Expression.FP64Literal;
 import io.substrait.expression.Expression.FixedBinaryLiteral;
@@ -16,12 +17,15 @@ import io.substrait.expression.Expression.I64Literal;
 import io.substrait.expression.Expression.I8Literal;
 import io.substrait.expression.Expression.IfThen;
 import io.substrait.expression.Expression.InPredicate;
+import io.substrait.expression.Expression.IntervalCompoundLiteral;
 import io.substrait.expression.Expression.IntervalDayLiteral;
 import io.substrait.expression.Expression.IntervalYearLiteral;
 import io.substrait.expression.Expression.ListLiteral;
 import io.substrait.expression.Expression.MapLiteral;
 import io.substrait.expression.Expression.MultiOrList;
 import io.substrait.expression.Expression.NullLiteral;
+import io.substrait.expression.Expression.PrecisionTimestampLiteral;
+import io.substrait.expression.Expression.PrecisionTimestampTZLiteral;
 import io.substrait.expression.Expression.ScalarFunctionInvocation;
 import io.substrait.expression.Expression.ScalarSubquery;
 import io.substrait.expression.Expression.SetPredicate;
@@ -38,157 +42,167 @@ import io.substrait.expression.Expression.VarCharLiteral;
 import io.substrait.expression.Expression.WindowFunctionInvocation;
 import io.substrait.expression.ExpressionVisitor;
 import io.substrait.expression.FieldReference;
+import io.substrait.util.EmptyVisitationContext;
 
 /** ExpressionStringify gives a simple debug text output for Expressions */
 public class ExpressionStringify extends ParentStringify
-    implements ExpressionVisitor<String, RuntimeException> {
+    implements ExpressionVisitor<String, EmptyVisitationContext, RuntimeException> {
 
   public ExpressionStringify(int indent) {
     super(indent);
   }
 
   @Override
-  public String visit(NullLiteral expr) throws RuntimeException {
+  public String visit(NullLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<NullLiteral>";
   }
 
   @Override
-  public String visit(BoolLiteral expr) throws RuntimeException {
+  public String visit(BoolLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<BoolLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(I8Literal expr) throws RuntimeException {
+  public String visit(I8Literal expr, EmptyVisitationContext context) throws RuntimeException {
     return "<I8Literal " + expr.value() + ">";
   }
 
   @Override
-  public String visit(I16Literal expr) throws RuntimeException {
+  public String visit(I16Literal expr, EmptyVisitationContext context) throws RuntimeException {
     return "<I16Literal " + expr.value() + ">";
   }
 
   @Override
-  public String visit(I32Literal expr) throws RuntimeException {
+  public String visit(I32Literal expr, EmptyVisitationContext context) throws RuntimeException {
     return "<I32Literal " + expr.value() + ">";
   }
 
   @Override
-  public String visit(I64Literal expr) throws RuntimeException {
+  public String visit(I64Literal expr, EmptyVisitationContext context) throws RuntimeException {
     return "<I64Literal " + expr.value() + ">";
   }
 
   @Override
-  public String visit(FP32Literal expr) throws RuntimeException {
+  public String visit(FP32Literal expr, EmptyVisitationContext context) throws RuntimeException {
     return "<FP32Literal " + expr.value() + ">";
   }
 
   @Override
-  public String visit(FP64Literal expr) throws RuntimeException {
+  public String visit(FP64Literal expr, EmptyVisitationContext context) throws RuntimeException {
     return "<FP64Literal " + expr.value() + ">";
   }
 
   @Override
-  public String visit(StrLiteral expr) throws RuntimeException {
+  public String visit(StrLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<StrLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(BinaryLiteral expr) throws RuntimeException {
+  public String visit(BinaryLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<BinaryLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(TimeLiteral expr) throws RuntimeException {
+  public String visit(TimeLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<TimeLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(DateLiteral expr) throws RuntimeException {
+  public String visit(DateLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<DateLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(TimestampLiteral expr) throws RuntimeException {
+  public String visit(TimestampLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<TimestampLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(TimestampTZLiteral expr) throws RuntimeException {
+  public String visit(TimestampTZLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<TimestampTZLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(IntervalYearLiteral expr) throws RuntimeException {
+  public String visit(IntervalYearLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<IntervalYearLiteral " + expr.months() + " " + expr.years() + ">";
   }
 
   @Override
-  public String visit(IntervalDayLiteral expr) throws RuntimeException {
+  public String visit(IntervalDayLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<IntervalYearLiteral " + expr.seconds() + " " + expr.days() + ">";
   }
 
   @Override
-  public String visit(UUIDLiteral expr) throws RuntimeException {
+  public String visit(UUIDLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<UUIDLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(FixedCharLiteral expr) throws RuntimeException {
+  public String visit(FixedCharLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<FixedCharLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(VarCharLiteral expr) throws RuntimeException {
+  public String visit(VarCharLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<VarCharLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(FixedBinaryLiteral expr) throws RuntimeException {
+  public String visit(FixedBinaryLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<FixedBinaryLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(DecimalLiteral expr) throws RuntimeException {
+  public String visit(DecimalLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<FixedBinaryLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(MapLiteral expr) throws RuntimeException {
+  public String visit(MapLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<MapLiteral >";
   }
 
   @Override
-  public String visit(ListLiteral expr) throws RuntimeException {
+  public String visit(ListLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<ListLiteral >";
   }
 
   @Override
-  public String visit(EmptyListLiteral expr) throws RuntimeException {
+  public String visit(EmptyListLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<EmptyListLiteral >";
   }
 
   @Override
-  public String visit(StructLiteral expr) throws RuntimeException {
+  public String visit(StructLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<StructLiteral >";
   }
 
   @Override
-  public String visit(UserDefinedLiteral expr) throws RuntimeException {
+  public String visit(UserDefinedLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
     return "<UserDefinedLiteral " + expr.value() + ">";
   }
 
   @Override
-  public String visit(Switch expr) throws RuntimeException {
+  public String visit(Switch expr, EmptyVisitationContext context) throws RuntimeException {
     return "<Switch " + expr.switchClauses() + ">";
   }
 
   @Override
-  public String visit(IfThen expr) throws RuntimeException {
+  public String visit(IfThen expr, EmptyVisitationContext context) throws RuntimeException {
     return "<IfThen " + expr.ifClauses() + ">";
   }
 
   @Override
-  public String visit(ScalarFunctionInvocation expr) throws RuntimeException {
+  public String visit(ScalarFunctionInvocation expr, EmptyVisitationContext context)
+      throws RuntimeException {
     var sb = new StringBuilder("<ScalarFn>");
 
     sb.append(expr.declaration());
@@ -200,46 +214,47 @@ public class ExpressionStringify extends ParentStringify
       sb.append("arg" + i + " = ");
       var funcArgVisitor = new FunctionArgStringify(indent);
 
-      sb.append(arg.accept(expr.declaration(), i, funcArgVisitor));
+      sb.append(arg.accept(expr.declaration(), i, funcArgVisitor, context));
       sb.append(" ");
     }
     return sb.toString();
   }
 
   @Override
-  public String visit(WindowFunctionInvocation expr) throws RuntimeException {
+  public String visit(WindowFunctionInvocation expr, EmptyVisitationContext context)
+      throws RuntimeException {
     var sb = new StringBuilder("WindowFunctionInvocation#");
 
     return sb.toString();
   }
 
   @Override
-  public String visit(Cast expr) throws RuntimeException {
+  public String visit(Cast expr, EmptyVisitationContext context) throws RuntimeException {
     var sb = new StringBuilder("<Cast#");
 
     sb.append(expr.getType().accept(new TypeStringify(this.indent))).append(" ");
-    sb.append(expr.input().accept(this)).append(" ");
+    sb.append(expr.input().accept(this, context)).append(" ");
     sb.append(expr.failureBehavior().toString());
     sb.append(">");
     return sb.toString();
   }
 
   @Override
-  public String visit(SingleOrList expr) throws RuntimeException {
+  public String visit(SingleOrList expr, EmptyVisitationContext context) throws RuntimeException {
     var sb = new StringBuilder("SingleOrList#");
 
     return sb.toString();
   }
 
   @Override
-  public String visit(MultiOrList expr) throws RuntimeException {
+  public String visit(MultiOrList expr, EmptyVisitationContext context) throws RuntimeException {
     var sb = new StringBuilder("Cast#");
 
     return sb.toString();
   }
 
   @Override
-  public String visit(FieldReference expr) throws RuntimeException {
+  public String visit(FieldReference expr, EmptyVisitationContext context) throws RuntimeException {
     StringBuilder sb = new StringBuilder("FieldRef#");
     var type = expr.getType();
     // sb.append(expr.inputExpression());
@@ -254,23 +269,57 @@ public class ExpressionStringify extends ParentStringify
   }
 
   @Override
-  public String visit(SetPredicate expr) throws RuntimeException {
+  public String visit(SetPredicate expr, EmptyVisitationContext context) throws RuntimeException {
     var sb = new StringBuilder("SetPredicate#");
 
     return sb.toString();
   }
 
   @Override
-  public String visit(ScalarSubquery expr) throws RuntimeException {
+  public String visit(ScalarSubquery expr, EmptyVisitationContext context) throws RuntimeException {
     var sb = new StringBuilder("ScalarSubquery#");
 
     return sb.toString();
   }
 
   @Override
-  public String visit(InPredicate expr) throws RuntimeException {
+  public String visit(InPredicate expr, EmptyVisitationContext context) throws RuntimeException {
     var sb = new StringBuilder("InPredicate#");
 
     return sb.toString();
+  }
+
+  @Override
+  public String visit(PrecisionTimestampLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<PrecisionTimestampLiteral " + expr.value() + ">";
+  }
+
+  @Override
+  public String visit(PrecisionTimestampTZLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<PrecisionTimestampTZLiteral " + expr.value() + ">";
+  }
+
+  @Override
+  public String visit(IntervalCompoundLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<IntervalCompoundLiteral "
+        + expr.subseconds()
+        + " "
+        + expr.seconds()
+        + " "
+        + expr.days()
+        + " "
+        + expr.months()
+        + " "
+        + expr.years()
+        + ">";
+  }
+
+  @Override
+  public String visit(EmptyMapLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<EmptyMapLiteral>";
   }
 }

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/FunctionArgStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/FunctionArgStringify.java
@@ -5,27 +5,31 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.FunctionArg.FuncArgVisitor;
 import io.substrait.extension.SimpleExtension.Function;
 import io.substrait.type.Type;
+import io.substrait.util.EmptyVisitationContext;
 
 /** FunctionArgStringify produces a simple debug string for Function Arguments */
 public class FunctionArgStringify extends ParentStringify
-    implements FuncArgVisitor<String, RuntimeException> {
+    implements FuncArgVisitor<String, EmptyVisitationContext, RuntimeException> {
 
   public FunctionArgStringify(int indent) {
     super(indent);
   }
 
   @Override
-  public String visitExpr(Function fnDef, int argIdx, Expression e) throws RuntimeException {
-    return e.accept(new ExpressionStringify(indent + 1));
+  public String visitExpr(Function fnDef, int argIdx, Expression e, EmptyVisitationContext context)
+      throws RuntimeException {
+    return e.accept(new ExpressionStringify(indent + 1), context);
   }
 
   @Override
-  public String visitType(Function fnDef, int argIdx, Type t) throws RuntimeException {
+  public String visitType(Function fnDef, int argIdx, Type t, EmptyVisitationContext context)
+      throws RuntimeException {
     return t.accept(new TypeStringify(indent));
   }
 
   @Override
-  public String visitEnumArg(Function fnDef, int argIdx, EnumArg e) throws RuntimeException {
+  public String visitEnumArg(Function fnDef, int argIdx, EnumArg e, EmptyVisitationContext context)
+      throws RuntimeException {
     return e.toString();
   }
 }

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/TypeStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/TypeStringify.java
@@ -13,10 +13,12 @@ import io.substrait.type.Type.I16;
 import io.substrait.type.Type.I32;
 import io.substrait.type.Type.I64;
 import io.substrait.type.Type.I8;
+import io.substrait.type.Type.IntervalCompound;
 import io.substrait.type.Type.IntervalDay;
 import io.substrait.type.Type.IntervalYear;
 import io.substrait.type.Type.ListType;
 import io.substrait.type.Type.Map;
+import io.substrait.type.Type.PrecisionTime;
 import io.substrait.type.Type.Str;
 import io.substrait.type.Type.Struct;
 import io.substrait.type.Type.Time;
@@ -170,6 +172,16 @@ public class TypeStringify extends ParentStringify
 
   @Override
   public String visit(UserDefined type) throws RuntimeException {
+    return type.getClass().getSimpleName();
+  }
+
+  @Override
+  public String visit(PrecisionTime type) throws RuntimeException {
+    return type.getClass().getSimpleName();
+  }
+
+  @Override
+  public String visit(IntervalCompound type) throws RuntimeException {
     return type.getClass().getSimpleName();
   }
 }

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   `maven-publish`
   signing
-  id("java")
+  id("java-library")
   id("scala")
   id("idea")
   id("com.diffplug.spotless") version "7.1.0"
@@ -113,10 +113,10 @@ sourceSets {
 }
 
 dependencies {
-  implementation(project(":core"))
+  api(project(":core"))
   implementation("org.scala-lang:scala-library:2.12.16")
-  implementation("org.apache.spark:spark-core_2.12:${SPARK_VERSION}")
-  implementation("org.apache.spark:spark-sql_2.12:${SPARK_VERSION}")
+  api("org.apache.spark:spark-core_2.12:${SPARK_VERSION}")
+  api("org.apache.spark:spark-sql_2.12:${SPARK_VERSION}")
   implementation("org.apache.spark:spark-catalyst_2.12:${SPARK_VERSION}")
   implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
 


### PR DESCRIPTION
The substrait spark example was using a static outdated version of the substrait spark mappings. This PR changes the substrait spark example to always use the latest substrait spark mappings and updates the code according to the latest changes.

Additionally, it changes the substrait spark mapping Gradle build to declare the spark-core and spark-sql dependencies as `api` dependencies so we don't have to redeclare them for the substrait spark example. This also required to change the `java` Gradle plugin to the `java-library` Gradle plugin.