### PR TITLE
fix(isthmus): tpcds q67

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -620,8 +620,19 @@ public class ProtoRelConverter {
 
   protected Aggregate newAggregate(AggregateRel rel) {
     Rel input = from(rel.getInput());
+    Type.Struct inputSchema;
+    if (input instanceof Project) {
+      List<Type> types =
+          ((Project) input)
+              .getExpressions().stream().map(Expression::getType).collect(Collectors.toList());
+      inputSchema = Type.Struct.builder().fields(types).nullable(false).build();
+    } else {
+      inputSchema = input.getRecordType();
+    }
+
     ProtoExpressionConverter protoExprConverter =
-        new ProtoExpressionConverter(lookup, extensions, input.getRecordType(), this);
+        new ProtoExpressionConverter(lookup, extensions, inputSchema, this);
+
     ProtoAggregateFunctionConverter protoAggrFuncConverter =
         new ProtoAggregateFunctionConverter(lookup, extensions, protoExprConverter);
 

--- a/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TpcdsQueryTest extends PlanTestBase {
   private static final Set<Integer> toSubstraitExclusions = Set.of(9, 27, 36, 70, 86);
   private static final Set<Integer> fromSubstraitPojoExclusions = Set.of(1, 30, 81);
-  private static final Set<Integer> fromSubstraitProtoExclusions = Set.of(1, 30, 67, 81);
+  private static final Set<Integer> fromSubstraitProtoExclusions = Set.of(1, 30, 81);
 
   static IntStream testCases() {
     return IntStream.rangeClosed(1, 99).filter(n -> !toSubstraitExclusions.contains(n));


### PR DESCRIPTION
The fix handles conversion between sql and substrait, when aggregation is done using `rollup` function and there is an outer projection. Minimal representative example:


Failing:

```sql

select i_category from (
select i_category, count(*) from item group by
rollup(
i_category
)
)
```
Workable:

```sql

select i_category from (
select i_category, count(*) from item group by
--rollup(
i_category
--)
)
```

