### PR TITLE
fix(core): disable @Generated annotations for immutables

### DIFF
--- a/core/src/main/java/io/substrait/package-info.java
+++ b/core/src/main/java/io/substrait/package-info.java
@@ -1,0 +1,2 @@
+@org.immutables.value.Value.Style(allowedClasspathAnnotations = {java.lang.Override.class})
+package io.substrait;


### PR DESCRIPTION
By default immutables adds a `@org.immutables.value.Generated` annotation to all generated classes which is causing compilation warnings by consumers that do not include immutables as a dependency which they also don't need to include since the annotation is purely informational.

This change disables adding the `@Generated` annotations to avoid causing compilation warnings for substrait-java consumers.