### PR TITLE
fix(spark): convert UnsafeArrayData literal to substrait

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
@@ -42,7 +42,8 @@ class ToSubstraitLiteral {
         arrayData: ArrayData,
         elementType: DataType,
         containsNull: Boolean): SExpression.Literal = {
-      val elements = arrayData.array.map(any => apply(Literal(any, elementType)))
+      val elements =
+        arrayData.toArray(elementType).map((any: Any) => apply(Literal(any, elementType)))
       if (elements.isEmpty) {
         return emptyList(false, ToSubstraitType.convert(elementType, nullable = containsNull).get)
       }


### PR DESCRIPTION
UnsafeArrayData doesnt support the `array` method https://github.com/apache/spark/blob/c0416713e8e1e5fb81f218feb339cfbeacb61b72/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/UnsafeArrayData.java#L105