### PR TITLE
build: fix commitlint ignore regex for dependabot

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -124,5 +124,5 @@ module.exports = {
     }
   },
   // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-  "ignores": [(message) => /^build(deps): bump \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
+  "ignores": [(message) => /^build\(deps\): bump .+ from .+ to .+$/m.test(message)]
 }


### PR DESCRIPTION
I had copied and modified the regular expression from the https://github.com/substrait-io/substrait project which turns out to not work properly here and I forgot to escape the brackets.

I tested this one now and it works now.