### PR TITLE
chore(isthmus): debug log missing Calcite mapping

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -90,7 +90,7 @@ public abstract class FunctionConverter<
     for (String key : alm.keySet()) {
       Collection<Sig> sigs = calciteOperators.get(key);
       if (sigs.isEmpty()) {
-        LOGGER.atInfo().log("No binding for function: {}", key);
+        LOGGER.atDebug().log("No binding for function: {}", key);
       }
 
       for (Sig sig : sigs) {


### PR DESCRIPTION
There is an info level log in FunctionConverter for every every Calcite operator for which there is no direct Substrait mapping. This message makes the logs extremely busy and provides no value to end users. This change reclassifies the message as debug log.