### PR TITLE
feat(spark): dialect YAML file for spark converter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ shadow = "9.2.2"
 slf4j = "2.0.17"
 spark = "3.4.4"
 spotless = "8.0.0"
+validator = "1.5.9"
 
 [libraries]
 antlr4 = { module = "org.antlr:antlr4", version.ref = "antlr" }
@@ -44,6 +45,7 @@ jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
 jackson-datatype-jdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" }
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml" }
+json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "validator"}
 json-smart = { module = "net.minidev:json-smart", version.ref = "json-smart" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,8 @@
 Substrait Java is a project that makes it easier to build [Substrait](https://substrait.io/) plans through Java. The project has two main parts:
 1) **Core** is the module that supports building Substrait plans directly through Java. This is much easier than manipulating the Substrait protobuf directly. It has no direct support for going from SQL to Substrait (that's covered by the second part)
 2) **Isthmus** is the module that allows going from SQL to a Substrait plan. Both Java APIs and a top level script for conversion are present. Not all SQL is supported yet by this module, but a lot is. For example, all of the TPC-H queries and all but a few of the TPC-DS queries are translatable.
-3) **Spark** is the module that provides an API for translating a Substrait plan to and from a Spark query plan.  The most commonly used logical relations and functions are supported, including those generated from all of the TPC-H and TCP-DS queries.
+3) **Spark** is the module that provides an API for translating a Substrait plan to and from a Spark query plan.  The most commonly used logical relations and functions are supported, including those generated from all of the TPC-H and TPC-DS queries.
+The supported features are formally specified in the Substrait dialect file [spark_dialect.yaml](spark/spark_dialect.yaml).
 
 ## Building
 After you've cloned the project through git, Substrait Java is built with a tool called [Gradle](https://gradle.org/). To build, execute the following:

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -100,6 +100,8 @@ dependencies {
   implementation(libs.spark.hive)
   implementation(libs.spark.catalyst)
   implementation(libs.slf4j.api)
+  implementation(libs.bundles.jackson)
+  implementation(libs.json.schema.validator)
 
   testImplementation(libs.scalatest)
   testImplementation(platform(libs.junit.bom))
@@ -117,6 +119,13 @@ spotless {
     scalafmt().configFile(".scalafmt.conf")
     toggleOffOn()
   }
+}
+
+tasks.register<JavaExec>("dialect") {
+  dependsOn(":core:shadowJar")
+  classpath = java.sourceSets["main"].runtimeClasspath
+  mainClass = "io.substrait.spark.utils.DialectGenerator"
+  args = listOf("spark_dialect.yaml")
 }
 
 tasks {

--- a/spark/spark_dialect.yaml
+++ b/spark/spark_dialect.yaml
@@ -1,0 +1,864 @@
+---
+name: "Spark Dialect"
+supported_types:
+- type: "I8"
+  system_metadata:
+    name: "ByteType"
+    supported_as_column: true
+- type: "I16"
+  system_metadata:
+    name: "ShortType"
+    supported_as_column: true
+- type: "I32"
+  system_metadata:
+    name: "IntegerType"
+    supported_as_column: true
+- type: "I64"
+  system_metadata:
+    name: "LongType"
+    supported_as_column: true
+- type: "FP32"
+  system_metadata:
+    name: "FloatType"
+    supported_as_column: true
+- type: "FP64"
+  system_metadata:
+    name: "DoubleType"
+    supported_as_column: true
+- type: "DECIMAL"
+  system_metadata:
+    name: "DecimalType"
+    supported_as_column: true
+- type: "DATE"
+  system_metadata:
+    name: "DateType"
+    supported_as_column: true
+- type: "STRING"
+  system_metadata:
+    name: "StringType"
+    supported_as_column: true
+- type: "VARCHAR"
+  system_metadata:
+    name: "StringType"
+    supported_as_column: true
+- type: "FIXED_CHAR"
+  system_metadata:
+    name: "StringType"
+    supported_as_column: true
+- type: "BINARY"
+  system_metadata:
+    name: "BinaryType"
+    supported_as_column: true
+- type: "BOOL"
+  system_metadata:
+    name: "BooleanType"
+    supported_as_column: true
+- type: "PRECISION_TIMESTAMP"
+  system_metadata:
+    name: "TimestampNTZType"
+    supported_as_column: true
+- type: "PRECISION_TIMESTAMP_TZ"
+  system_metadata:
+    name: "TimestampType"
+    supported_as_column: true
+- type: "INTERVAL_DAY"
+  system_metadata:
+    name: "DayTimeIntervalType"
+    supported_as_column: true
+- type: "INTERVAL_YEAR"
+  system_metadata:
+    name: "YearMonthIntervalType"
+    supported_as_column: true
+- type: "LIST"
+  system_metadata:
+    name: "ArrayType"
+    supported_as_column: true
+- type: "MAP"
+  system_metadata:
+    name: "MapType"
+    supported_as_column: true
+- type: "STRUCT"
+  system_metadata:
+    name: "StructType"
+    supported_as_column: true
+supported_expressions:
+- "LITERAL"
+- "SELECTION"
+- "SCALAR_FUNCTION"
+- "IF_THEN"
+- "SINGULAR_OR_LIST"
+- "CAST"
+- expression: "SUBQUERY"
+  subquery_types:
+  - "SCALAR"
+  - "IN_PREDICATE"
+supported_relations:
+- "FILTER"
+- "FETCH"
+- "AGGREGATE"
+- "SORT"
+- "PROJECT"
+- "CROSS"
+- "UPDATE"
+- "CONSISTENT_PARTITION_WINDOW"
+- "EXPAND"
+- "WRITE"
+- relation: "READ"
+  read_types:
+  - "VIRTUAL_TABLE"
+  - "LOCAL_FILES"
+  - "NAMED_TABLE"
+- relation: "DDL"
+  write_types:
+  - "NAMED_OBJECT"
+- relation: "JOIN"
+  join_types:
+  - "INNER"
+  - "OUTER"
+  - "LEFT"
+  - "RIGHT"
+  - "LEFT_SEMI"
+  - "LEFT_ANTI"
+- relation: "SET"
+  operations:
+  - "UNION_ALL"
+dependencies:
+  rounding: "extension:io.substrait:functions_rounding"
+  comparison: "extension:io.substrait:functions_comparison"
+  logarithmic: "extension:io.substrait:functions_logarithmic"
+  datetime: "extension:io.substrait:functions_datetime"
+  rounding_decimal: "extension:io.substrait:functions_rounding_decimal"
+  string: "extension:io.substrait:functions_string"
+  arithmetic: "extension:io.substrait:functions_arithmetic"
+  aggregate_generic: "extension:io.substrait:functions_aggregate_generic"
+  boolean: "extension:io.substrait:functions_boolean"
+  spark: "extension:substrait:spark"
+  arithmetic_decimal: "extension:io.substrait:functions_arithmetic_decimal"
+  aggregate_approx: "extension:io.substrait:functions_aggregate_approx"
+supported_scalar_functions:
+- source: "arithmetic_decimal"
+  name: "add"
+  system_metadata:
+    name: "+"
+    notation: "INFIX"
+  supported_impls:
+  - "dec_dec"
+- source: "arithmetic"
+  name: "add"
+  system_metadata:
+    name: "+"
+    notation: "INFIX"
+  supported_impls:
+  - "i8_i8"
+  - "i16_i16"
+  - "i32_i32"
+  - "i64_i64"
+  - "fp32_fp32"
+  - "fp64_fp64"
+- source: "arithmetic_decimal"
+  name: "subtract"
+  system_metadata:
+    name: "-"
+    notation: "INFIX"
+  supported_impls:
+  - "dec_dec"
+- source: "arithmetic"
+  name: "subtract"
+  system_metadata:
+    name: "-"
+    notation: "INFIX"
+  supported_impls:
+  - "i8_i8"
+  - "i16_i16"
+  - "i32_i32"
+  - "i64_i64"
+  - "fp32_fp32"
+  - "fp64_fp64"
+- source: "arithmetic_decimal"
+  name: "multiply"
+  system_metadata:
+    name: "*"
+    notation: "INFIX"
+  supported_impls:
+  - "dec_dec"
+- source: "arithmetic"
+  name: "multiply"
+  system_metadata:
+    name: "*"
+    notation: "INFIX"
+  supported_impls:
+  - "i8_i8"
+  - "i16_i16"
+  - "i32_i32"
+  - "i64_i64"
+  - "fp32_fp32"
+  - "fp64_fp64"
+- source: "arithmetic_decimal"
+  name: "divide"
+  system_metadata:
+    name: "/"
+    notation: "INFIX"
+  supported_impls:
+  - "dec_dec"
+- source: "arithmetic"
+  name: "divide"
+  system_metadata:
+    name: "/"
+    notation: "INFIX"
+  supported_impls:
+  - "fp64_fp64"
+- source: "arithmetic_decimal"
+  name: "abs"
+  system_metadata:
+    name: "abs"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec"
+- source: "arithmetic"
+  name: "abs"
+  system_metadata:
+    name: "abs"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i8"
+  - "i16"
+  - "i32"
+  - "i64"
+  - "fp32"
+  - "fp64"
+- source: "arithmetic_decimal"
+  name: "modulus"
+  system_metadata:
+    name: "%"
+    notation: "INFIX"
+  supported_impls:
+  - "dec_dec"
+- source: "arithmetic"
+  name: "modulus"
+  system_metadata:
+    name: "%"
+    notation: "INFIX"
+  supported_impls:
+  - "i8_i8"
+  - "i16_i16"
+  - "i32_i32"
+  - "i64_i64"
+- source: "rounding"
+  name: "round"
+  system_metadata:
+    name: "round"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i8_i32"
+  - "i16_i32"
+  - "i32_i32"
+  - "i64_i32"
+  - "fp32_i32"
+  - "fp64_i32"
+- source: "rounding_decimal"
+  name: "round"
+  system_metadata:
+    name: "round"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec_i32"
+- source: "rounding"
+  name: "floor"
+  system_metadata:
+    name: "FLOOR"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "rounding_decimal"
+  name: "floor"
+  system_metadata:
+    name: "FLOOR"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec"
+- source: "rounding"
+  name: "ceil"
+  system_metadata:
+    name: "CEIL"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "rounding_decimal"
+  name: "ceil"
+  system_metadata:
+    name: "CEIL"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec"
+- source: "arithmetic"
+  name: "power"
+  system_metadata:
+    name: "POWER"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64_fp64"
+- source: "arithmetic"
+  name: "exp"
+  system_metadata:
+    name: "EXP"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "sqrt"
+  system_metadata:
+    name: "SQRT"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "sin"
+  system_metadata:
+    name: "SIN"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "cos"
+  system_metadata:
+    name: "COS"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "tan"
+  system_metadata:
+    name: "TAN"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "asin"
+  system_metadata:
+    name: "ASIN"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "acos"
+  system_metadata:
+    name: "ACOS"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "atan"
+  system_metadata:
+    name: "ATAN"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "atan2"
+  system_metadata:
+    name: "ATAN2"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64_fp64"
+- source: "arithmetic"
+  name: "sinh"
+  system_metadata:
+    name: "SINH"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "cosh"
+  system_metadata:
+    name: "COSH"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "tanh"
+  system_metadata:
+    name: "TANH"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "asinh"
+  system_metadata:
+    name: "ASINH"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "acosh"
+  system_metadata:
+    name: "ACOSH"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "arithmetic"
+  name: "atanh"
+  system_metadata:
+    name: "ATANH"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "logarithmic"
+  name: "ln"
+  system_metadata:
+    name: "ln"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "logarithmic"
+  name: "log10"
+  system_metadata:
+    name: "LOG10"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+- source: "boolean"
+  name: "not"
+  system_metadata:
+    name: "not"
+    notation: "FUNCTION"
+  supported_impls:
+  - "bool"
+- source: "comparison"
+  name: "lt"
+  system_metadata:
+    name: "<"
+    notation: "INFIX"
+  supported_impls:
+  - "any_any"
+- source: "datetime"
+  name: "lt"
+  system_metadata:
+    name: "<"
+    notation: "INFIX"
+  supported_impls:
+  - "ts_ts"
+  - "pts_pts"
+  - "tstz_tstz"
+  - "ptstz_ptstz"
+  - "date_date"
+  - "iday_iday"
+  - "iyear_iyear"
+- source: "comparison"
+  name: "lte"
+  system_metadata:
+    name: "<="
+    notation: "INFIX"
+  supported_impls:
+  - "any_any"
+- source: "datetime"
+  name: "lte"
+  system_metadata:
+    name: "<="
+    notation: "INFIX"
+  supported_impls:
+  - "ts_ts"
+  - "pts_pts"
+  - "tstz_tstz"
+  - "ptstz_ptstz"
+  - "date_date"
+  - "iday_iday"
+  - "iyear_iyear"
+- source: "comparison"
+  name: "gt"
+  system_metadata:
+    name: ">"
+    notation: "INFIX"
+  supported_impls:
+  - "any_any"
+- source: "datetime"
+  name: "gt"
+  system_metadata:
+    name: ">"
+    notation: "INFIX"
+  supported_impls:
+  - "ts_ts"
+  - "pts_pts"
+  - "tstz_tstz"
+  - "ptstz_ptstz"
+  - "date_date"
+  - "iday_iday"
+  - "iyear_iyear"
+- source: "comparison"
+  name: "gte"
+  system_metadata:
+    name: ">="
+    notation: "INFIX"
+  supported_impls:
+  - "any_any"
+- source: "datetime"
+  name: "gte"
+  system_metadata:
+    name: ">="
+    notation: "INFIX"
+  supported_impls:
+  - "ts_ts"
+  - "pts_pts"
+  - "tstz_tstz"
+  - "ptstz_ptstz"
+  - "date_date"
+  - "iday_iday"
+  - "iyear_iyear"
+- source: "comparison"
+  name: "equal"
+  system_metadata:
+    name: "="
+    notation: "INFIX"
+  supported_impls:
+  - "any_any"
+- source: "comparison"
+  name: "is_not_distinct_from"
+  system_metadata:
+    name: "<=>"
+    notation: "INFIX"
+  supported_impls:
+  - "any_any"
+- source: "comparison"
+  name: "is_null"
+  system_metadata:
+    name: "isnull"
+    notation: "FUNCTION"
+  supported_impls:
+  - "any"
+- source: "comparison"
+  name: "is_not_null"
+  system_metadata:
+    name: "isnotnull"
+    notation: "FUNCTION"
+  supported_impls:
+  - "any"
+- source: "string"
+  name: "ends_with"
+  system_metadata:
+    name: "endswith"
+    notation: "FUNCTION"
+  supported_impls:
+  - "vchar_vchar"
+  - "vchar_str"
+  - "vchar_fchar"
+  - "str_str"
+  - "str_vchar"
+  - "str_fchar"
+  - "fchar_fchar"
+  - "fchar_str"
+  - "fchar_vchar"
+- source: "string"
+  name: "like"
+  system_metadata:
+    name: "like"
+    notation: "FUNCTION"
+  supported_impls:
+  - "vchar_vchar"
+  - "str_str"
+- source: "string"
+  name: "contains"
+  system_metadata:
+    name: "contains"
+    notation: "FUNCTION"
+  supported_impls:
+  - "vchar_vchar"
+  - "vchar_str"
+  - "vchar_fchar"
+  - "str_str"
+  - "str_vchar"
+  - "str_fchar"
+  - "fchar_fchar"
+  - "fchar_str"
+  - "fchar_vchar"
+- source: "string"
+  name: "starts_with"
+  system_metadata:
+    name: "startswith"
+    notation: "FUNCTION"
+  supported_impls:
+  - "vchar_vchar"
+  - "vchar_str"
+  - "vchar_fchar"
+  - "str_str"
+  - "str_vchar"
+  - "str_fchar"
+  - "fchar_fchar"
+  - "fchar_str"
+  - "fchar_vchar"
+- source: "string"
+  name: "substring"
+  system_metadata:
+    name: "substring"
+    notation: "FUNCTION"
+  supported_impls:
+  - "vchar_i32_i32"
+  - "str_i32_i32"
+  - "fchar_i32_i32"
+- source: "string"
+  name: "upper"
+  system_metadata:
+    name: "upper"
+    notation: "FUNCTION"
+  supported_impls:
+  - "str"
+  - "vchar"
+  - "fchar"
+- source: "string"
+  name: "lower"
+  system_metadata:
+    name: "lower"
+    notation: "FUNCTION"
+  supported_impls:
+  - "str"
+  - "vchar"
+  - "fchar"
+- source: "arithmetic"
+  name: "shift_left"
+  system_metadata:
+    name: "shiftleft"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i32_i32"
+  - "i64_i32"
+- source: "arithmetic"
+  name: "shift_right"
+  system_metadata:
+    name: "shiftright"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i32_i32"
+  - "i64_i32"
+- source: "arithmetic"
+  name: "shift_right_unsigned"
+  system_metadata:
+    name: "shiftrightunsigned"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i32_i32"
+  - "i64_i32"
+- source: "arithmetic"
+  name: "bitwise_and"
+  system_metadata:
+    name: "&"
+    notation: "INFIX"
+  supported_impls:
+  - "i8_i8"
+  - "i16_i16"
+  - "i32_i32"
+  - "i64_i64"
+- source: "arithmetic"
+  name: "bitwise_or"
+  system_metadata:
+    name: "|"
+    notation: "INFIX"
+  supported_impls:
+  - "i8_i8"
+  - "i16_i16"
+  - "i32_i32"
+  - "i64_i64"
+- source: "arithmetic"
+  name: "bitwise_xor"
+  system_metadata:
+    name: "^"
+    notation: "INFIX"
+  supported_impls:
+  - "i8_i8"
+  - "i16_i16"
+  - "i32_i32"
+  - "i64_i64"
+- source: "spark"
+  name: "add"
+  system_metadata:
+    name: "date_add"
+    notation: "FUNCTION"
+  supported_impls:
+  - "date_i32"
+supported_aggregate_functions:
+- source: "arithmetic_decimal"
+  name: "sum"
+  system_metadata:
+    name: "sum"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec"
+- source: "arithmetic"
+  name: "sum"
+  system_metadata:
+    name: "sum"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i8"
+  - "i16"
+  - "i32"
+  - "i64"
+  - "fp32"
+  - "fp64"
+- source: "arithmetic_decimal"
+  name: "avg"
+  system_metadata:
+    name: "avg"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec"
+- source: "arithmetic"
+  name: "avg"
+  system_metadata:
+    name: "avg"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i8"
+  - "i16"
+  - "i32"
+  - "i64"
+  - "fp32"
+  - "fp64"
+- source: "arithmetic_decimal"
+  name: "min"
+  system_metadata:
+    name: "min"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec"
+- source: "arithmetic"
+  name: "min"
+  system_metadata:
+    name: "min"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i8"
+  - "i16"
+  - "i32"
+  - "i64"
+  - "fp32"
+  - "fp64"
+- source: "datetime"
+  name: "min"
+  system_metadata:
+    name: "min"
+    notation: "FUNCTION"
+  supported_impls:
+  - "date"
+  - "time"
+  - "ts"
+  - "pts"
+  - "tstz"
+  - "ptstz"
+  - "iday"
+  - "iyear"
+- source: "arithmetic_decimal"
+  name: "max"
+  system_metadata:
+    name: "max"
+    notation: "FUNCTION"
+  supported_impls:
+  - "dec"
+- source: "arithmetic"
+  name: "max"
+  system_metadata:
+    name: "max"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i8"
+  - "i16"
+  - "i32"
+  - "i64"
+  - "fp32"
+  - "fp64"
+- source: "datetime"
+  name: "max"
+  system_metadata:
+    name: "max"
+    notation: "FUNCTION"
+  supported_impls:
+  - "date"
+  - "time"
+  - "ts"
+  - "pts"
+  - "tstz"
+  - "ptstz"
+  - "iday"
+  - "iyear"
+- source: "aggregate_generic"
+  name: "any_value"
+  system_metadata:
+    name: "first"
+    notation: "FUNCTION"
+  supported_impls:
+  - "any"
+- source: "aggregate_approx"
+  name: "approx_count_distinct"
+  system_metadata:
+    name: "approx_count_distinct"
+    notation: "FUNCTION"
+  supported_impls:
+  - "any"
+- source: "arithmetic"
+  name: "std_dev"
+  system_metadata:
+    name: "stddev_samp"
+    notation: "FUNCTION"
+  supported_impls:
+  - "fp64"
+supported_window_functions:
+- source: "arithmetic"
+  name: "row_number"
+  system_metadata:
+    name: "row_number"
+    notation: "FUNCTION"
+  supported_impls:
+  - ""
+- source: "arithmetic"
+  name: "rank"
+  system_metadata:
+    name: "rank"
+    notation: "FUNCTION"
+  supported_impls:
+  - ""
+- source: "arithmetic"
+  name: "dense_rank"
+  system_metadata:
+    name: "dense_rank"
+    notation: "FUNCTION"
+  supported_impls:
+  - ""
+- source: "arithmetic"
+  name: "percent_rank"
+  system_metadata:
+    name: "percent_rank"
+    notation: "FUNCTION"
+  supported_impls:
+  - ""
+- source: "arithmetic"
+  name: "cume_dist"
+  system_metadata:
+    name: "cume_dist"
+    notation: "FUNCTION"
+  supported_impls:
+  - ""
+- source: "arithmetic"
+  name: "ntile"
+  system_metadata:
+    name: "ntile"
+    notation: "FUNCTION"
+  supported_impls:
+  - "i32"
+- source: "arithmetic"
+  name: "lead"
+  system_metadata:
+    name: "lead"
+    notation: "FUNCTION"
+  supported_impls:
+  - "any_i32_any"
+- source: "arithmetic"
+  name: "lag"
+  system_metadata:
+    name: "lag"
+    notation: "FUNCTION"
+  supported_impls:
+  - "any_i32_any"
+- source: "arithmetic"
+  name: "nth_value"
+  system_metadata:
+    name: "nth_value"
+    notation: "FUNCTION"
+  supported_impls:
+  - "any_i32"

--- a/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
+++ b/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
@@ -16,12 +16,13 @@
  */
 package io.substrait.spark
 
+import io.substrait.spark.utils.Util
+
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.types._
 
 import io.substrait.`type`.{NamedStruct, Type, TypeVisitor}
 import io.substrait.function.TypeExpression
-import io.substrait.utils.Util
 
 import scala.collection.JavaConverters
 import scala.collection.JavaConverters.asScalaBufferConverter
@@ -36,55 +37,55 @@ private class ToSparkType(dfsNames: Seq[String])
 
   var nameIdx: Int = 0 // where in dfsNames we're currently at
 
-  override def visit(expr: Type.I8): DataType = ByteType
-  override def visit(expr: Type.I16): DataType = ShortType
-  override def visit(expr: Type.I32): DataType = IntegerType
-  override def visit(expr: Type.I64): DataType = LongType
+  override def visit(expr: Type.I8): ByteType = ByteType
+  override def visit(expr: Type.I16): ShortType = ShortType
+  override def visit(expr: Type.I32): IntegerType = IntegerType
+  override def visit(expr: Type.I64): LongType = LongType
 
-  override def visit(expr: Type.FP32): DataType = FloatType
-  override def visit(expr: Type.FP64): DataType = DoubleType
+  override def visit(expr: Type.FP32): FloatType = FloatType
+  override def visit(expr: Type.FP64): DoubleType = DoubleType
 
-  override def visit(expr: Type.Decimal): DataType =
+  override def visit(expr: Type.Decimal): DecimalType =
     DecimalType(expr.precision(), expr.scale())
 
-  override def visit(expr: Type.Date): DataType = DateType
+  override def visit(expr: Type.Date): DateType = DateType
 
-  override def visit(expr: Type.Str): DataType = StringType
+  override def visit(expr: Type.Str): StringType = StringType
 
-  override def visit(expr: Type.Binary): DataType = BinaryType
+  override def visit(expr: Type.Binary): BinaryType = BinaryType
 
-  override def visit(expr: Type.FixedChar): DataType = StringType
+  override def visit(expr: Type.FixedChar): StringType = StringType
 
-  override def visit(expr: Type.VarChar): DataType = StringType
+  override def visit(expr: Type.VarChar): StringType = StringType
 
-  override def visit(expr: Type.Bool): DataType = BooleanType
+  override def visit(expr: Type.Bool): BooleanType = BooleanType
 
-  override def visit(expr: Type.PrecisionTimestamp): DataType = {
+  override def visit(expr: Type.PrecisionTimestamp): TimestampNTZType = {
     Util.assertMicroseconds(expr.precision())
     TimestampNTZType
   }
-  override def visit(expr: Type.PrecisionTimestampTZ): DataType = {
+  override def visit(expr: Type.PrecisionTimestampTZ): TimestampType = {
     Util.assertMicroseconds(expr.precision())
     TimestampType
   }
 
-  override def visit(expr: Type.IntervalDay): DataType = {
+  override def visit(expr: Type.IntervalDay): DayTimeIntervalType = {
     Util.assertMicroseconds(expr.precision())
     DayTimeIntervalType.DEFAULT
   }
 
-  override def visit(expr: Type.IntervalYear): DataType = YearMonthIntervalType.DEFAULT
+  override def visit(expr: Type.IntervalYear): YearMonthIntervalType = YearMonthIntervalType.DEFAULT
 
-  override def visit(expr: Type.ListType): DataType =
+  override def visit(expr: Type.ListType): ArrayType =
     ArrayType(expr.elementType().accept(this), containsNull = expr.elementType().nullable())
 
-  override def visit(expr: Type.Map): DataType =
+  override def visit(expr: Type.Map): MapType =
     MapType(
       expr.key().accept(this),
       expr.value().accept(this),
       valueContainsNull = expr.value().nullable())
 
-  override def visit(expr: Type.Struct): DataType =
+  override def visit(expr: Type.Struct): StructType =
     StructType(
       expr.fields.asScala.zipWithIndex
         .map {

--- a/spark/src/main/scala/io/substrait/spark/expression/FunctionConverter.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/FunctionConverter.scala
@@ -17,6 +17,7 @@
 package io.substrait.spark.expression
 
 import io.substrait.spark.ToSubstraitType
+import io.substrait.spark.utils.Util
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.SQLConfHelper
@@ -31,7 +32,6 @@ import io.substrait.expression.{EnumArg, Expression => SExpression, ExpressionCr
 import io.substrait.expression.Expression.FailureBehavior
 import io.substrait.extension.SimpleExtension
 import io.substrait.function.{ParameterizedType, ToTypeString}
-import io.substrait.utils.Util
 
 import java.{util => ju}
 

--- a/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
@@ -16,12 +16,12 @@
  */
 package io.substrait.spark.expression
 
+import io.substrait.spark.utils.Util
+
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistryBase
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.types.{DayTimeIntervalType, IntegerType}
-
-import io.substrait.utils.Util
 
 import scala.reflect.ClassTag
 
@@ -85,6 +85,7 @@ object TrimFunction {
     case ("ltrim", Seq(srcStr, trimStr)) => Some(StringTrimLeft(srcStr, trimStr))
     case ("rtrim", Seq(srcStr)) => Some(StringTrimRight(srcStr))
     case ("rtrim", Seq(srcStr, trimStr)) => Some(StringTrimRight(srcStr, trimStr))
+    case _ => None
   }
 }
 
@@ -105,6 +106,8 @@ class FunctionMappings {
       (signature, args) match {
         case DateFunction(expr) => expr
         case TrimFunction(expr) => expr
+        case _ =>
+          throw new UnsupportedOperationException(s"Cannot convert $signature with arguments $args")
       }
     SpecialSig(scala.reflect.classTag[T].runtimeClass, name, key, builder)
   }

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -18,6 +18,7 @@ package io.substrait.spark.expression
 
 import io.substrait.spark.{DefaultExpressionVisitor, HasOutputStack, SparkExtension, ToSparkType}
 import io.substrait.spark.logical.ToLogicalPlan
+import io.substrait.spark.utils.Util
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.{CaseWhen, Cast, Expression, In, InSubquery, ListQuery, Literal, MakeDecimal, NamedExpression, ScalarSubquery}
@@ -32,7 +33,6 @@ import io.substrait.expression.{EnumArg, Expression => SExpression}
 import io.substrait.extension.SimpleExtension
 import io.substrait.util.DecimalUtil
 import io.substrait.util.EmptyVisitationContext
-import io.substrait.utils.Util
 
 import scala.collection.JavaConverters.{asScalaBufferConverter, mapAsScalaMapConverter}
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
@@ -17,6 +17,7 @@
 package io.substrait.spark.expression
 
 import io.substrait.spark.{HasOutputStack, ToSubstraitType}
+import io.substrait.spark.utils.Util
 
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Project}
@@ -25,7 +26,6 @@ import org.apache.spark.substrait.SparkTypeUtil
 
 import io.substrait.expression.{EnumArg, Expression => SExpression, ExpressionCreator, FieldReference}
 import io.substrait.expression.Expression.FailureBehavior
-import io.substrait.utils.Util
 
 import java.util.Optional
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
@@ -17,6 +17,7 @@
 package io.substrait.spark.expression
 
 import io.substrait.spark.ToSubstraitType
+import io.substrait.spark.utils.Util
 
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, Literal}
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
@@ -25,7 +26,6 @@ import org.apache.spark.unsafe.types.UTF8String
 
 import io.substrait.expression.{Expression => SExpression}
 import io.substrait.expression.ExpressionCreator._
-import io.substrait.utils.Util
 
 import scala.collection.JavaConverters
 

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -18,6 +18,7 @@ package io.substrait.spark.logical
 
 import io.substrait.spark.{FileHolder, SparkExtension, ToSubstraitType}
 import io.substrait.spark.expression._
+import io.substrait.spark.utils.Util
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SaveMode
@@ -53,7 +54,6 @@ import io.substrait.relation.Set.SetOp
 import io.substrait.relation.files.{FileFormat, FileOrFiles}
 import io.substrait.relation.files.FileOrFiles.PathType
 import io.substrait.util.EmptyVisitationContext
-import io.substrait.utils.Util
 
 import java.util
 import java.util.{Collections, Optional}

--- a/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
@@ -1,0 +1,291 @@
+package io.substrait.spark.utils
+
+import io.substrait.spark.SparkExtension.{COLLECTION, SparkScalarFunctions}
+import io.substrait.spark.expression.FunctionMappings.{AGGREGATE_SIGS, SCALAR_SIGS, WINDOW_SIGS}
+import io.substrait.spark.expression.Sig
+
+import org.apache.spark.sql.catalyst.expressions.{BinaryOperator, Expression, Literal}
+import org.apache.spark.sql.types.{ByteType, DateType, DayTimeIntervalType, DoubleType, FloatType, IntegerType, LongType, NullType, ShortType, TimestampNTZType, TimestampType, YearMonthIntervalType}
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.networknt.schema.{InputFormat, JsonSchemaFactory, SchemaValidatorsConfig, SpecVersion}
+import io.substrait.extension.SimpleExtension
+
+import java.io.{File, FileInputStream, FileWriter, OutputStreamWriter, PrintWriter}
+
+import scala.collection.JavaConverters.asScalaBufferConverter
+
+case class Dialect(
+    name: String,
+    supported_types: Seq[SupportedType],
+    supported_expressions: Seq[Any],
+    supported_relations: Seq[Any],
+    dependencies: Map[String, String],
+    supported_scalar_functions: Seq[SupportedFunction],
+    supported_aggregate_functions: Seq[SupportedFunction],
+    supported_window_functions: Seq[SupportedFunction])
+
+// Types section
+case class TypeMetadata(name: String, supported_as_column: Boolean)
+case class SupportedType(`type`: String, system_metadata: TypeMetadata)
+
+// Functions section
+case class FunctionMetadata(name: String, notation: String)
+case class SupportedFunction(
+    source: String,
+    name: String,
+    system_metadata: FunctionMetadata,
+    supported_impls: Seq[String])
+
+class DialectGenerator {
+  val schemaPath = "../substrait/text/dialect_schema.yaml"
+
+  private val sourceURNs = Map(
+    "extension:io.substrait:functions_aggregate_approx" -> "aggregate_approx",
+    "extension:io.substrait:functions_aggregate_generic" -> "aggregate_generic",
+    "extension:io.substrait:functions_arithmetic" -> "arithmetic",
+    "extension:io.substrait:functions_arithmetic_decimal" -> "arithmetic_decimal",
+    "extension:io.substrait:functions_boolean" -> "boolean",
+    "extension:io.substrait:functions_comparison" -> "comparison",
+    "extension:io.substrait:functions_datetime" -> "datetime",
+    "extension:io.substrait:functions_logarithmic" -> "logarithmic",
+    "extension:io.substrait:functions_rounding" -> "rounding",
+    "extension:io.substrait:functions_rounding_decimal" -> "rounding_decimal",
+    "extension:io.substrait:functions_string" -> "string",
+    "extension:substrait:spark" -> "spark"
+  )
+
+  def generate(): Dialect = {
+    val types = supportedTypes()
+    val expressions = supportedExpressions()
+    val relations = supportedRelations()
+    val scalars = SCALAR_SIGS.flatMap(supportedFunctions(SparkScalarFunctions))
+    val aggregates =
+      AGGREGATE_SIGS.flatMap(supportedFunctions(COLLECTION.aggregateFunctions().asScala))
+    val windows =
+      WINDOW_SIGS.flatMap(supportedFunctions(COLLECTION.windowFunctions().asScala))
+
+    Dialect(
+      "Spark Dialect",
+      types,
+      expressions,
+      relations,
+      sourceURNs.map(_.swap),
+      scalars,
+      aggregates,
+      windows)
+  }
+
+  def generateYaml(): String = {
+    // Generate the dialect YAML
+    val mapper = new ObjectMapper(new YAMLFactory()).registerModules(DefaultScalaModule)
+    val yaml = mapper.writeValueAsString(generate())
+
+    // Validate against the substrait dialect schema
+    val jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+    val config = SchemaValidatorsConfig.builder.build
+    val schema = jsonSchemaFactory.getSchema(
+      new FileInputStream(new File(schemaPath)),
+      InputFormat.YAML,
+      config)
+    val errors = schema.validate(yaml, InputFormat.YAML)
+    if (!errors.isEmpty) {
+      throw new Exception(errors.toString)
+    }
+    yaml
+  }
+
+  private def supportedTypes(): Seq[SupportedType] = {
+    Seq(
+      SupportedType("I8", TypeMetadata("ByteType", true)),
+      SupportedType("I16", TypeMetadata("ShortType", true)),
+      SupportedType("I32", TypeMetadata("IntegerType", true)),
+      SupportedType("I64", TypeMetadata("LongType", true)),
+      SupportedType("FP32", TypeMetadata("FloatType", true)),
+      SupportedType("FP64", TypeMetadata("DoubleType", true)),
+      SupportedType("DECIMAL", TypeMetadata("DecimalType", true)),
+      SupportedType("DATE", TypeMetadata("DateType", true)),
+      SupportedType("STRING", TypeMetadata("StringType", true)),
+      SupportedType("VARCHAR", TypeMetadata("StringType", true)),
+      SupportedType("FIXED_CHAR", TypeMetadata("StringType", true)),
+      SupportedType("BINARY", TypeMetadata("BinaryType", true)),
+      SupportedType("BOOL", TypeMetadata("BooleanType", true)),
+      SupportedType("PRECISION_TIMESTAMP", TypeMetadata("TimestampNTZType", true)),
+      SupportedType("PRECISION_TIMESTAMP_TZ", TypeMetadata("TimestampType", true)),
+      SupportedType("INTERVAL_DAY", TypeMetadata("DayTimeIntervalType", true)),
+      SupportedType("INTERVAL_YEAR", TypeMetadata("YearMonthIntervalType", true)),
+      SupportedType("LIST", TypeMetadata("ArrayType", true)),
+      SupportedType("MAP", TypeMetadata("MapType", true)),
+      SupportedType("STRUCT", TypeMetadata("StructType", true))
+    )
+  }
+
+  private def supportedExpressions(): Seq[Any] = {
+    Seq(
+      "LITERAL",
+      "SELECTION",
+      "SCALAR_FUNCTION",
+      "IF_THEN",
+      "SINGULAR_OR_LIST",
+      "CAST",
+      Map(
+        "expression" -> "SUBQUERY",
+        "subquery_types" -> Seq("SCALAR", "IN_PREDICATE")
+      )
+    )
+  }
+
+  private def supportedRelations(): Seq[Any] = {
+    Seq(
+      "FILTER",
+      "FETCH",
+      "AGGREGATE",
+      "SORT",
+      "PROJECT",
+      "CROSS",
+      "UPDATE",
+      "CONSISTENT_PARTITION_WINDOW",
+      "EXPAND",
+      "WRITE",
+      Map(
+        "relation" -> "READ",
+        "read_types" -> Seq("VIRTUAL_TABLE", "LOCAL_FILES", "NAMED_TABLE")
+      ),
+      Map(
+        "relation" -> "DDL",
+        "write_types" -> Seq("NAMED_OBJECT")
+      ),
+      Map(
+        "relation" -> "JOIN",
+        "join_types" -> Seq("INNER", "OUTER", "LEFT", "RIGHT", "LEFT_SEMI", "LEFT_ANTI")
+      ),
+      Map(
+        "relation" -> "SET",
+        "operations" -> Seq("UNION_ALL")
+      )
+    )
+  }
+
+  // The supported functions section is generated from the existing FunctionMappings code.
+  private def supportedFunctions(functions: Seq[SimpleExtension.Function])(
+      sig: Sig): Seq[SupportedFunction] = {
+    val inst = if (classOf[Expression].isAssignableFrom(sig.expClass)) {
+      val cons = sig.expClass.getDeclaredConstructors.minBy(c => c.getParameterCount)
+      val i = cons.getParameterCount
+      i match {
+        case 0 => cons.newInstance()
+        case 1 => cons.newInstance(null)
+        case 2 => cons.newInstance(null, null)
+        case 3 => cons.newInstance(null, null, null)
+        case _ =>
+          throw new UnsupportedOperationException(
+            s"${sig.expClass} constructor requires $i parameters")
+      }
+    } else {
+      throw new UnsupportedOperationException(s"${sig.expClass} is not an Expression")
+    }
+
+    val sqlName = inst match {
+      case bo: BinaryOperator => bo.sqlOperator
+      case e: Expression => e.prettyName
+      case _ => "NO NAME"
+    }
+
+    val notation = inst match {
+      case _: BinaryOperator => "INFIX"
+      case _ => "FUNCTION"
+    }
+
+    // create a map of function parameter variants grouped by URN
+    val variants = functions.filter(_.name() == sig.name)
+    val groups: Map[String, Seq[String]] = inst match {
+      case expr: Expression =>
+        variants
+          .map {
+            v =>
+              {
+                val signature = v.key().split(":", 2).apply(1)
+                // generate sample arguments for this variant
+                val args = if (signature.isEmpty) {
+                  Seq.empty
+                } else {
+                  signature.split("_").toSeq.map(argValue)
+                }
+                // test it against the function expression
+                if (
+                  expr.children != null && expr.children.size == args.size && expr
+                    .withNewChildren(args)
+                    .checkInputDataTypes()
+                    .isSuccess
+                ) {
+                  (v.urn, signature)
+                } else {
+                  ("FAILED", signature)
+                }
+              }
+          }
+          .groupBy(_._1) // group by URN
+          .filter(_._1 != "FAILED")
+          .mapValues(_.map(_._2))
+      case _ =>
+        println(s"NO INPUT TYPES")
+        Map.empty
+    }
+    groups.map {
+      case (urn, sigs) =>
+        SupportedFunction(
+          sourceURNs.getOrElse(urn, ""),
+          sig.name,
+          FunctionMetadata(sqlName, notation),
+          sigs)
+    }.toSeq
+  }
+
+  // Generate a type-appropriate sample value
+  private def argValue(argType: String): Literal = {
+    argType match {
+      case "i8" => Literal(Byte.MaxValue, ByteType)
+      case "i16" => Literal(Short.MaxValue, ShortType)
+      case "i32" => Literal(Integer.MAX_VALUE, IntegerType)
+      case "i64" => Literal(Long.MaxValue, LongType)
+      case "fp32" => Literal(Float.MaxValue, FloatType)
+      case "fp64" => Literal(Double.MaxValue, DoubleType)
+      case "dec" => Literal(BigDecimal(1))
+      case "str" => Literal("str")
+      case "vchar" => Literal("str")
+      case "fchar" => Literal("str")
+      case "any" => Literal("any") // can be any literal type - use string
+      case "bool" => Literal(true)
+      case "date" => Literal(0, DateType)
+      case "ts" => Literal(0L, TimestampNTZType)
+      case "tstz" => Literal(0L, TimestampType)
+      case "pts" => Literal(0L, TimestampNTZType)
+      case "ptstz" => Literal(0L, TimestampType)
+      case "iyear" => Literal(0, YearMonthIntervalType())
+      case "iday" => Literal(0L, DayTimeIntervalType())
+      case "req" => Literal("req")
+      case _ => Literal(null, NullType)
+    }
+  }
+}
+
+object DialectGenerator extends DialectGenerator {
+  def main(args: Array[String]) = {
+    val yaml = generateYaml()
+
+    val out = args match {
+      case Array(t) =>
+        val f = new File(t)
+        if (!f.exists()) {
+          f.createNewFile()
+        }
+        new FileWriter(t)
+      case _ => new OutputStreamWriter(System.out)
+    }
+
+    out.write(yaml)
+    out.flush()
+  }
+}

--- a/spark/src/main/scala/io/substrait/spark/utils/Util.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/Util.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.substrait.utils
+package io.substrait.spark.utils
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer

--- a/spark/src/test/scala/io/substrait/spark/DialectSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/DialectSuite.scala
@@ -1,0 +1,60 @@
+package io.substrait.spark
+
+import io.substrait.spark.utils.{Dialect, DialectGenerator}
+import io.substrait.spark.utils.DialectGenerator.schemaPath
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.networknt.schema.{InputFormat, JsonSchemaFactory, SchemaValidatorsConfig, SpecVersion}
+
+import java.io.{File, FileInputStream}
+
+import scala.io.Source
+
+class DialectSuite extends SparkFunSuite with SharedSparkSession with SubstraitPlanTestBase {
+  private val dialectPath = "spark_dialect.yaml"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sparkContext.setLogLevel("WARN")
+  }
+
+  test("validate published dialect") {
+    val jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012)
+    val config = SchemaValidatorsConfig.builder.build
+    val schema = jsonSchemaFactory.getSchema(
+      new FileInputStream(new File(schemaPath)),
+      InputFormat.YAML,
+      config)
+    val dialect = Source.fromFile(dialectPath).mkString
+    val errors = schema.validate(dialect, InputFormat.YAML)
+    assertResult(java.util.Set.of())(errors)
+  }
+
+  test("generate validated YAML") {
+    val tempPathName = "build/tmp/test/dialect.yaml"
+    val tempFile = new File(tempPathName)
+    if (tempFile.exists()) {
+      tempFile.delete()
+    }
+    DialectGenerator.main(Array(tempPathName))
+    assertResult(true)(tempFile.exists())
+  }
+
+  test("compare generated dialect") {
+    val mapper = new ObjectMapper(new YAMLFactory()).registerModules(DefaultScalaModule)
+
+    val genDialect = DialectGenerator.generate()
+    val publishedDialect =
+      mapper.readValue(new File(dialectPath), scala.reflect.classTag[Dialect].runtimeClass)
+    // The following will fail if the generated dialect differs from the published one.
+    // If this is caused by an intentional change, the published dialect should be regenerated using:
+    // `./gradlew dialect`
+    assertResult(publishedDialect)(genDialect)
+  }
+
+}


### PR DESCRIPTION
Adds the formal dialect definition for the Spark converter. The file is generated from code which extracts the relevant information from the exisitng FunctionMapper definitions. This ensures that the dialect YAML remains in-sync with the code.
Tests have been introduced to ensure that the dialect conforms to the schema (defined in teh base substrait library), and that the published dialect YAML is the equivalent to one that would be generated from the current code.