### PR TITLE
fix: namespace -> urn

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -569,9 +569,9 @@ public class SubstraitBuilder {
   // Aggregate Functions
 
   public AggregateFunctionInvocation aggregateFn(
-      String namespace, String key, Type outputType, Expression... args) {
+      String urn, String key, Type outputType, Expression... args) {
     SimpleExtension.AggregateFunctionVariant declaration =
-        extensions.getAggregateFunction(SimpleExtension.FunctionAnchor.of(namespace, key));
+        extensions.getAggregateFunction(SimpleExtension.FunctionAnchor.of(urn, key));
     return AggregateFunctionInvocation.builder()
         .arguments(Arrays.stream(args).collect(java.util.stream.Collectors.toList()))
         .outputType(outputType)
@@ -771,9 +771,9 @@ public class SubstraitBuilder {
   }
 
   public Expression.ScalarFunctionInvocation scalarFn(
-      String namespace, String key, Type outputType, FunctionArg... args) {
+      String urn, String key, Type outputType, FunctionArg... args) {
     SimpleExtension.ScalarFunctionVariant declaration =
-        extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(namespace, key));
+        extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
     return Expression.ScalarFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
@@ -782,7 +782,7 @@ public class SubstraitBuilder {
   }
 
   public Expression.WindowFunctionInvocation windowFn(
-      String namespace,
+      String urn,
       String key,
       Type outputType,
       Expression.AggregationPhase aggregationPhase,
@@ -792,7 +792,7 @@ public class SubstraitBuilder {
       WindowBound upperBound,
       Expression... args) {
     SimpleExtension.WindowFunctionVariant declaration =
-        extensions.getWindowFunction(SimpleExtension.FunctionAnchor.of(namespace, key));
+        extensions.getWindowFunction(SimpleExtension.FunctionAnchor.of(urn, key));
     return Expression.WindowFunctionInvocation.builder()
         .declaration(declaration)
         .outputType(outputType)
@@ -807,8 +807,8 @@ public class SubstraitBuilder {
 
   // Types
 
-  public Type.UserDefined userDefinedType(String namespace, String typeName) {
-    return Type.UserDefined.builder().urn(namespace).name(typeName).nullable(false).build();
+  public Type.UserDefined userDefinedType(String urn, String typeName) {
+    return Type.UserDefined.builder().urn(urn).name(typeName).nullable(false).build();
   }
 
   // Misc

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -43,9 +43,8 @@ public class Deserializers {
         throws IOException, JsonProcessingException {
       String typeString = p.getValueAsString();
       try {
-        String namespace =
-            (String) ctxt.findInjectableValue(SimpleExtension.URN_LOCATOR_KEY, null, null);
-        return TypeStringParser.parse(typeString, namespace, converter);
+        String urn = (String) ctxt.findInjectableValue(SimpleExtension.URN_LOCATOR_KEY, null, null);
+        return TypeStringParser.parse(typeString, urn, converter);
       } catch (Exception ex) {
         throw JsonMappingException.from(
             p, "Unable to parse string " + typeString.replace("\n", " \\n"), ex);

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -21,40 +21,39 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 
 public class ParseToPojo {
 
-  public static Type type(String namespace, SubstraitTypeParser.StartContext ctx) {
-    Visitor visitor = Visitor.simple(namespace);
+  public static Type type(String urn, SubstraitTypeParser.StartContext ctx) {
+    Visitor visitor = Visitor.simple(urn);
     return (Type) ctx.accept(visitor);
   }
 
   public static ParameterizedType parameterizedType(
-      String namespace, SubstraitTypeParser.StartContext ctx) {
-    return (ParameterizedType) ctx.accept(Visitor.parameterized(namespace));
+      String urn, SubstraitTypeParser.StartContext ctx) {
+    return (ParameterizedType) ctx.accept(Visitor.parameterized(urn));
   }
 
-  public static TypeExpression typeExpression(
-      String namespace, SubstraitTypeParser.StartContext ctx) {
-    return ctx.accept(Visitor.expression(namespace));
+  public static TypeExpression typeExpression(String urn, SubstraitTypeParser.StartContext ctx) {
+    return ctx.accept(Visitor.expression(urn));
   }
 
   public static class Visitor implements SubstraitTypeVisitor<TypeExpression> {
     private final VisitorType expressionType;
-    private final String namespace;
+    private final String urn;
 
-    public static Visitor simple(String namespace) {
-      return new Visitor(VisitorType.SIMPLE, namespace);
+    public static Visitor simple(String urn) {
+      return new Visitor(VisitorType.SIMPLE, urn);
     }
 
-    public static Visitor parameterized(String namespace) {
-      return new Visitor(VisitorType.PARAMETERIZED, namespace);
+    public static Visitor parameterized(String urn) {
+      return new Visitor(VisitorType.PARAMETERIZED, urn);
     }
 
-    public static Visitor expression(String namespace) {
-      return new Visitor(VisitorType.EXPRESSION, namespace);
+    public static Visitor expression(String urn) {
+      return new Visitor(VisitorType.EXPRESSION, urn);
     }
 
-    private Visitor(VisitorType exprType, String namespace) {
+    private Visitor(VisitorType exprType, String urn) {
       this.expressionType = exprType;
-      this.namespace = namespace;
+      this.urn = urn;
     }
 
     enum VisitorType {
@@ -199,7 +198,7 @@ public class ParseToPojo {
     @Override
     public Type visitUserDefined(SubstraitTypeParser.UserDefinedContext ctx) {
       String name = ctx.Identifier().getSymbol().getText();
-      return withNull(ctx).userDefined(namespace, name);
+      return withNull(ctx).userDefined(urn, name);
     }
 
     @Override

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -28,7 +28,7 @@ public class TypeExtensionTest {
 
   static final TypeCreator R = TypeCreator.of(false);
 
-  static final String NAMESPACE = "extension:test:custom_extensions";
+  static final String URN = "extension:test:custom_extensions";
   final SimpleExtension.ExtensionCollection extensionCollection;
 
   {
@@ -38,8 +38,8 @@ public class TypeExtensionTest {
   }
 
   final SubstraitBuilder b = new SubstraitBuilder(extensionCollection);
-  Type customType1 = b.userDefinedType(NAMESPACE, "customType1");
-  Type customType2 = b.userDefinedType(NAMESPACE, "customType2");
+  Type customType1 = b.userDefinedType(URN, "customType1");
+  Type customType2 = b.userDefinedType(URN, "customType2");
   final PlanProtoConverter planProtoConverter = new PlanProtoConverter();
   final ProtoPlanConverter protoPlanConverter = new ProtoPlanConverter(extensionCollection);
 
@@ -61,15 +61,12 @@ public class TypeExtensionTest {
                         Stream.of(
                                 b.fieldReference(input, 0),
                                 b.scalarFn(
-                                    NAMESPACE,
+                                    URN,
                                     "scalar1:u!customType1",
                                     R.I64,
                                     b.fieldReference(input, 0)),
                                 b.scalarFn(
-                                    NAMESPACE,
-                                    "scalar2:i64",
-                                    customType2,
-                                    b.fieldReference(input, 1)))
+                                    URN, "scalar2:i64", customType2, b.fieldReference(input, 1)))
                             .collect(Collectors.toList()),
                     b.namedScan(tableName, columnNames, types))));
 
@@ -93,10 +90,7 @@ public class TypeExtensionTest {
                     input ->
                         Stream.of(
                                 b.scalarFn(
-                                    NAMESPACE,
-                                    "array_index:list_i64",
-                                    R.I64,
-                                    b.fieldReference(input, 0)))
+                                    URN, "array_index:list_i64", R.I64, b.fieldReference(input, 0)))
                             .collect(Collectors.toList()),
                     b.namedScan(tableName, columnNames, types))));
     io.substrait.proto.Plan protoPlan = planProtoConverter.toProto(plan);

--- a/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
+++ b/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
@@ -17,56 +17,56 @@ public class TestTypeParser {
   private final ParameterizedTypeCreator pr = ParameterizedTypeCreator.REQUIRED;
   private final ParameterizedTypeCreator pn = ParameterizedTypeCreator.NULLABLE;
 
-  private static final String NAMESPACE = "test";
+  private static final String URN = "test";
 
   @Test
   public void basic() {
-    simpleTests(ParseToPojo.Visitor.simple(NAMESPACE));
+    simpleTests(ParseToPojo.Visitor.simple(URN));
   }
 
   @Test
   public void compound() {
-    compoundTests(ParseToPojo.Visitor.simple(NAMESPACE));
+    compoundTests(ParseToPojo.Visitor.simple(URN));
   }
 
   @Test
   public void parameterizedSimple() {
-    simpleTests(ParseToPojo.Visitor.parameterized(NAMESPACE));
+    simpleTests(ParseToPojo.Visitor.parameterized(URN));
   }
 
   @Test
   public void parameterizedCompound() {
-    compoundTests(ParseToPojo.Visitor.parameterized(NAMESPACE));
+    compoundTests(ParseToPojo.Visitor.parameterized(URN));
   }
 
   @Test
   public void parameterizedParameterized() {
-    parameterizedTests(ParseToPojo.Visitor.parameterized(NAMESPACE));
+    parameterizedTests(ParseToPojo.Visitor.parameterized(URN));
   }
 
   @Test
   public void derivationSimple() {
-    simpleTests(ParseToPojo.Visitor.expression(NAMESPACE));
+    simpleTests(ParseToPojo.Visitor.expression(URN));
   }
 
   @Test
   public void derivationCompound() {
-    compoundTests(ParseToPojo.Visitor.expression(NAMESPACE));
+    compoundTests(ParseToPojo.Visitor.expression(URN));
   }
 
   @Test
   public void derivationParameterized() {
-    parameterizedTests(ParseToPojo.Visitor.expression(NAMESPACE));
+    parameterizedTests(ParseToPojo.Visitor.expression(URN));
   }
 
   @Test
   public void derivationExpression() {
     test(
-        ParseToPojo.Visitor.expression(NAMESPACE),
+        ParseToPojo.Visitor.expression(URN),
         eo.fixedCharE(eo.plus(pr.parameter("L1"), pr.parameter("L2"))),
         "FIXEDCHAR<L1+L2>");
     test(
-        ParseToPojo.Visitor.expression(NAMESPACE),
+        ParseToPojo.Visitor.expression(URN),
         eo.program(pr.fixedCharE("L1"), new TypeExpressionCreator.Assign("L1", eo.i(1))),
         "L1=1\nFIXEDCHAR<L1>");
   }
@@ -78,7 +78,7 @@ public class TestTypeParser {
     test(v, r.I64, "I64");
     test(v, r.FP32, "FP32");
     test(v, r.FP64, "FP64");
-    test(v, r.userDefined(NAMESPACE, "foo"), "u!foo");
+    test(v, r.userDefined(URN, "foo"), "u!foo");
 
     // Nullable
     test(v, n.I8, "I8?");
@@ -87,7 +87,7 @@ public class TestTypeParser {
     test(v, n.I64, "i64?");
     test(v, n.FP32, "FP32?");
     test(v, n.FP64, "FP64?");
-    test(v, n.userDefined(NAMESPACE, "foo"), "u!foo?");
+    test(v, n.userDefined(URN, "foo"), "u!foo?");
   }
 
   private void compoundTests(ParseToPojo.Visitor v) {

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 public class CustomFunctionTest extends PlanTestBase {
 
   // Define custom functions in a "functions_custom.yaml" extension
-  static final String NAMESPACE = "extension:substrait:functions_custom";
+  static final String URN = "extension:substrait:functions_custom";
   static final String FUNCTIONS_CUSTOM;
 
   static {
@@ -63,8 +63,8 @@ public class CustomFunctionTest extends PlanTestBase {
   // Create user-defined types
   static final String aTypeName = "a_type";
   static final String bTypeName = "b_type";
-  static final UserTypeFactory aTypeFactory = new UserTypeFactory(NAMESPACE, aTypeName);
-  static final UserTypeFactory bTypeFactory = new UserTypeFactory(NAMESPACE, bTypeName);
+  static final UserTypeFactory aTypeFactory = new UserTypeFactory(URN, aTypeName);
+  static final UserTypeFactory bTypeFactory = new UserTypeFactory(URN, bTypeName);
 
   // Mapper for user-defined types
   static final UserTypeMapper userTypeMapper =
@@ -73,10 +73,10 @@ public class CustomFunctionTest extends PlanTestBase {
         @Override
         public Type toSubstrait(RelDataType relDataType) {
           if (aTypeFactory.isTypeFromFactory(relDataType)) {
-            return TypeCreator.of(relDataType.isNullable()).userDefined(NAMESPACE, aTypeName);
+            return TypeCreator.of(relDataType.isNullable()).userDefined(URN, aTypeName);
           }
           if (bTypeFactory.isTypeFromFactory(relDataType)) {
-            return TypeCreator.of(relDataType.isNullable()).userDefined(NAMESPACE, bTypeName);
+            return TypeCreator.of(relDataType.isNullable()).userDefined(URN, bTypeName);
           }
           return null;
         }
@@ -84,7 +84,7 @@ public class CustomFunctionTest extends PlanTestBase {
         @Nullable
         @Override
         public RelDataType toCalcite(Type.UserDefined type) {
-          if (type.urn().equals(NAMESPACE)) {
+          if (type.urn().equals(URN)) {
             if (type.name().equals(aTypeName)) {
               return aTypeFactory.createCalcite(type.nullable());
             }
@@ -294,9 +294,7 @@ public class CustomFunctionTest extends PlanTestBase {
     Rel rel =
         b.project(
             input ->
-                List.of(
-                    b.scalarFn(
-                        NAMESPACE, "custom_scalar:str", R.STRING, b.fieldReference(input, 0))),
+                List.of(b.scalarFn(URN, "custom_scalar:str", R.STRING, b.fieldReference(input, 0))),
             b.remap(1),
             b.namedScan(List.of("example"), List.of("a"), List.of(R.STRING)));
 
@@ -311,8 +309,7 @@ public class CustomFunctionTest extends PlanTestBase {
         b.project(
             input ->
                 List.of(
-                    b.scalarFn(
-                        NAMESPACE, "custom_scalar_any:any", R.STRING, b.fieldReference(input, 0))),
+                    b.scalarFn(URN, "custom_scalar_any:any", R.STRING, b.fieldReference(input, 0))),
             b.remap(1),
             b.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
 
@@ -328,10 +325,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
-                        "custom_scalar_any_to_any:any",
-                        R.FP64,
-                        b.fieldReference(input, 0))),
+                        URN, "custom_scalar_any_to_any:any", R.FP64, b.fieldReference(input, 0))),
             b.remap(1),
             b.namedScan(List.of("example"), List.of("a"), List.of(R.FP64)));
 
@@ -347,7 +341,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_any1any1_to_any1:any_any",
                         R.FP64,
                         b.fieldReference(input, 0),
@@ -367,7 +361,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_any1any1_to_any1:any_any",
                         R.FP64,
                         b.fieldReference(input, 0),
@@ -391,7 +385,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_any1any2_to_any2:any_any",
                         R.STRING,
                         b.fieldReference(input, 0),
@@ -411,7 +405,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_listany_to_listany:list",
                         R.list(R.I64),
                         b.fieldReference(input, 0))),
@@ -430,7 +424,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_listany_any_to_listany:list_any",
                         R.list(R.STRING),
                         b.fieldReference(input, 0),
@@ -451,7 +445,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_liststring_to_liststring:list",
                         R.list(R.STRING),
                         b.fieldReference(input, 0))),
@@ -470,7 +464,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_liststring_any_to_liststring:list_any",
                         R.list(R.STRING),
                         b.fieldReference(input, 0),
@@ -491,7 +485,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_liststring_anyvariadic0_to_liststring:list_any",
                         R.list(R.STRING),
                         b.fieldReference(input, 0),
@@ -516,7 +510,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_liststring_anyvariadic0_to_liststring:list_any",
                         R.list(R.STRING),
                         b.fieldReference(input, 0))),
@@ -535,7 +529,7 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "custom_scalar_liststring_anyvariadic1_to_liststring:list_any",
                         R.list(R.STRING),
                         b.fieldReference(input, 0),
@@ -560,7 +554,7 @@ public class CustomFunctionTest extends PlanTestBase {
                 List.of(
                     b.measure(
                         b.aggregateFn(
-                            NAMESPACE, "custom_aggregate:i64", R.I64, b.fieldReference(input, 0)))),
+                            URN, "custom_aggregate:i64", R.I64, b.fieldReference(input, 0)))),
             b.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
@@ -577,13 +571,12 @@ public class CustomFunctionTest extends PlanTestBase {
             input ->
                 List.of(
                     b.scalarFn(
-                        NAMESPACE,
+                        URN,
                         "to_b_type:u!a_type",
-                        R.userDefined(NAMESPACE, "b_type"),
+                        R.userDefined(URN, "b_type"),
                         b.fieldReference(input, 0))),
             b.remap(1),
-            b.namedScan(
-                List.of("example"), List.of("a"), List.of(N.userDefined(NAMESPACE, "a_type"))));
+            b.namedScan(List.of("example"), List.of("a"), List.of(N.userDefined(URN, "a_type"))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel);
     Rel relReturned = calciteToSubstrait.apply(calciteRel);
@@ -594,18 +587,14 @@ public class CustomFunctionTest extends PlanTestBase {
   void customTypesLiteralInFunctionsRoundtrip() {
     Builder bldr = Expression.Literal.newBuilder();
     Any anyValue = Any.pack(bldr.setI32(10).build());
-    UserDefinedLiteral val =
-        ExpressionCreator.userDefinedLiteral(false, NAMESPACE, "a_type", anyValue);
+    UserDefinedLiteral val = ExpressionCreator.userDefinedLiteral(false, URN, "a_type", anyValue);
 
     Rel rel1 =
         b.project(
             input ->
-                List.of(
-                    b.scalarFn(
-                        NAMESPACE, "to_b_type:u!a_type", R.userDefined(NAMESPACE, "b_type"), val)),
+                List.of(b.scalarFn(URN, "to_b_type:u!a_type", R.userDefined(URN, "b_type"), val)),
             b.remap(1),
-            b.namedScan(
-                List.of("example"), List.of("a"), List.of(N.userDefined(NAMESPACE, "a_type"))));
+            b.namedScan(List.of("example"), List.of("a"), List.of(N.userDefined(URN, "a_type"))));
 
     RelNode calciteRel = substraitToCalcite.convert(rel1);
     Rel rel2 = calciteToSubstrait.apply(calciteRel);


### PR DESCRIPTION
Change usages of `namespace` to correctly be `urn`.

Closes #583
