### PR TITLE
build: config option renamed in spotless 8 plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ allprojects {
         googleJavaFormat()
         removeUnusedImports()
         trimTrailingWhitespace()
-        removeWildcardImports()
+        forbidWildcardImports()
       }
     }
   }


### PR DESCRIPTION
The `removeWildcardImports` configuration option was renamed to `forbidWildcardImports` in v8.0.0 of the Spotless Gradle plugin.

https://github.com/diffplug/spotless/releases/tag/gradle/8.0.0

This change uses the new named to avoid a build time warning.