### PR TITLE
fix(spark): add versions for jackson dependencies

### DIFF
--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
   implementation(libs.spark.hive)
   implementation(libs.spark.catalyst)
   implementation(libs.slf4j.api)
+  implementation(platform(libs.jackson.bom))
   implementation(libs.bundles.jackson)
   implementation(libs.json.schema.validator)
 


### PR DESCRIPTION
The spark module had unversioned dependencies on a bundle of Jackson modules. This caused publishing to Maven Central to break.

This change adds a Jackson BOM dependency to the spark module to provide version information.