### PR TITLE
fix(isthmus-cli): fix tpch_smoke.sh test script

### DIFF
--- a/isthmus-cli/src/test/script/tpch_smoke.sh
+++ b/isthmus-cli/src/test/script/tpch_smoke.sh
@@ -11,11 +11,8 @@ TPCH="../../../../isthmus/src/test/resources/tpch"
 DDL=$(cat ${TPCH}/schema.sql)
 QUERY_FOLDER="${TPCH}/queries"
 
-##for QUERYNUM in {1..22}; do
-# TODO: failed query: 8 12 15. 15 failed due to comments
-QUERY_TO_RUN=(1 2 3 4 5 6 7 9 10 11 13 14 16 17 18 19 20 21 22)
-for QUERY_NUM in "${QUERY_TO_RUN[@]}"; do
-     if [ "${QUERY_NUM}" -lt 10 ]; then
+for QUERY_NUM in {1..22}; do
+    if [ "${QUERY_NUM}" -lt 10 ]; then
        QUERY=$(cat "${QUERY_FOLDER}/0${QUERY_NUM}.sql")
      else
        QUERY=$(cat "${QUERY_FOLDER}/${QUERY_NUM}.sql")
@@ -23,5 +20,5 @@ for QUERY_NUM in "${QUERY_TO_RUN[@]}"; do
 
     echo "Processing tpc-h query ${QUERY_NUM}"
     echo "${QUERY}"
-    $CMD "${QUERY}" --create "${DDL}"
+    $CMD --create "${DDL}" -- "${QUERY}"
 done


### PR DESCRIPTION
- The tpch_smoke.sh script did not test all 22 TPC-H queries since they failed to convert previously.
- This simple fix to the test script avoids the issue of picocli confusing the comments in the SQL with CLI arguments by providing the SQL arguments last.
- Additionally, the progress we made in increasing TPC-H query conversion rate makes all 22 queries convert without throwing an exception.

fixes #86 
fixes #87 