### PR TITLE
build: improve commitlint ignore regex for dependabot

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -124,5 +124,5 @@ module.exports = {
     }
   },
   // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-  "ignores": [(message) => /^build\(deps\): bump .+ from .+ to .+$/m.test(message)]
+  "ignores": [(message) => /^build\(deps\): bump .+ from .+ to .+$/s.test(message)]
 }


### PR DESCRIPTION
I swear I had tested this before and some dependabot PRs that were previously failing due to commitlint did actually work. It turns out the regex was still not perfect since e.g. the following PRs are still failing with the commitlint check:
- https://github.com/substrait-io/substrait-java/pull/465
- https://github.com/substrait-io/substrait-java/pull/486

switching from multiline matching `m` to single line matching aka dot matches new line `s`