### PR TITLE
style: use explicit types instead of var keyword

### DIFF
--- a/buildSrc/src/main/resources/substrait-pmd.xml
+++ b/buildSrc/src/main/resources/substrait-pmd.xml
@@ -12,6 +12,7 @@
 
   <rule ref="category/java/codestyle.xml/UnnecessaryModifier" />
   <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" />
+  <rule ref="category/java/codestyle.xml/UseExplicitTypes" />
   <rule ref="category/java/bestpractices.xml/MissingOverride" />
   <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" />
 </ruleset>

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/App.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/App.java
@@ -29,8 +29,8 @@ public final class App {
       }
       String exampleClass = args[0];
 
-      var clz = Class.forName(App.class.getPackageName() + "." + exampleClass);
-      var action = (Action) clz.getDeclaredConstructor().newInstance();
+      Class<?> clz = Class.forName(App.class.getPackageName() + "." + exampleClass);
+      Action action = (Action) clz.getDeclaredConstructor().newInstance();
 
       if (args.length == 2) {
         action.run(args[1]);

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/SparkSQL.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/SparkSQL.java
@@ -12,6 +12,8 @@ import io.substrait.spark.logical.ToSubstraitRel;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 
@@ -53,7 +55,7 @@ public class SparkSQL implements App.Action {
               + " GROUP BY vehicles.colour"
               + " ORDER BY count(*)";
 
-      var result = spark.sql(sqlQuery);
+      Dataset<Row> result = spark.sql(sqlQuery);
       result.show();
 
       LogicalPlan logical = result.logicalPlan();

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
@@ -42,7 +42,10 @@ import io.substrait.expression.Expression.VarCharLiteral;
 import io.substrait.expression.Expression.WindowFunctionInvocation;
 import io.substrait.expression.ExpressionVisitor;
 import io.substrait.expression.FieldReference;
+import io.substrait.expression.FunctionArg;
+import io.substrait.type.Type;
 import io.substrait.util.EmptyVisitationContext;
+import java.util.List;
 
 /** ExpressionStringify gives a simple debug text output for Expressions */
 public class ExpressionStringify extends ParentStringify
@@ -203,16 +206,16 @@ public class ExpressionStringify extends ParentStringify
   @Override
   public String visit(ScalarFunctionInvocation expr, EmptyVisitationContext context)
       throws RuntimeException {
-    var sb = new StringBuilder("<ScalarFn>");
+    StringBuilder sb = new StringBuilder("<ScalarFn>");
 
     sb.append(expr.declaration());
     // sb.append(" (");
-    var args = expr.arguments();
-    for (var i = 0; i < args.size(); i++) {
-      var arg = args.get(i);
+    List<FunctionArg> args = expr.arguments();
+    for (int i = 0; i < args.size(); i++) {
+      FunctionArg arg = args.get(i);
       sb.append(getContinuationIndentString());
       sb.append("arg" + i + " = ");
-      var funcArgVisitor = new FunctionArgStringify(indent);
+      FunctionArgStringify funcArgVisitor = new FunctionArgStringify(indent);
 
       sb.append(arg.accept(expr.declaration(), i, funcArgVisitor, context));
       sb.append(" ");
@@ -223,14 +226,14 @@ public class ExpressionStringify extends ParentStringify
   @Override
   public String visit(WindowFunctionInvocation expr, EmptyVisitationContext context)
       throws RuntimeException {
-    var sb = new StringBuilder("WindowFunctionInvocation#");
+    StringBuilder sb = new StringBuilder("WindowFunctionInvocation#");
 
     return sb.toString();
   }
 
   @Override
   public String visit(Cast expr, EmptyVisitationContext context) throws RuntimeException {
-    var sb = new StringBuilder("<Cast#");
+    StringBuilder sb = new StringBuilder("<Cast#");
 
     sb.append(expr.getType().accept(new TypeStringify(this.indent))).append(" ");
     sb.append(expr.input().accept(this, context)).append(" ");
@@ -241,14 +244,14 @@ public class ExpressionStringify extends ParentStringify
 
   @Override
   public String visit(SingleOrList expr, EmptyVisitationContext context) throws RuntimeException {
-    var sb = new StringBuilder("SingleOrList#");
+    StringBuilder sb = new StringBuilder("SingleOrList#");
 
     return sb.toString();
   }
 
   @Override
   public String visit(MultiOrList expr, EmptyVisitationContext context) throws RuntimeException {
-    var sb = new StringBuilder("Cast#");
+    StringBuilder sb = new StringBuilder("Cast#");
 
     return sb.toString();
   }
@@ -256,7 +259,7 @@ public class ExpressionStringify extends ParentStringify
   @Override
   public String visit(FieldReference expr, EmptyVisitationContext context) throws RuntimeException {
     StringBuilder sb = new StringBuilder("FieldRef#");
-    var type = expr.getType();
+    Type type = expr.getType();
     // sb.append(expr.inputExpression());
     sb.append("/").append(type.accept(new TypeStringify(indent))).append("/");
     expr.segments()
@@ -270,21 +273,21 @@ public class ExpressionStringify extends ParentStringify
 
   @Override
   public String visit(SetPredicate expr, EmptyVisitationContext context) throws RuntimeException {
-    var sb = new StringBuilder("SetPredicate#");
+    StringBuilder sb = new StringBuilder("SetPredicate#");
 
     return sb.toString();
   }
 
   @Override
   public String visit(ScalarSubquery expr, EmptyVisitationContext context) throws RuntimeException {
-    var sb = new StringBuilder("ScalarSubquery#");
+    StringBuilder sb = new StringBuilder("ScalarSubquery#");
 
     return sb.toString();
   }
 
   @Override
   public String visit(InPredicate expr, EmptyVisitationContext context) throws RuntimeException {
-    var sb = new StringBuilder("InPredicate#");
+    StringBuilder sb = new StringBuilder("InPredicate#");
 
     return sb.toString();
   }

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/ParentStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/ParentStringify.java
@@ -21,7 +21,7 @@ public class ParentStringify {
 
   StringBuilder getIndent() {
 
-    var sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder();
     if (indent != 0) {
       sb.append("\n");
     }
@@ -33,7 +33,7 @@ public class ParentStringify {
 
   StringBuilder getIndentString() {
 
-    var sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder();
     sb.append(indentChar.repeat(this.indent * this.indentSize));
     sb.append("+- ");
     return sb;
@@ -41,7 +41,7 @@ public class ParentStringify {
 
   StringBuilder getContinuationIndentString() {
 
-    var sb = new StringBuilder();
+    StringBuilder sb = new StringBuilder();
     if (indent != 0) {
       sb.append("\n");
     }

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/TypeStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/TypeStringify.java
@@ -151,7 +151,7 @@ public class TypeStringify extends ParentStringify
 
   @Override
   public String visit(Struct type) throws RuntimeException {
-    var sb = new StringBuffer(type.getClass().getSimpleName());
+    StringBuffer sb = new StringBuffer(type.getClass().getSimpleName());
     type.fields()
         .forEach(
             f -> {

--- a/isthmus/src/main/java/io/substrait/isthmus/PreCalciteAggregateValidator.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/PreCalciteAggregateValidator.java
@@ -136,7 +136,7 @@ public class PreCalciteAggregateValidator {
      * </ul>
      */
     public static Aggregate transformToValidCalciteAggregate(Aggregate aggregate) {
-      var at = new PreCalciteAggregateTransformer(aggregate);
+      PreCalciteAggregateTransformer at = new PreCalciteAggregateTransformer(aggregate);
 
       List<Aggregate.Measure> newMeasures =
           aggregate.getMeasures().stream().map(at::updateMeasure).collect(Collectors.toList());

--- a/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
@@ -78,7 +78,7 @@ public class SchemaCollector {
      * @return a map of qualified table names to their associated Substrait schemas
      */
     public static Map<List<String>, NamedStruct> gatherTables(Rel rootRel) {
-      var visitor = new TableGatherer();
+      TableGatherer visitor = new TableGatherer();
       rootRel.accept(visitor, EmptyVisitationContext.INSTANCE);
       return visitor.tableMap;
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import io.substrait.extendedexpression.ExtendedExpression;
 import io.substrait.extendedexpression.ExtendedExpressionProtoConverter;
+import io.substrait.extendedexpression.ImmutableExtendedExpression.Builder;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.calcite.SubstraitTable;
 import io.substrait.isthmus.expression.RexExpressionConverter;
@@ -85,7 +86,7 @@ public class SqlExpressionToSubstrait extends SqlConverterBase {
    */
   public io.substrait.proto.ExtendedExpression convert(
       String[] sqlExpressions, List<String> createStatements) throws SqlParseException {
-    var result = registerCreateTablesForExtendedExpression(createStatements);
+    Result result = registerCreateTablesForExtendedExpression(createStatements);
     return executeInnerSQLExpressions(
         sqlExpressions,
         result.validator,
@@ -116,7 +117,7 @@ public class SqlExpressionToSubstrait extends SqlConverterBase {
       expressionReferences.add(expressionReference);
     }
     NamedStruct namedStruct = toNamedStruct(nameToTypeMap);
-    var extendedExpression =
+    Builder extendedExpression =
         ExtendedExpression.builder()
             .referredExpressions(expressionReferences)
             .baseSchema(namedStruct);
@@ -182,8 +183,8 @@ public class SqlExpressionToSubstrait extends SqlConverterBase {
   }
 
   private NamedStruct toNamedStruct(Map<String, RelDataType> nameToTypeMap) {
-    var names = new ArrayList<String>();
-    var types = new ArrayList<Type>();
+    ArrayList<String> names = new ArrayList<String>();
+    ArrayList<Type> types = new ArrayList<Type>();
     for (Map.Entry<String, RelDataType> entry : nameToTypeMap.entrySet()) {
       String k = entry.getKey();
       RelDataType v = entry.getValue();

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitToCalcite.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitToCalcite.java
@@ -222,7 +222,7 @@ public class SubstraitToCalcite {
     }
 
     public static Map<List<String>, NamedStruct> gatherTables(Rel rel) {
-      var visitor = new NamedStructGatherer();
+      NamedStructGatherer visitor = new NamedStructGatherer();
       rel.accept(visitor, EmptyVisitationContext.INSTANCE);
       return visitor.tableMap;
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -7,6 +7,7 @@ import io.substrait.function.NullableType;
 import io.substrait.function.TypeExpression;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
+import io.substrait.type.Type.Struct;
 import io.substrait.type.TypeCreator;
 import io.substrait.type.TypeVisitor;
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.jspecify.annotations.Nullable;
@@ -52,14 +54,14 @@ public class TypeConverter {
       throw new IllegalArgumentException("Expected type of struct.");
     }
 
-    var names = new ArrayList<String>();
-    var struct = (Type.Struct) toSubstrait(type, names);
+    ArrayList<String> names = new ArrayList<String>();
+    Struct struct = (Type.Struct) toSubstrait(type, names);
     return NamedStruct.of(names, struct);
   }
 
   private Type toSubstrait(RelDataType type, List<String> names) {
     // Check for user mapped types first as they may re-use SqlTypeNames
-    var userType = userTypeMapper.toSubstrait(type);
+    Type userType = userTypeMapper.toSubstrait(type);
     if (userType != null) {
       return userType;
     }
@@ -136,8 +138,8 @@ public class TypeConverter {
         }
       case ROW:
         {
-          var children = new ArrayList<Type>();
-          for (var field : type.getFieldList()) {
+          ArrayList<Type> children = new ArrayList<Type>();
+          for (RelDataTypeField field : type.getFieldList()) {
             names.add(field.getName());
             children.add(toSubstrait(field.getType(), names));
           }
@@ -357,7 +359,7 @@ public class TypeConverter {
 
     @Override
     public RelDataType visit(Type.UserDefined expr) throws RuntimeException {
-      var type = userTypeMapper.toCalcite(expr);
+      RelDataType type = userTypeMapper.toCalcite(expr);
       if (type != null) {
         return type;
       }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
@@ -81,7 +81,7 @@ public class AggregateFunctionConverter
       AggregateCall call,
       Function<RexNode, Expression> topLevelConverter) {
 
-    var m = getFunctionFinder(call);
+    FunctionFinder m = getFunctionFinder(call);
     if (m == null) {
       return Optional.empty();
     }
@@ -89,7 +89,7 @@ public class AggregateFunctionConverter
       return Optional.empty();
     }
 
-    var wrapped = new WrappedAggregateCall(call, input, rexBuilder, inputType);
+    WrappedAggregateCall wrapped = new WrappedAggregateCall(call, input, rexBuilder, inputType);
     return m.attemptMatch(wrapped, topLevelConverter);
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -60,8 +60,8 @@ public class CallConverters {
             if (call.getKind() != SqlKind.REINTERPRET) {
               return null;
             }
-            var operand = visitor.apply(call.getOperands().get(0));
-            var type = typeConverter.toSubstrait(call.getType());
+            Expression operand = visitor.apply(call.getOperands().get(0));
+            Type type = typeConverter.toSubstrait(call.getType());
 
             // For now, we only support handling of SqlKind.REINTEPRETET for the case of stored
             // user-defined literals
@@ -100,12 +100,12 @@ public class CallConverters {
         // else)
         assert call.getOperands().size() % 2 == 1;
 
-        var caseArgs =
+        List<Expression> caseArgs =
             call.getOperands().stream().map(visitor).collect(java.util.stream.Collectors.toList());
 
-        var last = caseArgs.size() - 1;
+        int last = caseArgs.size() - 1;
         // for if/else, process in reverse to maintain query order
-        var caseConditions = new ArrayList<Expression.IfClause>();
+        List<Expression.IfClause> caseConditions = new ArrayList<>();
         for (int i = 0; i < last; i += 2) {
           caseConditions.add(
               Expression.IfClause.builder()
@@ -114,7 +114,7 @@ public class CallConverters {
                   .build());
         }
 
-        var defaultResult = caseArgs.get(last);
+        Expression defaultResult = caseArgs.get(last);
         return ExpressionCreator.ifThenStatement(defaultResult, caseConditions);
       };
 
@@ -129,7 +129,7 @@ public class CallConverters {
             if (call.getKind() != SqlKind.SEARCH) {
               return null;
             } else {
-              var expandSearch = RexUtil.expandSearch(rexBuilder, null, call);
+              RexNode expandSearch = RexUtil.expandSearch(rexBuilder, null, call);
               // if no expansion happened, avoid infinite recursion.
               return expandSearch.equals(call) ? null : visitor.apply(expandSearch);
             }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FieldSelectionConverter.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus.expression;
 
 import io.substrait.expression.Expression;
+import io.substrait.expression.Expression.Literal;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FieldReference;
 import io.substrait.isthmus.CallConverter;
@@ -32,8 +33,8 @@ public class FieldSelectionConverter implements CallConverter {
       return Optional.empty();
     }
 
-    var toDereference = call.getOperands().get(0);
-    var reference = call.getOperands().get(1);
+    RexNode toDereference = call.getOperands().get(0);
+    RexNode reference = call.getOperands().get(1);
 
     if (reference.getKind() != SqlKind.LITERAL || !(reference instanceof RexLiteral)) {
       LOGGER
@@ -45,14 +46,14 @@ public class FieldSelectionConverter implements CallConverter {
       return Optional.empty();
     }
 
-    var literal = (new LiteralConverter(typeConverter)).convert((RexLiteral) reference);
+    Literal literal = (new LiteralConverter(typeConverter)).convert((RexLiteral) reference);
 
-    var input = topLevelConverter.apply(toDereference);
+    Expression input = topLevelConverter.apply(toDereference);
 
     switch (toDereference.getType().getSqlTypeName()) {
       case ROW:
         {
-          var index = toInt(literal);
+          Optional<Integer> index = toInt(literal);
           if (index.isEmpty()) {
             return Optional.empty();
           }
@@ -64,7 +65,7 @@ public class FieldSelectionConverter implements CallConverter {
         }
       case ARRAY:
         {
-          var index = toInt(literal);
+          Optional<Integer> index = toInt(literal);
           if (index.isEmpty()) {
             return Optional.empty();
           }
@@ -78,7 +79,7 @@ public class FieldSelectionConverter implements CallConverter {
 
       case MAP:
         {
-          var mapKey = toString(literal);
+          Optional<String> mapKey = toString(literal);
           if (mapKey.isEmpty()) {
             return Optional.empty();
           }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConstructorConverter.java
@@ -4,11 +4,13 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.CallConverter;
 import io.substrait.isthmus.TypeConverter;
+import io.substrait.type.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -62,8 +64,8 @@ public class LiteralConstructorConverter implements CallConverter {
   }
 
   private Optional<Expression> toEmptyListLiteral(RexCall call) {
-    var calciteElementType = call.getType().getComponentType();
-    var substraitElementType = typeConverter.toSubstrait(calciteElementType);
+    RelDataType calciteElementType = call.getType().getComponentType();
+    Type substraitElementType = typeConverter.toSubstrait(calciteElementType);
     return Optional.of(
         ExpressionCreator.emptyList(call.getType().isNullable(), substraitElementType));
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -88,9 +88,9 @@ public class LiteralConverter {
         return ExpressionCreator.bool(n, literal.getValueAs(Boolean.class));
       case CHAR:
         {
-          var val = literal.getValue();
+          Comparable val = literal.getValue();
           if (val instanceof NlsString) {
-            var nls = (NlsString) val;
+            NlsString nls = (NlsString) val;
             return ExpressionCreator.fixedChar(n, nls.getValue());
           }
           throw new UnsupportedOperationException("Unable to handle char type: " + val);
@@ -167,8 +167,8 @@ public class LiteralConverter {
       case INTERVAL_MONTH:
         {
           long intervalLength = Objects.requireNonNull(literal.getValueAs(Long.class));
-          var years = intervalLength / 12;
-          var months = intervalLength - years * 12;
+          long years = intervalLength / 12;
+          long months = intervalLength - years * 12;
           return ExpressionCreator.intervalYear(n, (int) years, (int) months);
         }
       case INTERVAL_DAY:
@@ -183,12 +183,12 @@ public class LiteralConverter {
       case INTERVAL_SECOND:
         {
           // Calcite represents day/time intervals in milliseconds, despite a default scale of 6.
-          var totalMillis = Objects.requireNonNull(literal.getValueAs(Long.class));
-          var interval = Duration.ofMillis(totalMillis);
+          Long totalMillis = Objects.requireNonNull(literal.getValueAs(Long.class));
+          Duration interval = Duration.ofMillis(totalMillis);
 
-          var days = interval.toDays();
-          var seconds = interval.minusDays(days).toSeconds();
-          var micros = interval.toMillisPart() * 1000;
+          long days = interval.toDays();
+          long seconds = interval.minusDays(days).toSeconds();
+          int micros = interval.toMillisPart() * 1000;
 
           return ExpressionCreator.intervalDay(n, (int) days, (int) seconds, micros, 6);
         }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -10,6 +10,7 @@ import io.substrait.type.StringTypeVisitor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;
@@ -72,8 +73,8 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
 
   @Override
   public Expression visitCall(RexCall call) {
-    for (var c : callConverters) {
-      var out = c.convert(call, rexNode -> rexNode.accept(this));
+    for (CallConverter c : callConverters) {
+      Optional<Expression> out = c.convert(call, rexNode -> rexNode.accept(this));
       if (out.isPresent()) {
         return out.get();
       }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -72,8 +72,9 @@ public class ScalarFunctionConverter
       SubstraitFunctionMapping mapping,
       RexCall call,
       Function<RexNode, Expression> topLevelConverter) {
-    var finder = new FunctionFinder(mapping.substraitName(), call.op, mapping.functions());
-    var wrapped =
+    FunctionFinder finder =
+        new FunctionFinder(mapping.substraitName(), call.op, mapping.functions());
+    WrappedScalarCall wrapped =
         new WrappedScalarCall(call) {
           @Override
           public Stream<RexNode> getOperands() {
@@ -87,7 +88,7 @@ public class ScalarFunctionConverter
   private Optional<Expression> defaultConvert(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
     FunctionFinder finder = signatures.get(call.op);
-    var wrapped = new WrappedScalarCall(call);
+    WrappedScalarCall wrapped = new WrappedScalarCall(call);
 
     return attemptMatch(finder, wrapped, topLevelConverter);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/SortFieldConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/SortFieldConverter.java
@@ -10,7 +10,7 @@ public class SortFieldConverter {
   /** Converts a {@link RexFieldCollation} to a {@link Expression.SortField}. */
   public static Expression.SortField toSortField(
       RexFieldCollation rexFieldCollation, RexExpressionConverter rexExpressionConverter) {
-    var expr = rexFieldCollation.left.accept(rexExpressionConverter);
+    Expression expr = rexFieldCollation.left.accept(rexExpressionConverter);
     Expression.SortDirection direction = asSortDirection(rexFieldCollation);
 
     return Expression.SortField.builder().expr(expr).direction(direction).build();

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowBoundConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowBoundConverter.java
@@ -3,6 +3,7 @@ package io.substrait.isthmus.expression;
 import io.substrait.expression.WindowBound;
 import java.math.BigDecimal;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -16,10 +17,10 @@ public class WindowBoundConverter {
     if (rexWindowBound.isUnbounded()) {
       return WindowBound.UNBOUNDED;
     } else {
-      var node = rexWindowBound.getOffset();
+      RexNode node = rexWindowBound.getOffset();
 
       if (node instanceof RexLiteral) {
-        var literal = (RexLiteral) node;
+        RexLiteral literal = (RexLiteral) node;
         if (SqlTypeName.EXACT_TYPES.contains(literal.getTypeName())) {
           BigDecimal offset = (BigDecimal) literal.getValue4();
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowFunctionConverter.java
@@ -57,7 +57,7 @@ public class WindowFunctionConverter
     RexOver over = call.over;
     RexWindow window = over.getWindow();
 
-    var partitionExprs =
+    List<Expression> partitionExprs =
         window.partitionKeys.stream()
             .map(r -> r.accept(call.rexExpressionConverter))
             .collect(java.util.stream.Collectors.toList());
@@ -96,7 +96,7 @@ public class WindowFunctionConverter
       RexOver over,
       Function<RexNode, Expression> topLevelConverter,
       RexExpressionConverter rexExpressionConverter) {
-    var aggFunction = over.getAggOperator();
+    SqlAggFunction aggFunction = over.getAggOperator();
 
     SqlAggFunction lookupFunction =
         AggregateFunctions.toSubstraitAggVariant(aggFunction).orElse(aggFunction);
@@ -108,7 +108,7 @@ public class WindowFunctionConverter
       return Optional.empty();
     }
 
-    var wrapped = new WrappedWindowCall(over, rexExpressionConverter);
+    WrappedWindowCall wrapped = new WrappedWindowCall(over, rexExpressionConverter);
     return m.attemptMatch(wrapped, topLevelConverter);
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/WindowRelFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/WindowRelFunctionConverter.java
@@ -83,7 +83,7 @@ public class WindowRelFunctionConverter
       RexWindowBound upperBound,
       boolean isRows,
       Function<RexNode, Expression> topLevelConverter) {
-    var aggFunction = (SqlAggFunction) winAggCall.getOperator();
+    SqlAggFunction aggFunction = (SqlAggFunction) winAggCall.getOperator();
 
     SqlAggFunction lookupFunction =
         AggregateFunctions.toSubstraitAggVariant(aggFunction).orElse(aggFunction);
@@ -95,7 +95,8 @@ public class WindowRelFunctionConverter
       return Optional.empty();
     }
 
-    var wrapped = new WrappedWindowRelCall(winAggCall, lowerBound, upperBound, isRows);
+    WrappedWindowRelCall wrapped =
+        new WrappedWindowRelCall(winAggCall, lowerBound, upperBound, isRows);
     return m.attemptMatch(wrapped, topLevelConverter);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -70,7 +70,7 @@ public class AggregationFunctionsTest extends PlanTestBase {
   @ParameterizedTest
   @ValueSource(strings = {"max", "min", "sum", "sum0", "avg"})
   void emptyGrouping(String aggFunction) {
-    var rel =
+    Aggregate rel =
         b.aggregate(
             input -> b.grouping(input), input -> functions(input, aggFunction), numericTypesTable);
     assertFullRoundTrip(rel);
@@ -79,7 +79,7 @@ public class AggregationFunctionsTest extends PlanTestBase {
   @ParameterizedTest
   @ValueSource(strings = {"max", "min", "sum", "sum0", "avg"})
   void withGrouping(String aggFunction) {
-    var rel =
+    Aggregate rel =
         b.aggregate(
             input -> b.grouping(input, 0),
             input -> functions(input, aggFunction),

--- a/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
@@ -1,6 +1,8 @@
 package io.substrait.isthmus;
 
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -16,7 +18,7 @@ public class ApplyJoinPlanTest extends PlanTestBase {
 
   private static void validateOuterRef(
       Map<RexFieldAccess, Integer> fieldAccessDepthMap, String refName, String colName, int depth) {
-    var entry =
+    Optional<Entry<RexFieldAccess, Integer>> entry =
         fieldAccessDepthMap.entrySet().stream()
             .filter(f -> f.getKey().getReferenceExpr().toString().equals(refName))
             .filter(f -> f.getKey().getField().getName().equals(colName))
@@ -27,7 +29,7 @@ public class ApplyJoinPlanTest extends PlanTestBase {
 
   private static Map<RexFieldAccess, Integer> buildOuterFieldRefMap(RelRoot root) {
     final OuterReferenceResolver resolver = new OuterReferenceResolver();
-    var fieldAccessDepthMap = resolver.getFieldAccessDepthMap();
+    Map<RexFieldAccess, Integer> fieldAccessDepthMap = resolver.getFieldAccessDepthMap();
     Assertions.assertEquals(0, fieldAccessDepthMap.size());
     resolver.apply(root.rel);
     return fieldAccessDepthMap;
@@ -57,7 +59,7 @@ public class ApplyJoinPlanTest extends PlanTestBase {
     validateOuterRef(fieldAccessDepthMap, "$cor0", "SS_ITEM_SK", 1);
 
     // TODO validate end to end conversion
-    var sE2E = new SqlToSubstrait();
+    SqlToSubstrait sE2E = new SqlToSubstrait();
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> sE2E.execute(sql, TPCDS_CATALOG),

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
@@ -105,7 +105,7 @@ public class CalciteCallTest extends CalciteObjs {
       RexNode call,
       Consumer<Expression.ScalarFunctionInvocation> consumer,
       boolean bidirectional) {
-    var expression = call.accept(rexExpressionConverter);
+    Expression expression = call.accept(rexExpressionConverter);
     assertTrue(expression instanceof Expression.ScalarFunctionInvocation);
     Expression.ScalarFunctionInvocation func = (Expression.ScalarFunctionInvocation) expression;
     assertEquals(expectedName, func.declaration().key());

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -243,7 +243,7 @@ class CalciteTypeTest extends CalciteObjs {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void userDefinedType(boolean nullable) {
-    var type = uTypeFactory.createSubstrait(nullable);
+    Type type = uTypeFactory.createSubstrait(nullable);
     testType(typeConverter, type, uTypeFactory.createCalcite(nullable), null);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
@@ -37,7 +37,7 @@ public class ComplexSortTest extends PlanTestBase {
 
     @Override
     protected void explain_(RelNode rel, List<Pair<String, @Nullable Object>> values) {
-      var collation = rel.getTraitSet().getCollation();
+      RelCollation collation = rel.getTraitSet().getCollation();
       if (!collation.isDefault()) {
         StringBuilder s = new StringBuilder();
         spacer.spaces(s);
@@ -70,7 +70,7 @@ public class ComplexSortTest extends PlanTestBase {
             + "  LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
-    var sw = new StringWriter();
+    StringWriter sw = new StringWriter();
     relReturned.explain(new CollationRelWriter(sw));
     assertEquals(expected, sw.toString());
   }
@@ -100,7 +100,7 @@ public class ComplexSortTest extends PlanTestBase {
             + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
-    var sw = new StringWriter();
+    StringWriter sw = new StringWriter();
     relReturned.explain(new CollationRelWriter(sw));
     assertEquals(expected, sw.toString());
   }
@@ -130,7 +130,7 @@ public class ComplexSortTest extends PlanTestBase {
             + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
-    var sw = new StringWriter();
+    StringWriter sw = new StringWriter();
     relReturned.explain(new CollationRelWriter(sw));
     assertEquals(expected, sw.toString());
   }
@@ -160,7 +160,7 @@ public class ComplexSortTest extends PlanTestBase {
             + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
-    var sw = new StringWriter();
+    StringWriter sw = new StringWriter();
     relReturned.explain(new CollationRelWriter(sw));
     assertEquals(expected, sw.toString());
   }
@@ -193,7 +193,7 @@ public class ComplexSortTest extends PlanTestBase {
             + "      LogicalTableScan(table=[[example]])\n";
 
     RelNode relReturned = substraitToCalcite.convert(rel);
-    var sw = new StringWriter();
+    StringWriter sw = new StringWriter();
     relReturned.explain(new CollationRelWriter(sw));
     assertEquals(expected, sw.toString());
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.Any;
 import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.Expression.UserDefinedLiteral;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.SimpleExtension;
@@ -14,6 +15,7 @@ import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
 import io.substrait.isthmus.utils.UserTypeFactory;
 import io.substrait.proto.Expression;
+import io.substrait.proto.Expression.Literal.Builder;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelProtoConverter;
@@ -299,7 +301,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -315,7 +317,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -334,7 +336,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a"), List.of(R.FP64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -354,7 +356,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.FP64, R.FP64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -398,7 +400,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.FP64, R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -417,7 +419,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a"), List.of(R.list(R.I64))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -438,7 +440,7 @@ public class CustomFunctionTest extends PlanTestBase {
                 List.of("example"), List.of("a", "b"), List.of(R.list(R.STRING), R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -457,7 +459,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a"), List.of(R.list(R.STRING))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -478,7 +480,7 @@ public class CustomFunctionTest extends PlanTestBase {
                 List.of("example"), List.of("a", "b"), List.of(R.list(R.STRING), R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -503,7 +505,7 @@ public class CustomFunctionTest extends PlanTestBase {
                 List.of(R.list(R.STRING), R.STRING, R.STRING, R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -522,7 +524,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a"), List.of(R.list(R.STRING))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -543,7 +545,7 @@ public class CustomFunctionTest extends PlanTestBase {
                 List.of("example"), List.of("a", "b"), List.of(R.list(R.STRING), R.STRING)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -562,7 +564,7 @@ public class CustomFunctionTest extends PlanTestBase {
             b.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
@@ -584,15 +586,16 @@ public class CustomFunctionTest extends PlanTestBase {
                 List.of("example"), List.of("a"), List.of(N.userDefined(NAMESPACE, "a_type"))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
-    var relReturned = calciteToSubstrait.apply(calciteRel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
   }
 
   @Test
   void customTypesLiteralInFunctionsRoundtrip() {
-    var bldr = Expression.Literal.newBuilder();
-    var anyValue = Any.pack(bldr.setI32(10).build());
-    var val = ExpressionCreator.userDefinedLiteral(false, NAMESPACE, "a_type", anyValue);
+    Builder bldr = Expression.Literal.newBuilder();
+    Any anyValue = Any.pack(bldr.setI32(10).build());
+    UserDefinedLiteral val =
+        ExpressionCreator.userDefinedLiteral(false, NAMESPACE, "a_type", anyValue);
 
     Rel rel1 =
         b.project(
@@ -608,7 +611,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel2 = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel1, rel2);
 
-    var extensionCollector = new ExtensionCollector();
+    ExtensionCollector extensionCollector = new ExtensionCollector();
     io.substrait.proto.Rel protoRel = new RelProtoConverter(extensionCollector).toProto(rel1);
     Rel rel3 = new ProtoRelConverter(extensionCollector, extensionCollection).from(protoRel);
     assertEquals(rel1, rel3);

--- a/isthmus/src/test/java/io/substrait/isthmus/EmptyArrayLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/EmptyArrayLiteralTest.java
@@ -1,8 +1,11 @@
 package io.substrait.isthmus;
 
 import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.Expression.EmptyListLiteral;
 import io.substrait.expression.ExpressionCreator;
+import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
+import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -14,9 +17,9 @@ public class EmptyArrayLiteralTest extends PlanTestBase {
 
   @Test
   void emptyArrayLiteral() {
-    var colType = N.I8;
-    var emptyListLiteral = ExpressionCreator.emptyList(false, N.I8);
-    var rel =
+    Type colType = N.I8;
+    EmptyListLiteral emptyListLiteral = ExpressionCreator.emptyList(false, N.I8);
+    Project rel =
         b.project(
             input -> List.of(emptyListLiteral),
             Rel.Remap.offset(1, 1),
@@ -26,9 +29,9 @@ public class EmptyArrayLiteralTest extends PlanTestBase {
 
   @Test
   void nullableEmptyArrayLiteral() {
-    var colType = N.I8;
-    var emptyListLiteral = ExpressionCreator.emptyList(true, N.I8);
-    var rel =
+    Type colType = N.I8;
+    EmptyListLiteral emptyListLiteral = ExpressionCreator.emptyList(true, N.I8);
+    Project rel =
         b.project(
             input -> List.of(emptyListLiteral),
             Rel.Remap.offset(1, 1),

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -60,7 +60,7 @@ public class FunctionConversionTest extends PlanTestBase {
             ExpressionCreator.date(false, 10561),
             ExpressionCreator.intervalDay(false, 120, 0, 0, 6));
 
-    var calciteExpr = expr.accept(expressionRexConverter, Context.newContext());
+    RexNode calciteExpr = expr.accept(expressionRexConverter, Context.newContext());
     assertEquals(
         TypeConverter.DEFAULT.toCalcite(typeFactory, TypeCreator.REQUIRED.DATE),
         calciteExpr.getType());

--- a/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
@@ -19,7 +19,8 @@ public class NameRoundtripTest extends PlanTestBase {
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(createStatement);
 
     SqlToSubstrait s = new SqlToSubstrait();
-    var substraitToCalcite = new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory);
+    SubstraitToCalcite substraitToCalcite =
+        new SubstraitToCalcite(EXTENSION_COLLECTION, typeFactory);
 
     String query = "SELECT \"a\", \"B\" FROM foo GROUP BY a, b";
     List<String> expectedNames = List.of("a", "B");

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
@@ -77,7 +77,7 @@ public class NestedStructQueryTest extends PlanTestBase {
         new AbstractTable() {
           @Override
           public RelDataType getRowType(RelDataTypeFactory factory) {
-            var helper = new TypeHelper(factory);
+            TypeHelper helper = new TypeHelper(factory);
             return helper.struct2(
                 "x", helper.i32(),
                 "a", helper.i32());
@@ -106,7 +106,7 @@ public class NestedStructQueryTest extends PlanTestBase {
         new AbstractTable() {
           @Override
           public RelDataType getRowType(RelDataTypeFactory factory) {
-            var helper = new TypeHelper(factory);
+            TypeHelper helper = new TypeHelper(factory);
             return helper.struct2(
                 "x", helper.i32(),
                 "a", helper.struct("b", helper.i32()));
@@ -143,7 +143,7 @@ public class NestedStructQueryTest extends PlanTestBase {
         new AbstractTable() {
           @Override
           public RelDataType getRowType(RelDataTypeFactory factory) {
-            var helper = new TypeHelper(factory);
+            TypeHelper helper = new TypeHelper(factory);
             return helper.struct2(
                 "aa", helper.i32(),
                 "a", helper.struct("b", helper.struct("c", helper.i32())));
@@ -185,7 +185,7 @@ public class NestedStructQueryTest extends PlanTestBase {
         new AbstractTable() {
           @Override
           public RelDataType getRowType(RelDataTypeFactory factory) {
-            var helper = new TypeHelper(factory);
+            TypeHelper helper = new TypeHelper(factory);
 
             return helper.struct2("x", helper.i32(), "a", helper.list(helper.i32()));
           }
@@ -221,7 +221,7 @@ public class NestedStructQueryTest extends PlanTestBase {
         new AbstractTable() {
           @Override
           public RelDataType getRowType(RelDataTypeFactory factory) {
-            var helper = new TypeHelper(factory);
+            TypeHelper helper = new TypeHelper(factory);
 
             return helper.struct2(
                 "x",
@@ -273,7 +273,7 @@ public class NestedStructQueryTest extends PlanTestBase {
           @Override
           public RelDataType getRowType(RelDataTypeFactory factory) {
 
-            var helper = new TypeHelper(factory);
+            TypeHelper helper = new TypeHelper(factory);
             return helper.struct(
                 "a",
                 helper.struct(

--- a/isthmus/src/test/java/io/substrait/isthmus/OptimizerIntegrationTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OptimizerIntegrationTest.java
@@ -19,7 +19,7 @@ public class OptimizerIntegrationTest extends PlanTestBase {
 
   @Test
   void conversionHandlesBuiltInSum0CallAddedByRule() throws SqlParseException, IOException {
-    var query =
+    String query =
         "select O_CUSTKEY, count(distinct O_ORDERKEY), count(*) from orders group by O_CUSTKEY";
     // verify that the query works generally
     assertFullRoundTrip(query);
@@ -41,7 +41,7 @@ public class OptimizerIntegrationTest extends PlanTestBase {
             .build();
     HepPlanner planner = new HepPlanner(program);
     planner.setRoot(originalPlan);
-    var newPlan = planner.findBestExp();
+    RelNode newPlan = planner.findBestExp();
 
     assertDoesNotThrow(
         () ->

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -91,7 +91,7 @@ public class PlanTestBase {
     Plan plan = new ProtoPlanConverter(extensions).from(protoPlan1);
     io.substrait.proto.Plan protoPlan2 = new PlanProtoConverter().toProto(plan);
     assertEquals(protoPlan1, protoPlan2);
-    var rootRels = s.sqlToRelNode(query, catalogReader);
+    List<RelRoot> rootRels = s.sqlToRelNode(query, catalogReader);
     assertEquals(rootRels.size(), plan.getRoots().size());
     for (int i = 0; i < rootRels.size(); i++) {
       Plan.Root rootRel = SubstraitRelVisitor.convert(rootRels.get(i), extensions);
@@ -125,7 +125,7 @@ public class PlanTestBase {
     // Assert (sql -> calcite -> substrait) and (sql -> substrait -> calcite -> substrait) are same.
     // Return list of sql -> Substrait rel -> Calcite rel.
 
-    var substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
+    SubstraitToCalcite substraitToCalcite = new SubstraitToCalcite(extensions, typeFactory);
 
     SqlToSubstrait s = new SqlToSubstrait();
 
@@ -221,7 +221,7 @@ public class PlanTestBase {
    */
   protected void assertFullRoundTrip(Rel pojo1) {
     // TODO: reuse the Plan.Root based assertFullRoundTrip by generating names
-    var extensionCollector = new ExtensionCollector();
+    ExtensionCollector extensionCollector = new ExtensionCollector();
 
     // Substrait POJO 1 -> Substrait Proto
     io.substrait.proto.Rel proto = new RelProtoConverter(extensionCollector).toProto(pojo1);
@@ -252,7 +252,7 @@ public class PlanTestBase {
    * </ul>
    */
   protected void assertFullRoundTrip(Plan.Root pojo1) {
-    var extensionCollector = new ExtensionCollector();
+    ExtensionCollector extensionCollector = new ExtensionCollector();
 
     // Substrait POJO 1 -> Substrait Proto
     io.substrait.proto.RelRoot proto = new RelProtoConverter(extensionCollector).toProto(pojo1);

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
@@ -66,7 +66,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
   @Test
   public void crossJoin() throws IOException, SqlParseException {
     int[] counter = new int[1];
-    var crossJoinCountingVisitor =
+    RelCopyOnWriteVisitor<RuntimeException> crossJoinCountingVisitor =
         new RelCopyOnWriteVisitor<RuntimeException>() {
           @Override
           public Optional<Rel> visit(Cross cross, EmptyVisitationContext context)
@@ -75,7 +75,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
             return super.visit(cross, context);
           }
         };
-    var featureBoard = ImmutableFeatureBoard.builder().build();
+    ImmutableFeatureBoard featureBoard = ImmutableFeatureBoard.builder().build();
 
     String query1 =
         "select\n"

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -135,7 +135,7 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
     assertPlanRoundtrip(newPlan);
 
     // convert newPlan back to sql
-    var pojoRel = newPlan.getRoots().get(0).getInput();
+    Rel pojoRel = newPlan.getRoots().get(0).getInput();
     RelNode relnodeRoot = new SubstraitToSql().substraitRelToCalciteRel(pojoRel, TPCH_CATALOG);
     String newSql = SubstraitSqlDialect.toSql(relnodeRoot).getSql();
     assertTrue(newSql.toUpperCase().contains("APPROX_COUNT_DISTINCT"));

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
@@ -16,6 +16,7 @@ import org.apache.calcite.rel.metadata.ProxyingMetadataHandlerProvider;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -45,7 +46,7 @@ public class RelCreator {
 
     try {
       SqlParser parser = SqlParser.create(sql, SqlParser.Config.DEFAULT);
-      var parsed = parser.parseQuery();
+      SqlNode parsed = parser.parseQuery();
       cluster.setMetadataQuerySupplier(
           () ->
               new RelMetadataQuery(

--- a/isthmus/src/test/java/io/substrait/isthmus/SchemaCollectorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SchemaCollectorTest.java
@@ -71,7 +71,7 @@ public class SchemaCollectorTest extends PlanTestBase {
                 List.of("level1", "level2a", "level3", "t1"), List.of("col1"), List.of(N.I64)),
             b.namedScan(List.of("level1", "level2b", "t2"), List.of("col2"), List.of(N.I32)));
 
-    var rootSchema = schemaCollector.toSchema(rel);
+    CalciteSchema rootSchema = schemaCollector.toSchema(rel);
     CalciteSchema level1 = rootSchema.getSubSchema("level1", false);
 
     CalciteSchema level2a = level1.getSubSchema("level2a", false);

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.Expression;
+import io.substrait.expression.Expression.Switch;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.isthmus.SubstraitRelNodeConverter.Context;
@@ -54,12 +55,12 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
 
   @Test
   public void switchExpression() {
-    var expr =
+    Switch expr =
         b.switchExpression(
             b.fieldReference(commonTable, 0),
             List.of(b.switchClause(b.i32(0), b.fieldReference(commonTable, 3))),
             b.bool(false));
-    var calciteExpr = expr.accept(converter, Context.newContext());
+    RexNode calciteExpr = expr.accept(converter, Context.newContext());
 
     assertTypeMatch(calciteExpr.getType(), N.BOOLEAN);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.calcite.rel.RelNode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +44,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
                   input -> List.of(b.count(input, 0)),
                   commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING, R.I64);
     }
 
@@ -57,7 +58,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
                   b.remap(1, 2),
                   commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), N.STRING, R.I64);
     }
   }
@@ -68,7 +69,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void direct() {
       Plan.Root root = b.root(b.cross(commonTable, commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), commonTableTypeTwice);
     }
 
@@ -76,7 +77,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void emit() {
       Plan.Root root = b.root(b.cross(commonTable, commonTable, b.remap(0, 1, 4, 6)));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, R.FP32, R.I32, N.STRING);
     }
   }
@@ -87,7 +88,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void direct() {
       Plan.Root root = b.root(b.fetch(20, 40, commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), commonTableType);
     }
 
@@ -95,7 +96,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void emit() {
       Plan.Root root = b.root(b.fetch(20, 40, b.remap(0, 2), commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
     }
   }
@@ -106,7 +107,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void direct() {
       Plan.Root root = b.root(b.filter(input -> b.bool(true), commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), commonTableType);
     }
 
@@ -114,7 +115,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void emit() {
       Plan.Root root = b.root(b.filter(input -> b.bool(true), b.remap(0, 2), commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
     }
   }
@@ -125,7 +126,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void direct() {
       Plan.Root root = b.root(b.innerJoin(input -> b.bool(true), commonTable, commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), commonTableTypeTwice);
     }
 
@@ -134,7 +135,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       Plan.Root root =
           b.root(b.innerJoin(input -> b.bool(true), b.remap(0, 6), commonTable, commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
     }
 
@@ -150,7 +151,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
                   b.remap(6, 7, 8),
                   b.join(ji -> b.bool(true), JoinType.LEFT, joinTable, joinTable)));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.STRING, R.FP64, N.STRING);
     }
 
@@ -166,7 +167,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
                   b.remap(6, 7, 8),
                   b.join(ji -> b.bool(true), JoinType.RIGHT, joinTable, joinTable)));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), N.STRING, N.FP64, R.STRING);
     }
 
@@ -182,7 +183,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
                   b.remap(6, 7, 8),
                   b.join(ji -> b.bool(true), JoinType.OUTER, joinTable, joinTable)));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), N.STRING, N.FP64, N.STRING);
     }
   }
@@ -194,7 +195,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       Plan.Root root =
           b.root(b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.I32, R.FP32)));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, R.FP32);
     }
 
@@ -205,7 +206,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
               b.namedScan(
                   List.of("example"), List.of("a", "b"), List.of(R.I32, R.FP32), b.remap(1)));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.FP32);
     }
   }
@@ -216,7 +217,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void direct() {
       Plan.Root root = b.root(b.project(input -> b.fieldReferences(input, 1, 0, 2), commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(
           relNode.getRowType(), R.I32, R.FP32, N.STRING, N.BOOLEAN, R.FP32, R.I32, N.STRING);
     }
@@ -228,7 +229,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
               b.project(
                   input -> b.fieldReferences(input, 1, 0, 2), b.remap(0, 2, 4, 6), commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING, R.FP32, N.STRING);
     }
   }
@@ -239,7 +240,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void direct() {
       Plan.Root root = b.root(b.set(SetOp.UNION_ALL, commonTable, commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), commonTableType);
     }
 
@@ -247,7 +248,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void emit() {
       Plan.Root root = b.root(b.set(SetOp.UNION_ALL, b.remap(0, 2), commonTable, commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
     }
   }
@@ -258,7 +259,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     public void direct() {
       Plan.Root root = b.root(b.sort(input -> b.sortFields(input, 0, 1, 2), commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), commonTableType);
     }
 
@@ -267,7 +268,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
       Plan.Root root =
           b.root(b.sort(input -> b.sortFields(input, 0, 1, 2), b.remap(0, 2), commonTable));
 
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
     }
   }
@@ -283,7 +284,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
               .build();
 
       Plan.Root root = b.root(emptyScan);
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), List.of(R.I32, N.STRING));
     }
 
@@ -296,7 +297,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
               .build();
 
       Plan.Root root = b.root(emptyScanWithRemap);
-      var relNode = converter.convert(root.getInput());
+      RelNode relNode = converter.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32);
     }
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
@@ -37,7 +37,7 @@ public class WindowFunctionTest extends PlanTestBase {
     @ParameterizedTest
     @ValueSource(strings = {"rank", "dense_rank", "percent_rank"})
     void rankFunctions(String rankFunction) throws IOException, SqlParseException {
-      var query =
+      String query =
           String.format(
               "select O_ORDERKEY, %s() over (order by O_SHIPPRIORITY) from ORDERS", rankFunction);
       assertFullRoundTrip(query);
@@ -46,7 +46,7 @@ public class WindowFunctionTest extends PlanTestBase {
     @ParameterizedTest
     @ValueSource(strings = {"rank", "dense_rank", "percent_rank"})
     void rankFunctionsWithPartitions(String rankFunction) throws IOException, SqlParseException {
-      var query =
+      String query =
           String.format(
               "select O_ORDERKEY, %s() over (partition by O_CUSTKEY order by O_SHIPPRIORITY) from ORDERS",
               rankFunction);
@@ -88,7 +88,7 @@ public class WindowFunctionTest extends PlanTestBase {
       LogicalProject(EXPR$0=[MIN($7) OVER (PARTITION BY $1 ORDER BY $4 ROWS UNBOUNDED PRECEDING)])
         LogicalTableScan(table=[[ORDERS]])
       */
-      var overClause = "partition by O_CUSTKEY order by O_ORDERDATE rows unbounded preceding";
+      String overClause = "partition by O_CUSTKEY order by O_ORDERDATE rows unbounded preceding";
       assertFullRoundTrip(
           String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
     }
@@ -99,7 +99,7 @@ public class WindowFunctionTest extends PlanTestBase {
       LogicalProject(EXPR$0=[MAX($7) OVER (PARTITION BY $1 ORDER BY $4 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)])
         LogicalTableScan(table=[[ORDERS]])
       */
-      var overClaus =
+      String overClaus =
           "partition by O_CUSTKEY order by O_ORDERDATE rows between current row AND unbounded following";
       assertFullRoundTrip(
           String.format("select max(O_SHIPPRIORITY) over (%s) from ORDERS", overClaus));
@@ -111,7 +111,7 @@ public class WindowFunctionTest extends PlanTestBase {
       LogicalProject(EXPR$0=[MIN($7) OVER (PARTITION BY $1 ORDER BY $4 ROWS 1 PRECEDING)])
         LogicalTableScan(table=[[ORDERS]])
       */
-      var overClause =
+      String overClause =
           "partition by O_CUSTKEY order by O_ORDERDATE rows between 1 preceding and current row";
       assertFullRoundTrip(
           String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
@@ -123,7 +123,7 @@ public class WindowFunctionTest extends PlanTestBase {
       LogicalProject(EXPR$0=[MAX($7) OVER (PARTITION BY $1 ORDER BY $4 ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)])
         LogicalTableScan(table=[[ORDERS]])
       */
-      var overClause =
+      String overClause =
           "partition by O_CUSTKEY order by O_ORDERDATE rows between current row and 2 following";
       assertFullRoundTrip(
           String.format("select max(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
@@ -135,7 +135,7 @@ public class WindowFunctionTest extends PlanTestBase {
       LogicalProject(EXPR$0=[MIN($7) OVER (PARTITION BY $1 ORDER BY $4 ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING)])
        LogicalTableScan(table=[[ORDERS]])
       */
-      var overClause =
+      String overClause =
           "partition by O_CUSTKEY order by O_ORDERDATE  rows between 3 preceding and 4 following";
       assertFullRoundTrip(
           String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
@@ -147,7 +147,7 @@ public class WindowFunctionTest extends PlanTestBase {
       LogicalProject(EXPR$0=[MIN($7) OVER (PARTITION BY $1 ORDER BY $3 RANGE 10 PRECEDING)])
         LogicalTableScan(table=[[ORDERS]])
       */
-      var overClause =
+      String overClause =
           "partition by O_CUSTKEY order by O_TOTALPRICE range between 10 preceding and current row";
       assertFullRoundTrip(
           String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
@@ -159,7 +159,7 @@ public class WindowFunctionTest extends PlanTestBase {
       LogicalProject(EXPR$0=[MIN($7) OVER (PARTITION BY $1 ORDER BY $3 RANGE BETWEEN CURRENT ROW AND 11 FOLLOWING)])
         LogicalTableScan(table=[[ORDERS]])
       */
-      var overClause =
+      String overClause =
           "partition by O_CUSTKEY order by O_TOTALPRICE range between current row and 11 following";
       assertFullRoundTrip(
           String.format("select min(O_SHIPPRIORITY) over (%s) from ORDERS", overClause));
@@ -182,7 +182,7 @@ public class WindowFunctionTest extends PlanTestBase {
   void rejectQueriesWithIgnoreNulls() {
     // IGNORE NULLS cannot be specified in the Substrait representation.
     // Queries using it should be rejected.
-    var query = "select last_value(L_LINENUMBER) ignore nulls over () from lineitem";
+    String query = "select last_value(L_LINENUMBER) ignore nulls over () from lineitem";
     assertThrows(IllegalArgumentException.class, () -> assertFullRoundTrip(query));
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import io.substrait.isthmus.AggregateFunctions;
 import io.substrait.isthmus.PlanTestBase;
 import io.substrait.isthmus.TypeConverter;
+import io.substrait.isthmus.expression.FunctionConverter.FunctionFinder;
 import java.util.List;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
@@ -20,7 +21,7 @@ public class AggregateFunctionConverterTest extends PlanTestBase {
         new AggregateFunctionConverter(
             extensions.aggregateFunctions(), List.of(), typeFactory, TypeConverter.DEFAULT);
 
-    var functionFinder =
+    FunctionFinder functionFinder =
         converter.getFunctionFinder(
             AggregateCall.create(
                 new SqlSumEmptyIsZeroAggFunction(),


### PR DESCRIPTION
In my opinion using explicit types instead of the `var` keyword makes the code more readable since all types used in a source file are visible through import statements and it is clear what the type of a field/variable is just by looking at the code.

This is why I'm proposing to switch to using explicit types and enforcing the use of explicit types through the corresponding PMD rule.