### PR TITLE
build: ignore dependabot commits during commitlint

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "rules": {
     "body-leading-blank": [1, "always"],
     "body-max-line-length": [2, "always", 100],
@@ -122,5 +122,7 @@
         "description": "Add issue references (e.g. \"fix #123\", \"re #123\".)"
       }
     }
-  }
+  },
+  // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
+  "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
 }

--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -124,5 +124,5 @@ module.exports = {
     }
   },
   // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-  "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
+  "ignores": [(message) => /^build(deps): bump \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build(deps): "
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build(deps): "


### PR DESCRIPTION
This PR adds a dependabot config for Gradle and Github Actions dependencies.

I tested it on my fork: https://github.com/nielspardon/substrait-java/pulls

I tried the git submodule config but that is limited in that it does not support further configuration to e.g. only update to tags so I would not use dependabot for the git submodule updates.

I had to modify the `commitlint` configuration to allow the dependabot PRs to bypass the commit linting. The reason is that dependabot PRs create commits where the commit body contains lines longer than 100 characters which is otherwise not allowed by the current `commitlint` config.