### PR TITLE
feat(isthmus): add method converting SQL to POJO Plan

### DIFF
--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
@@ -10,6 +10,7 @@ import io.substrait.isthmus.ImmutableFeatureBoard;
 import io.substrait.isthmus.SqlExpressionToSubstrait;
 import io.substrait.isthmus.SqlToSubstrait;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import io.substrait.plan.PlanProtoConverter;
 import io.substrait.proto.ExtendedExpression;
 import io.substrait.proto.Plan;
 import java.io.IOException;
@@ -94,7 +95,7 @@ public class IsthmusEntryPoint implements Callable<Integer> {
       Prepare.CatalogReader catalog =
           SubstraitCreateStatementParser.processCreateStatementsToCatalog(
               createStatements.toArray(String[]::new));
-      Plan plan = converter.execute(sql, catalog);
+      Plan plan = new PlanProtoConverter().toProto(converter.convert(sql, catalog));
       printMessage(plan);
     }
     return 0;

--- a/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ApplyJoinPlanTest.java
@@ -62,7 +62,7 @@ public class ApplyJoinPlanTest extends PlanTestBase {
     SqlToSubstrait sE2E = new SqlToSubstrait();
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> sE2E.execute(sql, TPCDS_CATALOG),
+        () -> sE2E.convert(sql, TPCDS_CATALOG),
         "Lateral join is not supported");
   }
 
@@ -83,7 +83,7 @@ public class ApplyJoinPlanTest extends PlanTestBase {
     // TODO validate end to end conversion
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> new SqlToSubstrait().execute(sql, TPCDS_CATALOG),
+        () -> new SqlToSubstrait().convert(sql, TPCDS_CATALOG),
         "APPLY is not supported");
   }
 
@@ -123,7 +123,7 @@ public class ApplyJoinPlanTest extends PlanTestBase {
     // TODO validate end to end conversion
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> new SqlToSubstrait().execute(sql, TPCDS_CATALOG),
+        () -> new SqlToSubstrait().convert(sql, TPCDS_CATALOG),
         "APPLY is not supported");
   }
 
@@ -138,7 +138,7 @@ public class ApplyJoinPlanTest extends PlanTestBase {
     // TODO validate end to end conversion
     Assertions.assertThrows(
         UnsupportedOperationException.class,
-        () -> new SqlToSubstrait().execute(sql, TPCDS_CATALOG),
+        () -> new SqlToSubstrait().convert(sql, TPCDS_CATALOG),
         "APPLY is not supported");
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/KeyConstraintsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/KeyConstraintsTest.java
@@ -14,6 +14,6 @@ public class KeyConstraintsTest extends PlanTestBase {
     String values = asString("keyconstraints_schema.sql");
     Prepare.CatalogReader catalog =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(values);
-    s.execute(asString(String.format("tpcds/queries/%02d.sql", query)), catalog);
+    s.convert(asString(String.format("tpcds/queries/%02d.sql", query)), catalog);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
@@ -25,14 +25,10 @@ public class NameRoundtripTest extends PlanTestBase {
     String query = "SELECT \"a\", \"B\" FROM foo GROUP BY a, b";
     List<String> expectedNames = List.of("a", "B");
 
-    List<org.apache.calcite.rel.RelRoot> calciteRelRoots = s.sqlToRelNode(query, catalogReader);
-    assertEquals(1, calciteRelRoots.size());
+    Plan plan = s.convert(query, catalogReader);
+    assertEquals(1, plan.getRoots().size());
 
-    org.apache.calcite.rel.RelRoot calciteRelRoot1 = calciteRelRoots.get(0);
-    assertEquals(expectedNames, calciteRelRoot1.validatedRowType.getFieldNames());
-
-    io.substrait.plan.Plan.Root substraitRelRoot =
-        SubstraitRelVisitor.convert(calciteRelRoot1, EXTENSION_COLLECTION);
+    io.substrait.plan.Plan.Root substraitRelRoot = plan.getRoots().get(0);
     assertEquals(expectedNames, substraitRelRoot.getNames());
 
     org.apache.calcite.rel.RelRoot calciteRelRoot2 = substraitToCalcite.convert(substraitRelRoot);

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
@@ -60,7 +60,7 @@ public class NestedStructQueryTest extends PlanTestBase {
     final Schema schema = new SubstraitSchema(Map.of("my_table", table));
     final CalciteCatalogReader catalog = schemaToCatalog("nested", schema);
     final SqlToSubstrait sqlToSubstrait = new SqlToSubstrait();
-    Plan plan = sqlToSubstrait.execute(query, catalog);
+    Plan plan = toProto(sqlToSubstrait.convert(query, catalog));
     Expression obtainedExpression =
         plan.getRelations(0).getRoot().getInput().getProject().getExpressions(0);
     Expression expectedExpression = TextFormat.parse(expectedExpressionText, Expression.class);

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.substrait.isthmus.utils.SetUtils;
 import io.substrait.plan.Plan;
-import io.substrait.plan.PlanProtoConverter;
 import io.substrait.plan.ProtoPlanConverter;
 import io.substrait.proto.AggregateFunction;
 import io.substrait.relation.Cross;
@@ -23,7 +22,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
 
   private io.substrait.proto.Plan getProtoPlan(String query1) throws SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
-    return s.execute(query1, TPCH_CATALOG);
+    return toProto(s.convert(query1, TPCH_CATALOG));
   }
 
   @Test
@@ -54,8 +53,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
     String distinctQuery = "select count(DISTINCT L_ORDERKEY) from lineitem";
     io.substrait.proto.Plan protoPlan = getProtoPlan(distinctQuery);
     assertAggregateInvocationDistinct(protoPlan);
-    assertAggregateInvocationDistinct(
-        new PlanProtoConverter().toProto(new ProtoPlanConverter().from(protoPlan)));
+    assertAggregateInvocationDistinct(toProto(new ProtoPlanConverter().from(protoPlan)));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -9,7 +9,6 @@ import io.substrait.expression.Expression;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.sql.SubstraitSqlDialect;
 import io.substrait.plan.Plan;
-import io.substrait.plan.ProtoPlanConverter;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.CopyOnWriteUtils;
 import io.substrait.relation.NamedScan;
@@ -77,8 +76,7 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
 
   private Plan buildPlanFromQuery(String query) throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
-    io.substrait.proto.Plan protoPlan1 = s.execute(query, TPCH_CATALOG);
-    return new ProtoPlanConverter().from(protoPlan1);
+    return s.convert(query, TPCH_CATALOG);
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
@@ -18,9 +18,10 @@ public class SubqueryPlanTest extends PlanTestBase {
   public void existsCorrelatedSubquery() throws SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     Plan plan =
-        s.execute(
-            "select l_partkey from lineitem where exists (select o_orderdate from orders where o_orderkey = l_orderkey)",
-            TPCH_CATALOG);
+        toProto(
+            s.convert(
+                "select l_partkey from lineitem where exists (select o_orderdate from orders where o_orderkey = l_orderkey)",
+                TPCH_CATALOG));
 
     Expression.Subquery subquery =
         plan.getRelations(0)
@@ -59,9 +60,10 @@ public class SubqueryPlanTest extends PlanTestBase {
   public void uniqueCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     Plan plan =
-        s.execute(
-            "select l_partkey from lineitem where unique (select o_orderdate from orders where o_orderkey = l_orderkey)",
-            TPCH_CATALOG);
+        toProto(
+            s.convert(
+                "select l_partkey from lineitem where unique (select o_orderdate from orders where o_orderkey = l_orderkey)",
+                TPCH_CATALOG));
 
     Expression.Subquery subquery =
         plan.getRelations(0)
@@ -104,7 +106,7 @@ public class SubqueryPlanTest extends PlanTestBase {
     SqlToSubstrait s = new SqlToSubstrait();
     String sql =
         "select l_orderkey from lineitem where l_partkey in (select p_partkey from part where p_partkey = l_partkey)";
-    Plan plan = s.execute(sql, TPCH_CATALOG);
+    Plan plan = toProto(s.convert(sql, TPCH_CATALOG));
 
     Expression.Subquery subquery =
         plan.getRelations(0)
@@ -142,7 +144,7 @@ public class SubqueryPlanTest extends PlanTestBase {
     SqlToSubstrait s = new SqlToSubstrait();
     String sql =
         "select l_orderkey from lineitem where l_partkey not in (select p_partkey from part where p_partkey = l_partkey)";
-    Plan plan = s.execute(sql, TPCH_CATALOG);
+    Plan plan = toProto(s.convert(sql, TPCH_CATALOG));
     Expression.Subquery subquery =
         plan.getRelations(0)
             .getRoot()
@@ -192,7 +194,7 @@ public class SubqueryPlanTest extends PlanTestBase {
             + "          FROM partsupp ps\n"
             + "          WHERE ps.ps_partkey = p.p_partkey\n"
             + "          AND   PS.ps_suppkey = l.l_suppkey))";
-    Plan plan = s.execute(sql, TPCH_CATALOG);
+    Plan plan = toProto(s.convert(sql, TPCH_CATALOG));
 
     Expression.Subquery outer_subquery =
         plan.getRelations(0)
@@ -266,7 +268,7 @@ public class SubqueryPlanTest extends PlanTestBase {
   public void nestedScalarCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String sql = asString("subquery/nested_scalar_subquery_in_filter.sql");
-    Plan plan = s.execute(sql, TPCH_CATALOG);
+    Plan plan = toProto(s.convert(sql, TPCH_CATALOG));
     String planText = JsonFormat.printer().includingDefaultValueFields().print(plan);
 
     System.out.println(planText);
@@ -344,7 +346,7 @@ public class SubqueryPlanTest extends PlanTestBase {
     Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> {
-          s.execute(sql, TPCH_CATALOG);
+          s.convert(sql, TPCH_CATALOG);
         });
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryTest.java
@@ -2,7 +2,7 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import io.substrait.proto.Plan;
+import io.substrait.plan.Plan;
 import java.io.IOException;
 import java.util.stream.IntStream;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -24,9 +24,14 @@ public class TpchQueryTest extends PlanTestBase {
   public void testQuery(int query) throws IOException {
     String inputSql = asString(String.format("tpch/queries/%02d.sql", query));
 
-    Plan plan = assertDoesNotThrow(() -> toSubstraitPlan(inputSql), "SQL to Substrait");
+    Plan plan = assertDoesNotThrow(() -> toSubstraitPlan(inputSql), "SQL to Substrait POJO");
 
-    assertDoesNotThrow(() -> toSql(plan), "Substrait to SQL");
+    assertDoesNotThrow(() -> toSql(plan), "Substrait POJO to SQL");
+
+    io.substrait.proto.Plan proto =
+        assertDoesNotThrow(() -> toProto(plan), "Substrait POJO to Substrait PROTO");
+
+    assertDoesNotThrow(() -> toSql(proto), "Substrait PROTO to SQL");
   }
 
   private Plan toSubstraitPlan(String sql) throws SqlParseException {


### PR DESCRIPTION
I noticed that #432 could benefit from this refactoring.

BREAKING CHANGE: deprecates SqlToSubstrait.execute()

- adds a new `convert()` method to `SqlToSubstrait` which converts a SQL statements string to a POJO `Plan` instead of a proto `Plan`
- deprecates the `execute()` method in `SqlToSubstrait` which converts a SQL statements string to a proto `Plan`
- changes any uses of `execute()` in the code to `convert()`
- removes the `@VisibleForTesting` annotation from `SqlToSubstrait.createSqlToRelConverter()` and `SqlToSubstrait.getBestExpRelRoot()` since they are not actually used in testing and makes them `protected` instead of package private
- adds `@VisibleForTesting` annotation to `SqlToSubstrait.sqlToRelNode()` which is actually still used in testing
- changes the `TpcdsQueryTest` and `TpchQueryTest` to test POJO to SQL and PROTO to SQL separately since I noticed that TPC-DS query 67 only fails for PROTO to SQL but started working to POJO to SQL