### PR TITLE
build: use Gradle version catalog for dependencies and plugins

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -21,30 +21,12 @@ plugins {
 
 val String.v: String get() = rootProject.extra["$this.version"] as String
 
-// Note: Gradle allows to declare dependency on "bom" as "api",
-// and it makes the contraints to be transitively visible
-// However Maven can't express that, so the approach is to use Gradle resolution
-// and generate pom files with resolved versions
-// See https://github.com/gradle/gradle/issues/9866
-
-fun DependencyConstraintHandlerScope.apiv(
-    notation: String,
-    versionProp: String = notation.substringAfterLast(':')
-) =
-    "api"(notation + ":" + versionProp.v)
-
-fun DependencyConstraintHandlerScope.runtimev(
-    notation: String,
-    versionProp: String = notation.substringAfterLast(':')
-) =
-    "runtime"(notation + ":" + versionProp.v)
-
 javaPlatform {
     allowDependencies()
 }
 
 dependencies {
-    api(platform("com.fasterxml.jackson:jackson-bom:${"jackson".v}"))
+    api(platform(libs.jackson.bom))
 
     // Parenthesis are needed here: https://github.com/gradle/gradle/issues/9248
     (constraints) {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   `kotlin-dsl`
-  id("com.diffplug.spotless") version "6.19.0"
+  alias(libs.plugins.spotless)
 }
 
 repositories { gradlePluginPortal() }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,3 @@
+dependencyResolutionManagement {
+  versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,25 +7,22 @@ plugins {
   `maven-publish`
   id("java")
   id("idea")
-  id("com.github.vlsi.gradle-extensions") version "1.74"
-  id("com.diffplug.spotless") version "7.1.0"
-  id("org.jreleaser") version "1.18.0" apply false
+  alias(libs.plugins.gradle.extensions)
+  alias(libs.plugins.spotless)
+  alias(libs.plugins.jreleaser) apply false
 }
-
-var IMMUTABLES_VERSION = properties.get("immutables.version")
-var JUNIT_VERSION = properties.get("junit.version")
-var SLF4J_VERSION = properties.get("slf4j.version")
 
 repositories { mavenCentral() }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 dependencies {
-  testImplementation("org.junit.jupiter:junit-jupiter-api:${JUNIT_VERSION}")
-  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${JUNIT_VERSION}")
-  implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
-  annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
-  compileOnly("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.junit.jupiter.engine)
+  implementation(libs.slf4j.api)
+  annotationProcessor(libs.immutables.value)
+  compileOnly(libs.immutables.annotations)
 }
 
 val submodulesUpdate by

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,10 +11,10 @@ plugins {
   id("java-library")
   id("idea")
   id("antlr")
-  id("com.google.protobuf") version "0.9.4"
-  id("com.diffplug.spotless") version "7.1.0"
-  id("com.gradleup.shadow") version "8.3.8"
-  id("org.jreleaser")
+  alias(libs.plugins.protobuf)
+  alias(libs.plugins.spotless)
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.jreleaser)
   id("substrait.java-conventions")
 }
 
@@ -99,13 +99,6 @@ jreleaser {
   release { github { enabled = false } }
 }
 
-val ANTLR_VERSION = properties.get("antlr.version")
-val IMMUTABLES_VERSION = properties.get("immutables.version")
-val JACKSON_VERSION = properties.get("jackson.version")
-val JUNIT_VERSION = properties.get("junit.version")
-val SLF4J_VERSION = properties.get("slf4j.version")
-val PROTOBUF_VERSION = properties.get("protobuf.version")
-
 // This allows specifying deps to be shadowed so that they don't get included in the POM file
 val shadowImplementation by configurations.creating
 
@@ -114,21 +107,21 @@ configurations[JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME].extendsFrom(shadowImp
 configurations[JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME].extendsFrom(shadowImplementation)
 
 dependencies {
-  testImplementation(platform("org.junit:junit-bom:${JUNIT_VERSION}"))
-  testImplementation("org.junit.jupiter:junit-jupiter")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-  api("com.google.protobuf:protobuf-java:${PROTOBUF_VERSION}")
-  implementation("com.fasterxml.jackson.core:jackson-databind:${JACKSON_VERSION}")
-  implementation("com.fasterxml.jackson.core:jackson-annotations:${JACKSON_VERSION}")
-  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${JACKSON_VERSION}")
-  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${JACKSON_VERSION}")
-  api("org.jspecify:jspecify:1.0.0")
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.platform.launcher)
 
-  antlr("org.antlr:antlr4:${ANTLR_VERSION}")
-  shadowImplementation("org.antlr:antlr4-runtime:${ANTLR_VERSION}")
-  implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
-  annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
-  compileOnly("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
+  implementation(platform(libs.jackson.bom))
+  implementation(libs.bundles.jackson)
+
+  api(libs.protobuf.java)
+  api(libs.jspecify)
+
+  antlr(libs.antlr4)
+  shadowImplementation(libs.antlr4.runtime)
+  implementation(libs.slf4j.api)
+  annotationProcessor(libs.immutables.value)
+  compileOnly(libs.immutables.annotations)
 }
 
 configurations[JavaPlugin.API_CONFIGURATION_NAME].let { apiConfiguration ->
@@ -281,4 +274,4 @@ tasks.named<AntlrTask>("generateGrammarSource") {
     layout.buildDirectory.dir("generated/sources/antlr/main/java/io/substrait/type").get().asFile
 }
 
-protobuf { protoc { artifact = "com.google.protobuf:protoc:${PROTOBUF_VERSION}" } }
+protobuf { protoc { artifact = "com.google.protobuf:protoc:" + libs.protoc.get().getVersion() } }

--- a/examples/substrait-spark/build.gradle.kts
+++ b/examples/substrait-spark/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   // Apply the application plugin to add support for building a CLI application in Java.
   id("java")
-  id("com.diffplug.spotless") version "7.1.0"
+  alias(libs.plugins.spotless)
   id("substrait.java-conventions")
 }
 
@@ -15,8 +15,8 @@ dependencies {
 
   // For a real Spark application, these would not be required since they would be in the Spark
   // server classpath
-  runtimeOnly("org.apache.spark:spark-core_2.12:3.5.1")
-  runtimeOnly("org.apache.spark:spark-hive_2.12:3.5.1")
+  runtimeOnly(libs.spark.core)
+  runtimeOnly(libs.spark.hive)
 }
 
 tasks.jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,24 +7,6 @@ org.gradle.parallel=true
 # Build cache can be disabled with --no-build-cache option
 org.gradle.caching=true
 
-#plugins
-com.google.protobuf.version=0.8.10
-org.jetbrains.gradle.plugin.idea-ext.version=0.5
-kotlin.version=1.5.31
-com.github.vlsi.vlsi-release-plugins.version=1.74
-
-# library version
-antlr.version=4.13.1
-calcite.version=1.40.0
-guava.version=32.1.3-jre
-immutables.version=2.10.1
-jackson.version=2.16.1
-junit.version=5.8.1
-protobuf.version=3.25.5
-slf4j.version=2.0.13
-sparkbundle.version=3.4
-spark.version=3.4.2
-
 #version that is going to be updated automatically by releases
 version = 0.63.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,79 @@
+[versions]
+antlr = "4.13.1"
+calcite = "1.40.0"
+commons-lang3 = "[3.18.0,)"
+graal = "22.1.0"
+graal-plugin = "0.10.0"
+gradle-extensions = "1.74"
+guava = "32.1.3-jre"
+httpclient5 = "5.4.4"
+immutables = "2.10.1"
+jackson = "2.16.1"
+jreleaser = "1.18.0"
+json-smart = "2.5.2"
+jspecify = "1.0.0"
+junit = "5.8.1"
+picocli = "4.7.5"
+protobuf-plugin = "0.9.4"
+protobuf = "3.25.5"
+reflections = "0.9.12"
+scala-library = "2.12.16"
+scalatest = "3.2.18"
+scalatestplus-junit5 = "3.2.18.0"
+shadow = "8.3.8"
+slf4j = "2.0.13"
+spark = "3.4.2"
+spotless = "7.1.0"
+
+[libraries]
+antlr4 = { module = "org.antlr:antlr4", version.ref = "antlr" }
+antlr4-runtime = { module = "org.antlr:antlr4-runtime" , version.ref = "antlr" }
+calcite-babel = { module = "org.apache.calcite:calcite-babel", version.ref = "calcite" }
+calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }
+calcite-plus = { module = "org.apache.calcite:calcite-plus", version.ref = "calcite" }
+calcite-server = { module = "org.apache.calcite:calcite-server", version.ref = "calcite" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graal" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpclient5" }
+immutables-value = { module = "org.immutables:value", version.ref = "immutables" }
+immutables-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
+jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
+jackson-datatype-jdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
+json-smart = { module = "net.minidev:json-smart", version.ref = "json-smart" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+junit-platform-engine = { module = "org.junit.platform:junit-platform-engine" }
+picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
+picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
+protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
+protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf" }
+protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
+reflections = { module = "org.reflections:reflections", version.ref = "reflections"}
+scala-library = { module = "org.scala-lang:scala-library", version.ref = "scala-library" }
+scalatest = { module = "org.scalatest:scalatest_2.12", version.ref = "scalatest" }
+scalatestplus-junit5 = { module = "org.scalatestplus:junit-5-10_2.12", version.ref = "scalatestplus-junit5" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4j-jdk14 = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }
+spark-catalyst = { module = "org.apache.spark:spark-catalyst_2.12", version.ref = "spark" }
+spark-core = { module = "org.apache.spark:spark-core_2.12", version.ref = "spark" }
+spark-hive = { module = "org.apache.spark:spark-hive_2.12", version.ref = "spark" }
+spark-sql = { module = "org.apache.spark:spark-sql_2.12", version.ref = "spark" }
+
+[bundles]
+jackson = [ "jackson-databind", "jackson-annotations", "jackson-datatype-jdk8", "jackson-dataformat-yaml" ]
+
+[plugins]
+graal = { id = "com.palantir.graal", version.ref = "graal-plugin" }
+gradle-extensions = { id = "com.github.vlsi.gradle-extensions", version.ref = "gradle-extensions" }
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -3,8 +3,8 @@ import java.nio.charset.StandardCharsets
 plugins {
   id("java")
   id("idea")
-  id("com.palantir.graal") version "0.10.0"
-  id("com.diffplug.spotless") version "7.1.0"
+  alias(libs.plugins.graal)
+  alias(libs.plugins.spotless)
   id("substrait.java-conventions")
 }
 
@@ -16,39 +16,30 @@ java {
 
 configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }
 
-val CALCITE_VERSION = properties.get("calcite.version")
-val GUAVA_VERSION = properties.get("guava.version")
-val IMMUTABLES_VERSION = properties.get("immutables.version")
-val JUNIT_VERSION = properties.get("junit.version")
-val PROTOBUF_VERSION = properties.get("protobuf.version")
-val SLF4J_VERSION = properties.get("slf4j.version")
-
 dependencies {
   implementation(project(":core"))
   implementation(project(":isthmus"))
-  testImplementation(platform("org.junit:junit-bom:${JUNIT_VERSION}"))
-  testImplementation("org.junit.jupiter:junit-jupiter")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-  implementation("org.reflections:reflections:0.9.12")
-  implementation("com.google.guava:guava:${GUAVA_VERSION}")
-  implementation("org.graalvm.sdk:graal-sdk:22.1.0")
-  implementation("info.picocli:picocli:4.7.5")
-  annotationProcessor("info.picocli:picocli-codegen:4.7.5")
-  implementation("com.google.protobuf:protobuf-java-util:${PROTOBUF_VERSION}") {
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.platform.launcher)
+  implementation(libs.reflections)
+  implementation(libs.guava)
+  implementation(libs.graal.sdk)
+  implementation(libs.picocli)
+  annotationProcessor(libs.picocli.codegen)
+  implementation(libs.protobuf.java.util) {
     exclude("com.google.guava", "guava")
       .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
   }
-  implementation("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
-  annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
-  testImplementation("org.apache.calcite:calcite-plus:${CALCITE_VERSION}") {
+  annotationProcessor(libs.immutables.value)
+  implementation(libs.immutables.annotations)
+  testImplementation(libs.calcite.plus) {
     exclude(group = "commons-lang", module = "commons-lang")
       .because(
         "calcite-core brings in commons-lang:commons-lang:2.4 which has a security vulnerability"
       )
   }
-  annotationProcessor("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
-  compileOnly("com.github.bsideup.jabel:jabel-javac-plugin:0.4.2")
-  runtimeOnly("org.slf4j:slf4j-jdk14:${SLF4J_VERSION}")
+  runtimeOnly(libs.slf4j.jdk14)
 }
 
 sourceSets { main { java.srcDir("build/generated/sources/version/") } }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
   signing
   id("java-library")
   id("idea")
-  id("com.diffplug.spotless") version "7.1.0"
-  id("com.gradleup.shadow") version "8.3.8"
-  id("com.google.protobuf") version "0.9.4"
-  id("org.jreleaser")
+  alias(libs.plugins.shadow)
+  alias(libs.plugins.spotless)
+  alias(libs.plugins.protobuf)
+  alias(libs.plugins.jreleaser)
   id("substrait.java-conventions")
 }
 
@@ -101,16 +101,9 @@ java {
 
 configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }
 
-val CALCITE_VERSION = properties.get("calcite.version")
-val GUAVA_VERSION = properties.get("guava.version")
-val IMMUTABLES_VERSION = properties.get("immutables.version")
-val JUNIT_VERSION = properties.get("junit.version")
-val SLF4J_VERSION = properties.get("slf4j.version")
-val PROTOBUF_VERSION = properties.get("protobuf.version")
-
 dependencies {
   api(project(":core"))
-  api("org.apache.calcite:calcite-core:${CALCITE_VERSION}") {
+  api(libs.calcite.core) {
     exclude(group = "commons-lang", module = "commons-lang")
       .because(
         "calcite-core brings in commons-lang:commons-lang:2.4 which has a security vulnerability"
@@ -120,37 +113,37 @@ dependencies {
     // calcite-core:1.39.0 has dependencies that contain vulnerabilities:
     // - CVE-2025-27820 (org.apache.httpcomponents.client5:httpclient5 < 5.4.3)
     // - CVE-2024-57699 (net.minidev:json-smart < 2.5.2)
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.4.4")
-    implementation("net.minidev:json-smart:2.5.2")
+    implementation(libs.httpclient5)
+    implementation(libs.json.smart)
     // calcite-core:1.40.0 has dependencies that contain vulnerabilities:
     // - CVE-2025-48924 (org.apache.commons:commons-lang3 < 3.18.0)
-    implementation("org.apache.commons:commons-lang3:[3.18.0,)")
+    implementation(libs.commons.lang3)
   }
-  implementation("org.apache.calcite:calcite-server:${CALCITE_VERSION}") {
+  implementation(libs.calcite.server) {
     exclude(group = "commons-lang", module = "commons-lang")
       .because(
         "calcite-core brings in commons-lang:commons-lang:2.4 which has a security vulnerability"
       )
   }
-  testImplementation(platform("org.junit:junit-bom:${JUNIT_VERSION}"))
-  testImplementation("org.junit.jupiter:junit-jupiter")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-  implementation("com.google.guava:guava:${GUAVA_VERSION}")
-  implementation("com.google.protobuf:protobuf-java-util:${PROTOBUF_VERSION}") {
+  testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.platform.launcher)
+  implementation(libs.guava)
+  implementation(libs.protobuf.java.util) {
     exclude("com.google.guava", "guava")
       .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
   }
-  implementation("org.immutables:value-annotations:${IMMUTABLES_VERSION}")
-  implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
-  annotationProcessor("org.immutables:value:${IMMUTABLES_VERSION}")
-  testImplementation("org.apache.calcite:calcite-plus:${CALCITE_VERSION}") {
+  annotationProcessor(libs.immutables.value)
+  compileOnly(libs.immutables.annotations)
+  implementation(libs.slf4j.api)
+  testImplementation(libs.calcite.plus) {
     exclude(group = "commons-lang", module = "commons-lang")
       .because(
         "calcite-core brings in commons-lang:commons-lang:2.4 which has a security vulnerability"
       )
   }
-  testImplementation("com.google.protobuf:protobuf-java:${PROTOBUF_VERSION}")
-  api("org.jspecify:jspecify:1.0.0")
+  testImplementation(libs.protobuf.java)
+  api(libs.jspecify)
 }
 
 tasks {
@@ -173,4 +166,4 @@ tasks { build { dependsOn(shadowJar) } }
 
 sourceSets { test { proto.srcDirs("src/test/resources/extensions") } }
 
-protobuf { protoc { artifact = "com.google.protobuf:protoc:${PROTOBUF_VERSION}" } }
+protobuf { protoc { artifact = "com.google.protobuf:protoc:" + libs.protoc.get().getVersion() } }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,14 +3,3 @@ rootProject.name = "substrait"
 includeBuild("build-logic")
 
 include("bom", "core", "isthmus", "isthmus-cli", "spark", "examples:substrait-spark")
-
-pluginManagement {
-  plugins {
-    fun String.v() = extra["$this.version"].toString()
-    fun PluginDependenciesSpec.idv(id: String, key: String = id) = id(id) version key.v()
-
-    idv("com.google.protobuf")
-    idv("org.jetbrains.gradle.plugin.idea-ext")
-    kotlin("jvm") version "kotlin".v()
-  }
-}

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
   id("java-library")
   id("scala")
   id("idea")
-  id("com.diffplug.spotless") version "7.1.0"
-  id("org.jreleaser")
+  alias(libs.plugins.spotless)
+  alias(libs.plugins.jreleaser)
   id("substrait.java-conventions")
 }
 
@@ -104,30 +104,30 @@ java {
 
 tasks.withType<ScalaCompile>() { scalaCompileOptions.additionalParameters = listOf("-release:17") }
 
-var SLF4J_VERSION = properties.get("slf4j.version")
 var SPARKBUNDLE_VERSION = properties.get("sparkbundle.version")
-var SPARK_VERSION = properties.get("spark.version")
 
 sourceSets {
-  main { scala { setSrcDirs(listOf("src/main/scala", "src/main/spark-${SPARKBUNDLE_VERSION}")) } }
+  main { scala { setSrcDirs(listOf("src/main/scala", "src/main/spark-3.4")) } }
   test { scala { setSrcDirs(listOf("src/test/scala", "src/test/spark-3.2", "src/main/scala")) } }
 }
 
 dependencies {
   api(project(":core"))
-  implementation("org.scala-lang:scala-library:2.12.16")
-  api("org.apache.spark:spark-core_2.12:${SPARK_VERSION}")
-  api("org.apache.spark:spark-sql_2.12:${SPARK_VERSION}")
-  implementation("org.apache.spark:spark-catalyst_2.12:${SPARK_VERSION}")
-  implementation("org.slf4j:slf4j-api:${SLF4J_VERSION}")
+  implementation(libs.scala.library)
+  api(libs.spark.core)
+  api(libs.spark.sql)
+  implementation(libs.spark.catalyst)
+  implementation(libs.slf4j.api)
 
-  testImplementation("org.scalatest:scalatest_2.12:3.2.18")
-  testRuntimeOnly("org.junit.platform:junit-platform-engine:1.10.0")
-  testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.10.0")
-  testRuntimeOnly("org.scalatestplus:junit-5-10_2.12:3.2.18.0")
-  testImplementation("org.apache.spark:spark-core_2.12:${SPARK_VERSION}:tests")
-  testImplementation("org.apache.spark:spark-sql_2.12:${SPARK_VERSION}:tests")
-  testImplementation("org.apache.spark:spark-catalyst_2.12:${SPARK_VERSION}:tests")
+  testImplementation(libs.scalatest)
+  testImplementation(platform(libs.junit.bom))
+  testRuntimeOnly(libs.junit.platform.engine)
+  testRuntimeOnly(libs.junit.platform.launcher)
+  testRuntimeOnly(libs.scalatestplus.junit5)
+
+  testImplementation(variantOf(libs.spark.core) { classifier("tests") })
+  testImplementation(variantOf(libs.spark.sql) { classifier("tests") })
+  testImplementation(variantOf(libs.spark.catalyst) { classifier("tests") })
 }
 
 spotless {


### PR DESCRIPTION
The way dependency versions are currently declared is not working well with dependabot. To make it easier for dependabot to detect the dependency versions I suggest to move the dependency versions into a [Gradle version catalog](https://docs.gradle.org/current/userguide/version_catalogs.html) (`libs.versions.toml`).

This PR moves both the dependency and Gradle plugin versions into a version catalog.