### PR TITLE
test: correct use of String.format

### DIFF
--- a/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
@@ -168,24 +168,21 @@ public class ArithmeticFunctionTest extends PlanTestBase {
   @ParameterizedTest
   @CsvSource({"i8, 8", "i16, 160", "i32, 32000", "i64, CAST(6000000004 AS BIGINT)"})
   void bitwise_and_scalar(String column, String mask) throws Exception {
-    String query =
-        String.format("SELECT BITAND(" + column + ", " + mask + ") AS m FROM numbers", column);
+    String query = String.format("SELECT BITAND(%s, %s) FROM numbers", column, mask);
     assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @CsvSource({"i8, 8", "i16, 160", "i32, 32000", "i64, CAST(6000000004 AS BIGINT)"})
   void bitwise_xor_scalar(String column, String mask) throws Exception {
-    String query =
-        String.format("SELECT BITXOR(" + column + ", " + mask + ") AS m FROM numbers", column);
+    String query = String.format("SELECT BITXOR(%s, %s) FROM numbers", column, mask);
     assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
   @CsvSource({"i8, 8", "i16, 160", "i32, 32000", "i64, CAST(6000000004 AS BIGINT)"})
   void bitwise_or_scalar(String column, String mask) throws Exception {
-    String query =
-        String.format("SELECT BITOR(" + column + ", " + mask + ") AS m FROM numbers", column);
+    String query = String.format("SELECT BITOR(%s, %s) FROM numbers", column, mask);
     assertFullRoundTrip(query, CREATES);
   }
 }


### PR DESCRIPTION
ArithmeticFunctionTest included some incorrect String.format() constructs that I missed in a code review. This change corrects them. There are no behavioral changes to the tests.