### PR TITLE
feat: enable handling of URNs alongside URIs

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -108,6 +108,8 @@ configurations[JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME].extendsFrom(sh
 
 dependencies {
   testImplementation(platform(libs.junit.bom))
+  testImplementation(libs.protobuf.java.util)
+
   testImplementation(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.platform.launcher)
 

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -699,7 +699,7 @@ public class SubstraitBuilder {
   // Types
 
   public Type.UserDefined userDefinedType(String namespace, String typeName) {
-    return Type.UserDefined.builder().uri(namespace).name(typeName).nullable(false).build();
+    return Type.UserDefined.builder().urn(namespace).name(typeName).nullable(false).build();
   }
 
   // Misc

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -666,13 +666,13 @@ public interface Expression extends FunctionArg {
   abstract class UserDefinedLiteral implements Literal {
     public abstract ByteString value();
 
-    public abstract String uri();
+    public abstract String urn();
 
     public abstract String name();
 
     @Override
     public Type getType() {
-      return Type.withNullability(nullable()).userDefined(uri(), name());
+      return Type.withNullability(nullable()).userDefined(urn(), name());
     }
 
     public static ImmutableExpression.UserDefinedLiteral.Builder builder() {

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -287,10 +287,10 @@ public class ExpressionCreator {
   }
 
   public static Expression.UserDefinedLiteral userDefinedLiteral(
-      boolean nullable, String uri, String name, Any value) {
+      boolean nullable, String urn, String name, Any value) {
     return Expression.UserDefinedLiteral.builder()
         .nullable(nullable)
-        .uri(uri)
+        .urn(urn)
         .name(name)
         .value(value.toByteString())
         .build();

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -361,7 +361,7 @@ public class ExpressionProtoConverter
   public Expression visit(
       io.substrait.expression.Expression.UserDefinedLiteral expr, EmptyVisitationContext context) {
     int typeReference =
-        extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.uri(), expr.name()));
+        extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.urn(), expr.name()));
     return lit(
         bldr -> {
           try {

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -495,7 +495,7 @@ public class ProtoExpressionConverter {
           SimpleExtension.Type type =
               lookup.getType(userDefinedLiteral.getTypeReference(), extensions);
           return ExpressionCreator.userDefinedLiteral(
-              literal.getNullable(), type.uri(), type.name(), userDefinedLiteral.getValue());
+              literal.getNullable(), type.urn(), type.name(), userDefinedLiteral.getValue());
         }
       default:
         throw new IllegalStateException("Unexpected value: " + literal.getLiteralTypeCase());

--- a/core/src/main/java/io/substrait/extendedexpression/ProtoExtendedExpressionConverter.java
+++ b/core/src/main/java/io/substrait/extendedexpression/ProtoExtendedExpressionConverter.java
@@ -28,6 +28,9 @@ public class ProtoExtendedExpressionConverter {
   }
 
   public ProtoExtendedExpressionConverter(SimpleExtension.ExtensionCollection extensionCollection) {
+    if (extensionCollection == null) {
+      throw new IllegalArgumentException("ExtensionCollection is required");
+    }
     this.extensionCollection = extensionCollection;
   }
 
@@ -35,7 +38,7 @@ public class ProtoExtendedExpressionConverter {
     // fill in simple extension information through a discovery in the current proto-extended
     // expression
     ExtensionLookup functionLookup =
-        ImmutableExtensionLookup.builder().from(extendedExpression).build();
+        ImmutableExtensionLookup.builder(extensionCollection).from(extendedExpression).build();
 
     NamedStruct baseSchemaProto = extendedExpression.getBaseSchema();
 

--- a/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
@@ -13,26 +13,6 @@ public abstract class AbstractExtensionLookup implements ExtensionLookup {
     this.typeAnchorMap = typeAnchorMap;
   }
 
-  /**
-   * Gets the function anchor for a given reference (primarily for testing).
-   *
-   * @param reference The function reference
-   * @return The function anchor, or null if not found
-   */
-  public SimpleExtension.FunctionAnchor getFunctionAnchor(int reference) {
-    return functionAnchorMap.get(reference);
-  }
-
-  /**
-   * Gets the type anchor for a given reference (primarily for testing).
-   *
-   * @param reference The type reference
-   * @return The type anchor, or null if not found
-   */
-  public SimpleExtension.TypeAnchor getTypeAnchor(int reference) {
-    return typeAnchorMap.get(reference);
-  }
-
   @Override
   public SimpleExtension.ScalarFunctionVariant getScalarFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {

--- a/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
@@ -13,6 +13,26 @@ public abstract class AbstractExtensionLookup implements ExtensionLookup {
     this.typeAnchorMap = typeAnchorMap;
   }
 
+  /**
+   * Gets the function anchor for a given reference (primarily for testing).
+   *
+   * @param reference The function reference
+   * @return The function anchor, or null if not found
+   */
+  public SimpleExtension.FunctionAnchor getFunctionAnchor(int reference) {
+    return functionAnchorMap.get(reference);
+  }
+
+  /**
+   * Gets the type anchor for a given reference (primarily for testing).
+   *
+   * @param reference The type reference
+   * @return The type anchor, or null if not found
+   */
+  public SimpleExtension.TypeAnchor getTypeAnchor(int reference) {
+    return typeAnchorMap.get(reference);
+  }
+
   @Override
   public SimpleExtension.ScalarFunctionVariant getScalarFunction(
       int reference, SimpleExtension.ExtensionCollection extensions) {

--- a/core/src/main/java/io/substrait/extension/BidiMap.java
+++ b/core/src/main/java/io/substrait/extension/BidiMap.java
@@ -1,0 +1,65 @@
+package io.substrait.extension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** We don't depend on guava... */
+class BidiMap<T1, T2> {
+  private final Map<T1, T2> forwardMap;
+  private final Map<T2, T1> reverseMap;
+
+  BidiMap(Map<T1, T2> forwardMap) {
+    this.forwardMap = forwardMap;
+    this.reverseMap = new HashMap<>();
+    for (Map.Entry<T1, T2> entry : forwardMap.entrySet()) {
+      reverseMap.put(entry.getValue(), entry.getKey());
+    }
+  }
+
+  BidiMap() {
+    this.forwardMap = new HashMap<>();
+    this.reverseMap = new HashMap<>();
+  }
+
+  T2 get(T1 t1) {
+    return forwardMap.get(t1);
+  }
+
+  T1 reverseGet(T2 t2) {
+    return reverseMap.get(t2);
+  }
+
+  /**
+   * Associates the specified values in both directions. Throws if either value is already mapped to
+   * a different value.
+   */
+  void put(T1 t1, T2 t2) {
+    T2 existingForward = forwardMap.get(t1);
+    T1 existingReverse = reverseMap.get(t2);
+
+    if (existingForward != null && !existingForward.equals(t2)) {
+      throw new IllegalArgumentException("Key already exists in map with different value");
+    }
+    if (existingReverse != null && !existingReverse.equals(t1)) {
+      throw new IllegalArgumentException("Key already exists in map with different value");
+    }
+
+    forwardMap.put(t1, t2);
+    reverseMap.put(t2, t1);
+  }
+
+  void merge(BidiMap<T1, T2> other) {
+    for (Map.Entry<T1, T2> entry : other.forwardEntrySet()) {
+      put(entry.getKey(), entry.getValue());
+    }
+  }
+
+  Set<Map.Entry<T1, T2>> forwardEntrySet() {
+    return forwardMap.entrySet();
+  }
+
+  Set<Map.Entry<T2, T1>> reverseEntrySet() {
+    return reverseMap.entrySet();
+  }
+}

--- a/core/src/main/java/io/substrait/extension/BidiMap.java
+++ b/core/src/main/java/io/substrait/extension/BidiMap.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 /** We don't depend on guava... */
-class BidiMap<T1, T2> {
+public class BidiMap<T1, T2> {
   private final Map<T1, T2> forwardMap;
   private final Map<T2, T1> reverseMap;
 

--- a/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
+++ b/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
@@ -5,19 +5,23 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class DefaultExtensionCatalog {
-  public static final String FUNCTIONS_AGGREGATE_APPROX = "/functions_aggregate_approx.yaml";
-  public static final String FUNCTIONS_AGGREGATE_GENERIC = "/functions_aggregate_generic.yaml";
-  public static final String FUNCTIONS_ARITHMETIC = "/functions_arithmetic.yaml";
-  public static final String FUNCTIONS_ARITHMETIC_DECIMAL = "/functions_arithmetic_decimal.yaml";
-  public static final String FUNCTIONS_BOOLEAN = "/functions_boolean.yaml";
-  public static final String FUNCTIONS_COMPARISON = "/functions_comparison.yaml";
-  public static final String FUNCTIONS_DATETIME = "/functions_datetime.yaml";
-  public static final String FUNCTIONS_GEOMETRY = "/functions_geometry.yaml";
-  public static final String FUNCTIONS_LOGARITHMIC = "/functions_logarithmic.yaml";
-  public static final String FUNCTIONS_ROUNDING = "/functions_rounding.yaml";
-  public static final String FUNCTIONS_ROUNDING_DECIMAL = "/functions_rounding_decimal.yaml";
-  public static final String FUNCTIONS_SET = "/functions_set.yaml";
-  public static final String FUNCTIONS_STRING = "/functions_string.yaml";
+  public static final String FUNCTIONS_AGGREGATE_APPROX =
+      "extension:io.substrait:functions_aggregate_approx";
+  public static final String FUNCTIONS_AGGREGATE_GENERIC =
+      "extension:io.substrait:functions_aggregate_generic";
+  public static final String FUNCTIONS_ARITHMETIC = "extension:io.substrait:functions_arithmetic";
+  public static final String FUNCTIONS_ARITHMETIC_DECIMAL =
+      "extension:io.substrait:functions_arithmetic_decimal";
+  public static final String FUNCTIONS_BOOLEAN = "extension:io.substrait:functions_boolean";
+  public static final String FUNCTIONS_COMPARISON = "extension:io.substrait:functions_comparison";
+  public static final String FUNCTIONS_DATETIME = "extension:io.substrait:functions_datetime";
+  public static final String FUNCTIONS_GEOMETRY = "extension:io.substrait:functions_geometry";
+  public static final String FUNCTIONS_LOGARITHMIC = "extension:io.substrait:functions_logarithmic";
+  public static final String FUNCTIONS_ROUNDING = "extension:io.substrait:functions_rounding";
+  public static final String FUNCTIONS_ROUNDING_DECIMAL =
+      "extension:io.substrait:functions_rounding_decimal";
+  public static final String FUNCTIONS_SET = "extension:io.substrait:functions_set";
+  public static final String FUNCTIONS_STRING = "extension:io.substrait:functions_string";
 
   public static final SimpleExtension.ExtensionCollection DEFAULT_COLLECTION =
       loadDefaultCollection();

--- a/core/src/main/java/io/substrait/extension/ExtensionCollector.java
+++ b/core/src/main/java/io/substrait/extension/ExtensionCollector.java
@@ -3,6 +3,7 @@ package io.substrait.extension;
 import io.substrait.proto.ExtendedExpression;
 import io.substrait.proto.Plan;
 import io.substrait.proto.SimpleExtensionDeclaration;
+import io.substrait.proto.SimpleExtensionURI;
 import io.substrait.proto.SimpleExtensionURN;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,14 +20,27 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ExtensionCollector extends AbstractExtensionLookup {
   private final BidiMap<Integer, SimpleExtension.FunctionAnchor> funcMap;
   private final BidiMap<Integer, SimpleExtension.TypeAnchor> typeMap;
+  private final SimpleExtension.ExtensionCollection extensionCollection;
 
   // start at 0 to make sure functionAnchors start with 1 according to spec
   private int counter = 0;
 
+  private String getUriFromUrn(String urn) {
+    return extensionCollection.getUriFromUrn(urn);
+  }
+
   public ExtensionCollector() {
+    this(SimpleExtension.loadDefaults());
+  }
+
+  public ExtensionCollector(SimpleExtension.ExtensionCollection extensionCollection) {
     super(new HashMap<>(), new HashMap<>());
+    if (extensionCollection == null) {
+      throw new IllegalArgumentException("ExtensionCollection is required");
+    }
     funcMap = new BidiMap<>(functionAnchorMap);
     typeMap = new BidiMap<>(typeAnchorMap);
+    this.extensionCollection = extensionCollection;
   }
 
   public int getFunctionReference(SimpleExtension.Function declaration) {
@@ -53,6 +67,7 @@ public class ExtensionCollector extends AbstractExtensionLookup {
     SimpleExtensions simpleExtensions = getExtensions();
 
     builder.addAllExtensionUrns(simpleExtensions.urns.values());
+    builder.addAllExtensionUris(simpleExtensions.uris.values());
     builder.addAllExtensions(simpleExtensions.extensionList);
   }
 
@@ -60,63 +75,116 @@ public class ExtensionCollector extends AbstractExtensionLookup {
     SimpleExtensions simpleExtensions = getExtensions();
 
     builder.addAllExtensionUrns(simpleExtensions.urns.values());
+    builder.addAllExtensionUris(simpleExtensions.uris.values());
     builder.addAllExtensions(simpleExtensions.extensionList);
   }
 
   private SimpleExtensions getExtensions() {
     AtomicInteger urnPos = new AtomicInteger(1);
+    AtomicInteger uriPos = new AtomicInteger(1);
     HashMap<String, SimpleExtensionURN> urns = new HashMap<>();
+    HashMap<String, SimpleExtensionURI> uris = new HashMap<>();
 
     ArrayList<SimpleExtensionDeclaration> extensionList = new ArrayList<>();
     for (Map.Entry<Integer, SimpleExtension.FunctionAnchor> e : funcMap.forwardEntrySet()) {
-      SimpleExtensionURN urn =
+      String urn = e.getValue().urn();
+      String uri = getUriFromUrn(urn);
+
+      // Create URN entry
+      SimpleExtensionURN urnObj =
           urns.computeIfAbsent(
-              e.getValue().urn(),
+              urn,
               k ->
                   SimpleExtensionURN.newBuilder()
                       .setExtensionUrnAnchor(urnPos.getAndIncrement())
                       .setUrn(k)
                       .build());
+
+      // Create URI entry if mapping exists
+      SimpleExtensionURI uriObj = null;
+      if (uri != null) {
+        uriObj =
+            uris.computeIfAbsent(
+                uri,
+                k ->
+                    SimpleExtensionURI.newBuilder()
+                        .setExtensionUriAnchor(uriPos.getAndIncrement())
+                        .setUri(k)
+                        .build());
+      }
+
+      // Create function declaration with both URN and URI references
+      SimpleExtensionDeclaration.ExtensionFunction.Builder funcBuilder =
+          SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+              .setFunctionAnchor(e.getKey())
+              .setName(e.getValue().key())
+              .setExtensionUrnReference(urnObj.getExtensionUrnAnchor());
+
+      if (uriObj != null) {
+        funcBuilder.setExtensionUriReference(uriObj.getExtensionUriAnchor());
+      }
+
       SimpleExtensionDeclaration decl =
-          SimpleExtensionDeclaration.newBuilder()
-              .setExtensionFunction(
-                  SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
-                      .setFunctionAnchor(e.getKey())
-                      .setName(e.getValue().key())
-                      .setExtensionUrnReference(urn.getExtensionUrnAnchor()))
-              .build();
+          SimpleExtensionDeclaration.newBuilder().setExtensionFunction(funcBuilder).build();
       extensionList.add(decl);
     }
+
     for (Map.Entry<Integer, SimpleExtension.TypeAnchor> e : typeMap.forwardEntrySet()) {
-      SimpleExtensionURN urn =
+      String urn = e.getValue().urn();
+      String uri = getUriFromUrn(urn);
+
+      // Create URN entry
+      SimpleExtensionURN urnObj =
           urns.computeIfAbsent(
-              e.getValue().urn(),
+              urn,
               k ->
                   SimpleExtensionURN.newBuilder()
                       .setExtensionUrnAnchor(urnPos.getAndIncrement())
                       .setUrn(k)
                       .build());
+
+      // Create URI entry if mapping exists
+      SimpleExtensionURI uriObj = null;
+      if (uri != null) {
+        uriObj =
+            uris.computeIfAbsent(
+                uri,
+                k ->
+                    SimpleExtensionURI.newBuilder()
+                        .setExtensionUriAnchor(uriPos.getAndIncrement())
+                        .setUri(k)
+                        .build());
+      }
+
+      // Create type declaration with both URN and URI references
+      SimpleExtensionDeclaration.ExtensionType.Builder typeBuilder =
+          SimpleExtensionDeclaration.ExtensionType.newBuilder()
+              .setTypeAnchor(e.getKey())
+              .setName(e.getValue().key())
+              .setExtensionUrnReference(urnObj.getExtensionUrnAnchor());
+
+      if (uriObj != null) {
+        typeBuilder.setExtensionUriReference(uriObj.getExtensionUriAnchor());
+      }
+
       SimpleExtensionDeclaration decl =
-          SimpleExtensionDeclaration.newBuilder()
-              .setExtensionType(
-                  SimpleExtensionDeclaration.ExtensionType.newBuilder()
-                      .setTypeAnchor(e.getKey())
-                      .setName(e.getValue().key())
-                      .setExtensionUrnReference(urn.getExtensionUrnAnchor()))
-              .build();
+          SimpleExtensionDeclaration.newBuilder().setExtensionType(typeBuilder).build();
       extensionList.add(decl);
     }
-    return new SimpleExtensions(urns, extensionList);
+    return new SimpleExtensions(urns, uris, extensionList);
   }
 
   private static final class SimpleExtensions {
     final HashMap<String, SimpleExtensionURN> urns;
+    final HashMap<String, SimpleExtensionURI> uris;
     final ArrayList<SimpleExtensionDeclaration> extensionList;
 
     SimpleExtensions(
         HashMap<String, SimpleExtensionURN> urns,
+        HashMap<String, SimpleExtensionURI> uris,
         ArrayList<SimpleExtensionDeclaration> extensionList) {
       this.urns = urns;
+      this.uris = uris;
       this.extensionList = extensionList;
     }
   }

--- a/core/src/main/java/io/substrait/extension/ExtensionCollector.java
+++ b/core/src/main/java/io/substrait/extension/ExtensionCollector.java
@@ -30,7 +30,7 @@ public class ExtensionCollector extends AbstractExtensionLookup {
   }
 
   public ExtensionCollector() {
-    this(SimpleExtension.loadDefaults());
+    this(DefaultExtensionCatalog.DEFAULT_COLLECTION);
   }
 
   public ExtensionCollector(SimpleExtension.ExtensionCollection extensionCollection) {

--- a/core/src/main/java/io/substrait/extension/ExtensionCollector.java
+++ b/core/src/main/java/io/substrait/extension/ExtensionCollector.java
@@ -68,7 +68,7 @@ public class ExtensionCollector extends AbstractExtensionLookup {
     HashMap<String, SimpleExtensionURN> urns = new HashMap<>();
 
     ArrayList<SimpleExtensionDeclaration> extensionList = new ArrayList<>();
-    for (Map.Entry<Integer, SimpleExtension.FunctionAnchor> e : funcMap.forwardMap.entrySet()) {
+    for (Map.Entry<Integer, SimpleExtension.FunctionAnchor> e : funcMap.forwardEntrySet()) {
       SimpleExtensionURN urn =
           urns.computeIfAbsent(
               e.getValue().urn(),
@@ -87,7 +87,7 @@ public class ExtensionCollector extends AbstractExtensionLookup {
               .build();
       extensionList.add(decl);
     }
-    for (Map.Entry<Integer, SimpleExtension.TypeAnchor> e : typeMap.forwardMap.entrySet()) {
+    for (Map.Entry<Integer, SimpleExtension.TypeAnchor> e : typeMap.forwardEntrySet()) {
       SimpleExtensionURN urn =
           urns.computeIfAbsent(
               e.getValue().urn(),
@@ -118,30 +118,6 @@ public class ExtensionCollector extends AbstractExtensionLookup {
         ArrayList<SimpleExtensionDeclaration> extensionList) {
       this.urns = urns;
       this.extensionList = extensionList;
-    }
-  }
-
-  /** We don't depend on guava... */
-  private static class BidiMap<T1, T2> {
-    private final Map<T1, T2> forwardMap;
-    private final Map<T2, T1> reverseMap;
-
-    public BidiMap(Map<T1, T2> forwardMap) {
-      this.forwardMap = forwardMap;
-      this.reverseMap = new HashMap<>();
-    }
-
-    public T2 get(T1 t1) {
-      return forwardMap.get(t1);
-    }
-
-    public T1 reverseGet(T2 t2) {
-      return reverseMap.get(t2);
-    }
-
-    public void put(T1 t1, T2 t2) {
-      forwardMap.put(t1, t2);
-      reverseMap.put(t2, t1);
     }
   }
 }

--- a/core/src/main/java/io/substrait/extension/ExtensionCollector.java
+++ b/core/src/main/java/io/substrait/extension/ExtensionCollector.java
@@ -3,7 +3,7 @@ package io.substrait.extension;
 import io.substrait.proto.ExtendedExpression;
 import io.substrait.proto.Plan;
 import io.substrait.proto.SimpleExtensionDeclaration;
-import io.substrait.proto.SimpleExtensionURI;
+import io.substrait.proto.SimpleExtensionURN;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,30 +52,30 @@ public class ExtensionCollector extends AbstractExtensionLookup {
   public void addExtensionsToPlan(Plan.Builder builder) {
     SimpleExtensions simpleExtensions = getExtensions();
 
-    builder.addAllExtensionUris(simpleExtensions.uris.values());
+    builder.addAllExtensionUrns(simpleExtensions.urns.values());
     builder.addAllExtensions(simpleExtensions.extensionList);
   }
 
   public void addExtensionsToExtendedExpression(ExtendedExpression.Builder builder) {
     SimpleExtensions simpleExtensions = getExtensions();
 
-    builder.addAllExtensionUris(simpleExtensions.uris.values());
+    builder.addAllExtensionUrns(simpleExtensions.urns.values());
     builder.addAllExtensions(simpleExtensions.extensionList);
   }
 
   private SimpleExtensions getExtensions() {
-    AtomicInteger uriPos = new AtomicInteger(1);
-    HashMap<String, SimpleExtensionURI> uris = new HashMap<>();
+    AtomicInteger urnPos = new AtomicInteger(1);
+    HashMap<String, SimpleExtensionURN> urns = new HashMap<>();
 
     ArrayList<SimpleExtensionDeclaration> extensionList = new ArrayList<>();
     for (Map.Entry<Integer, SimpleExtension.FunctionAnchor> e : funcMap.forwardMap.entrySet()) {
-      SimpleExtensionURI uri =
-          uris.computeIfAbsent(
-              e.getValue().namespace(),
+      SimpleExtensionURN urn =
+          urns.computeIfAbsent(
+              e.getValue().urn(),
               k ->
-                  SimpleExtensionURI.newBuilder()
-                      .setExtensionUriAnchor(uriPos.getAndIncrement())
-                      .setUri(k)
+                  SimpleExtensionURN.newBuilder()
+                      .setExtensionUrnAnchor(urnPos.getAndIncrement())
+                      .setUrn(k)
                       .build());
       SimpleExtensionDeclaration decl =
           SimpleExtensionDeclaration.newBuilder()
@@ -83,18 +83,18 @@ public class ExtensionCollector extends AbstractExtensionLookup {
                   SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
                       .setFunctionAnchor(e.getKey())
                       .setName(e.getValue().key())
-                      .setExtensionUriReference(uri.getExtensionUriAnchor()))
+                      .setExtensionUrnReference(urn.getExtensionUrnAnchor()))
               .build();
       extensionList.add(decl);
     }
     for (Map.Entry<Integer, SimpleExtension.TypeAnchor> e : typeMap.forwardMap.entrySet()) {
-      SimpleExtensionURI uri =
-          uris.computeIfAbsent(
-              e.getValue().namespace(),
+      SimpleExtensionURN urn =
+          urns.computeIfAbsent(
+              e.getValue().urn(),
               k ->
-                  SimpleExtensionURI.newBuilder()
-                      .setExtensionUriAnchor(uriPos.getAndIncrement())
-                      .setUri(k)
+                  SimpleExtensionURN.newBuilder()
+                      .setExtensionUrnAnchor(urnPos.getAndIncrement())
+                      .setUrn(k)
                       .build());
       SimpleExtensionDeclaration decl =
           SimpleExtensionDeclaration.newBuilder()
@@ -102,21 +102,21 @@ public class ExtensionCollector extends AbstractExtensionLookup {
                   SimpleExtensionDeclaration.ExtensionType.newBuilder()
                       .setTypeAnchor(e.getKey())
                       .setName(e.getValue().key())
-                      .setExtensionUriReference(uri.getExtensionUriAnchor()))
+                      .setExtensionUrnReference(urn.getExtensionUrnAnchor()))
               .build();
       extensionList.add(decl);
     }
-    return new SimpleExtensions(uris, extensionList);
+    return new SimpleExtensions(urns, extensionList);
   }
 
   private static final class SimpleExtensions {
-    final HashMap<String, SimpleExtensionURI> uris;
+    final HashMap<String, SimpleExtensionURN> urns;
     final ArrayList<SimpleExtensionDeclaration> extensionList;
 
     SimpleExtensions(
-        HashMap<String, SimpleExtensionURI> uris,
+        HashMap<String, SimpleExtensionURN> urns,
         ArrayList<SimpleExtensionDeclaration> extensionList) {
-      this.uris = uris;
+      this.urns = urns;
       this.extensionList = extensionList;
     }
   }

--- a/core/src/main/java/io/substrait/extension/ImmutableExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/ImmutableExtensionLookup.java
@@ -25,26 +25,181 @@ public class ImmutableExtensionLookup extends AbstractExtensionLookup {
     return new Builder();
   }
 
+  public static Builder builder(SimpleExtension.ExtensionCollection extensionCollection) {
+    return new Builder(extensionCollection);
+  }
+
   public static class Builder {
     private final Map<Integer, SimpleExtension.FunctionAnchor> functionMap = new HashMap<>();
     private final Map<Integer, SimpleExtension.TypeAnchor> typeMap = new HashMap<>();
+    private final SimpleExtension.ExtensionCollection extensionCollection;
+
+    public Builder() {
+      this.extensionCollection = SimpleExtension.loadDefaults();
+    }
+
+    public Builder(SimpleExtension.ExtensionCollection extensionCollection) {
+      if (extensionCollection == null) {
+        throw new IllegalArgumentException("ExtensionCollection is required");
+      }
+      this.extensionCollection = extensionCollection;
+    }
+
+    /**
+     * Resolves URN from URI using the URI/URN mapping.
+     *
+     * @param uri The URI to resolve
+     * @return The corresponding URN, or null if no mapping exists
+     */
+    private String resolveUrnFromUri(String uri) {
+      return extensionCollection.getUrnFromUri(uri);
+    }
+
+    private SimpleExtension.FunctionAnchor resolveFunctionAnchor(
+        SimpleExtensionDeclaration.ExtensionFunction func,
+        Map<Integer, String> urnMap,
+        Map<Integer, String> uriMap) {
+
+      // 1. Try non-zero URN reference
+      if (func.getExtensionUrnReference() != 0) {
+        String urnFromUrnRef = urnMap.get(func.getExtensionUrnReference());
+        if (urnFromUrnRef != null) {
+          return SimpleExtension.FunctionAnchor.of(urnFromUrnRef, func.getName());
+        }
+      }
+
+      // 2. Try non-zero URI reference
+      if (func.getExtensionUriReference() != 0) {
+        String uriFromUriRef = uriMap.get(func.getExtensionUriReference());
+        if (uriFromUriRef != null) {
+          String urnFromUriRef = resolveUrnFromUri(uriFromUriRef);
+          if (urnFromUriRef != null) {
+            return SimpleExtension.FunctionAnchor.of(urnFromUriRef, func.getName());
+          }
+          // URI found but could not be resolved to URN
+        }
+      }
+
+      /* At this point both URI and URN are 0, so we need to
+        first see if they both resolve.
+      */
+
+      String urn = urnMap.get(func.getExtensionUrnReference());
+      String uri = uriMap.get(func.getExtensionUriReference());
+
+      // 3. Try both 0 URI and 0 URN if both resolve
+      if (uri != null && urn != null) {
+        String resolvedUrn = resolveUrnFromUri(uri);
+        if (urn.equals(resolvedUrn)) {
+          return SimpleExtension.FunctionAnchor.of(urn, func.getName());
+        }
+        throw new IllegalStateException(
+            String.format(
+                "Conflicting URI/URN mapping at reference 0: URI '%s' maps to URN '%s', but reference 0 also specifies URN '%s'. "
+                    + "These must be consistent for proper resolution.",
+                uri, resolvedUrn, urn));
+      }
+
+      // 4. Try only 0 URN
+      if (urn != null) {
+        return SimpleExtension.FunctionAnchor.of(urn, func.getName());
+      }
+      // 5. Try only 0 URI
+      if (uri != null && resolveUrnFromUri(uri) != null) {
+        return SimpleExtension.FunctionAnchor.of(resolveUrnFromUri(uri), func.getName());
+      }
+      throw new IllegalStateException(
+          String.format(
+              "All resolution strategies failed for URI %s and URN %s (perhaps a URI <-> URN mapping was not registered during the migration) ",
+              uri, urn));
+    }
+
+    private SimpleExtension.TypeAnchor resolveTypeAnchor(
+        SimpleExtensionDeclaration.ExtensionType type,
+        Map<Integer, String> urnMap,
+        Map<Integer, String> uriMap) {
+
+      // 1. Try non-zero URN reference
+      if (type.getExtensionUrnReference() != 0) {
+        String urnFromUrnRef = urnMap.get(type.getExtensionUrnReference());
+        if (urnFromUrnRef != null) {
+          return SimpleExtension.TypeAnchor.of(urnFromUrnRef, type.getName());
+        }
+      }
+
+      // 2. Try non-zero URI reference
+      if (type.getExtensionUriReference() != 0) {
+        String uriFromUriRef = uriMap.get(type.getExtensionUriReference());
+        if (uriFromUriRef != null) {
+          String urnFromUriRef = resolveUrnFromUri(uriFromUriRef);
+          if (urnFromUriRef != null) {
+            return SimpleExtension.TypeAnchor.of(urnFromUriRef, type.getName());
+          }
+          // URI found but could not be resolved to URN
+        }
+      }
+
+      /* At this point both URI and URN are 0, so we need to
+        first see if they both resolve.
+      */
+
+      String urn = urnMap.get(type.getExtensionUrnReference());
+      String uri = uriMap.get(type.getExtensionUriReference());
+
+      // 3. Try both 0 URI and 0 URN if both resolve
+      if (uri != null && urn != null) {
+        String resolvedUrn = resolveUrnFromUri(uri);
+        if (urn.equals(resolvedUrn)) {
+          return SimpleExtension.TypeAnchor.of(urn, type.getName());
+        }
+        throw new IllegalStateException(
+            String.format(
+                "Conflicting URI/URN mapping at reference 0: URI '%s' maps to URN '%s', but reference 0 also specifies URN '%s'. "
+                    + "These must be consistent for proper resolution.",
+                uri, resolvedUrn, urn));
+      }
+
+      // 4. Try only 0 URN
+      if (urn != null) {
+        return SimpleExtension.TypeAnchor.of(urn, type.getName());
+      }
+      // 5. Try only 0 URI
+      if (uri != null && resolveUrnFromUri(uri) != null) {
+        return SimpleExtension.TypeAnchor.of(resolveUrnFromUri(uri), type.getName());
+      }
+      throw new IllegalStateException(
+          String.format(
+              "All resolution strategies failed for URI %s and URN %s (perhaps a URI <-> URN mapping was not registered during the migration) ",
+              uri, urn));
+    }
 
     public Builder from(Plan plan) {
-      return from(plan.getExtensionUrnsList(), plan.getExtensionsList());
+      return from(
+          plan.getExtensionUrnsList(), plan.getExtensionUrisList(), plan.getExtensionsList());
     }
 
     public Builder from(ExtendedExpression extendedExpression) {
       return from(
-          extendedExpression.getExtensionUrnsList(), extendedExpression.getExtensionsList());
+          extendedExpression.getExtensionUrnsList(),
+          extendedExpression.getExtensionUrisList(),
+          extendedExpression.getExtensionsList());
     }
 
     private Builder from(
         List<SimpleExtensionURN> simpleExtensionURNs,
+        List<io.substrait.proto.SimpleExtensionURI> simpleExtensionURIs,
         List<SimpleExtensionDeclaration> simpleExtensionDeclarations) {
       Map<Integer, String> urnMap = new HashMap<>();
+      Map<Integer, String> uriMap = new HashMap<>();
+
       // Handle URN format
       for (SimpleExtensionURN extension : simpleExtensionURNs) {
         urnMap.put(extension.getExtensionUrnAnchor(), extension.getUrn());
+      }
+
+      // Handle deprecated URI format
+      for (io.substrait.proto.SimpleExtensionURI extension : simpleExtensionURIs) {
+        uriMap.put(extension.getExtensionUriAnchor(), extension.getUri());
       }
 
       // Add all functions used in plan to the functionMap
@@ -54,14 +209,7 @@ public class ImmutableExtensionLookup extends AbstractExtensionLookup {
         }
         SimpleExtensionDeclaration.ExtensionFunction func = extension.getExtensionFunction();
         int reference = func.getFunctionAnchor();
-        String urn = urnMap.get(func.getExtensionUrnReference());
-        if (urn == null) {
-          throw new IllegalStateException(
-              "Could not find extension URN for function reference "
-                  + func.getExtensionUrnReference());
-        }
-        String name = func.getName();
-        SimpleExtension.FunctionAnchor anchor = SimpleExtension.FunctionAnchor.of(urn, name);
+        SimpleExtension.FunctionAnchor anchor = resolveFunctionAnchor(func, urnMap, uriMap);
         functionMap.put(reference, anchor);
       }
 
@@ -72,13 +220,7 @@ public class ImmutableExtensionLookup extends AbstractExtensionLookup {
         }
         SimpleExtensionDeclaration.ExtensionType type = extension.getExtensionType();
         int reference = type.getTypeAnchor();
-        String urn = urnMap.get(type.getExtensionUrnReference());
-        if (urn == null) {
-          throw new IllegalStateException(
-              "Could not find extension URN for type reference " + type.getExtensionUrnReference());
-        }
-        String name = type.getName();
-        SimpleExtension.TypeAnchor anchor = SimpleExtension.TypeAnchor.of(urn, name);
+        SimpleExtension.TypeAnchor anchor = resolveTypeAnchor(type, urnMap, uriMap);
         typeMap.put(reference, anchor);
       }
 

--- a/core/src/main/java/io/substrait/extension/ImmutableExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/ImmutableExtensionLookup.java
@@ -35,7 +35,7 @@ public class ImmutableExtensionLookup extends AbstractExtensionLookup {
     private final SimpleExtension.ExtensionCollection extensionCollection;
 
     public Builder() {
-      this.extensionCollection = SimpleExtension.loadDefaults();
+      this.extensionCollection = DefaultExtensionCatalog.DEFAULT_COLLECTION;
     }
 
     public Builder(SimpleExtension.ExtensionCollection extensionCollection) {

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -1,10 +1,10 @@
 package io.substrait.extension;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,8 +26,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Scanner;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -41,12 +44,25 @@ import org.slf4j.LoggerFactory;
 public class SimpleExtension {
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleExtension.class);
 
-  // Key for looking up URI in InjectableValues
-  public static final String URI_LOCATOR_KEY = "uri";
+  // Key for looking up URN in InjectableValues
+  public static final String URN_LOCATOR_KEY = "urn";
 
-  private static ObjectMapper objectMapper(String namespace) {
+  private static final Predicate<String> URN_CHECKER =
+      Pattern.compile("^extension:[^:]+:[^:]+$").asPredicate();
+
+  private static void validateUrn(String urn) {
+    if (urn == null || urn.trim().isEmpty()) {
+      throw new IllegalArgumentException("URN cannot be null or empty");
+    }
+    if (!URN_CHECKER.test(urn)) {
+      throw new IllegalArgumentException(
+          "URN must follow format 'extension:<namespace>:<name>', got: " + urn);
+    }
+  }
+
+  private static ObjectMapper objectMapper(String urn) {
     InjectableValues.Std iv = new InjectableValues.Std();
-    iv.addValue(URI_LOCATOR_KEY, namespace);
+    iv.addValue(URN_LOCATOR_KEY, urn);
 
     return new ObjectMapper(new YAMLFactory())
         .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
@@ -184,25 +200,22 @@ public class SimpleExtension {
   }
 
   public interface Anchor {
-    String namespace();
+    String urn();
 
     String key();
   }
 
   @Value.Immutable
   public interface FunctionAnchor extends Anchor {
-    static FunctionAnchor of(String namespace, String key) {
-      return ImmutableSimpleExtension.FunctionAnchor.builder()
-          .namespace(namespace)
-          .key(key)
-          .build();
+    static FunctionAnchor of(String urn, String key) {
+      return ImmutableSimpleExtension.FunctionAnchor.builder().urn(urn).key(key).build();
     }
   }
 
   @Value.Immutable
   public interface TypeAnchor extends Anchor {
-    static TypeAnchor of(String namespace, String name) {
-      return ImmutableSimpleExtension.TypeAnchor.builder().namespace(namespace).key(name).build();
+    static TypeAnchor of(String urn, String name) {
+      return ImmutableSimpleExtension.TypeAnchor.builder().urn(urn).key(name).build();
     }
   }
 
@@ -226,7 +239,7 @@ public class SimpleExtension {
 
   public abstract static class Function {
     private final Supplier<FunctionAnchor> anchorSupplier =
-        Util.memoize(() -> FunctionAnchor.of(uri(), key()));
+        Util.memoize(() -> FunctionAnchor.of(urn(), key()));
     private final Supplier<String> keySupplier = Util.memoize(() -> constructKey(name(), args()));
     private final Supplier<List<Argument>> requiredArgsSupplier =
         Util.memoize(
@@ -241,8 +254,8 @@ public class SimpleExtension {
     }
 
     @Value.Default
-    public String uri() {
-      // we can't use null detection here since we initially construct this without a uri, then
+    public String urn() {
+      // we can't use null detection here since we initially construct this without a urn, then
       // resolve later.
       return "";
     }
@@ -366,8 +379,8 @@ public class SimpleExtension {
 
     public abstract List<ScalarFunctionVariant> impls();
 
-    public Stream<ScalarFunctionVariant> resolve(String uri) {
-      return impls().stream().map(f -> f.resolve(uri, name(), description()));
+    public Stream<ScalarFunctionVariant> resolve(String urn) {
+      return impls().stream().map(f -> f.resolve(urn, name(), description()));
     }
   }
 
@@ -375,9 +388,9 @@ public class SimpleExtension {
   @JsonSerialize(as = ImmutableSimpleExtension.ScalarFunctionVariant.class)
   @Value.Immutable
   public abstract static class ScalarFunctionVariant extends Function {
-    public ScalarFunctionVariant resolve(String uri, String name, String description) {
+    public ScalarFunctionVariant resolve(String urn, String name, String description) {
       return ImmutableSimpleExtension.ScalarFunctionVariant.builder()
-          .uri(uri)
+          .urn(urn)
           .name(name)
           .description(description)
           .nullability(nullability())
@@ -402,8 +415,8 @@ public class SimpleExtension {
 
     public abstract List<AggregateFunctionVariant> impls();
 
-    public Stream<AggregateFunctionVariant> resolve(String uri) {
-      return impls().stream().map(f -> f.resolve(uri, name(), description()));
+    public Stream<AggregateFunctionVariant> resolve(String urn) {
+      return impls().stream().map(f -> f.resolve(urn, name(), description()));
     }
   }
 
@@ -419,8 +432,8 @@ public class SimpleExtension {
 
     public abstract List<WindowFunctionVariant> impls();
 
-    public Stream<WindowFunctionVariant> resolve(String uri) {
-      return impls().stream().map(f -> f.resolve(uri, name(), description()));
+    public Stream<WindowFunctionVariant> resolve(String urn) {
+      return impls().stream().map(f -> f.resolve(urn, name(), description()));
     }
 
     public static ImmutableSimpleExtension.WindowFunction.Builder builder() {
@@ -446,9 +459,9 @@ public class SimpleExtension {
     @Nullable
     public abstract TypeExpression intermediate();
 
-    AggregateFunctionVariant resolve(String uri, String name, String description) {
+    AggregateFunctionVariant resolve(String urn, String name, String description) {
       return ImmutableSimpleExtension.AggregateFunctionVariant.builder()
-          .uri(uri)
+          .urn(urn)
           .name(name)
           .description(description)
           .nullability(nullability())
@@ -488,9 +501,9 @@ public class SimpleExtension {
       return super.toString();
     }
 
-    WindowFunctionVariant resolve(String uri, String name, String description) {
+    WindowFunctionVariant resolve(String urn, String name, String description) {
       return ImmutableSimpleExtension.WindowFunctionVariant.builder()
-          .uri(uri)
+          .urn(urn)
           .name(name)
           .description(description)
           .nullability(nullability())
@@ -515,12 +528,12 @@ public class SimpleExtension {
   @Value.Immutable
   public abstract static class Type {
     private final Supplier<TypeAnchor> anchorSupplier =
-        Util.memoize(() -> TypeAnchor.of(uri(), name()));
+        Util.memoize(() -> TypeAnchor.of(urn(), name()));
 
     public abstract String name();
 
-    @JacksonInject(SimpleExtension.URI_LOCATOR_KEY)
-    public abstract String uri();
+    @JacksonInject(SimpleExtension.URN_LOCATOR_KEY)
+    public abstract String urn();
 
     // TODO: Handle conversion of structure object to Named Struct representation
     protected abstract Optional<Object> structure();
@@ -532,10 +545,14 @@ public class SimpleExtension {
 
   @JsonDeserialize(as = ImmutableSimpleExtension.ExtensionSignatures.class)
   @JsonSerialize(as = ImmutableSimpleExtension.ExtensionSignatures.class)
+  @JsonIgnoreProperties(ignoreUnknown = true)
   @Value.Immutable
   public abstract static class ExtensionSignatures {
     @JsonProperty("types")
     public abstract List<Type> types();
+
+    @JsonProperty("urn")
+    public abstract String urn();
 
     @JsonProperty("scalar_functions")
     public abstract List<ScalarFunction> scalars();
@@ -553,27 +570,27 @@ public class SimpleExtension {
           + (windows() == null ? 0 : windows().size());
     }
 
-    public Stream<SimpleExtension.Function> resolve(String uri) {
+    public Stream<SimpleExtension.Function> resolve(String urn) {
       return Stream.concat(
           Stream.concat(
-              scalars() == null ? Stream.of() : scalars().stream().flatMap(f -> f.resolve(uri)),
+              scalars() == null ? Stream.of() : scalars().stream().flatMap(f -> f.resolve(urn)),
               aggregates() == null
                   ? Stream.of()
-                  : aggregates().stream().flatMap(f -> f.resolve(uri))),
-          windows() == null ? Stream.of() : windows().stream().flatMap(f -> f.resolve(uri)));
+                  : aggregates().stream().flatMap(f -> f.resolve(urn))),
+          windows() == null ? Stream.of() : windows().stream().flatMap(f -> f.resolve(urn)));
     }
   }
 
   @Value.Immutable
   public abstract static class ExtensionCollection {
-    private final Supplier<Set<String>> namespaceSupplier =
+    private final Supplier<Set<String>> urnSupplier =
         Util.memoize(
             () -> {
               return Stream.concat(
                       Stream.concat(
-                          scalarFunctions().stream().map(Function::uri),
-                          aggregateFunctions().stream().map(Function::uri)),
-                      windowFunctions().stream().map(Function::uri))
+                          scalarFunctions().stream().map(Function::urn),
+                          aggregateFunctions().stream().map(Function::urn)),
+                      windowFunctions().stream().map(Function::urn))
                   .collect(Collectors.toSet());
             });
 
@@ -627,11 +644,11 @@ public class SimpleExtension {
       if (type != null) {
         return type;
       }
-      checkNamespace(anchor.namespace());
+      checkUrn(anchor.urn());
       throw new IllegalArgumentException(
           String.format(
-              "Unexpected type with name %s. The namespace %s is loaded but no type with this name found.",
-              anchor.key(), anchor.namespace()));
+              "Unexpected type with name %s. The URN %s is loaded but no type with this name found.",
+              anchor.key(), anchor.urn()));
     }
 
     public ScalarFunctionVariant getScalarFunction(FunctionAnchor anchor) {
@@ -639,16 +656,16 @@ public class SimpleExtension {
       if (variant != null) {
         return variant;
       }
-      checkNamespace(anchor.namespace());
+      checkUrn(anchor.urn());
       throw new IllegalArgumentException(
           String.format(
-              "Unexpected scalar function with key %s. The namespace %s is loaded "
+              "Unexpected scalar function with key %s. The URN %s is loaded "
                   + "but no scalar function with this key found.",
-              anchor.key(), anchor.namespace()));
+              anchor.key(), anchor.urn()));
     }
 
-    private void checkNamespace(String name) {
-      if (namespaceSupplier.get().contains(name)) {
+    private void checkUrn(String name) {
+      if (urnSupplier.get().contains(name)) {
         return;
       }
 
@@ -665,12 +682,12 @@ public class SimpleExtension {
         return variant;
       }
 
-      checkNamespace(anchor.namespace());
+      checkUrn(anchor.urn());
       throw new IllegalArgumentException(
           String.format(
-              "Unexpected aggregate function with key %s. The namespace %s is loaded "
+              "Unexpected aggregate function with key %s. The URN %s is loaded "
                   + "but no aggregate function with this key was found.",
-              anchor.key(), anchor.namespace()));
+              anchor.key(), anchor.urn()));
     }
 
     public WindowFunctionVariant getWindowFunction(FunctionAnchor anchor) {
@@ -678,12 +695,12 @@ public class SimpleExtension {
       if (variant != null) {
         return variant;
       }
-      checkNamespace(anchor.namespace());
+      checkUrn(anchor.urn());
       throw new IllegalArgumentException(
           String.format(
-              "Unexpected window aggregate function with key %s. The namespace %s is loaded "
+              "Unexpected window aggregate function with key %s. The URN %s is loaded "
                   + "but no window aggregate function with this key was found.",
-              anchor.key(), anchor.namespace()));
+              anchor.key(), anchor.urn()));
     }
 
     public ExtensionCollection merge(ExtensionCollection extensionCollection) {
@@ -710,7 +727,7 @@ public class SimpleExtension {
             .map(
                 path -> {
                   try (InputStream stream = ExtensionCollection.class.getResourceAsStream(path)) {
-                    return load(path, stream);
+                    return load(stream);
                   } catch (IOException e) {
                     throw new UncheckedIOException(e);
                   }
@@ -723,41 +740,51 @@ public class SimpleExtension {
     return complete;
   }
 
-  public static ExtensionCollection load(String namespace, String str) {
+  public static ExtensionCollection load(String content) {
     try {
-      ExtensionSignatures doc = objectMapper(namespace).readValue(str, ExtensionSignatures.class);
-      return buildExtensionCollection(namespace, doc);
-    } catch (JsonProcessingException e) {
+      // Parse with basic YAML mapper first to extract URN (if present)
+      ObjectMapper basicYamlMapper = new ObjectMapper(new YAMLFactory());
+      com.fasterxml.jackson.databind.JsonNode rootNode = basicYamlMapper.readTree(content);
+
+      // URN is required
+      com.fasterxml.jackson.databind.JsonNode urnNode = rootNode.get("urn");
+      if (urnNode == null) {
+        throw new IllegalArgumentException("Extension YAML file must contain a 'urn' field");
+      }
+      String urn = urnNode.asText();
+      validateUrn(urn);
+
+      // Then parse with URN-aware mapper
+      ExtensionSignatures doc = objectMapper(urn).readValue(content, ExtensionSignatures.class);
+      return buildExtensionCollection(urn, doc);
+    } catch (IOException e) {
       throw new IllegalStateException(e);
     }
   }
 
-  public static ExtensionCollection load(String namespace, InputStream stream) {
-    try {
-      ExtensionSignatures doc =
-          objectMapper(namespace).readValue(stream, ExtensionSignatures.class);
-      return buildExtensionCollection(namespace, doc);
-    } catch (RuntimeException ex) {
-      throw ex;
-    } catch (Exception ex) {
-      throw new IllegalStateException("Failure while parsing " + namespace, ex);
+  public static ExtensionCollection load(InputStream stream) {
+    try (Scanner scanner = new Scanner(stream)) {
+      scanner.useDelimiter("\\A");
+      String content = scanner.next();
+      return load(content);
     }
   }
 
   public static ExtensionCollection buildExtensionCollection(
-      String namespace, ExtensionSignatures extensionSignatures) {
+      String urn, ExtensionSignatures extensionSignatures) {
+    validateUrn(urn);
     List<ScalarFunctionVariant> scalarFunctionVariants =
         extensionSignatures.scalars().stream()
-            .flatMap(t -> t.resolve(namespace))
+            .flatMap(t -> t.resolve(urn))
             .collect(Collectors.toList());
 
     List<AggregateFunctionVariant> aggregateFunctionVariants =
         extensionSignatures.aggregates().stream()
-            .flatMap(t -> t.resolve(namespace))
+            .flatMap(t -> t.resolve(urn))
             .collect(Collectors.toList());
 
     Stream<WindowFunctionVariant> windowFunctionVariants =
-        extensionSignatures.windows().stream().flatMap(t -> t.resolve(namespace));
+        extensionSignatures.windows().stream().flatMap(t -> t.resolve(urn));
 
     // Aggregate functions can be used as Window Functions
     Stream<WindowFunctionVariant> windowAggFunctionVariants =
@@ -789,7 +816,13 @@ public class SimpleExtension {
         "Loaded {} aggregate functions and {} scalar functions from {}.",
         collection.aggregateFunctions().size(),
         collection.scalarFunctions().size(),
-        namespace);
+        extensionSignatures.urn());
     return collection;
+  }
+
+  public static ExtensionCollection buildExtensionCollection(
+      ExtensionSignatures extensionSignatures) {
+    String urn = extensionSignatures.urn();
+    return buildExtensionCollection(urn, extensionSignatures);
   }
 }

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -1,6 +1,7 @@
 package io.substrait.plan;
 
 import io.substrait.extension.ExtensionCollector;
+import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.Plan;
 import io.substrait.proto.PlanRel;
 import io.substrait.proto.Rel;
@@ -12,9 +13,22 @@ import java.util.List;
 /** Converts from {@link io.substrait.plan.Plan} to {@link io.substrait.proto.Plan} */
 public class PlanProtoConverter {
 
+  private final SimpleExtension.ExtensionCollection extensionCollection;
+
+  public PlanProtoConverter() {
+    this(SimpleExtension.loadDefaults());
+  }
+
+  public PlanProtoConverter(SimpleExtension.ExtensionCollection extensionCollection) {
+    if (extensionCollection == null) {
+      throw new IllegalArgumentException("ExtensionCollection is required");
+    }
+    this.extensionCollection = extensionCollection;
+  }
+
   public Plan toProto(io.substrait.plan.Plan plan) {
     List<PlanRel> planRels = new ArrayList<>();
-    ExtensionCollector functionCollector = new ExtensionCollector();
+    ExtensionCollector functionCollector = new ExtensionCollector(extensionCollection);
     for (io.substrait.plan.Plan.Root root : plan.getRoots()) {
       Rel input = new RelProtoConverter(functionCollector).toProto(root.getInput());
       planRels.add(

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -1,5 +1,6 @@
 package io.substrait.plan;
 
+import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.proto.Plan;
@@ -16,7 +17,7 @@ public class PlanProtoConverter {
   private final SimpleExtension.ExtensionCollection extensionCollection;
 
   public PlanProtoConverter() {
-    this(SimpleExtension.loadDefaults());
+    this(DefaultExtensionCatalog.DEFAULT_COLLECTION);
   }
 
   public PlanProtoConverter(SimpleExtension.ExtensionCollection extensionCollection) {

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -21,6 +21,9 @@ public class ProtoPlanConverter {
   }
 
   public ProtoPlanConverter(SimpleExtension.ExtensionCollection extensionCollection) {
+    if (extensionCollection == null) {
+      throw new IllegalArgumentException("ExtensionCollection is required");
+    }
     this.extensionCollection = extensionCollection;
   }
 
@@ -30,7 +33,8 @@ public class ProtoPlanConverter {
   }
 
   public Plan from(io.substrait.proto.Plan plan) {
-    ExtensionLookup functionLookup = ImmutableExtensionLookup.builder().from(plan).build();
+    ExtensionLookup functionLookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
     ProtoRelConverter relConverter = getProtoRelConverter(functionLookup);
     List<Plan.Root> roots = new ArrayList<>();
     for (PlanRel planRel : plan.getRelationsList()) {

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -44,7 +44,7 @@ public class Deserializers {
       String typeString = p.getValueAsString();
       try {
         String namespace =
-            (String) ctxt.findInjectableValue(SimpleExtension.URI_LOCATOR_KEY, null, null);
+            (String) ctxt.findInjectableValue(SimpleExtension.URN_LOCATOR_KEY, null, null);
         return TypeStringParser.parse(typeString, namespace, converter);
       } catch (Exception ex) {
         throw JsonMappingException.from(

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -389,7 +389,7 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   @Value.Immutable
   abstract class UserDefined implements Type {
 
-    public abstract String uri();
+    public abstract String urn();
 
     public abstract String name();
 

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -108,8 +108,8 @@ public class TypeCreator {
     return Type.Map.builder().nullable(nullable).key(key).value(value).build();
   }
 
-  public Type userDefined(String uri, String name) {
-    return Type.UserDefined.builder().nullable(nullable).uri(uri).name(name).build();
+  public Type userDefined(String urn, String name) {
+    return Type.UserDefined.builder().nullable(nullable).urn(urn).name(name).build();
   }
 
   public static TypeCreator of(boolean nullability) {

--- a/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
+++ b/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
@@ -16,16 +16,16 @@ public class TypeStringParser {
 
   private TypeStringParser() {}
 
-  public static Type parseSimple(String str, String namespace) {
-    return parse(str, namespace, ParseToPojo::type);
+  public static Type parseSimple(String str, String urn) {
+    return parse(str, urn, ParseToPojo::type);
   }
 
-  public static ParameterizedType parseParameterized(String str, String namespace) {
-    return parse(str, namespace, ParseToPojo::parameterizedType);
+  public static ParameterizedType parseParameterized(String str, String urn) {
+    return parse(str, urn, ParseToPojo::parameterizedType);
   }
 
-  public static TypeExpression parseExpression(String str, String namespace) {
-    return parse(str, namespace, ParseToPojo::typeExpression);
+  public static TypeExpression parseExpression(String str, String urn) {
+    return parse(str, urn, ParseToPojo::typeExpression);
   }
 
   private static SubstraitTypeParser.StartContext parse(String str) {
@@ -40,8 +40,8 @@ public class TypeStringParser {
   }
 
   public static <T> T parse(
-      String str, String namespace, BiFunction<String, SubstraitTypeParser.StartContext, T> func) {
-    return func.apply(namespace, parse(str));
+      String str, String urn, BiFunction<String, SubstraitTypeParser.StartContext, T> func) {
+    return func.apply(urn, parse(str));
   }
 
   public static TypeExpression parse(String str, ParseToPojo.Visitor visitor) {

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -164,7 +164,7 @@ abstract class BaseProtoConverter<T, I>
   @Override
   public final T visit(final Type.UserDefined expr) {
     int ref =
-        extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.uri(), expr.name()));
+        extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.urn(), expr.name()));
     return typeContainer(expr).userDefined(ref);
   }
 }

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -90,7 +90,7 @@ public class ProtoTypeConverter {
         {
           io.substrait.proto.Type.UserDefined userDefined = type.getUserDefined();
           SimpleExtension.Type t = lookup.getType(userDefined.getTypeReference(), extensions);
-          return n(userDefined.getNullability()).userDefined(t.uri(), t.name());
+          return n(userDefined.getNullability()).userDefined(t.urn(), t.name());
         }
       case USER_DEFINED_TYPE_REFERENCE:
         throw new UnsupportedOperationException("Unsupported user defined reference: " + type);

--- a/core/src/test/java/io/substrait/extension/ExtensionCollectionMergeTest.java
+++ b/core/src/test/java/io/substrait/extension/ExtensionCollectionMergeTest.java
@@ -1,0 +1,87 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ExtensionCollectionMergeTest {
+
+  @Test
+  public void testMergeCollectionsWithDifferentUriUrnMappings() {
+    String yaml1 =
+        "%YAML 1.2\n"
+            + "---\n"
+            + "urn: extension:ns1:collection1\n"
+            + "scalar_functions:\n"
+            + "  - name: func1\n"
+            + "    impls:\n"
+            + "      - args: []\n"
+            + "        return: boolean\n";
+
+    String yaml2 =
+        "%YAML 1.2\n"
+            + "---\n"
+            + "urn: extension:ns2:collection2\n"
+            + "scalar_functions:\n"
+            + "  - name: func2\n"
+            + "    impls:\n"
+            + "      - args: []\n"
+            + "        return: i32\n";
+
+    SimpleExtension.ExtensionCollection collection1 =
+        SimpleExtension.load("uri1://extensions", yaml1);
+    SimpleExtension.ExtensionCollection collection2 =
+        SimpleExtension.load("uri2://extensions", yaml2);
+
+    SimpleExtension.ExtensionCollection merged = collection1.merge(collection2);
+
+    assertEquals("extension:ns1:collection1", merged.getUrnFromUri("uri1://extensions"));
+    assertEquals("extension:ns2:collection2", merged.getUrnFromUri("uri2://extensions"));
+    assertEquals("uri1://extensions", merged.getUriFromUrn("extension:ns1:collection1"));
+    assertEquals("uri2://extensions", merged.getUriFromUrn("extension:ns2:collection2"));
+
+    assertTrue(merged.scalarFunctions().size() >= 2);
+  }
+
+  @Test
+  public void testMergeCollectionsWithIdenticalMappings() {
+    String yaml =
+        "%YAML 1.2\n"
+            + "---\n"
+            + "urn: extension:shared:extension\n"
+            + "scalar_functions:\n"
+            + "  - name: shared_func\n"
+            + "    impls:\n"
+            + "      - args: []\n"
+            + "        return: boolean\n";
+
+    SimpleExtension.ExtensionCollection collection1 = SimpleExtension.load("shared://uri", yaml);
+    SimpleExtension.ExtensionCollection collection2 = SimpleExtension.load("shared://uri", yaml);
+
+    SimpleExtension.ExtensionCollection merged =
+        assertDoesNotThrow(() -> collection1.merge(collection2));
+
+    assertEquals("extension:shared:extension", merged.getUrnFromUri("shared://uri"));
+    assertEquals("shared://uri", merged.getUriFromUrn("extension:shared:extension"));
+  }
+
+  @Test
+  public void testMergeCollectionsWithConflictingMappings() {
+    String yaml1 =
+        "%YAML 1.2\n" + "---\n" + "urn: extension:conflict:urn1\n" + "scalar_functions: []\n";
+
+    String yaml2 =
+        "%YAML 1.2\n" + "---\n" + "urn: extension:conflict:urn2\n" + "scalar_functions: []\n";
+
+    SimpleExtension.ExtensionCollection collection1 = SimpleExtension.load("conflict://uri", yaml1);
+    SimpleExtension.ExtensionCollection collection2 =
+        SimpleExtension.load("conflict://uri", yaml2); // Same URI, different URN
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> collection1.merge(collection2));
+    assertTrue(exception.getMessage().contains("Key already exists in map with different value"));
+  }
+}

--- a/core/src/test/java/io/substrait/extension/ExtensionCollectionUriUrnTest.java
+++ b/core/src/test/java/io/substrait/extension/ExtensionCollectionUriUrnTest.java
@@ -1,0 +1,60 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ExtensionCollectionUriUrnTest {
+
+  @Test
+  public void testHasUrnAndHasUri() {
+    String yamlContent =
+        "%YAML 1.2\n"
+            + "---\n"
+            + "urn: extension:test:exists\n"
+            + "scalar_functions:\n"
+            + "  - name: test_function\n";
+
+    SimpleExtension.ExtensionCollection collection =
+        SimpleExtension.load("file:///tmp/test.yaml", yamlContent);
+
+    assertTrue(collection.getUrnFromUri("file:///tmp/test.yaml") != null);
+    assertTrue(collection.getUriFromUrn("extension:test:exists") != null);
+    assertFalse(collection.getUrnFromUri("nonexistent://uri") != null);
+    assertFalse(collection.getUriFromUrn("extension:nonexistent:urn") != null);
+  }
+
+  @Test
+  public void testGetNonexistentMappings() {
+    String yamlContent =
+        "%YAML 1.2\n" + "---\n" + "urn: extension:test:minimal\n" + "scalar_functions: []\n";
+
+    SimpleExtension.ExtensionCollection collection =
+        SimpleExtension.load("minimal://extension", yamlContent);
+
+    assertNull(collection.getUrnFromUri("nonexistent://uri"));
+    assertNull(collection.getUriFromUrn("extension:nonexistent:urn"));
+  }
+
+  @Test
+  public void testEmptyUriThrowsException() {
+    String yamlContent =
+        "%YAML 1.2\n" + "---\n" + "urn: extension:test:empty\n" + "scalar_functions: []\n";
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> SimpleExtension.load("", yamlContent));
+    assertTrue(exception.getMessage().contains("URI cannot be null or empty"));
+  }
+
+  @Test
+  public void testNullUriThrowsException() {
+    String yamlContent =
+        "%YAML 1.2\n" + "---\n" + "urn: extension:test:null\n" + "scalar_functions: []\n";
+
+    // The system throws NPE when null is passed, which is expected behavior
+    assertThrows(IllegalArgumentException.class, () -> SimpleExtension.load(null, yamlContent));
+  }
+}

--- a/core/src/test/java/io/substrait/extension/ExtensionCollectorUriUrnTest.java
+++ b/core/src/test/java/io/substrait/extension/ExtensionCollectorUriUrnTest.java
@@ -1,0 +1,41 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.proto.Plan;
+import org.junit.jupiter.api.Test;
+
+public class ExtensionCollectorUriUrnTest {
+
+  @Test
+  public void testExtensionCollectorScalarFuncWithoutURI() {
+    String uri = "test://uri";
+    BidiMap<String, String> uriUrnMap = new BidiMap<String, String>();
+    uriUrnMap.put(uri, "extension:test:basic");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    ExtensionCollector collector = new ExtensionCollector(extensionCollection);
+
+    SimpleExtension.ScalarFunctionVariant func =
+        ImmutableSimpleExtension.ScalarFunctionVariant.builder()
+            .urn("extension:test:basic")
+            .name("test_func")
+            .returnType(io.substrait.function.TypeExpressionCreator.REQUIRED.BOOLEAN)
+            .build();
+
+    int functionRef = collector.getFunctionReference(func);
+    assertEquals(1, functionRef);
+
+    Plan.Builder planBuilder = Plan.newBuilder();
+    collector.addExtensionsToPlan(planBuilder);
+
+    Plan plan = planBuilder.build();
+    assertEquals(1, plan.getExtensionUrnsCount());
+    assertEquals("extension:test:basic", plan.getExtensionUrns(0).getUrn());
+
+    assertEquals(1, plan.getExtensionUrisCount());
+    assertEquals("test://uri", plan.getExtensionUris(0).getUri());
+  }
+}

--- a/core/src/test/java/io/substrait/extension/ImmutableExtensionLookupUriUrnTest.java
+++ b/core/src/test/java/io/substrait/extension/ImmutableExtensionLookupUriUrnTest.java
@@ -36,8 +36,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     // Test with no ExtensionCollection (no URI/URN mapping available)
     ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
 
-    assertEquals("extension:test:urn", lookup.getFunctionAnchor(1).urn());
-    assertEquals("test_func", lookup.getFunctionAnchor(1).key());
+    assertEquals("extension:test:urn", lookup.functionAnchorMap.get(1).urn());
+    assertEquals("test_func", lookup.functionAnchorMap.get(1).key());
   }
 
   @Test
@@ -72,8 +72,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:test:mapped", lookup.getFunctionAnchor(1).urn());
-    assertEquals("legacy_func", lookup.getFunctionAnchor(1).key());
+    assertEquals("extension:test:mapped", lookup.functionAnchorMap.get(1).urn());
+    assertEquals("legacy_func", lookup.functionAnchorMap.get(1).key());
   }
 
   @Test
@@ -105,7 +105,7 @@ public class ImmutableExtensionLookupUriUrnTest {
               ImmutableExtensionLookup.builder().from(plan).build();
             });
 
-    assertTrue(exception.getMessage().contains("All resolution strategies failed"));
+    assertTrue(exception.getMessage().contains("could not be resolved to a URN"));
     assertTrue(exception.getMessage().contains("http://example.com/unmapped"));
     assertTrue(exception.getMessage().contains("URI <-> URN mapping"));
   }
@@ -133,8 +133,8 @@ public class ImmutableExtensionLookupUriUrnTest {
               ImmutableExtensionLookup.builder().from(plan).build();
             });
 
-    assertTrue(exception.getMessage().contains("All resolution strategies failed"));
-    assertTrue(exception.getMessage().contains("null")); // Both URI and URN should be null
+    assertTrue(exception.getMessage().contains("no URN is registered at that anchor"));
+    assertTrue(exception.getMessage().contains("999")); // The missing anchor reference
   }
 
   // ==========================================================================
@@ -164,8 +164,8 @@ public class ImmutableExtensionLookupUriUrnTest {
 
     ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
 
-    assertEquals("extension:test:case1", lookup.getFunctionAnchor(1).urn());
-    assertEquals("case1_func", lookup.getFunctionAnchor(1).key());
+    assertEquals("extension:test:case1", lookup.functionAnchorMap.get(1).urn());
+    assertEquals("case1_func", lookup.functionAnchorMap.get(1).key());
   }
 
   @Test
@@ -198,8 +198,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:test:case2", lookup.getFunctionAnchor(1).urn());
-    assertEquals("case2_func", lookup.getFunctionAnchor(1).key());
+    assertEquals("extension:test:case2", lookup.functionAnchorMap.get(1).urn());
+    assertEquals("case2_func", lookup.functionAnchorMap.get(1).key());
   }
 
   @Test
@@ -244,8 +244,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:test:case3", lookup.getFunctionAnchor(1).urn());
-    assertEquals("case3_func", lookup.getFunctionAnchor(1).key());
+    assertEquals("extension:test:case3", lookup.functionAnchorMap.get(1).urn());
+    assertEquals("case3_func", lookup.functionAnchorMap.get(1).key());
   }
 
   @Test
@@ -322,8 +322,8 @@ public class ImmutableExtensionLookupUriUrnTest {
 
     ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
 
-    assertEquals("extension:test:case4", lookup.getFunctionAnchor(1).urn());
-    assertEquals("case4_func", lookup.getFunctionAnchor(1).key());
+    assertEquals("extension:test:case4", lookup.functionAnchorMap.get(1).urn());
+    assertEquals("case4_func", lookup.functionAnchorMap.get(1).key());
   }
 
   @Test
@@ -357,8 +357,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:test:case5", lookup.getFunctionAnchor(1).urn());
-    assertEquals("case5_func", lookup.getFunctionAnchor(1).key());
+    assertEquals("extension:test:case5", lookup.functionAnchorMap.get(1).urn());
+    assertEquals("case5_func", lookup.functionAnchorMap.get(1).key());
   }
 
   // ==========================================================================
@@ -388,8 +388,8 @@ public class ImmutableExtensionLookupUriUrnTest {
 
     ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
 
-    assertEquals("extension:test:case1", lookup.getTypeAnchor(1).urn());
-    assertEquals("case1_type", lookup.getTypeAnchor(1).key());
+    assertEquals("extension:test:case1", lookup.typeAnchorMap.get(1).urn());
+    assertEquals("case1_type", lookup.typeAnchorMap.get(1).key());
   }
 
   @Test
@@ -422,8 +422,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:test:case2", lookup.getTypeAnchor(1).urn());
-    assertEquals("case2_type", lookup.getTypeAnchor(1).key());
+    assertEquals("extension:test:case2", lookup.typeAnchorMap.get(1).urn());
+    assertEquals("case2_type", lookup.typeAnchorMap.get(1).key());
   }
 
   @Test
@@ -468,8 +468,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:test:case3", lookup.getTypeAnchor(1).urn());
-    assertEquals("case3_type", lookup.getTypeAnchor(1).key());
+    assertEquals("extension:test:case3", lookup.typeAnchorMap.get(1).urn());
+    assertEquals("case3_type", lookup.typeAnchorMap.get(1).key());
   }
 
   @Test
@@ -546,8 +546,8 @@ public class ImmutableExtensionLookupUriUrnTest {
 
     ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
 
-    assertEquals("extension:test:case4", lookup.getTypeAnchor(1).urn());
-    assertEquals("case4_type", lookup.getTypeAnchor(1).key());
+    assertEquals("extension:test:case4", lookup.typeAnchorMap.get(1).urn());
+    assertEquals("case4_type", lookup.typeAnchorMap.get(1).key());
   }
 
   @Test
@@ -581,8 +581,8 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:test:case5", lookup.getTypeAnchor(1).urn());
-    assertEquals("case5_type", lookup.getTypeAnchor(1).key());
+    assertEquals("extension:test:case5", lookup.typeAnchorMap.get(1).urn());
+    assertEquals("case5_type", lookup.typeAnchorMap.get(1).key());
   }
 
   @Test
@@ -615,7 +615,7 @@ public class ImmutableExtensionLookupUriUrnTest {
     ImmutableExtensionLookup lookup =
         ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
 
-    assertEquals("extension:types:mapped", lookup.getTypeAnchor(1).urn());
-    assertEquals("legacy_type", lookup.getTypeAnchor(1).key());
+    assertEquals("extension:types:mapped", lookup.typeAnchorMap.get(1).urn());
+    assertEquals("legacy_type", lookup.typeAnchorMap.get(1).key());
   }
 }

--- a/core/src/test/java/io/substrait/extension/ImmutableExtensionLookupUriUrnTest.java
+++ b/core/src/test/java/io/substrait/extension/ImmutableExtensionLookupUriUrnTest.java
@@ -1,0 +1,621 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.proto.Plan;
+import io.substrait.proto.SimpleExtensionDeclaration;
+import io.substrait.proto.SimpleExtensionURI;
+import io.substrait.proto.SimpleExtensionURN;
+import org.junit.jupiter.api.Test;
+
+public class ImmutableExtensionLookupUriUrnTest {
+
+  @Test
+  public void testUrnResolutionWorks() {
+    // Create URN-only plan (normal case)
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(1)
+            .setUrn("extension:test:urn")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("test_func")
+            .setExtensionUrnReference(1)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUrns(urnProto).addExtensions(decl).build();
+
+    // Test with no ExtensionCollection (no URI/URN mapping available)
+    ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
+
+    assertEquals("extension:test:urn", lookup.getFunctionAnchor(1).urn());
+    assertEquals("test_func", lookup.getFunctionAnchor(1).key());
+  }
+
+  @Test
+  public void testUriToUrnFallbackWorks() {
+    // Create an ExtensionCollection with URI/URN mapping
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/extensions/test", "extension:test:mapped");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    // Create URI-only plan (legacy case)
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(1)
+            .setUri("http://example.com/extensions/test")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("legacy_func")
+            .setExtensionUriReference(1) // References the URI anchor (deprecated field)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUris(uriProto).addExtensions(decl).build();
+
+    // Test with URI/URN mapping - should resolve URI to URN
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:test:mapped", lookup.getFunctionAnchor(1).urn());
+    assertEquals("legacy_func", lookup.getFunctionAnchor(1).key());
+  }
+
+  @Test
+  public void testUriWithoutMappingThrowsError() {
+    // Create URI-only plan without mapping
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(1)
+            .setUri("http://example.com/unmapped")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("unmapped_func")
+            .setExtensionUriReference(1) // References the URI anchor
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUris(uriProto).addExtensions(decl).build();
+
+    // Should throw error - URI present but no mapping available
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              ImmutableExtensionLookup.builder().from(plan).build();
+            });
+
+    assertTrue(exception.getMessage().contains("All resolution strategies failed"));
+    assertTrue(exception.getMessage().contains("http://example.com/unmapped"));
+    assertTrue(exception.getMessage().contains("URI <-> URN mapping"));
+  }
+
+  @Test
+  public void testMissingUrnAndUriThrowsError() {
+    // Create plan with missing URN/URI reference
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("missing_func")
+            .setExtensionUrnReference(999) // Non-existent reference
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensions(decl).build();
+
+    // Should throw error - neither URN nor URI found
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              ImmutableExtensionLookup.builder().from(plan).build();
+            });
+
+    assertTrue(exception.getMessage().contains("All resolution strategies failed"));
+    assertTrue(exception.getMessage().contains("null")); // Both URI and URN should be null
+  }
+
+  // ==========================================================================
+  // Simple tests for all 5 resolution cases - Functions
+  // ==========================================================================
+
+  @Test
+  public void testFunctionCase1_NonZeroUrnReference() {
+    // Case 1: Non-zero URN reference resolves
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(1)
+            .setUrn("extension:test:case1")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("case1_func")
+            .setExtensionUrnReference(1)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUrns(urnProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
+
+    assertEquals("extension:test:case1", lookup.getFunctionAnchor(1).urn());
+    assertEquals("case1_func", lookup.getFunctionAnchor(1).key());
+  }
+
+  @Test
+  public void testFunctionCase2_NonZeroUriReference() {
+    // Case 2: Non-zero URI reference resolves via mapping
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/case2", "extension:test:case2");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(1)
+            .setUri("http://example.com/case2")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("case2_func")
+            .setExtensionUriReference(1)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUris(uriProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:test:case2", lookup.getFunctionAnchor(1).urn());
+    assertEquals("case2_func", lookup.getFunctionAnchor(1).key());
+  }
+
+  @Test
+  public void testFunctionCase3_ZeroBothResolveConsistent() {
+    // Case 3: Both 0 references resolve to consistent URN
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/case3", "extension:test:case3");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(0)
+            .setUrn("extension:test:case3")
+            .build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(0)
+            .setUri("http://example.com/case3")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("case3_func")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan =
+        Plan.newBuilder()
+            .addExtensionUrns(urnProto)
+            .addExtensionUris(uriProto)
+            .addExtensions(decl)
+            .build();
+
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:test:case3", lookup.getFunctionAnchor(1).urn());
+    assertEquals("case3_func", lookup.getFunctionAnchor(1).key());
+  }
+
+  @Test
+  public void testFunctionCase3_ZeroBothResolveConflict() {
+    // Case 3: Both 0 references resolve but to different URNs - should throw
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/conflict", "extension:test:different");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(0)
+            .setUrn("extension:test:original")
+            .build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(0)
+            .setUri("http://example.com/conflict")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("conflict_func")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan =
+        Plan.newBuilder()
+            .addExtensionUrns(urnProto)
+            .addExtensionUris(uriProto)
+            .addExtensions(decl)
+            .build();
+
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+            });
+
+    assertTrue(exception.getMessage().contains("Conflicting URI/URN mapping"));
+    assertTrue(exception.getMessage().contains("These must be consistent"));
+  }
+
+  @Test
+  public void testFunctionCase4_ZeroUrnOnly() {
+    // Case 4: Only 0 URN reference resolves
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(0)
+            .setUrn("extension:test:case4")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("case4_func")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUrns(urnProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
+
+    assertEquals("extension:test:case4", lookup.getFunctionAnchor(1).urn());
+    assertEquals("case4_func", lookup.getFunctionAnchor(1).key());
+  }
+
+  @Test
+  public void testFunctionCase5_ZeroUriOnly() {
+    // Case 5: Only 0 URI reference resolves
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/case5", "extension:test:case5");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(0)
+            .setUri("http://example.com/case5")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionFunction func =
+        SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
+            .setFunctionAnchor(1)
+            .setName("case5_func")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionFunction(func).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUris(uriProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:test:case5", lookup.getFunctionAnchor(1).urn());
+    assertEquals("case5_func", lookup.getFunctionAnchor(1).key());
+  }
+
+  // ==========================================================================
+  // Simple tests for all 5 resolution cases - Types
+  // ==========================================================================
+
+  @Test
+  public void testTypeCase1_NonZeroUrnReference() {
+    // Case 1: Non-zero URN reference resolves
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(1)
+            .setUrn("extension:test:case1")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionType type =
+        SimpleExtensionDeclaration.ExtensionType.newBuilder()
+            .setTypeAnchor(1)
+            .setName("case1_type")
+            .setExtensionUrnReference(1)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionType(type).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUrns(urnProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
+
+    assertEquals("extension:test:case1", lookup.getTypeAnchor(1).urn());
+    assertEquals("case1_type", lookup.getTypeAnchor(1).key());
+  }
+
+  @Test
+  public void testTypeCase2_NonZeroUriReference() {
+    // Case 2: Non-zero URI reference resolves via mapping
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/case2", "extension:test:case2");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(1)
+            .setUri("http://example.com/case2")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionType type =
+        SimpleExtensionDeclaration.ExtensionType.newBuilder()
+            .setTypeAnchor(1)
+            .setName("case2_type")
+            .setExtensionUriReference(1)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionType(type).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUris(uriProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:test:case2", lookup.getTypeAnchor(1).urn());
+    assertEquals("case2_type", lookup.getTypeAnchor(1).key());
+  }
+
+  @Test
+  public void testTypeCase3_ZeroBothResolveConsistent() {
+    // Case 3: Both 0 references resolve to consistent URN
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/case3", "extension:test:case3");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(0)
+            .setUrn("extension:test:case3")
+            .build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(0)
+            .setUri("http://example.com/case3")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionType type =
+        SimpleExtensionDeclaration.ExtensionType.newBuilder()
+            .setTypeAnchor(1)
+            .setName("case3_type")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionType(type).build();
+
+    Plan plan =
+        Plan.newBuilder()
+            .addExtensionUrns(urnProto)
+            .addExtensionUris(uriProto)
+            .addExtensions(decl)
+            .build();
+
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:test:case3", lookup.getTypeAnchor(1).urn());
+    assertEquals("case3_type", lookup.getTypeAnchor(1).key());
+  }
+
+  @Test
+  public void testTypeCase3_ZeroBothResolveConflict() {
+    // Case 3: Both 0 references resolve but to different URNs - should throw
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/conflict", "extension:test:different");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(0)
+            .setUrn("extension:test:original")
+            .build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(0)
+            .setUri("http://example.com/conflict")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionType type =
+        SimpleExtensionDeclaration.ExtensionType.newBuilder()
+            .setTypeAnchor(1)
+            .setName("conflict_type")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionType(type).build();
+
+    Plan plan =
+        Plan.newBuilder()
+            .addExtensionUrns(urnProto)
+            .addExtensionUris(uriProto)
+            .addExtensions(decl)
+            .build();
+
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+            });
+
+    assertTrue(exception.getMessage().contains("Conflicting URI/URN mapping"));
+    assertTrue(exception.getMessage().contains("These must be consistent"));
+  }
+
+  @Test
+  public void testTypeCase4_ZeroUrnOnly() {
+    // Case 4: Only 0 URN reference resolves
+    SimpleExtensionURN urnProto =
+        SimpleExtensionURN.newBuilder()
+            .setExtensionUrnAnchor(0)
+            .setUrn("extension:test:case4")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionType type =
+        SimpleExtensionDeclaration.ExtensionType.newBuilder()
+            .setTypeAnchor(1)
+            .setName("case4_type")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionType(type).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUrns(urnProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup = ImmutableExtensionLookup.builder().from(plan).build();
+
+    assertEquals("extension:test:case4", lookup.getTypeAnchor(1).urn());
+    assertEquals("case4_type", lookup.getTypeAnchor(1).key());
+  }
+
+  @Test
+  public void testTypeCase5_ZeroUriOnly() {
+    // Case 5: Only 0 URI reference resolves
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/case5", "extension:test:case5");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(0)
+            .setUri("http://example.com/case5")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionType type =
+        SimpleExtensionDeclaration.ExtensionType.newBuilder()
+            .setTypeAnchor(1)
+            .setName("case5_type")
+            .setExtensionUrnReference(0)
+            .setExtensionUriReference(0)
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionType(type).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUris(uriProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:test:case5", lookup.getTypeAnchor(1).urn());
+    assertEquals("case5_type", lookup.getTypeAnchor(1).key());
+  }
+
+  @Test
+  public void testTypeUriToUrnFallbackWorks() {
+    // Test the same logic but for types instead of functions
+    BidiMap<String, String> uriUrnMap = new BidiMap<>();
+    uriUrnMap.put("http://example.com/types/test", "extension:types:mapped");
+
+    SimpleExtension.ExtensionCollection extensionCollection =
+        SimpleExtension.ExtensionCollection.builder().uriUrnMap(uriUrnMap).build();
+
+    SimpleExtensionURI uriProto =
+        SimpleExtensionURI.newBuilder()
+            .setExtensionUriAnchor(1)
+            .setUri("http://example.com/types/test")
+            .build();
+
+    SimpleExtensionDeclaration.ExtensionType type =
+        SimpleExtensionDeclaration.ExtensionType.newBuilder()
+            .setTypeAnchor(1)
+            .setName("legacy_type")
+            .setExtensionUriReference(1) // References the URI anchor
+            .build();
+
+    SimpleExtensionDeclaration decl =
+        SimpleExtensionDeclaration.newBuilder().setExtensionType(type).build();
+
+    Plan plan = Plan.newBuilder().addExtensionUris(uriProto).addExtensions(decl).build();
+
+    ImmutableExtensionLookup lookup =
+        ImmutableExtensionLookup.builder(extensionCollection).from(plan).build();
+
+    assertEquals("extension:types:mapped", lookup.getTypeAnchor(1).urn());
+    assertEquals("legacy_type", lookup.getTypeAnchor(1).key());
+  }
+}

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -32,9 +32,9 @@ public class TypeExtensionTest {
   final SimpleExtension.ExtensionCollection extensionCollection;
 
   {
-    InputStream inputStream =
-        this.getClass().getResourceAsStream("/extensions/custom_extensions.yaml");
-    extensionCollection = SimpleExtension.load(inputStream);
+    String path = "/extensions/custom_extensions.yaml";
+    InputStream inputStream = this.getClass().getResourceAsStream(path);
+    extensionCollection = SimpleExtension.load(path, inputStream);
   }
 
   final SubstraitBuilder b = new SubstraitBuilder(extensionCollection);

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -28,13 +28,13 @@ public class TypeExtensionTest {
 
   static final TypeCreator R = TypeCreator.of(false);
 
-  static final String NAMESPACE = "/custom_extensions";
+  static final String NAMESPACE = "extension:test:custom_extensions";
   final SimpleExtension.ExtensionCollection extensionCollection;
 
   {
     InputStream inputStream =
         this.getClass().getResourceAsStream("/extensions/custom_extensions.yaml");
-    extensionCollection = SimpleExtension.load(NAMESPACE, inputStream);
+    extensionCollection = SimpleExtension.load(inputStream);
   }
 
   final SubstraitBuilder b = new SubstraitBuilder(extensionCollection);

--- a/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
+++ b/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
@@ -1,0 +1,110 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.util.JsonFormat;
+import io.substrait.plan.PlanProtoConverter;
+import io.substrait.plan.ProtoPlanConverter;
+import io.substrait.proto.Plan;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests demonstrating the full URI/URN migration workflow: 1. Consume plans with mixed
+ * URI/URN references 2. Convert proto -> POJO using ImmutableExtensionLookup with URI/URN mapping
+ * 3. Convert POJO -> proto using PlanProtoConverter 4. Verify output contains proper
+ * extensioninformation
+ */
+public class UriUrnMigrationEndToEndTest {
+
+  private final SimpleExtension.ExtensionCollection defaultExtensions =
+      SimpleExtension.loadDefaults();
+
+  /** Load a proto Plan from a JSON resource file using JsonFormat */
+  private Plan loadPlanFromJson(String resourcePath) throws IOException {
+    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+      if (inputStream == null) {
+        throw new IOException("Resource not found: " + resourcePath);
+      }
+
+      String jsonContent =
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+              .lines()
+              .collect(Collectors.joining("\n"));
+
+      Plan.Builder planBuilder = Plan.newBuilder();
+      JsonFormat.parser().merge(jsonContent, planBuilder);
+      return planBuilder.build();
+    }
+  }
+
+  @Test
+  public void testUriUrnMigrationEndToEnd() throws IOException {
+
+    // List of (inputPath, expectedPath, extensionCollection) tuples
+    List<String[]> testCases =
+        Arrays.asList(
+            new String[] {
+              "uri-urn-migration/uri-only-input-plan.json",
+              "uri-urn-migration/uri-only-expected-plan.json"
+            },
+            new String[] {
+              "uri-urn-migration/complex-input-plan.json",
+              "uri-urn-migration/complex-expected-plan.json"
+            },
+            new String[] {
+              "uri-urn-migration/urn-only-input-plan.json",
+              "uri-urn-migration/urn-only-expected-plan.json"
+            },
+            new String[] {
+              "uri-urn-migration/mixed-partial-coverage-input-plan.json",
+              "uri-urn-migration/mixed-partial-coverage-expected-plan.json"
+            },
+            new String[] {
+              "uri-urn-migration/zero-urn-resolution-input-plan.json",
+              "uri-urn-migration/zero-urn-resolution-expected-plan.json"
+            });
+
+    for (String[] testCase : testCases) {
+      String inputPath = testCase[0];
+      String expectedPath = testCase[1];
+
+      Plan inputPlan = loadPlanFromJson(inputPath);
+      Plan expectedPlan = loadPlanFromJson(expectedPath);
+
+      ProtoPlanConverter protoToPojo = new ProtoPlanConverter(defaultExtensions);
+      io.substrait.plan.Plan pojoPlan = protoToPojo.from(inputPlan);
+
+      PlanProtoConverter pojoToProto = new PlanProtoConverter(defaultExtensions);
+      Plan actualPlan = pojoToProto.toProto(pojoPlan);
+
+      assertEquals(expectedPlan, actualPlan);
+    }
+  }
+
+  @Test
+  public void testUnresolvableUriThrowsException() throws IOException {
+    Plan inputPlan = loadPlanFromJson("uri-urn-migration/unresolvable-uri-plan.json");
+
+    ProtoPlanConverter protoToPojo = new ProtoPlanConverter(defaultExtensions);
+
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class,
+            () -> {
+              protoToPojo.from(inputPlan);
+            });
+
+    assertTrue(exception.getMessage().contains("All resolution strategies failed"));
+    assertTrue(exception.getMessage().contains("/functions_nonexistent.yaml"));
+  }
+}

--- a/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
+++ b/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
@@ -26,9 +26,6 @@ import org.junit.jupiter.api.Test;
  */
 public class UriUrnMigrationEndToEndTest {
 
-  private final SimpleExtension.ExtensionCollection defaultExtensions =
-      SimpleExtension.loadDefaults();
-
   /** Load a proto Plan from a JSON resource file using JsonFormat */
   private Plan loadPlanFromJson(String resourcePath) throws IOException {
     try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
@@ -81,10 +78,12 @@ public class UriUrnMigrationEndToEndTest {
       Plan inputPlan = loadPlanFromJson(inputPath);
       Plan expectedPlan = loadPlanFromJson(expectedPath);
 
-      ProtoPlanConverter protoToPojo = new ProtoPlanConverter(defaultExtensions);
+      ProtoPlanConverter protoToPojo =
+          new ProtoPlanConverter(DefaultExtensionCatalog.DEFAULT_COLLECTION);
       io.substrait.plan.Plan pojoPlan = protoToPojo.from(inputPlan);
 
-      PlanProtoConverter pojoToProto = new PlanProtoConverter(defaultExtensions);
+      PlanProtoConverter pojoToProto =
+          new PlanProtoConverter(DefaultExtensionCatalog.DEFAULT_COLLECTION);
       Plan actualPlan = pojoToProto.toProto(pojoPlan);
 
       assertEquals(expectedPlan, actualPlan);
@@ -95,7 +94,8 @@ public class UriUrnMigrationEndToEndTest {
   public void testUnresolvableUriThrowsException() throws IOException {
     Plan inputPlan = loadPlanFromJson("uri-urn-migration/unresolvable-uri-plan.json");
 
-    ProtoPlanConverter protoToPojo = new ProtoPlanConverter(defaultExtensions);
+    ProtoPlanConverter protoToPojo =
+        new ProtoPlanConverter(DefaultExtensionCatalog.DEFAULT_COLLECTION);
 
     IllegalStateException exception =
         assertThrows(

--- a/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
+++ b/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
@@ -104,7 +104,7 @@ public class UriUrnMigrationEndToEndTest {
               protoToPojo.from(inputPlan);
             });
 
-    assertTrue(exception.getMessage().contains("All resolution strategies failed"));
+    assertTrue(exception.getMessage().contains("could not be resolved to a URN"));
     assertTrue(exception.getMessage().contains("/functions_nonexistent.yaml"));
   }
 }

--- a/core/src/test/java/io/substrait/extension/UrnValidationTest.java
+++ b/core/src/test/java/io/substrait/extension/UrnValidationTest.java
@@ -1,6 +1,7 @@
 package io.substrait.extension;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -12,7 +13,8 @@ public class UrnValidationTest {
   public void testMissingUrnThrowsException() {
     String yamlWithoutUrn = "%YAML 1.2\n" + "---\n" + "scalar_functions:\n" + "  - name: test\n";
     IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> SimpleExtension.load(yamlWithoutUrn));
+        assertThrows(
+            IllegalArgumentException.class, () -> SimpleExtension.load("some/uri", yamlWithoutUrn));
     assertTrue(exception.getMessage().contains("Extension YAML file must contain a 'urn' field"));
   }
 
@@ -26,7 +28,8 @@ public class UrnValidationTest {
             + "  - name: test\n";
     IllegalArgumentException exception =
         assertThrows(
-            IllegalArgumentException.class, () -> SimpleExtension.load(yamlWithInvalidUrn));
+            IllegalArgumentException.class,
+            () -> SimpleExtension.load("some/uri", yamlWithInvalidUrn));
     assertTrue(
         exception.getMessage().contains("URN must follow format 'extension:<namespace>:<name>'"));
   }
@@ -39,6 +42,19 @@ public class UrnValidationTest {
             + "urn: extension:test:valid\n"
             + "scalar_functions:\n"
             + "  - name: test\n";
-    assertDoesNotThrow(() -> SimpleExtension.load(yamlWithValidUrn));
+    assertDoesNotThrow(() -> SimpleExtension.load("some/uri", yamlWithValidUrn));
+  }
+
+  @Test
+  public void testUriUrnMapIsPopulated() {
+    String yamlWithValidUrn =
+        "%YAML 1.2\n"
+            + "---\n"
+            + "urn: extension:test:valid\n"
+            + "scalar_functions:\n"
+            + "  - name: test\n";
+    SimpleExtension.ExtensionCollection collection =
+        SimpleExtension.load("test://uri", yamlWithValidUrn);
+    assertEquals("extension:test:valid", collection.getUrnFromUri("test://uri"));
   }
 }

--- a/core/src/test/java/io/substrait/extension/UrnValidationTest.java
+++ b/core/src/test/java/io/substrait/extension/UrnValidationTest.java
@@ -1,0 +1,44 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class UrnValidationTest {
+
+  @Test
+  public void testMissingUrnThrowsException() {
+    String yamlWithoutUrn = "%YAML 1.2\n" + "---\n" + "scalar_functions:\n" + "  - name: test\n";
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> SimpleExtension.load(yamlWithoutUrn));
+    assertTrue(exception.getMessage().contains("Extension YAML file must contain a 'urn' field"));
+  }
+
+  @Test
+  public void testInvalidUrnFormatThrowsException() {
+    String yamlWithInvalidUrn =
+        "%YAML 1.2\n"
+            + "---\n"
+            + "urn: invalid:format\n"
+            + "scalar_functions:\n"
+            + "  - name: test\n";
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class, () -> SimpleExtension.load(yamlWithInvalidUrn));
+    assertTrue(
+        exception.getMessage().contains("URN must follow format 'extension:<namespace>:<name>'"));
+  }
+
+  @Test
+  public void testValidUrnWorks() {
+    String yamlWithValidUrn =
+        "%YAML 1.2\n"
+            + "---\n"
+            + "urn: extension:test:valid\n"
+            + "scalar_functions:\n"
+            + "  - name: test\n";
+    assertDoesNotThrow(() -> SimpleExtension.load(yamlWithValidUrn));
+  }
+}

--- a/core/src/test/resources/extensions/custom_extensions.yaml
+++ b/core/src/test/resources/extensions/custom_extensions.yaml
@@ -1,5 +1,6 @@
 %YAML 1.2
 ---
+urn: extension:test:custom_extensions
 types:
   - name: "customType1"
   - name: "customType2"

--- a/core/src/test/resources/uri-urn-migration/complex-expected-plan.json
+++ b/core/src/test/resources/uri-urn-migration/complex-expected-plan.json
@@ -1,0 +1,162 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }
+  ],
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 2,
+        "name": "subtract:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 3,
+        "name": "multiply:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "direct": {}
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "dummy"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 2,
+                          "outputType": {
+                            "i32": {
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 5
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 10
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 7
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 3,
+                  "outputType": {
+                    "i32": {
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 3
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 4
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "result",
+          "product"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/complex-input-plan.json
+++ b/core/src/test/resources/uri-urn-migration/complex-input-plan.json
@@ -1,0 +1,148 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    },
+    {
+      "extensionUriAnchor": 0,
+      "uri": "/functions_string.yaml"
+    }
+  ],
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 2,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 2,
+        "name": "subtract:i32_i32",
+        "extensionUrnReference": 2
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 3,
+        "name": "multiply:i32_i32",
+        "extensionUriReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [
+                    "dummy"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {}
+                      }
+                    ]
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {}
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 2,
+                          "outputType": {
+                            "i32": {}
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 5
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 10
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 7
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "scalarFunction": {
+                  "functionReference": 3,
+                  "outputType": {
+                    "i32": {}
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 3
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 4
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "result",
+          "product"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/mixed-partial-coverage-expected-plan.json
+++ b/core/src/test/resources/uri-urn-migration/mixed-partial-coverage-expected-plan.json
@@ -1,0 +1,133 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }
+  ],
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 2,
+        "name": "multiply:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "direct": {}
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "x",
+                    "y"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 10
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 2,
+                          "outputType": {
+                            "i32": {
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 2
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 3
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "calculation"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/mixed-partial-coverage-input-plan.json
+++ b/core/src/test/resources/uri-urn-migration/mixed-partial-coverage-input-plan.json
@@ -1,0 +1,110 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 2,
+        "name": "multiply:i32_i32",
+        "extensionUriReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [
+                    "x",
+                    "y"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {}
+                      },
+                      {
+                        "i32": {}
+                      }
+                    ]
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {}
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 10
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 2,
+                          "outputType": {
+                            "i32": {}
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 2
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 3
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "calculation"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/unresolvable-uri-plan.json
+++ b/core/src/test/resources/uri-urn-migration/unresolvable-uri-plan.json
@@ -1,0 +1,73 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_nonexistent.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "nonexistent_function:i32_i32",
+        "extensionUriReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [
+                    "dummy"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {}
+                      }
+                    ]
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {}
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 7
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "result"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/uri-only-expected-plan.json
+++ b/core/src/test/resources/uri-urn-migration/uri-only-expected-plan.json
@@ -1,0 +1,98 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }
+  ],
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "direct": {}
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "dummy"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 7
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 3
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "result"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/uri-only-input-plan.json
+++ b/core/src/test/resources/uri-urn-migration/uri-only-input-plan.json
@@ -1,0 +1,80 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [
+                    "dummy"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {}
+                      }
+                    ]
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {}
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 7
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 3
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "result"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/urn-only-expected-plan.json
+++ b/core/src/test/resources/uri-urn-migration/urn-only-expected-plan.json
@@ -1,0 +1,133 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }
+  ],
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 2,
+        "name": "subtract:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "direct": {}
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "value1",
+                    "value2"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "numbers"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 2,
+                          "outputType": {
+                            "i32": {
+                              "nullability": "NULLABILITY_REQUIRED"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 20
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 5
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 10
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "sum_result"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/urn-only-input-plan.json
+++ b/core/src/test/resources/uri-urn-migration/urn-only-input-plan.json
@@ -1,0 +1,110 @@
+{
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUrnReference": 1
+      }
+    },
+    {
+      "extensionFunction": {
+        "functionAnchor": 2,
+        "name": "subtract:i32_i32",
+        "extensionUrnReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [
+                    "value1",
+                    "value2"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {}
+                      },
+                      {
+                        "i32": {}
+                      }
+                    ]
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "numbers"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {}
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "scalarFunction": {
+                          "functionReference": 2,
+                          "outputType": {
+                            "i32": {}
+                          },
+                          "arguments": [
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 20
+                                }
+                              }
+                            },
+                            {
+                              "value": {
+                                "literal": {
+                                  "i32": 5
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 10
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "sum_result"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/zero-urn-resolution-expected-plan.json
+++ b/core/src/test/resources/uri-urn-migration/zero-urn-resolution-expected-plan.json
@@ -1,0 +1,104 @@
+{
+  "extensionUris": [
+    {
+      "extensionUriAnchor": 1,
+      "uri": "/functions_arithmetic.yaml"
+    }
+  ],
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 1,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 1,
+        "extensionUrnReference": 1
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "common": {
+              "direct": {}
+            },
+            "input": {
+              "read": {
+                "common": {
+                  "direct": {}
+                },
+                "baseSchema": {
+                  "names": [
+                    "a",
+                    "b"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      },
+                      {
+                        "i32": {
+                          "nullability": "NULLABILITY_REQUIRED"
+                        }
+                      }
+                    ],
+                    "nullability": "NULLABILITY_REQUIRED"
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {
+                      "nullability": "NULLABILITY_REQUIRED"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 10
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 5
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "sum_result"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/core/src/test/resources/uri-urn-migration/zero-urn-resolution-input-plan.json
+++ b/core/src/test/resources/uri-urn-migration/zero-urn-resolution-input-plan.json
@@ -1,0 +1,85 @@
+{
+  "extensionUrns": [
+    {
+      "extensionUrnAnchor": 0,
+      "urn": "extension:io.substrait:functions_arithmetic"
+    }
+  ],
+  "extensions": [
+    {
+      "extensionFunction": {
+        "functionAnchor": 1,
+        "name": "add:i32_i32",
+        "extensionUriReference": 0,
+        "extensionUrnReference": 0
+      }
+    }
+  ],
+  "relations": [
+    {
+      "root": {
+        "input": {
+          "project": {
+            "input": {
+              "read": {
+                "baseSchema": {
+                  "names": [
+                    "a",
+                    "b"
+                  ],
+                  "struct": {
+                    "types": [
+                      {
+                        "i32": {}
+                      },
+                      {
+                        "i32": {}
+                      }
+                    ]
+                  }
+                },
+                "namedTable": {
+                  "names": [
+                    "test_table"
+                  ]
+                }
+              }
+            },
+            "expressions": [
+              {
+                "scalarFunction": {
+                  "functionReference": 1,
+                  "outputType": {
+                    "i32": {}
+                  },
+                  "arguments": [
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 10
+                        }
+                      }
+                    },
+                    {
+                      "value": {
+                        "literal": {
+                          "i32": 5
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "names": [
+          "sum_result"
+        ]
+      }
+    }
+  ],
+  "version": {
+    "minorNumber": 75
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -71,7 +71,7 @@ public class CallConverters {
               Type.UserDefined t = (Type.UserDefined) type;
 
               return Expression.UserDefinedLiteral.builder()
-                  .uri(t.uri())
+                  .urn(t.urn())
                   .name(t.name())
                   .value(literal.value())
                   .build();

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/EnumConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/EnumConverter.java
@@ -185,7 +185,7 @@ public class EnumConverter {
 
   private static ArgAnchor argAnchor(SimpleExtension.Function fnDef, int argIdx) {
     return new ArgAnchor(
-        SimpleExtension.FunctionAnchor.of(fnDef.getAnchor().namespace(), fnDef.getAnchor().key()),
+        SimpleExtension.FunctionAnchor.of(fnDef.getAnchor().urn(), fnDef.getAnchor().key()),
         argIdx);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -37,7 +37,7 @@ class CalciteTypeTest extends CalciteObjs {
             @Nullable
             @Override
             public RelDataType toCalcite(Type.UserDefined type) {
-              if (type.uri().equals(uTypeURI) && type.name().equals(uTypeName)) {
+              if (type.urn().equals(uTypeURI) && type.name().equals(uTypeName)) {
                 return uTypeFactory.createCalcite(type.nullable());
               }
               return null;

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -56,7 +56,7 @@ public class CustomFunctionTest extends PlanTestBase {
 
   // Load custom extension into an ExtensionCollection
   static final SimpleExtension.ExtensionCollection extensionCollection =
-      SimpleExtension.load(FUNCTIONS_CUSTOM);
+      SimpleExtension.load("custom.yaml", FUNCTIONS_CUSTOM);
 
   final SubstraitBuilder b = new SubstraitBuilder(extensionCollection);
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 public class CustomFunctionTest extends PlanTestBase {
 
   // Define custom functions in a "functions_custom.yaml" extension
-  static final String NAMESPACE = "/functions_custom";
+  static final String NAMESPACE = "extension:substrait:functions_custom";
   static final String FUNCTIONS_CUSTOM;
 
   static {
@@ -56,7 +56,7 @@ public class CustomFunctionTest extends PlanTestBase {
 
   // Load custom extension into an ExtensionCollection
   static final SimpleExtension.ExtensionCollection extensionCollection =
-      SimpleExtension.load("/functions_custom", FUNCTIONS_CUSTOM);
+      SimpleExtension.load(FUNCTIONS_CUSTOM);
 
   final SubstraitBuilder b = new SubstraitBuilder(extensionCollection);
 
@@ -84,7 +84,7 @@ public class CustomFunctionTest extends PlanTestBase {
         @Nullable
         @Override
         public RelDataType toCalcite(Type.UserDefined type) {
-          if (type.uri().equals(NAMESPACE)) {
+          if (type.urn().equals(NAMESPACE)) {
             if (type.name().equals(aTypeName)) {
               return aTypeFactory.createCalcite(type.nullable());
             }

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -37,7 +37,7 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
   private static final String COUNT_DISTINCT_SUBBQUERY =
       "select\n"
           + "  count(distinct l.l_orderkey),\n"
-          + "  count(distinct l.l_orderkey) + 1,\n"
+          + " count(distinct l.l_orderkey) + 1,\n"
           + "  sum(l.l_extendedprice * (1 - l.l_discount)) as revenue,\n"
           + "  o.o_orderdate,\n"
           + "  count(distinct o.o_shippriority)\n"

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -29,9 +29,10 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
 
   public static SimpleExtension.FunctionAnchor APPROX_COUNT_DISTINCT =
       SimpleExtension.FunctionAnchor.of(
-          "/functions_aggregate_approx.yaml", "approx_count_distinct:any");
+          "extension:io.substrait:functions_aggregate_approx", "approx_count_distinct:any");
   public static SimpleExtension.FunctionAnchor COUNT =
-      SimpleExtension.FunctionAnchor.of("/functions_aggregate_generic.yaml", "count:any");
+      SimpleExtension.FunctionAnchor.of(
+          "extension:io.substrait:functions_aggregate_generic", "count:any");
 
   private static final String COUNT_DISTINCT_SUBBQUERY =
       "select\n"

--- a/isthmus/src/test/java/io/substrait/isthmus/utils/UserTypeFactory.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/utils/UserTypeFactory.java
@@ -13,11 +13,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
 public class UserTypeFactory {
   private final InnerType N;
   private final InnerType R;
-  private final String uri;
+  private final String urn;
   private final String name;
 
-  public UserTypeFactory(String uri, String name) {
-    this.uri = uri;
+  public UserTypeFactory(String urn, String name) {
+    this.urn = urn;
     this.name = name;
     this.N = new InnerType(true, name);
     this.R = new InnerType(false, name);
@@ -32,7 +32,7 @@ public class UserTypeFactory {
   }
 
   public Type createSubstrait(boolean nullable) {
-    return TypeCreator.of(nullable).userDefined(uri, name);
+    return TypeCreator.of(nullable).userDefined(urn, name);
   }
 
   public boolean isTypeFromFactory(RelDataType type) {

--- a/isthmus/src/test/resources/extensions/functions_custom.yaml
+++ b/isthmus/src/test/resources/extensions/functions_custom.yaml
@@ -1,5 +1,6 @@
 %YAML 1.2
 ---
+urn: extension:substrait:functions_custom
 types:
   - name: "a_type"
   - name: "b_type"

--- a/spark/src/main/resources/spark.yml
+++ b/spark/src/main/resources/spark.yml
@@ -14,6 +14,7 @@
 # limitations under the License.
 %YAML 1.2
 ---
+urn: extension:substrait:spark
 scalar_functions:
   - name: add
     description: >-

--- a/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
+++ b/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
@@ -29,7 +29,7 @@ object SparkExtension {
   final val file = "/spark.yml"
 
   private val SparkImpls: SimpleExtension.ExtensionCollection =
-    SimpleExtension.load(getClass.getResourceAsStream(file))
+    SimpleExtension.load(file, getClass.getResourceAsStream(file))
 
   private val EXTENSION_COLLECTION: SimpleExtension.ExtensionCollection =
     DefaultExtensionCatalog.DEFAULT_COLLECTION;

--- a/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
+++ b/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
@@ -26,10 +26,10 @@ import scala.collection.JavaConverters
 import scala.collection.JavaConverters.asScalaBufferConverter
 
 object SparkExtension {
-  final val uri = "/spark.yml"
+  final val file = "/spark.yml"
 
   private val SparkImpls: SimpleExtension.ExtensionCollection =
-    SimpleExtension.load(Collections.singletonList(uri))
+    SimpleExtension.load(getClass.getResourceAsStream(file))
 
   private val EXTENSION_COLLECTION: SimpleExtension.ExtensionCollection =
     DefaultExtensionCatalog.DEFAULT_COLLECTION;


### PR DESCRIPTION
Closes #509

# Summary
This PR introduces a graceful URI -> URN migration. [See this issue in the upstream substrait repo for details.](https://github.com/substrait-io/substrait/issues/856)

The gist is that the library will be able to accept both uris and urns in input plans, but will always output both when producing plans. This is facilitated by keeping a map internally which tracks a bijection between uris and urns. A later PR will drop support for uris. 

This is a breaking change. 

# Recommended PR Review Strategy
To facilitate easier review of this PR, I suggest breaking the commits into three chunks.
1. [The first chunk](https://github.com/substrait-io/substrait-java/pull/522/files/3ee953c67c92e8e648109aba9c04e2f5de36e9ea) fully migrates uri to urn without any graceful handling. You can think about this as the target state of the repository once the migration is fully complete. The only other feature added here is to add some light urn validation (to ensure the format is `extension:<organization>:<name>`).
2. [The second chunk](https://github.com/substrait-io/substrait-java/pull/522/commits/c7639b3743e1e42d10239fbeaf17dbfc469576f0) just moves the internally used `BidiMap` to another file so that it can later be used to internally track the uri<->urn mapping. 
3. [The third chunk](https://github.com/substrait-io/substrait-java/pull/522/commits/7fd825a1156ad01cd57b4f3b863a9f68199159fe) is the real meat of the PR. This is where the uri<->urn mapping is introduced. This mapping is maintained internally inside of an `ExtensionCollection` which is now passed around as an argument to many of the classes.


# Testing
To robustly test this implementation, a new (light) test framework is introduced, where input plans are presented in JSON format. They then undergo proto -> POJO -> proto roundtrip conversion, and then compared with an expected JSON-format plan. The goal here is to ensure that regardless of the usage of uri or urn in input, both are present in the output. As an example, see [here](https://github.com/substrait-io/substrait-java/pull/522/files#diff-43e9e368b020f892836b0692ef4c9718986b247dcbf2d6d69876e8465008efd5) for an expected input plan in which only uri is used, and [here](https://github.com/substrait-io/substrait-java/pull/522/files#diff-e9db7e43d0728fd92da47f961b476991251ff88dca0b4bd1c88aa4ccc43ccd81) for the expected output plan, in which both uri and urn are present.

This test framework may be dropped once the migration is complete, though perhaps it will prove useful for other reasons. 