### PR TITLE
test(core): add more roundtrip tests for relations and expressions

### DIFF
--- a/core/src/test/java/io/substrait/type/proto/FieldReferenceRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/FieldReferenceRoundtripTest.java
@@ -1,0 +1,160 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Filter;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests field reference roundtrip behavior through relations. Field references are tested as part
+ * of the relation context since they require schema information for proper deserialization.
+ */
+public class FieldReferenceRoundtripTest extends TestBase {
+
+  final Rel baseTable =
+      b.namedScan(
+          Collections.singletonList("test_table"),
+          Arrays.asList("id", "amount", "name", "nested_struct"),
+          Arrays.asList(
+              R.I64,
+              R.FP64,
+              R.STRING,
+              Type.Struct.builder().nullable(false).addFields(R.I32, R.STRING, R.BOOLEAN).build()));
+
+  @Test
+  void simpleStructFieldReference() {
+    // Test simple root struct field reference via projection
+    Rel projection =
+        Project.builder().input(baseTable).addExpressions(b.fieldReference(baseTable, 0)).build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void multipleFieldReferences() {
+    // Test multiple field references in same projection
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(
+                b.fieldReference(baseTable, 0),
+                b.fieldReference(baseTable, 1),
+                b.fieldReference(baseTable, 2))
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void fieldReferenceInFilter() {
+    // Test field reference in filter condition
+    Expression condition = b.equal(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 0));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void fieldReferenceInComplexExpression() {
+    // Test field reference as part of arithmetic expression
+    Expression add = b.add(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 0));
+
+    Rel projection = Project.builder().input(baseTable).addExpressions(add).build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void fieldReferenceInNestedProjection() {
+    // Test field reference through nested projections
+    Rel firstProjection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 2))
+            .build();
+
+    Rel secondProjection =
+        Project.builder()
+            .input(firstProjection)
+            .addExpressions(b.fieldReference(firstProjection, 1))
+            .build();
+
+    verifyRoundTrip(secondProjection);
+  }
+
+  @Test
+  void fieldReferenceAllFields() {
+    // Test referencing all fields
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(
+                b.fieldReference(baseTable, 0),
+                b.fieldReference(baseTable, 1),
+                b.fieldReference(baseTable, 2),
+                b.fieldReference(baseTable, 3))
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void fieldReferenceWithBooleanLogic() {
+    // Test field references in boolean expressions
+    Expression condition =
+        b.and(
+            b.equal(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 0)),
+            b.equal(b.fieldReference(baseTable, 2), b.str("test")));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void fieldReferenceInMultipleArithmetic() {
+    // Test multiple field references in arithmetic
+    Expression add = b.add(b.fieldReference(baseTable, 1), b.fieldReference(baseTable, 1));
+    Expression multiply = b.multiply(add, b.fieldReference(baseTable, 1));
+
+    Rel projection = Project.builder().input(baseTable).addExpressions(multiply).build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void fieldReferenceReordering() {
+    // Test field reordering through projection (accessing fields out of order)
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(
+                b.fieldReference(baseTable, 3),
+                b.fieldReference(baseTable, 0),
+                b.fieldReference(baseTable, 2))
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void sameFieldReferencedMultipleTimes() {
+    // Test same field referenced multiple times
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(
+                b.fieldReference(baseTable, 0),
+                b.fieldReference(baseTable, 0),
+                b.fieldReference(baseTable, 0))
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/FilterRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/FilterRelRoundtripTest.java
@@ -1,0 +1,134 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Filter;
+import io.substrait.relation.Rel;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class FilterRelRoundtripTest extends TestBase {
+
+  final Rel baseTable =
+      b.namedScan(
+          Collections.singletonList("test_table"),
+          Arrays.asList("id", "amount", "name", "status"),
+          Arrays.asList(R.I64, R.FP64, R.STRING, R.BOOLEAN));
+
+  @Test
+  void simpleEqualityFilter() {
+    // Filter: WHERE id = 100
+    Expression condition = b.equal(b.fieldReference(baseTable, 0), b.i32(100));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void stringComparisonFilter() {
+    // Filter: WHERE name = 'John'
+    Expression condition = b.equal(b.fieldReference(baseTable, 2), b.str("John"));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void andConditionFilter() {
+    // Filter: WHERE id = 10 AND amount = 100.0
+    Expression condition =
+        b.and(
+            b.equal(b.fieldReference(baseTable, 0), b.i32(10)),
+            b.equal(b.fieldReference(baseTable, 1), b.fp64(100.0)));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void orConditionFilter() {
+    // Filter: WHERE id = 5 OR id = 95
+    Expression condition =
+        b.or(
+            b.equal(b.fieldReference(baseTable, 0), b.i32(5)),
+            b.equal(b.fieldReference(baseTable, 0), b.i32(95)));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void complexBooleanFilter() {
+    // Filter: WHERE (id = 10 AND amount = 100) OR status = true
+    Expression andCondition =
+        b.and(
+            b.equal(b.fieldReference(baseTable, 0), b.i32(10)),
+            b.equal(b.fieldReference(baseTable, 1), b.fp64(100.0)));
+
+    Expression condition =
+        b.or(andCondition, b.equal(b.fieldReference(baseTable, 3), b.bool(true)));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void multipleFieldComparison() {
+    // Filter: WHERE id = amount (comparing two fields)
+    Expression condition = b.equal(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 1));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void nestedFilters() {
+    // Apply filter on top of another filter
+    Expression firstCondition = b.equal(b.fieldReference(baseTable, 0), b.i32(10));
+    Rel firstFilter = Filter.builder().input(baseTable).condition(firstCondition).build();
+
+    Expression secondCondition = b.equal(b.fieldReference(firstFilter, 1), b.fp64(100.0));
+    Rel secondFilter = Filter.builder().input(firstFilter).condition(secondCondition).build();
+
+    verifyRoundTrip(secondFilter);
+  }
+
+  @Test
+  void filterWithArithmeticExpression() {
+    // Filter: WHERE amount * 2 = 100
+    Expression multiply = b.multiply(b.fieldReference(baseTable, 1), b.fp64(2.0));
+    Expression condition = b.equal(multiply, b.fp64(100.0));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void filterWithBooleanField() {
+    // Filter: WHERE status (direct boolean field)
+    Expression condition = b.fieldReference(baseTable, 3);
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+
+  @Test
+  void filterWithAddition() {
+    // Filter: WHERE id + id = id (field with itself)
+    Expression add = b.add(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 0));
+    Expression condition = b.equal(add, b.fieldReference(baseTable, 0));
+
+    Rel filter = Filter.builder().input(baseTable).condition(condition).build();
+
+    verifyRoundTrip(filter);
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/ProjectRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ProjectRelRoundtripTest.java
@@ -1,0 +1,149 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class ProjectRelRoundtripTest extends TestBase {
+
+  final Rel baseTable =
+      b.namedScan(
+          Collections.singletonList("test_table"),
+          Arrays.asList("col_a", "col_b", "col_c", "col_d"),
+          Arrays.asList(R.I64, R.FP64, R.STRING, R.I32));
+
+  @Test
+  void simpleProjection() {
+    // Project single field
+    Rel projection =
+        Project.builder().input(baseTable).addExpressions(b.fieldReference(baseTable, 0)).build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void multipleFieldProjection() {
+    // Project multiple fields
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(
+                b.fieldReference(baseTable, 0),
+                b.fieldReference(baseTable, 2),
+                b.fieldReference(baseTable, 1))
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void projectionWithComputedExpression() {
+    // Project with computed expression: col_a + 3 (both I64)
+    Expression addExpr = b.add(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 0));
+
+    Rel projection = Project.builder().input(baseTable).addExpressions(addExpr).build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void projectionWithMultipleComputedExpressions() {
+    // Project with multiple computed expressions
+    Expression add = b.add(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 0));
+    Expression multiply =
+        b.multiply(b.fieldReference(baseTable, 1), b.fieldReference(baseTable, 1));
+
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(
+                b.fieldReference(baseTable, 2), // original field
+                add, // computed col_a + 100
+                multiply) // computed col_b * 2.0
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void projectionWithLiterals() {
+    // Project with literal values
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(b.fieldReference(baseTable, 0), b.i32(100), b.str("constant_string"))
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void projectionWithAllFields() {
+    // Project all fields (identity projection)
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(
+                b.fieldReference(baseTable, 0),
+                b.fieldReference(baseTable, 1),
+                b.fieldReference(baseTable, 2),
+                b.fieldReference(baseTable, 3))
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void nestedProjection() {
+    // Project on top of another projection
+    Rel firstProjection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 2))
+            .build();
+
+    Rel secondProjection =
+        Project.builder()
+            .input(firstProjection)
+            .addExpressions(b.fieldReference(firstProjection, 1))
+            .build();
+
+    verifyRoundTrip(secondProjection);
+  }
+
+  @Test
+  void projectionWithComparison() {
+    // Project with comparison expression: col_a = col_d
+    Expression comparison = b.equal(b.fieldReference(baseTable, 0), b.fieldReference(baseTable, 3));
+
+    Rel projection =
+        Project.builder()
+            .input(baseTable)
+            .addExpressions(b.fieldReference(baseTable, 0), comparison)
+            .build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void projectionWithCast() {
+    // Project with type cast: CAST(col_d AS BIGINT)
+    Expression cast = b.cast(b.fieldReference(baseTable, 3), R.I64);
+
+    Rel projection = Project.builder().input(baseTable).addExpressions(cast).build();
+
+    verifyRoundTrip(projection);
+  }
+
+  @Test
+  void emptyProjection() {
+    // Project with no expressions (edge case - may produce empty output schema)
+    Rel projection = Project.builder().input(baseTable).build();
+
+    verifyRoundTrip(projection);
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/SortRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/SortRelRoundtripTest.java
@@ -1,0 +1,246 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Rel;
+import io.substrait.relation.Sort;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public class SortRelRoundtripTest extends TestBase {
+
+  final Rel baseTable =
+      b.namedScan(
+          Collections.singletonList("test_table"),
+          Arrays.asList("id", "amount", "name", "category", "timestamp"),
+          Arrays.asList(R.I64, R.FP64, R.STRING, R.STRING, R.TIMESTAMP));
+
+  @Test
+  void simpleSortAscending() {
+    // Sort by id ascending, nulls first
+    Expression.SortField sortField =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 0))
+            .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortAscendingNullsLast() {
+    // Sort by name ascending, nulls last
+    Expression.SortField sortField =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 2))
+            .direction(Expression.SortDirection.ASC_NULLS_LAST)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortDescendingNullsFirst() {
+    // Sort by amount descending, nulls first
+    Expression.SortField sortField =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 1))
+            .direction(Expression.SortDirection.DESC_NULLS_FIRST)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortDescendingNullsLast() {
+    // Sort by timestamp descending, nulls last
+    Expression.SortField sortField =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 4))
+            .direction(Expression.SortDirection.DESC_NULLS_LAST)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortClustered() {
+    // Sort with clustered direction (no specific order guarantee)
+    Expression.SortField sortField =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 3))
+            .direction(Expression.SortDirection.CLUSTERED)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void multipleSortFields() {
+    // Sort by category (asc), then amount (desc)
+    Expression.SortField sortField1 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 3))
+            .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+            .build();
+
+    Expression.SortField sortField2 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 1))
+            .direction(Expression.SortDirection.DESC_NULLS_LAST)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField1, sortField2).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortByThreeFields() {
+    // Sort by category, name, and id
+    Expression.SortField sortField1 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 3))
+            .direction(Expression.SortDirection.ASC_NULLS_LAST)
+            .build();
+
+    Expression.SortField sortField2 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 2))
+            .direction(Expression.SortDirection.ASC_NULLS_LAST)
+            .build();
+
+    Expression.SortField sortField3 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 0))
+            .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+            .build();
+
+    Rel sort =
+        Sort.builder().input(baseTable).addSortFields(sortField1, sortField2, sortField3).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortByComputedExpression() {
+    // Sort by computed expression: amount * 2
+    Expression computedExpr = b.multiply(b.fieldReference(baseTable, 1), b.fp64(2.0));
+
+    Expression.SortField sortField =
+        Expression.SortField.builder()
+            .expr(computedExpr)
+            .direction(Expression.SortDirection.DESC_NULLS_LAST)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortByStringField() {
+    // Sort by string field directly
+    Expression.SortField sortField =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 2))
+            .direction(Expression.SortDirection.ASC_NULLS_LAST)
+            .build();
+
+    Rel sort = Sort.builder().input(baseTable).addSortFields(sortField).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortWithMixedNullHandling() {
+    // Sort with different null handling for different fields
+    Expression.SortField sortField1 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 3))
+            .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+            .build();
+
+    Expression.SortField sortField2 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 1))
+            .direction(Expression.SortDirection.DESC_NULLS_FIRST)
+            .build();
+
+    Expression.SortField sortField3 =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 2))
+            .direction(Expression.SortDirection.ASC_NULLS_LAST)
+            .build();
+
+    Rel sort =
+        Sort.builder().input(baseTable).addSortFields(sortField1, sortField2, sortField3).build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void sortAllDirections() {
+    // Test all sort directions in single sort operation
+    Rel sort =
+        Sort.builder()
+            .input(baseTable)
+            .addSortFields(
+                Expression.SortField.builder()
+                    .expr(b.fieldReference(baseTable, 0))
+                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                    .build(),
+                Expression.SortField.builder()
+                    .expr(b.fieldReference(baseTable, 1))
+                    .direction(Expression.SortDirection.ASC_NULLS_LAST)
+                    .build(),
+                Expression.SortField.builder()
+                    .expr(b.fieldReference(baseTable, 2))
+                    .direction(Expression.SortDirection.DESC_NULLS_FIRST)
+                    .build(),
+                Expression.SortField.builder()
+                    .expr(b.fieldReference(baseTable, 3))
+                    .direction(Expression.SortDirection.DESC_NULLS_LAST)
+                    .build(),
+                Expression.SortField.builder()
+                    .expr(b.fieldReference(baseTable, 4))
+                    .direction(Expression.SortDirection.CLUSTERED)
+                    .build())
+            .build();
+
+    verifyRoundTrip(sort);
+  }
+
+  @Test
+  void nestedSort() {
+    // Sort on top of another sort
+    Expression.SortField firstSort =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(baseTable, 3))
+            .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+            .build();
+
+    Rel firstSortRel = Sort.builder().input(baseTable).addSortFields(firstSort).build();
+
+    Expression.SortField secondSort =
+        Expression.SortField.builder()
+            .expr(b.fieldReference(firstSortRel, 0))
+            .direction(Expression.SortDirection.DESC_NULLS_LAST)
+            .build();
+
+    Rel secondSortRel = Sort.builder().input(firstSortRel).addSortFields(secondSort).build();
+
+    verifyRoundTrip(secondSortRel);
+  }
+}


### PR DESCRIPTION
Added comprehensive roundtrip tests for `Filter`, `Project`, `Sort` relations, and `FieldReference` expressions to ensure proper serialization and deserialization of Substrait plans (`RelProtoConverter` -> `ProtoRelConverter`). 

This includes testing various structures like multiple fields, nested expressions, different sort directions, and complex boolean logic.