### PR TITLE
fix: use URNs for all standard substrait extension yamls

### DIFF
--- a/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
+++ b/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
@@ -1,17 +1,17 @@
 package io.substrait.extension;
 
 public class DefaultExtensionCatalog {
-  public static final String FUNCTIONS_AGGREGATE_APPROX = "/functions_aggregate_approx.yaml";
-  public static final String FUNCTIONS_AGGREGATE_GENERIC = "/functions_aggregate_generic.yaml";
-  public static final String FUNCTIONS_ARITHMETIC = "/functions_arithmetic.yaml";
-  public static final String FUNCTIONS_ARITHMETIC_DECIMAL = "/functions_arithmetic_decimal.yaml";
-  public static final String FUNCTIONS_BOOLEAN = "/functions_boolean.yaml";
-  public static final String FUNCTIONS_COMPARISON = "/functions_comparison.yaml";
-  public static final String FUNCTIONS_DATETIME = "/functions_datetime.yaml";
-  public static final String FUNCTIONS_GEOMETRY = "/functions_geometry.yaml";
-  public static final String FUNCTIONS_LOGARITHMIC = "/functions_logarithmic.yaml";
-  public static final String FUNCTIONS_ROUNDING = "/functions_rounding.yaml";
-  public static final String FUNCTIONS_ROUNDING_DECIMAL = "/functions_rounding_decimal.yaml";
-  public static final String FUNCTIONS_SET = "/functions_set.yaml";
-  public static final String FUNCTIONS_STRING = "/functions_string.yaml";
+  public static final String FUNCTIONS_AGGREGATE_APPROX = "urn:substrait:functions_aggregate_approx";
+  public static final String FUNCTIONS_AGGREGATE_GENERIC = "urn:substrait:functions_aggregate_generic";
+  public static final String FUNCTIONS_ARITHMETIC = "urn:substrait:functions_arithmetic";
+  public static final String FUNCTIONS_ARITHMETIC_DECIMAL = "urn:substrait:functions_arithmetic_decimal";
+  public static final String FUNCTIONS_BOOLEAN = "urn:substrait:functions_boolean";
+  public static final String FUNCTIONS_COMPARISON = "urn:substrait:functions_comparison";
+  public static final String FUNCTIONS_DATETIME = "urn:substrait:functions_datetime";
+  public static final String FUNCTIONS_GEOMETRY = "urn:substrait:functions_geometry";
+  public static final String FUNCTIONS_LOGARITHMIC = "urn:substrait:functions_logarithmic";
+  public static final String FUNCTIONS_ROUNDING = "urn:substrait:functions_rounding";
+  public static final String FUNCTIONS_ROUNDING_DECIMAL = "urn:substrait:functions_rounding_decimal";
+  public static final String FUNCTIONS_SET = "urn:substrait:functions_set";
+  public static final String FUNCTIONS_STRING = "urn:substrait:functions_string";
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -29,9 +29,9 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
 
   public static SimpleExtension.FunctionAnchor APPROX_COUNT_DISTINCT =
       SimpleExtension.FunctionAnchor.of(
-          "/functions_aggregate_approx.yaml", "approx_count_distinct:any");
+          "urn:substrait:functions_aggregate_approx", "approx_count_distinct:any");
   public static SimpleExtension.FunctionAnchor COUNT =
-      SimpleExtension.FunctionAnchor.of("/functions_aggregate_generic.yaml", "count:any");
+      SimpleExtension.FunctionAnchor.of("urn:substrait:functions_aggregate_generic", "count:any");
 
   private static final String COUNT_DISTINCT_SUBBQUERY =
       "select\n"


### PR DESCRIPTION
Closes #447 