### PR TITLE
fix(isthmus-cli): use correct version in Isthmus CLI help

### DIFF
--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
@@ -1,9 +1,5 @@
 package io.substrait.isthmus.cli;
 
-import static picocli.CommandLine.Command;
-import static picocli.CommandLine.Option;
-import static picocli.CommandLine.Parameters;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
@@ -22,10 +18,13 @@ import java.util.concurrent.Callable;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.prepare.Prepare;
 import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 @Command(
     name = "isthmus",
-    version = "isthmus 0.1",
+    versionProvider = io.substrait.isthmus.cli.IsthmusCliVersion.class,
     description = "Convert SQL Queries and SQL Expressions to Substrait",
     mixinStandardHelpOptions = true)
 public class IsthmusEntryPoint implements Callable<Integer> {


### PR DESCRIPTION
This PR changes the Isthmus CLI command to print the actual substrait-java and Substrait spec versions instead of the currently hardcoded `0.1` version.

Example output:

```bash
$ ./isthmus-cli/build/graal/isthmus -V
isthmus version 0.63.0
Substrait version 0.74.0
```

In order for me to locally test this PR I had to downgrade to Gradle 8 which means this PR depends on #455.

fixes https://github.com/substrait-io/substrait-java/issues/223