### PR TITLE
build: replace jreleaser with gradle-maven-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GIT_AUTHOR_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           GIT_COMMITTER_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}
-          JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,12 +4,11 @@ import com.github.vlsi.gradle.dsl.configureEach
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
-  `maven-publish`
   id("java")
   id("idea")
   alias(libs.plugins.gradle.extensions)
   alias(libs.plugins.spotless)
-  alias(libs.plugins.jreleaser) apply false
+  alias(libs.plugins.publish).apply(false)
 }
 
 repositories { mavenCentral() }
@@ -44,7 +43,7 @@ allprojects {
         googleJavaFormat()
         removeUnusedImports()
         trimTrailingWhitespace()
-        removeWildcardImports()
+        forbidWildcardImports()
       }
     }
   }

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -7,5 +7,4 @@ set -euo pipefail
 git submodule foreach 'git fetch --unshallow || true'
 
 ./gradlew clean
-./gradlew publishAllPublicationsToStagingRepository
-./gradlew jreleaserDeploy
+./gradlew publishAndReleaseToMavenCentral

--- a/ci/release/sanity.sh
+++ b/ci/release/sanity.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export GPG_TTY=$(tty)
 
 echo "Validate Central Publisher API credentials."
-BEARER=$(printf "%s:%s" "${SONATYPE_USER}" "${SONATYPE_PASSWORD}" | base64)
+BEARER=$(printf "%s:%s" "${ORG_GRADLE_PROJECT_mavenCentralUsername}" "${ORG_GRADLE_PROJECT_mavenCentralPassword}" | base64)
 CODE=$(curl --request GET 'https://central.sonatype.com/api/v1/publisher/published?namespace=io.substrait&name=core&version=0.1.0' --header 'accept: application/json' --header "Authorization: Bearer ${BEARER}" -sSL -w '%{http_code}' -o /dev/null)
 if [[ "$CODE" =~ ^2 ]]; then
     echo "Central Publisher API credentials configured successfully."
@@ -14,12 +14,12 @@ else
 fi
 
 echo "Validate Signing Private/Public Key."
-echo "$SIGNING_KEY" | base64 --decode | gpg --batch --import
-KEYGRIP=`gpg --with-keygrip --list-secret-keys $SIGNING_KEY_ID | sed -e '/^ *Keygrip  *=  */!d;s///;q'`
+echo "$ORG_GRADLE_PROJECT_signingInMemoryKey" | base64 --decode | gpg --batch --import
+KEYGRIP=`gpg --with-keygrip --list-secret-keys $ORG_GRADLE_PROJECT_signingInMemoryKeyId | sed -e '/^ *Keygrip  *=  */!d;s///;q'`
 echo "allow-preset-passphrase"  >> ~/.gnupg/gpg-agent.conf
 gpgconf --reload gpg-agent
-"$(gpgconf --list-dirs libexecdir)/gpg-preset-passphrase" -c $KEYGRIP <<< $SIGNING_PASSWORD
-echo "test_use_passphrase_from_cache" | gpg -q --batch --status-fd 1 --sign --local-user $SIGNING_KEY_ID --passphrase-fd 0 > /dev/null
+"$(gpgconf --list-dirs libexecdir)/gpg-preset-passphrase" -c $KEYGRIP <<< $ORG_GRADLE_PROJECT_signingInMemoryKeyPassword
+echo "test_use_passphrase_from_cache" | gpg -q --batch --status-fd 1 --sign --local-user $ORG_GRADLE_PROJECT_signingInMemoryKeyId --passphrase-fd 0 > /dev/null
 if [ $? -eq 0 ]; then
   echo "Public/Private Key Credentials configured successfully."
 else

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import org.gradle.api.provider.ValueSource
@@ -6,51 +8,17 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 import org.slf4j.LoggerFactory
 
 plugins {
-  `maven-publish`
-  signing
   id("java-library")
   id("idea")
   id("antlr")
   alias(libs.plugins.protobuf)
   alias(libs.plugins.spotless)
   alias(libs.plugins.shadow)
-  alias(libs.plugins.jreleaser)
+  alias(libs.plugins.publish)
   id("substrait.java-conventions")
 }
 
-val stagingRepositoryUrl = uri(layout.buildDirectory.dir("staging-deploy"))
-
 publishing {
-  publications {
-    create<MavenPublication>("maven-publish") {
-      from(components["java"])
-
-      pom {
-        name.set("Substrait Java")
-        description.set(
-          "Create a well-defined, cross-language specification for data compute operations"
-        )
-        url.set("https://github.com/substrait-io/substrait-java")
-        licenses {
-          license {
-            name.set("The Apache License, Version 2.0")
-            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-          }
-        }
-        developers {
-          developer {
-            id = "vbarua"
-            name = "Victor Barua"
-          }
-        }
-        scm {
-          connection.set("scm:git:git://github.com:substrait-io/substrait-java.git")
-          developerConnection.set("scm:git:ssh://github.com:substrait-io/substrait-java")
-          url.set("https://github.com/substrait-io/substrait-java/")
-        }
-      }
-    }
-  }
   repositories {
     maven {
       name = "local"
@@ -58,45 +26,45 @@ publishing {
       val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
       url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
     }
-    maven {
-      name = "staging"
-      url = stagingRepositoryUrl
-    }
   }
 }
 
-signing {
-  setRequired({
-    gradle.taskGraph.hasTask(":${project.name}:publishMaven-publishPublicationToStagingRepository")
-  })
-  val signingKeyId =
-    System.getenv("SIGNING_KEY_ID").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY_ID"].toString()
-  val signingPassword =
-    System.getenv("SIGNING_PASSWORD").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_PASSWORD"].toString()
-  val signingKey =
-    System.getenv("SIGNING_KEY").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY"].toString()
-  useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-  sign(publishing.publications["maven-publish"])
-}
+mavenPublishing {
+  publishToMavenCentral()
+  signAllPublications()
 
-jreleaser {
-  gitRootSearch = true
-  deploy {
-    maven {
-      mavenCentral {
-        register("sonatype") {
-          active = org.jreleaser.model.Active.ALWAYS
-          url = "https://central.sonatype.com/api/v1/publisher"
-          sign = false
-          stagingRepository(file(stagingRepositoryUrl).toString())
-        }
+  configure(JavaLibrary(javadocJar = JavadocJar.Javadoc(), sourcesJar = true))
+
+  coordinates(
+    groupId = project.group.toString(),
+    artifactId = project.name,
+    version = project.version.toString(),
+  )
+
+  pom {
+    name.set("Substrait Java")
+    description.set(
+      "Create a well-defined, cross-language specification for data compute operations"
+    )
+    url.set("https://github.com/substrait-io/substrait-java")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
       }
     }
+    developers {
+      developer {
+        id = "vbarua"
+        name = "Victor Barua"
+      }
+    }
+    scm {
+      connection.set("scm:git:git://github.com:substrait-io/substrait-java.git")
+      developerConnection.set("scm:git:ssh://github.com:substrait-io/substrait-java")
+      url.set("https://github.com/substrait-io/substrait-java/")
+    }
   }
-  release { github { enabled = false } }
 }
 
 // This allows specifying deps to be shadowed so that they don't get included in the POM file
@@ -230,11 +198,6 @@ tasks {
 
 // Set the release instead of using a Java 8 toolchain since ANTLR requires Java 11+ to run
 tasks.withType<JavaCompile>().configureEach { options.release = 8 }
-
-java {
-  withJavadocJar()
-  withSourcesJar()
-}
 
 configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,20 +10,20 @@ guava = "33.5.0-jre"
 httpclient5 = "5.5.1"
 immutables = "2.11.4"
 jackson = "2.20.0"
-jreleaser = "1.20.0"
 json-smart = "2.6.0"
 jspecify = "1.0.0"
 junit = "5.13.4"
 picocli = "4.7.7"
 protobuf-plugin = "0.9.5"
 protobuf = "3.25.8"
+publish = "0.34.0"
 scala-library = "2.12.20"
 scalatest = "3.2.19"
 scalatestplus-junit5 = "3.2.19.0"
 shadow = "9.2.2"
 slf4j = "2.0.17"
 spark = "3.4.4"
-spotless = "7.2.1"
+spotless = "8.0.0"
 
 [libraries]
 antlr4 = { module = "org.antlr:antlr4", version.ref = "antlr" }
@@ -73,7 +73,7 @@ jackson = [ "jackson-databind", "jackson-annotations", "jackson-datatype-jdk8", 
 [plugins]
 graal = { id = "org.graalvm.buildtools.native", version.ref = "graal-plugin" }
 gradle-extensions = { id = "com.github.vlsi.gradle-extensions", version.ref = "gradle-extensions" }
-jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
+publish = { id = "com.vanniktech.maven.publish", version.ref = "publish" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -1,47 +1,16 @@
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+
 plugins {
-  `maven-publish`
-  signing
   id("java-library")
   id("scala")
   id("idea")
   alias(libs.plugins.spotless)
-  alias(libs.plugins.jreleaser)
+  alias(libs.plugins.publish)
   id("substrait.java-conventions")
 }
 
-val stagingRepositoryUrl = uri(layout.buildDirectory.dir("staging-deploy"))
-
 publishing {
-  publications {
-    create<MavenPublication>("maven-publish") {
-      from(components["java"])
-
-      pom {
-        name.set("Substrait Java")
-        description.set(
-          "Create a well-defined, cross-language specification for data compute operations"
-        )
-        url.set("https://github.com/substrait-io/substrait-java")
-        licenses {
-          license {
-            name.set("The Apache License, Version 2.0")
-            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-          }
-        }
-        developers {
-          developer {
-            id = "vbarua"
-            name = "Victor Barua"
-          }
-        }
-        scm {
-          connection.set("scm:git:git://github.com:substrait-io/substrait-java.git")
-          developerConnection.set("scm:git:ssh://github.com:substrait-io/substrait-java")
-          url.set("https://github.com/substrait-io/substrait-java/")
-        }
-      }
-    }
-  }
   repositories {
     maven {
       name = "local"
@@ -49,45 +18,45 @@ publishing {
       val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
       url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
     }
-    maven {
-      name = "staging"
-      url = stagingRepositoryUrl
-    }
   }
 }
 
-signing {
-  setRequired({
-    gradle.taskGraph.hasTask(":${project.name}:publishMaven-publishPublicationToStagingRepository")
-  })
-  val signingKeyId =
-    System.getenv("SIGNING_KEY_ID").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY_ID"].toString()
-  val signingPassword =
-    System.getenv("SIGNING_PASSWORD").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_PASSWORD"].toString()
-  val signingKey =
-    System.getenv("SIGNING_KEY").takeUnless { it.isNullOrEmpty() }
-      ?: extra["SIGNING_KEY"].toString()
-  useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-  sign(publishing.publications["maven-publish"])
-}
+mavenPublishing {
+  publishToMavenCentral()
+  signAllPublications()
 
-jreleaser {
-  gitRootSearch = true
-  deploy {
-    maven {
-      mavenCentral {
-        register("sonatype") {
-          active = org.jreleaser.model.Active.ALWAYS
-          url = "https://central.sonatype.com/api/v1/publisher"
-          sign = false
-          stagingRepository(file(stagingRepositoryUrl).toString())
-        }
+  configure(JavaLibrary(javadocJar = JavadocJar.Javadoc(), sourcesJar = true))
+
+  coordinates(
+    groupId = project.group.toString(),
+    artifactId = project.name,
+    version = project.version.toString(),
+  )
+
+  pom {
+    name.set("Substrait Java")
+    description.set(
+      "Create a well-defined, cross-language specification for data compute operations"
+    )
+    url.set("https://github.com/substrait-io/substrait-java")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
       }
     }
+    developers {
+      developer {
+        id = "vbarua"
+        name = "Victor Barua"
+      }
+    }
+    scm {
+      connection.set("scm:git:git://github.com:substrait-io/substrait-java.git")
+      developerConnection.set("scm:git:ssh://github.com:substrait-io/substrait-java")
+      url.set("https://github.com/substrait-io/substrait-java/")
+    }
   }
-  release { github { enabled = false } }
 }
 
 configurations.all {
@@ -96,11 +65,7 @@ configurations.all {
   }
 }
 
-java {
-  toolchain { languageVersion = JavaLanguageVersion.of(17) }
-  withJavadocJar()
-  withSourcesJar()
-}
+java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }
 
 tasks.withType<ScalaCompile>() {
   scalaCompileOptions.additionalParameters = listOf("-release:17", "-Xfatal-warnings")


### PR DESCRIPTION
There are two issues with JReleaser:

1. It is a heavy weight plugin designed to manage the entire release process, similar to semantic-release, and it is only used for publishing to the Maven Central Publisher API.
2. Transitive dependency conflicts between Spotless 8.x and JRelease 1.x plugins prevent them being used together.

This change replaces JReleaser with the vanniktech gradle-maven-publish plugin. This is a lighter weight plugin that provides a replacement for the standard maven-publish plugin, adding the capability to publish to Maven Central.

This change also updates Spotless to 8.0.0 since conflicts with JReleaser no longer occur.