### PR TITLE
feat(core,isthmus): support grouping set index in Aggregate

### DIFF
--- a/core/src/main/java/io/substrait/relation/Aggregate.java
+++ b/core/src/main/java/io/substrait/relation/Aggregate.java
@@ -56,7 +56,13 @@ public abstract class Aggregate extends SingleInputRel implements HasExtension {
 
     final Stream<Type> measureTypes = getMeasures().stream().map(t -> t.getFunction().getType());
 
-    return TypeCreator.REQUIRED.struct(Stream.concat(groupingTypes, measureTypes));
+    // an aggregate relation with more than one grouping set receives an extra i32 column on the
+    // right-hand side per spec:
+    // https://substrait.io/relations/logical_relations/#aggregate-operation
+    final Stream<Type> groupingSetIndex = Stream.of(TypeCreator.REQUIRED.I32);
+
+    return TypeCreator.REQUIRED.struct(
+        Stream.concat(Stream.concat(groupingTypes, measureTypes), groupingSetIndex));
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -358,7 +358,7 @@ public class SubstraitRelNodeConverter
     // map grouping set index if it is not removed via remap
     final boolean emitDirect = remap.isEmpty();
     final boolean groupingSetIndexGetsRemapped =
-        remap.isPresent() && remap.get().indices().contains(lastFieldIndex);
+        remap.map(r -> r.indices().contains(lastFieldIndex)).orElse(false);
     if (aggregate.getGroupings().size() > 1 && (emitDirect || groupingSetIndexGetsRemapped)) {
       aggregateCalls.add(
           AggregateCall.create(
@@ -379,8 +379,7 @@ public class SubstraitRelNodeConverter
         for (int i = 0; i < remapList.size(); i++) {
           if (remapList.get(i).equals(lastFieldIndex)) {
             // replace last field index with field index of the GROUP_ID() function call
-            remapList.remove(i);
-            remapList.add(i, groupingCallIndex);
+            remapList.set(i, groupingCallIndex);
           }
         }
         remap = Optional.of(Remap.of(remapList));

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -375,7 +376,7 @@ public class SubstraitRelNodeConverter
               null));
       final int groupingCallIndex = aggregateCalls.size() - 1;
       if (groupingSetIndexGetsRemapped) {
-        List<Integer> remapList = new ArrayList<>(remap.get().indices());
+        List<Integer> remapList = new LinkedList<>(remap.get().indices());
         for (int i = 0; i < remapList.size(); i++) {
           if (remapList.get(i).equals(lastFieldIndex)) {
             // replace last field index with field index of the GROUP_ID() function call

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -34,10 +34,12 @@ import io.substrait.relation.NamedUpdate;
 import io.substrait.relation.NamedWrite;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
+import io.substrait.relation.Rel.Remap;
 import io.substrait.relation.Set;
 import io.substrait.relation.Sort;
 import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.NamedStruct;
+import io.substrait.type.TypeCreator;
 import io.substrait.util.VisitationContext;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,6 +76,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexSlot;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
@@ -348,8 +351,44 @@ public class SubstraitRelNodeConverter
         aggregate.getMeasures().stream()
             .map(measure -> fromMeasure(measure, context))
             .collect(java.util.stream.Collectors.toList());
+
+    Optional<Remap> remap = aggregate.getRemap();
+    final int lastFieldIndex = groupExprs.size() + aggregateCalls.size();
+
+    // map grouping set index if it is not removed via remap
+    final boolean emitDirect = remap.isEmpty();
+    final boolean groupingSetIndexGetsRemapped =
+        remap.isPresent() && remap.get().indices().contains(lastFieldIndex);
+    if (aggregate.getGroupings().size() > 1 && (emitDirect || groupingSetIndexGetsRemapped)) {
+      aggregateCalls.add(
+          AggregateCall.create(
+              SqlStdOperatorTable.GROUP_ID,
+              false,
+              false,
+              false,
+              Collections.emptyList(),
+              Collections.emptyList(),
+              -1,
+              null,
+              RelCollations.EMPTY,
+              typeConverter.toCalcite(typeFactory, TypeCreator.REQUIRED.I64),
+              null));
+      final int groupingCallIndex = aggregateCalls.size() - 1;
+      if (groupingSetIndexGetsRemapped) {
+        List<Integer> remapList = new ArrayList<>(remap.get().indices());
+        for (int i = 0; i < remapList.size(); i++) {
+          if (remapList.get(i).equals(lastFieldIndex)) {
+            // replace last field index with field index of the GROUP_ID() function call
+            remapList.remove(i);
+            remapList.add(i, groupingCallIndex);
+          }
+        }
+        remap = Optional.of(Remap.of(remapList));
+      }
+    }
+
     RelNode node = relBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
-    return applyRemap(node, aggregate.getRemap());
+    return applyRemap(node, remap);
   }
 
   private AggregateCall fromMeasure(Aggregate.Measure measure, Context context) {

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -313,8 +313,10 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
           } else if (groupIdCalls.contains(aggCall)) {
             remap.add(i + groupingFieldCount, groupingSetIndex);
           } else {
+            // this should never get triggered
             throw new IllegalStateException(
-                "encountered AggregateCall that is neither in filteredAggCalls nor in groupIdCalls");
+                "encountered AggregateCall that is neither in filteredAggCalls nor in groupIdCalls"
+                    + aggCall);
           }
         }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -290,26 +290,20 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
       // remove the grouping set index if there was no explicit GROUP_ID() function call
       if (groupIdCalls.isEmpty()) {
         int groupingExprSize =
-            groupings.stream()
-                .flatMap(g -> g.getExpressions().stream())
-                .distinct()
-                .collect(Collectors.toList())
-                .size();
+            Math.toIntExact(
+                groupings.stream().flatMap(g -> g.getExpressions().stream()).distinct().count());
         builder.remap(Remap.offset(0, groupingExprSize + aggCalls.size()));
       } else {
         // remap grouping set index at the field positions where the GROUP_ID() function calls were
         final int groupingFieldCount =
-            groupings.stream()
-                .flatMap(g -> g.getExpressions().stream())
-                .collect(Collectors.toList())
-                .size();
+            Math.toIntExact(groupings.stream().flatMap(g -> g.getExpressions().stream()).count());
         final int filterAggCallCount = aggCalls.size();
         final Integer groupingSetIndex = groupingFieldCount + filterAggCallCount;
 
-        final List<Integer> groupingFieldIndices =
-            IntStream.range(0, groupingFieldCount).mapToObj(i -> i).collect(Collectors.toList());
-
-        final List<Integer> remap = new ArrayList<>(groupingFieldIndices);
+        final List<Integer> remap =
+            IntStream.range(0, groupingFieldCount)
+                .mapToObj(i -> i)
+                .collect(Collectors.toCollection(ArrayList::new));
 
         for (int i = 0; i < aggregate.getAggCallList().size(); i++) {
           AggregateCall aggCall = aggregate.getAggCallList().get(i);

--- a/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
@@ -92,6 +92,14 @@ public class Substrait2SqlTest extends PlanTestBase {
         "select sum(l_discount) from lineitem group by grouping sets ((l_orderkey, L_COMMITDATE), l_shipdate, ()), l_linestatus");
     assertSqlSubstraitRelRoundTrip(
         "select sum(l_discount) from lineitem group by grouping sets ((l_orderkey, L_COMMITDATE), (l_orderkey, L_COMMITDATE, l_linestatus), l_shipdate, ())");
+
+    // GROUP_ID()
+    assertSqlSubstraitRelRoundTrip(
+        "select sum(l_discount), group_id() from lineitem group by grouping sets ((l_orderkey, L_COMMITDATE), l_shipdate)");
+    assertSqlSubstraitRelRoundTrip(
+        "select group_id(), sum(l_discount) from lineitem group by grouping sets ((l_orderkey, L_COMMITDATE), l_shipdate)");
+    assertSqlSubstraitRelRoundTrip(
+        "select group_id(), sum(l_discount), group_id() from lineitem group by grouping sets ((l_orderkey, L_COMMITDATE), l_shipdate)");
   }
 
   @Test


### PR DESCRIPTION
fixes #527 

- adds the int32 grouping set index to `Aggregate.deriveRecordType()`
- adds Calcite mappings to isthmus which maps a `GROUP_ID()` aggregate function call mapping for the grouping set index since it has the same semantic as the Substrait grouping set index
- ensures remap removes the grouping set index field if it there is no `GROUP_ID()` function call in the Calcite plan