### PR TITLE
build: use nmcp instead of jreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,5 +101,5 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}
-          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_KEY }}
+          MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}
+          MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,12 +9,25 @@ plugins {
   id("idea")
   alias(libs.plugins.gradle.extensions)
   alias(libs.plugins.spotless)
-  alias(libs.plugins.jreleaser) apply false
+  alias(libs.plugins.nmcp).apply(false)
+  alias(libs.plugins.nmcp.aggregation)
 }
 
 repositories { mavenCentral() }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
+
+nmcpAggregation {
+  centralPortal {
+    username =
+      System.getenv("MAVENCENTRAL_USERNAME").takeUnless { it.isNullOrEmpty() }
+        ?: extra["MAVENCENTRAL_USERNAME"].toString()
+    password =
+      System.getenv("MAVENCENTRAL_PASSWORD").takeUnless { it.isNullOrEmpty() }
+        ?: extra["MAVENCENTRAL_PASSWORD"].toString()
+    publishingType = "AUTOMATIC"
+  }
+}
 
 dependencies {
   testImplementation(platform(libs.junit.bom))
@@ -23,6 +36,10 @@ dependencies {
   implementation(libs.slf4j.api)
   annotationProcessor(libs.immutables.value)
   compileOnly(libs.immutables.annotations)
+
+  nmcpAggregation(project(":core"))
+  nmcpAggregation(project(":spark"))
+  nmcpAggregation(project(":isthmus"))
 }
 
 allprojects {
@@ -44,7 +61,7 @@ allprojects {
         googleJavaFormat()
         removeUnusedImports()
         trimTrailingWhitespace()
-        removeWildcardImports()
+        forbidWildcardImports()
       }
     }
   }

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -7,5 +7,4 @@ set -euo pipefail
 git submodule foreach 'git fetch --unshallow || true'
 
 ./gradlew clean
-./gradlew publishAllPublicationsToStagingRepository
-./gradlew jreleaserDeploy
+./gradlew publishAggregationToCentralPortal

--- a/ci/release/sanity.sh
+++ b/ci/release/sanity.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export GPG_TTY=$(tty)
 
 echo "Validate Central Publisher API credentials."
-BEARER=$(printf "%s:%s" "${SONATYPE_USER}" "${SONATYPE_PASSWORD}" | base64)
+BEARER=$(printf "%s:%s" "${MAVENCENTRAL_USERNAME}" "${MAVENCENTRAL_PASSWORD}" | base64)
 CODE=$(curl --request GET 'https://central.sonatype.com/api/v1/publisher/published?namespace=io.substrait&name=core&version=0.1.0' --header 'accept: application/json' --header "Authorization: Bearer ${BEARER}" -sSL -w '%{http_code}' -o /dev/null)
 if [[ "$CODE" =~ ^2 ]]; then
     echo "Central Publisher API credentials configured successfully."

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@ SIGNING_PASSWORD = password
 SIGNING_KEY = ALDqwcArqwfsdqweqwrwr
 
 #sonatype credentials
-SONATYPE_USER = admin
-SONATYPE_PASSWORD = password
+MAVENCENTRAL_USERNAME = admin
+MAVENCENTRAL_PASSWORD = password

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,10 +10,10 @@ guava = "33.5.0-jre"
 httpclient5 = "5.5.1"
 immutables = "2.11.4"
 jackson = "2.20.0"
-jreleaser = "1.20.0"
 json-smart = "2.6.0"
 jspecify = "1.0.0"
 junit = "5.13.4"
+nmcp = "1.2.0"
 picocli = "4.7.7"
 protobuf-plugin = "0.9.5"
 protobuf = "3.25.8"
@@ -23,7 +23,7 @@ scalatestplus-junit5 = "3.2.19.0"
 shadow = "9.2.2"
 slf4j = "2.0.17"
 spark = "3.4.4"
-spotless = "7.2.1"
+spotless = "8.0.0"
 
 [libraries]
 antlr4 = { module = "org.antlr:antlr4", version.ref = "antlr" }
@@ -73,7 +73,8 @@ jackson = [ "jackson-databind", "jackson-annotations", "jackson-datatype-jdk8", 
 [plugins]
 graal = { id = "org.graalvm.buildtools.native", version.ref = "graal-plugin" }
 gradle-extensions = { id = "com.github.vlsi.gradle-extensions", version.ref = "gradle-extensions" }
-jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+nmcp = { id = "com.gradleup.nmcp", version.ref = "nmcp" }
+nmcp-aggregation = { id = "com.gradleup.nmcp.aggregation", version.ref = "nmcp" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
   alias(libs.plugins.shadow)
   alias(libs.plugins.spotless)
   alias(libs.plugins.protobuf)
-  alias(libs.plugins.jreleaser)
+  alias(libs.plugins.nmcp)
   id("substrait.java-conventions")
 }
 
@@ -52,16 +52,12 @@ publishing {
       val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
       url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
     }
-    maven {
-      name = "staging"
-      url = stagingRepositoryUrl
-    }
   }
 }
 
 signing {
   setRequired({
-    gradle.taskGraph.hasTask(":${project.name}:publishMaven-publishPublicationToStagingRepository")
+    gradle.taskGraph.hasTask(":${project.name}:publishMaven-publishPublicationToNmcpRepository")
   })
   val signingKeyId =
     System.getenv("SIGNING_KEY_ID").takeUnless { it.isNullOrEmpty() }
@@ -74,23 +70,6 @@ signing {
       ?: extra["SIGNING_KEY"].toString()
   useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
   sign(publishing.publications["maven-publish"])
-}
-
-jreleaser {
-  gitRootSearch = true
-  deploy {
-    maven {
-      mavenCentral {
-        register("sonatype") {
-          active = org.jreleaser.model.Active.ALWAYS
-          url = "https://central.sonatype.com/api/v1/publisher"
-          sign = false
-          stagingRepository(file(stagingRepositoryUrl).toString())
-        }
-      }
-    }
-  }
-  release { github { enabled = false } }
 }
 
 java {


### PR DESCRIPTION
There are two issues with JReleaser:

1. It is a heavy weight plugin designed to manage the entire release process, similar to semantic-release, and it is only used for publishing to the Maven Central Publisher API.
2. Transitive dependency conflicts between Spotless 8.x and JRelease 1.x plugins prevent them being used together.

This change replaces JReleaser with the GradleUp nmcp (New Maven Central Publishing) plugin. This is a much lighter weight plugin that only provides capability to publish to Maven Central.

This change also updates Spotless to 8.0.0 since conflicts with JReleaser no longer occur.