### PR TITLE
ci: handle warnings in compileScala as errors

### DIFF
--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -102,7 +102,9 @@ java {
   withSourcesJar()
 }
 
-tasks.withType<ScalaCompile>() { scalaCompileOptions.additionalParameters = listOf("-release:17") }
+tasks.withType<ScalaCompile>() {
+  scalaCompileOptions.additionalParameters = listOf("-release:17", "-Xfatal-warnings")
+}
 
 var SPARKBUNDLE_VERSION = properties.get("sparkbundle.version")
 

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -50,6 +50,7 @@ import io.substrait.relation.files.FileFormat
 import io.substrait.util.EmptyVisitationContext
 import org.apache.hadoop.fs.Path
 
+import scala.annotation.nowarn
 import scala.collection.JavaConverters.asScalaBufferConverter
 import scala.collection.mutable.ArrayBuffer
 
@@ -180,6 +181,7 @@ class ToLogicalPlan(spark: SparkSession = SparkSession.builder().getOrCreate())
     }
   }
 
+  @nowarn("cat=deprecation")
   override def visit(join: relation.Join, context: EmptyVisitationContext): LogicalPlan = {
     val left = join.getLeft.accept(this, context)
     val right = join.getRight.accept(this, context)


### PR DESCRIPTION
Enable the `-Xfatal-warnings` flag for the Scala compiler to turn warnings into errors (i.e. fail the build).
Suppress this warning for the case where the spark converter is handling deprecated substrait enum values in the Join relation. We still want the converter to hande this legacy value without throwing an exception.

Resolves https://github.com/substrait-io/substrait-java/issues/321