### PR TITLE
build: run git submodule before protoc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,13 +25,6 @@ dependencies {
   compileOnly(libs.immutables.annotations)
 }
 
-val submodulesUpdate by
-  tasks.registering(Exec::class) {
-    group = "Build Setup"
-    description = "Updates (and inits) substrait git submodule"
-    commandLine = listOf("git", "submodule", "update", "--init", "--recursive")
-  }
-
 allprojects {
   repositories { mavenCentral() }
 
@@ -39,7 +32,6 @@ allprojects {
     useJUnitPlatform()
     testLogging { exceptionFormat = TestExceptionFormat.FULL }
   }
-  tasks.withType<JavaCompile> { dependsOn(submodulesUpdate) }
 
   group = "io.substrait"
   version = "${version}"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -278,4 +278,15 @@ tasks.named<AntlrTask>("generateGrammarSource") {
     layout.buildDirectory.dir("generated/sources/antlr/main/java/io/substrait/type").get().asFile
 }
 
-protobuf { protoc { artifact = "com.google.protobuf:protoc:" + libs.protoc.get().getVersion() } }
+val submodulesUpdate by
+  tasks.registering(Exec::class) {
+    group = "Build Setup"
+    description = "Updates (and inits) substrait git submodule"
+    commandLine = listOf("git", "submodule", "update", "--init", "--recursive")
+    workingDir = rootProject.projectDir
+  }
+
+protobuf {
+  generateProtoTasks { all().configureEach { dependsOn(submodulesUpdate) } }
+  protoc { artifact = "com.google.protobuf:protoc:" + libs.protoc.get().getVersion() }
+}


### PR DESCRIPTION
Currently, the git submodule update task is run too late since it only runs before `JavaCompile` but it is already needed by the Gradle protobuf plugin for protoc to generate the proto Java classes. This causes the first build after freshly cloning the repo to fail with:

```
> Task :isthmus:generateTestProto FAILED

> Task :submodulesUpdate
Submodule 'spec' (https://github.com/substrait-io/substrait.git) registered for path 'substrait'
Cloning into '/Users/par/git/substrait-java3/substrait'...
Submodule path 'substrait': checked out '793c64ba26e337c22f5e91b658be58b1eea7efd3'

Build substrait FAILURE reason:                                
    Execution failed for task ':isthmus:generateTestProto':
        protoc: stdout: . stderr: substrait/algebra.proto: File not found.
        substrait/type.proto: File not found.
        substrait.proto:5:1: Import "substrait/algebra.proto" was not found or had errors.
        substrait.proto:6:1: Import "substrait/type.proto" was not found or had errors.
        substrait.proto:13:3: "substrait.Expression.Literal" is not defined.
```

This PR changes the Gradle task dependency for the protoc tasks to depend on the git submodule update task which removes this failure on a fresh clone.