### PR TITLE
feat(isthmus): support fully qualified table names in SubstraitCreateStatementParser

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
@@ -48,7 +48,8 @@ public class SchemaCollector {
       // The last name in names is the table name. All others are schema names.
       String tableName = names.get(names.size() - 1);
 
-      CalciteSchema schema = Utils.createCalciteSchemaFromNames(rootSchema, names);
+      CalciteSchema schema =
+          Utils.createCalciteSchemaFromNames(rootSchema, names.subList(0, names.size() - 1));
 
       // Create the table if it is not present
       CalciteSchema.TableEntry table = schema.getTable(tableName, CASE_SENSITIVE);

--- a/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
@@ -1,6 +1,5 @@
 package io.substrait.isthmus;
 
-import io.substrait.isthmus.calcite.SubstraitSchema;
 import io.substrait.isthmus.calcite.SubstraitTable;
 import io.substrait.relation.NamedScan;
 import io.substrait.relation.NamedUpdate;
@@ -16,6 +15,7 @@ import java.util.Optional;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.jspecify.annotations.NonNull;
 
 /** For use in generating {@link CalciteSchema}s from Substrait {@link Rel}s */
 public class SchemaCollector {
@@ -30,7 +30,14 @@ public class SchemaCollector {
     this.typeConverter = typeConverter;
   }
 
-  public CalciteSchema toSchema(Rel rel) {
+  /**
+   * Returns a {@link CalciteSchema} containing all tables and schemas defined in {@link NamedScan}s
+   * and {@link NamedWrite}s within the provided relation operation tree.
+   *
+   * @param rel the relation operation tree to gather the tables and schemas from, must not be null
+   * @return the {@link CalciteSchema} containing the discovered tables and schemas
+   */
+  public CalciteSchema toSchema(@NonNull final Rel rel) {
     // Create the root schema under which all tables and schemas will be nested.
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false, false);
 
@@ -41,17 +48,7 @@ public class SchemaCollector {
       // The last name in names is the table name. All others are schema names.
       String tableName = names.get(names.size() - 1);
 
-      // Traverse all schemas, creating them if they are not present
-      CalciteSchema schema = rootSchema;
-      for (String schemaName : names.subList(0, names.size() - 1)) {
-        CalciteSchema subSchema = schema.getSubSchema(schemaName, CASE_SENSITIVE);
-        if (subSchema != null) {
-          schema = subSchema;
-        } else {
-          SubstraitSchema newSubSchema = new SubstraitSchema();
-          schema = schema.add(schemaName, newSubSchema);
-        }
-      }
+      CalciteSchema schema = Utils.createCalciteSchemaFromNames(rootSchema, names);
 
       // Create the table if it is not present
       CalciteSchema.TableEntry table = schema.getTable(tableName, CASE_SENSITIVE);

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -4,7 +4,6 @@ import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionProperty;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCostImpl;
@@ -19,9 +18,13 @@ import org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 
-class SqlConverterBase {
+public class SqlConverterBase {
   protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION =
       DefaultExtensionCatalog.DEFAULT_COLLECTION;
+
+  public static final CalciteConnectionConfig CONNECTION_CONFIG =
+      CalciteConnectionConfig.DEFAULT.set(
+          CalciteConnectionProperty.CASE_SENSITIVE, Boolean.FALSE.toString());
 
   final RelDataTypeFactory factory;
   final RelOptCluster relOptCluster;
@@ -34,7 +37,7 @@ class SqlConverterBase {
   final FeatureBoard featureBoard;
 
   protected SqlConverterBase(FeatureBoard features) {
-    this.factory = new JavaTypeFactoryImpl(SubstraitTypeSystem.TYPE_SYSTEM);
+    this.factory = SubstraitTypeSystem.TYPE_FACTORY;
     this.config =
         CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
     this.converterConfig = SqlToRelConverter.config().withTrimUnusedFields(true).withExpand(false);

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -12,6 +12,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   public static final RelDataTypeSystem TYPE_SYSTEM = new SubstraitTypeSystem();
 
+  public static final RelDataTypeFactory TYPE_FACTORY = new JavaTypeFactoryImpl(TYPE_SYSTEM);
+
   // Interval qualifier from year to month
   public static final SqlIntervalQualifier YEAR_MONTH_INTERVAL =
       new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO);
@@ -50,9 +52,5 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   @Override
   public boolean shouldConvertRaggedUnionTypesToVarying() {
     return true;
-  }
-
-  public static RelDataTypeFactory createTypeFactory() {
-    return new JavaTypeFactoryImpl(TYPE_SYSTEM);
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/Utils.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/Utils.java
@@ -63,20 +63,20 @@ public class Utils {
   }
 
   /**
-   * Traverses all names identifying a table, creating any schemas if they are not present in the
-   * root schema, returning the final sub schema.
+   * Traverses a list of hierarchical schema names, creating any schemas if they are not present in
+   * the root schema, returning the final sub schema or the root schema if the list of names is
+   * empty.
    *
    * @param rootSchema the root schema to add the missing schemas to
-   * @param names the list of hierarchical schema and table names ordered from parent to child with
-   *     the last element containing the table name
-   * @return the final sub schema
+   * @param names the list of hierarchical schema names ordered from parent to child
+   * @return the final sub schema or the root schema
    * @see io.substrait.isthmus.sql.SubstraitCreateStatementParser#processCreateStatementsToSchema
    * @see io.substrait.isthmus.SchemaCollector#toSchema
    */
   public static CalciteSchema createCalciteSchemaFromNames(
       @NonNull final CalciteSchema rootSchema, @NonNull final List<String> names) {
     CalciteSchema schema = rootSchema;
-    for (final String schemaName : names.subList(0, names.size() - 1)) {
+    for (final String schemaName : names) {
       final CalciteSchema subSchema = schema.getSubSchema(schemaName, false);
       if (subSchema != null) {
         schema = subSchema;

--- a/isthmus/src/main/java/io/substrait/isthmus/Utils.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/Utils.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.jspecify.annotations.NonNull;
 
 public class Utils {
   /**
@@ -73,14 +74,14 @@ public class Utils {
    * @see io.substrait.isthmus.SchemaCollector#toSchema
    */
   public static CalciteSchema createCalciteSchemaFromNames(
-      CalciteSchema rootSchema, List<String> names) {
+      @NonNull final CalciteSchema rootSchema, @NonNull final List<String> names) {
     CalciteSchema schema = rootSchema;
-    for (String schemaName : names.subList(0, names.size() - 1)) {
-      CalciteSchema subSchema = schema.getSubSchema(schemaName, false);
+    for (final String schemaName : names.subList(0, names.size() - 1)) {
+      final CalciteSchema subSchema = schema.getSubSchema(schemaName, false);
       if (subSchema != null) {
         schema = subSchema;
       } else {
-        SubstraitSchema newSubSchema = new SubstraitSchema();
+        final SubstraitSchema newSubSchema = new SubstraitSchema();
         schema = schema.add(schemaName, newSubSchema);
       }
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -58,6 +58,9 @@ public class SubstraitCreateStatementParser {
   /**
    * Parses a SQL string containing only CREATE statements into a list of {@link SubstraitTable}s
    *
+   * <p>This method only supports simple table names without any additional qualifiers. Only used
+   * with {@link io.substrait.isthmus.SqlExpressionToSubstrait}.
+   *
    * @param createStatements a SQL string containing only CREATE statements
    * @return a list of {@link SubstraitTable}s generated from the CREATE statements
    * @throws SqlParseException

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -101,7 +101,7 @@ public class SubstraitCreateStatementParser {
    * @param pos the position where this error occured, may be null
    * @return the {@link SqlParseException} with the given message and {@link SqlParserPos}
    */
-  protected static SqlParseException fail(
+  private static SqlParseException fail(
       @Nullable final String message, @Nullable final SqlParserPos pos) {
     return new SqlParseException(message, pos, null, null, new RuntimeException("fake lineage"));
   }
@@ -112,7 +112,7 @@ public class SubstraitCreateStatementParser {
    * @param message the exception message, may be null
    * @return the {@link SqlParseException} with the given message
    */
-  protected static SqlParseException fail(@Nullable final String message) {
+  private static SqlParseException fail(@Nullable final String message) {
     return fail(message, SqlParserPos.ZERO);
   }
 
@@ -123,7 +123,7 @@ public class SubstraitCreateStatementParser {
    * @return a {@link CalciteSchema} generated from the CREATE statements
    * @throws SqlParseException
    */
-  protected static CalciteSchema processCreateStatementsToSchema(
+  private static CalciteSchema processCreateStatementsToSchema(
       @NonNull final String... createStatements) throws SqlParseException {
     final CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
 
@@ -164,7 +164,7 @@ public class SubstraitCreateStatementParser {
    * @return the {@link SubstraitTable}
    * @throws SqlParseException
    */
-  protected static SubstraitTable createSubstraitTable(
+  private static SubstraitTable createSubstraitTable(
       @NonNull final String tableName, @NonNull final SqlNodeList columnList)
       throws SqlParseException {
     final List<String> names = new ArrayList<>();

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -97,6 +97,8 @@ public class SubstraitCreateStatementParser {
    * Parses one or more SQL strings containing only CREATE statements into a {@link
    * CalciteCatalogReader}
    *
+   * <p>This method expects the use of fully qualified table names in the CREATE statements.
+   *
    * @param createStatements a SQL string containing only CREATE statements, must not be null
    * @return a {@link CalciteCatalogReader} generated from the CREATE statements
    * @throws SqlParseException
@@ -153,7 +155,8 @@ public class SubstraitCreateStatementParser {
         final SqlCreateTable create = (SqlCreateTable) parsed;
         final List<String> names = create.name.names;
 
-        final CalciteSchema schema = Utils.createCalciteSchemaFromNames(rootSchema, names);
+        final CalciteSchema schema =
+            Utils.createCalciteSchemaFromNames(rootSchema, names.subList(0, names.size() - 1));
 
         // Create the table if it is not present
         final String tableName = names.get(names.size() - 1);

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.parser.ddl.SqlDdlParserImpl;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql.validate.SqlValidator;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /** Utility class for parsing CREATE statements into a {@link CalciteCatalogReader} */
@@ -61,22 +62,22 @@ public class SubstraitCreateStatementParser {
    * <p>This method only supports simple table names without any additional qualifiers. Only used
    * with {@link io.substrait.isthmus.SqlExpressionToSubstrait}.
    *
-   * @param createStatements a SQL string containing only CREATE statements
+   * @param createStatements a SQL string containing only CREATE statements, must not be null
    * @return a list of {@link SubstraitTable}s generated from the CREATE statements
    * @throws SqlParseException
    */
-  public static List<SubstraitTable> processCreateStatements(String createStatements)
+  public static List<SubstraitTable> processCreateStatements(@NonNull final String createStatements)
       throws SqlParseException {
-    SqlParser parser = SqlParser.create(createStatements, PARSER_CONFIG);
-    List<SubstraitTable> tableList = new ArrayList<>();
+    final SqlParser parser = SqlParser.create(createStatements, PARSER_CONFIG);
+    final List<SubstraitTable> tableList = new ArrayList<>();
 
-    SqlNodeList sqlNode = parser.parseStmtList();
-    for (SqlNode parsed : sqlNode) {
+    final SqlNodeList sqlNode = parser.parseStmtList();
+    for (final SqlNode parsed : sqlNode) {
       if (!(parsed instanceof SqlCreateTable)) {
         throw fail("Not a valid CREATE TABLE statement.");
       }
 
-      SqlCreateTable create = (SqlCreateTable) parsed;
+      final SqlCreateTable create = (SqlCreateTable) parsed;
 
       if (create.name.names.size() > 1) {
         throw fail("Only simple table names are allowed.", create.name.getParserPosition());
@@ -96,14 +97,14 @@ public class SubstraitCreateStatementParser {
    * Parses one or more SQL strings containing only CREATE statements into a {@link
    * CalciteCatalogReader}
    *
-   * @param createStatements a SQL string containing only CREATE statements
+   * @param createStatements a SQL string containing only CREATE statements, must not be null
    * @return a {@link CalciteCatalogReader} generated from the CREATE statements
    * @throws SqlParseException
    */
-  public static CalciteCatalogReader processCreateStatementsToCatalog(String... createStatements)
-      throws SqlParseException {
-    CalciteSchema rootSchema = processCreateStatementsToSchema(createStatements);
-    List<String> defaultSchema = Collections.emptyList();
+  public static CalciteCatalogReader processCreateStatementsToCatalog(
+      @NonNull final String... createStatements) throws SqlParseException {
+    final CalciteSchema rootSchema = processCreateStatementsToSchema(createStatements);
+    final List<String> defaultSchema = Collections.emptyList();
     return new CalciteCatalogReader(rootSchema, defaultSchema, TYPE_FACTORY, CONNECTION_CONFIG);
   }
 
@@ -114,7 +115,8 @@ public class SubstraitCreateStatementParser {
    * @param pos the position where this error occured, may be null
    * @return the {@link SqlParseException} with the given message and {@link SqlParserPos}
    */
-  protected static SqlParseException fail(@Nullable String message, @Nullable SqlParserPos pos) {
+  protected static SqlParseException fail(
+      @Nullable final String message, @Nullable final SqlParserPos pos) {
     return new SqlParseException(message, pos, null, null, new RuntimeException("fake lineage"));
   }
 
@@ -124,19 +126,19 @@ public class SubstraitCreateStatementParser {
    * @param message the exception message, may be null
    * @return the {@link SqlParseException} with the given message
    */
-  protected static SqlParseException fail(@Nullable String message) {
+  protected static SqlParseException fail(@Nullable final String message) {
     return fail(message, SqlParserPos.ZERO);
   }
 
   /**
    * Parses one or more SQL strings containing only CREATE statements into a {@link CalciteSchema}.
    *
-   * @param createStatements a SQL string containing only CREATE statements
+   * @param createStatements a SQL string containing only CREATE statements, must not be null
    * @return a {@link CalciteSchema} generated from the CREATE statements
    * @throws SqlParseException
    */
-  protected static CalciteSchema processCreateStatementsToSchema(final String... createStatements)
-      throws SqlParseException {
+  protected static CalciteSchema processCreateStatementsToSchema(
+      @NonNull final String... createStatements) throws SqlParseException {
     final CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
 
     for (final String statement : createStatements) {
@@ -151,7 +153,7 @@ public class SubstraitCreateStatementParser {
         final SqlCreateTable create = (SqlCreateTable) parsed;
         final List<String> names = create.name.names;
 
-        CalciteSchema schema = Utils.createCalciteSchemaFromNames(rootSchema, names);
+        final CalciteSchema schema = Utils.createCalciteSchemaFromNames(rootSchema, names);
 
         // Create the table if it is not present
         final String tableName = names.get(names.size() - 1);
@@ -171,18 +173,19 @@ public class SubstraitCreateStatementParser {
    * Creates a new {@link SubstraitTable} with the given table name and the table schema from the
    * given {@link SqlNodeList} containing {@link SqlColumnDeclaration}s.
    *
-   * @param tableName the table name to use
+   * @param tableName the table name to use, must not be null
    * @param columnList the {@link SqlNodeList} containing {@link SqlColumnDeclaration}s to create
-   *     the table schema from
+   *     the table schema from, must not be null
    * @return the {@link SubstraitTable}
    * @throws SqlParseException
    */
-  protected static SubstraitTable createSubstraitTable(String tableName, SqlNodeList columnList)
+  protected static SubstraitTable createSubstraitTable(
+      @NonNull final String tableName, @NonNull final SqlNodeList columnList)
       throws SqlParseException {
-    List<String> names = new ArrayList<>();
-    List<RelDataType> columnTypes = new ArrayList<>();
+    final List<String> names = new ArrayList<>();
+    final List<RelDataType> columnTypes = new ArrayList<>();
 
-    for (SqlNode node : columnList) {
+    for (final SqlNode node : columnList) {
       if (!(node instanceof SqlColumnDeclaration)) {
         if (node instanceof SqlKeyConstraint) {
           // key constraints declarations, like primary key declaration, are valid and should not
@@ -193,7 +196,7 @@ public class SubstraitCreateStatementParser {
         throw fail("Unexpected column list construction.", node.getParserPosition());
       }
 
-      SqlColumnDeclaration col = (SqlColumnDeclaration) node;
+      final SqlColumnDeclaration col = (SqlColumnDeclaration) node;
 
       if (col.name.names.size() != 1) {
         throw fail("Expected simple column names.", col.name.getParserPosition());

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteObjs.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteObjs.java
@@ -9,7 +9,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /** Set of classes/methods that make it easier to work with Calcite. */
 public abstract class CalciteObjs {
 
-  final RelDataTypeFactory type = SubstraitTypeSystem.createTypeFactory();
+  final RelDataTypeFactory type = SubstraitTypeSystem.TYPE_FACTORY;
   final RexBuilder rex = new RexBuilder(type);
 
   RelDataType t(SqlTypeName typeName, int... vals) {

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -26,10 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.adapter.tpcds.TpcdsSchema;
-import org.apache.calcite.config.CalciteConnectionConfig;
-import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
@@ -382,8 +379,7 @@ public class PlanTestBase {
     return new CalciteCatalogReader(
         rootSchema,
         defaultSchema,
-        new JavaTypeFactoryImpl(SubstraitTypeSystem.TYPE_SYSTEM),
-        CalciteConnectionConfig.DEFAULT.set(
-            CalciteConnectionProperty.CASE_SENSITIVE, Boolean.FALSE.toString()));
+        SubstraitTypeSystem.TYPE_FACTORY,
+        SqlConverterBase.CONNECTION_CONFIG);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCreator.java
@@ -1,10 +1,7 @@
 package io.substrait.isthmus;
 
 import java.util.Arrays;
-import org.apache.calcite.config.CalciteConnectionConfig;
-import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCostImpl;
@@ -38,19 +35,20 @@ public class RelCreator {
   }
 
   public RelCreator(CatalogReader catalogReader) {
-    RelDataTypeFactory factory = new JavaTypeFactoryImpl(SubstraitTypeSystem.TYPE_SYSTEM);
-    CalciteConnectionConfig config =
-        CalciteConnectionConfig.DEFAULT.set(CalciteConnectionProperty.CASE_SENSITIVE, "false");
-
     if (catalogReader == null) {
       CalciteSchema schema = CalciteSchema.createRootSchema(false);
-      catalog = new CalciteCatalogReader(schema, Arrays.asList(), factory, config);
+      catalog =
+          new CalciteCatalogReader(
+              schema,
+              Arrays.asList(),
+              SubstraitTypeSystem.TYPE_FACTORY,
+              SqlConverterBase.CONNECTION_CONFIG);
     } else {
       catalog = catalogReader;
     }
 
     VolcanoPlanner planner = new VolcanoPlanner(RelOptCostImpl.FACTORY, Contexts.EMPTY_CONTEXT);
-    cluster = RelOptCluster.create(planner, new RexBuilder(factory));
+    cluster = RelOptCluster.create(planner, new RexBuilder(SubstraitTypeSystem.TYPE_FACTORY));
   }
 
   public RelRoot parse(String sql) {

--- a/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
@@ -1,9 +1,10 @@
 package io.substrait.isthmus.sql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -18,8 +19,7 @@ class SubstraitCreateStatementParserTest {
 
     final CalciteSchema rootSchema = catalogReader.getRootSchema();
 
-    assertEquals(1, rootSchema.getTableNames().size());
-    assertNotNull(rootSchema.getTable("src1", false));
+    assertEquals(Set.of("SRC1"), rootSchema.getTableNames());
   }
 
   @Test
@@ -31,9 +31,7 @@ class SubstraitCreateStatementParserTest {
 
     final CalciteSchema rootSchema = catalogReader.getRootSchema();
 
-    assertEquals(2, rootSchema.getTableNames().size());
-    assertNotNull(rootSchema.getTable("src1", false));
-    assertNotNull(rootSchema.getTable("src2", false));
+    assertEquals(Set.of("SRC1", "SRC2"), rootSchema.getTableNames());
   }
 
   @Test
@@ -44,10 +42,9 @@ class SubstraitCreateStatementParserTest {
 
     final CalciteSchema rootSchema = catalogReader.getRootSchema();
 
-    assertEquals(0, rootSchema.getTableNames().size());
-    assertEquals(1, rootSchema.getSubSchemaMap().size());
-    assertNotNull(rootSchema.getSubSchema("schema1", false));
-    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src1", false));
+    assertTrue(rootSchema.getTableNames().isEmpty());
+    assertEquals(Set.of("SCHEMA1"), rootSchema.getSubSchemaMap().keySet());
+    assertEquals(Set.of("SRC1"), rootSchema.getSubSchema("schema1", false).getTableNames());
   }
 
   @Test
@@ -59,11 +56,9 @@ class SubstraitCreateStatementParserTest {
 
     final CalciteSchema rootSchema = catalogReader.getRootSchema();
 
-    assertEquals(0, rootSchema.getTableNames().size());
-    assertEquals(1, rootSchema.getSubSchemaMap().size());
-    assertNotNull(rootSchema.getSubSchema("schema1", false));
-    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src1", false));
-    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src2", false));
+    assertTrue(rootSchema.getTableNames().isEmpty());
+    assertEquals(Set.of("SCHEMA1"), rootSchema.getSubSchemaMap().keySet());
+    assertEquals(Set.of("SRC1", "SRC2"), rootSchema.getSubSchema("schema1", false).getTableNames());
   }
 
   @Test
@@ -75,12 +70,10 @@ class SubstraitCreateStatementParserTest {
 
     final CalciteSchema rootSchema = catalogReader.getRootSchema();
 
-    assertEquals(0, rootSchema.getTableNames().size());
-    assertEquals(2, rootSchema.getSubSchemaMap().size());
-    assertNotNull(rootSchema.getSubSchema("schema1", false));
-    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src1", false));
-    assertNotNull(rootSchema.getSubSchema("schema2", false));
-    assertNotNull(rootSchema.getSubSchema("schema2", false).getTable("src2", false));
+    assertTrue(rootSchema.getTableNames().isEmpty());
+    assertEquals(Set.of("SCHEMA1", "SCHEMA2"), rootSchema.getSubSchemaMap().keySet());
+    assertEquals(Set.of("SRC1"), rootSchema.getSubSchema("schema1", false).getTableNames());
+    assertEquals(Set.of("SRC2"), rootSchema.getSubSchema("schema2", false).getTableNames());
   }
 
   @Test
@@ -92,15 +85,13 @@ class SubstraitCreateStatementParserTest {
 
     final CalciteSchema rootSchema = catalogReader.getRootSchema();
 
-    assertEquals(0, rootSchema.getTableNames().size());
-    assertEquals(1, rootSchema.getSubSchemaMap().size());
-    assertNotNull(rootSchema.getSubSchema("catalog1", false));
-    assertNotNull(rootSchema.getSubSchema("catalog1", false).getSubSchema("schema1", false));
-    assertNotNull(
-        rootSchema
-            .getSubSchema("catalog1", false)
-            .getSubSchema("schema1", false)
-            .getTable("src1", false));
+    assertTrue(rootSchema.getTableNames().isEmpty());
+    assertEquals(Set.of("CATALOG1"), rootSchema.getSubSchemaMap().keySet());
+    assertEquals(
+        Set.of("SCHEMA1"), rootSchema.getSubSchema("catalog1", false).getSubSchemaMap().keySet());
+    assertEquals(
+        Set.of("SRC1"),
+        rootSchema.getSubSchema("catalog1", false).getSubSchema("schema1", false).getTableNames());
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
@@ -1,0 +1,118 @@
+package io.substrait.isthmus.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.junit.jupiter.api.Test;
+
+class SubstraitCreateStatementParserTest {
+  @Test
+  void testProcessCreateStatementsToCatalogWithSingleCreateTableWithTableNameOnly()
+      throws SqlParseException {
+    CalciteCatalogReader catalogReader =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "create table src1 (intcol int, charcol varchar(10))");
+
+    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 1);
+    assertNotNull(catalogReader.getRootSchema().getTable("src1", false));
+  }
+
+  @Test
+  void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithTableNameOnly()
+      throws SqlParseException {
+    CalciteCatalogReader catalogReader =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "create table src1 (intcol int, charcol varchar(10))",
+            "create table src2 (intcol int, charcol varchar(10))");
+
+    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 2);
+    assertNotNull(catalogReader.getRootSchema().getTable("src1", false));
+    assertNotNull(catalogReader.getRootSchema().getTable("src2", false));
+  }
+
+  @Test
+  void testProcessCreateStatementsToCatalogWithSingleCreateTableWithSchemaAndTableName()
+      throws SqlParseException {
+    CalciteCatalogReader catalogReader =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "create table schema1.src1 (intcol int, charcol varchar(10))");
+
+    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
+    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 1);
+    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema1", false));
+    assertNotNull(
+        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src1", false));
+  }
+
+  @Test
+  void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithSameSchema()
+      throws SqlParseException {
+    CalciteCatalogReader catalogReader =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "create table schema1.src1 (intcol int, charcol varchar(10))",
+            "create table schema1.src2 (intcol int, charcol varchar(10))");
+
+    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
+    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 1);
+    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema1", false));
+    assertNotNull(
+        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src1", false));
+    assertNotNull(
+        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src2", false));
+  }
+
+  @Test
+  void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithDifferentSchemas()
+      throws SqlParseException {
+    CalciteCatalogReader catalogReader =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "create table schema1.src1 (intcol int, charcol varchar(10))",
+            "create table schema2.src2 (intcol int, charcol varchar(10))");
+
+    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
+    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 2);
+    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema1", false));
+    assertNotNull(
+        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src1", false));
+    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema2", false));
+    assertNotNull(
+        catalogReader.getRootSchema().getSubSchema("schema2", false).getTable("src2", false));
+  }
+
+  @Test
+  void testProcessCreateStatementsToCatalogWithSingleCreateTableWithCatalogAndSchemaAndTableName()
+      throws SqlParseException {
+    CalciteCatalogReader catalogReader =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "create table catalog1.schema1.src1 (intcol int, charcol varchar(10))");
+
+    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
+    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 1);
+    assertNotNull(catalogReader.getRootSchema().getSubSchema("catalog1", false));
+    assertNotNull(
+        catalogReader
+            .getRootSchema()
+            .getSubSchema("catalog1", false)
+            .getSubSchema("schema1", false));
+    assertNotNull(
+        catalogReader
+            .getRootSchema()
+            .getSubSchema("catalog1", false)
+            .getSubSchema("schema1", false)
+            .getTable("src1", false));
+  }
+
+  @Test
+  void testProcessCreateStatementsToCatalogWithMultipleCreateTableForSameTableThrowsException()
+      throws SqlParseException {
+    assertThrows(
+        SqlParseException.class,
+        () ->
+            SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+                "create table src1 (intcol int, charcol varchar(10))",
+                "create table src1 (intcol int, charcol varchar(20))"));
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
@@ -12,7 +12,7 @@ class SubstraitCreateStatementParserTest {
   @Test
   void testProcessCreateStatementsToCatalogWithSingleCreateTableWithTableNameOnly()
       throws SqlParseException {
-    CalciteCatalogReader catalogReader =
+    final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table src1 (intcol int, charcol varchar(10))");
 
@@ -23,7 +23,7 @@ class SubstraitCreateStatementParserTest {
   @Test
   void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithTableNameOnly()
       throws SqlParseException {
-    CalciteCatalogReader catalogReader =
+    final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table src1 (intcol int, charcol varchar(10))",
             "create table src2 (intcol int, charcol varchar(10))");
@@ -36,7 +36,7 @@ class SubstraitCreateStatementParserTest {
   @Test
   void testProcessCreateStatementsToCatalogWithSingleCreateTableWithSchemaAndTableName()
       throws SqlParseException {
-    CalciteCatalogReader catalogReader =
+    final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table schema1.src1 (intcol int, charcol varchar(10))");
 
@@ -50,7 +50,7 @@ class SubstraitCreateStatementParserTest {
   @Test
   void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithSameSchema()
       throws SqlParseException {
-    CalciteCatalogReader catalogReader =
+    final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table schema1.src1 (intcol int, charcol varchar(10))",
             "create table schema1.src2 (intcol int, charcol varchar(10))");
@@ -67,7 +67,7 @@ class SubstraitCreateStatementParserTest {
   @Test
   void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithDifferentSchemas()
       throws SqlParseException {
-    CalciteCatalogReader catalogReader =
+    final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table schema1.src1 (intcol int, charcol varchar(10))",
             "create table schema2.src2 (intcol int, charcol varchar(10))");
@@ -85,7 +85,7 @@ class SubstraitCreateStatementParserTest {
   @Test
   void testProcessCreateStatementsToCatalogWithSingleCreateTableWithCatalogAndSchemaAndTableName()
       throws SqlParseException {
-    CalciteCatalogReader catalogReader =
+    final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table catalog1.schema1.src1 (intcol int, charcol varchar(10))");
 

--- a/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/sql/SubstraitCreateStatementParserTest.java
@@ -4,110 +4,107 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
 class SubstraitCreateStatementParserTest {
   @Test
-  void testProcessCreateStatementsToCatalogWithSingleCreateTableWithTableNameOnly()
-      throws SqlParseException {
+  void testToCatalogWithSingleCreateTableWithTableNameOnly() throws SqlParseException {
     final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table src1 (intcol int, charcol varchar(10))");
 
-    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 1);
-    assertNotNull(catalogReader.getRootSchema().getTable("src1", false));
+    final CalciteSchema rootSchema = catalogReader.getRootSchema();
+
+    assertEquals(1, rootSchema.getTableNames().size());
+    assertNotNull(rootSchema.getTable("src1", false));
   }
 
   @Test
-  void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithTableNameOnly()
-      throws SqlParseException {
+  void testToCatalogWithMultipleCreateTableWithTableNameOnly() throws SqlParseException {
     final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table src1 (intcol int, charcol varchar(10))",
             "create table src2 (intcol int, charcol varchar(10))");
 
-    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 2);
-    assertNotNull(catalogReader.getRootSchema().getTable("src1", false));
-    assertNotNull(catalogReader.getRootSchema().getTable("src2", false));
+    final CalciteSchema rootSchema = catalogReader.getRootSchema();
+
+    assertEquals(2, rootSchema.getTableNames().size());
+    assertNotNull(rootSchema.getTable("src1", false));
+    assertNotNull(rootSchema.getTable("src2", false));
   }
 
   @Test
-  void testProcessCreateStatementsToCatalogWithSingleCreateTableWithSchemaAndTableName()
-      throws SqlParseException {
+  void testToCatalogWithSingleCreateTableWithSchemaAndTableName() throws SqlParseException {
     final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table schema1.src1 (intcol int, charcol varchar(10))");
 
-    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
-    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 1);
-    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema1", false));
-    assertNotNull(
-        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src1", false));
+    final CalciteSchema rootSchema = catalogReader.getRootSchema();
+
+    assertEquals(0, rootSchema.getTableNames().size());
+    assertEquals(1, rootSchema.getSubSchemaMap().size());
+    assertNotNull(rootSchema.getSubSchema("schema1", false));
+    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src1", false));
   }
 
   @Test
-  void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithSameSchema()
-      throws SqlParseException {
+  void testToCatalogWithMultipleCreateTableWithSameSchema() throws SqlParseException {
     final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table schema1.src1 (intcol int, charcol varchar(10))",
             "create table schema1.src2 (intcol int, charcol varchar(10))");
 
-    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
-    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 1);
-    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema1", false));
-    assertNotNull(
-        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src1", false));
-    assertNotNull(
-        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src2", false));
+    final CalciteSchema rootSchema = catalogReader.getRootSchema();
+
+    assertEquals(0, rootSchema.getTableNames().size());
+    assertEquals(1, rootSchema.getSubSchemaMap().size());
+    assertNotNull(rootSchema.getSubSchema("schema1", false));
+    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src1", false));
+    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src2", false));
   }
 
   @Test
-  void testProcessCreateStatementsToCatalogWithMultipleCreateTableWithDifferentSchemas()
-      throws SqlParseException {
+  void testToCatalogWithMultipleCreateTableWithDifferentSchemas() throws SqlParseException {
     final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table schema1.src1 (intcol int, charcol varchar(10))",
             "create table schema2.src2 (intcol int, charcol varchar(10))");
 
-    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
-    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 2);
-    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema1", false));
-    assertNotNull(
-        catalogReader.getRootSchema().getSubSchema("schema1", false).getTable("src1", false));
-    assertNotNull(catalogReader.getRootSchema().getSubSchema("schema2", false));
-    assertNotNull(
-        catalogReader.getRootSchema().getSubSchema("schema2", false).getTable("src2", false));
+    final CalciteSchema rootSchema = catalogReader.getRootSchema();
+
+    assertEquals(0, rootSchema.getTableNames().size());
+    assertEquals(2, rootSchema.getSubSchemaMap().size());
+    assertNotNull(rootSchema.getSubSchema("schema1", false));
+    assertNotNull(rootSchema.getSubSchema("schema1", false).getTable("src1", false));
+    assertNotNull(rootSchema.getSubSchema("schema2", false));
+    assertNotNull(rootSchema.getSubSchema("schema2", false).getTable("src2", false));
   }
 
   @Test
-  void testProcessCreateStatementsToCatalogWithSingleCreateTableWithCatalogAndSchemaAndTableName()
+  void testToCatalogWithSingleCreateTableWithCatalogAndSchemaAndTableName()
       throws SqlParseException {
     final CalciteCatalogReader catalogReader =
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(
             "create table catalog1.schema1.src1 (intcol int, charcol varchar(10))");
 
-    assertEquals(catalogReader.getRootSchema().getTableNames().size(), 0);
-    assertEquals(catalogReader.getRootSchema().getSubSchemaMap().size(), 1);
-    assertNotNull(catalogReader.getRootSchema().getSubSchema("catalog1", false));
+    final CalciteSchema rootSchema = catalogReader.getRootSchema();
+
+    assertEquals(0, rootSchema.getTableNames().size());
+    assertEquals(1, rootSchema.getSubSchemaMap().size());
+    assertNotNull(rootSchema.getSubSchema("catalog1", false));
+    assertNotNull(rootSchema.getSubSchema("catalog1", false).getSubSchema("schema1", false));
     assertNotNull(
-        catalogReader
-            .getRootSchema()
-            .getSubSchema("catalog1", false)
-            .getSubSchema("schema1", false));
-    assertNotNull(
-        catalogReader
-            .getRootSchema()
+        rootSchema
             .getSubSchema("catalog1", false)
             .getSubSchema("schema1", false)
             .getTable("src1", false));
   }
 
   @Test
-  void testProcessCreateStatementsToCatalogWithMultipleCreateTableForSameTableThrowsException()
-      throws SqlParseException {
+  void testToCatalogWithMultipleCreateTableForSameTableThrowsException() throws SqlParseException {
     assertThrows(
         SqlParseException.class,
         () ->


### PR DESCRIPTION
Currently, the `SubstraitCreateStatementParser` can only parse `CREATE TABLE` statement with simple table names without any additional qualifiers. This PR changes the code to support parsing statements with fully qualified table names.

In order to support this I refactored `SchemaCollector` and extracted some functionality into `Utils.createCalciteSchemaFromNames` so I can reuse it in `SubstraitCreateStatementParser`.

I did not change `SubstraitCreateStatementParser.processCreateStatements` which is used with extended expressions where I wasn't sure whether supporting fully qualified table names would be useful or a breaking change.

I changed private fields and methods in `SubstraitCreateStatementParser` to protected to allow consumers to potentially extend it and reuse functionality.

Added a new `SubstraitCreateStatementParserTest` class testing various combinations of create statements with and without fully qualified names.