### PR TITLE
feat(spark): add LogicalRDD support

### DIFF
--- a/spark/src/test/scala/io/substrait/spark/RelationsSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/RelationsSuite.scala
@@ -1,7 +1,9 @@
 package io.substrait.spark
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 
 class RelationsSuite extends SparkFunSuite with SharedSparkSession with SubstraitPlanTestBase {
 
@@ -37,5 +39,64 @@ class RelationsSuite extends SparkFunSuite with SharedSparkSession with Substrai
       // the struct() cast gets evaluated into a literal struct value by spark
       "select * from (values (1, cast(struct(1, 'a') as struct<f1: int, f2: string>)) as table(int_col, col))"
     )
+  }
+
+  test("create_dataset - LocalRelation") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val df = Seq(
+      (1, "one"),
+      (2, "two"),
+      (3, "three")
+    ).toDF("id", "value")
+
+    assertSparkSubstraitRelRoundTrip(df.queryExecution.optimizedPlan)
+  }
+
+  test("createdataframe - LogicalRDD") {
+    val data = Seq(
+      Row(1, "one"),
+      Row(2, "two"),
+      Row(3, "three")
+    )
+
+    val schema = StructType(
+      List(
+        StructField("id", IntegerType, true),
+        StructField("value", StringType, true)
+      ))
+
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(data),
+      schema
+    )
+
+    assertSparkSubstraitRelRoundTrip(df.queryExecution.optimizedPlan)
+  }
+
+  test("Limit RDD size") {
+    val data = Seq(
+      Row(1, "one"),
+      Row(2, "two"),
+      Row(3, "three"),
+      Row(4, "four")
+    )
+
+    val schema = StructType(
+      List(
+        StructField("id", IntegerType, true),
+        StructField("value", StringType, true)
+      ))
+
+    val df = spark.createDataFrame(
+      spark.sparkContext.parallelize(data),
+      schema
+    )
+
+    assertResult(4)(df.count())
+
+    val plan = assertSparkSubstraitRelRoundTrip(df.queryExecution.optimizedPlan, 2)
+    assertResult(2)(plan.count())
   }
 }


### PR DESCRIPTION
Support conversion of dataframes that are created using the Spark createDataFrame() method.
This produces a LogicalRDD in the query plan which can be converted to a substrait VirtualTableScan.
Introduces overridable `rddLimit` to guard against serialising very large datasets.