### PR TITLE
build: limit immutables dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.engine)
   implementation(libs.slf4j.api)
-  annotationProcessor(libs.immutables.value)
+  annotationProcessor(libs.immutables.processor)
   compileOnly(libs.immutables.annotations)
 
   nmcpAggregation(project(":core"))

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -99,7 +99,7 @@ dependencies {
   antlr(libs.antlr4)
   shadowImplementation(libs.antlr4.runtime)
   implementation(libs.slf4j.api)
-  annotationProcessor(libs.immutables.value)
+  annotationProcessor(libs.immutables.processor)
   compileOnly(libs.immutables.annotations)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "co
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graal" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpclient5" }
-immutables-value = { module = "org.immutables:value", version.ref = "immutables" }
+immutables-processor = { module = "org.immutables:value-processor", version.ref = "immutables" }
 immutables-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind" }

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     exclude("com.google.guava", "guava")
       .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
   }
-  annotationProcessor(libs.immutables.value)
+  annotationProcessor(libs.immutables.processor)
   implementation(libs.immutables.annotations)
   testImplementation(libs.calcite.plus) {
     exclude(group = "commons-lang", module = "commons-lang")

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -110,7 +110,7 @@ dependencies {
     exclude("com.google.guava", "guava")
       .because("Brings in Guava for Android, which we don't want (and breaks multimaps).")
   }
-  annotationProcessor(libs.immutables.value)
+  annotationProcessor(libs.immutables.processor)
   compileOnly(libs.immutables.annotations)
   implementation(libs.slf4j.api)
   testImplementation(libs.calcite.plus) {


### PR DESCRIPTION
The build depends on org.immutables:value as an annotation processor, which contains components beyond those strictly required for annotation processing.

This change limits the immutables dependencies and their scope to minimise the dependency footprint and avoid runtime classpath pollution.