### PR TITLE
build(isthmus-cli): use classgraph instead of reflections

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 antlr = "4.13.2"
 calcite = "1.40.0"
+classgraph = "4.8.181"
 commons-lang3 = "[3.18.0,)"
 graal = "25.0.0"
 graal-plugin = "0.11.0"
@@ -16,7 +17,6 @@ junit = "5.13.4"
 picocli = "4.7.7"
 protobuf-plugin = "0.9.5"
 protobuf = "3.25.8"
-reflections = "0.10.2"
 scala-library = "2.12.20"
 scalatest = "3.2.19"
 scalatestplus-junit5 = "3.2.19.0"
@@ -32,6 +32,7 @@ calcite-babel = { module = "org.apache.calcite:calcite-babel", version.ref = "ca
 calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calcite" }
 calcite-plus = { module = "org.apache.calcite:calcite-plus", version.ref = "calcite" }
 calcite-server = { module = "org.apache.calcite:calcite-server", version.ref = "calcite" }
+classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graal" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
@@ -56,7 +57,6 @@ picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "pico
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
 protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf" }
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
-reflections = { module = "org.reflections:reflections", version.ref = "reflections"}
 scala-library = { module = "org.scala-lang:scala-library", version.ref = "scala-library" }
 scalatest = { module = "org.scalatest:scalatest_2.12", version.ref = "scalatest" }
 scalatestplus-junit5 = { module = "org.scalatestplus:junit-5-13_2.12", version.ref = "scalatestplus-junit5" }

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.platform.launcher)
-  implementation(libs.reflections)
+  implementation(libs.classgraph)
   implementation(libs.guava)
   compileOnly(libs.graal.sdk)
   implementation(libs.picocli)
@@ -62,6 +62,10 @@ graalvmNative {
       buildArgs.add("--features=io.substrait.isthmus.cli.RegisterAtRuntime")
       buildArgs.add("--future-defaults=all")
       jvmArgs.add("--sun-misc-unsafe-memory-access=allow")
+
+      // Capture the classpath since native-compile erases it
+      val isthmusClasspath = classpath.joinToString(":")
+      jvmArgs.add("-Disthmus.classpath=$isthmusClasspath")
     }
   }
 }


### PR DESCRIPTION
org.reflections:reflections is used to locate classes that need to be registered during the GraalVM native image build process. Reflections is no longer maintained and there have been no releases since 2021.

This change replaces reflections with classgraph, which is actively maintained.

Closes #532