### PR TITLE
fix(isthmus): support TPC-DS queries 1, 30, 81

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 antlr = "4.13.2"
-calcite = "1.40.0"
+calcite = "1.41.0"
 classgraph = "4.8.184"
 commons-lang3 = "[3.18.0,)"
 graal = "25.0.0"

--- a/isthmus-cli/proxies.json
+++ b/isthmus-cli/proxies.json
@@ -2,6 +2,7 @@
   ["org.apache.calcite.rel.metadata.BuiltInMetadata$Collation$Handler"],
   ["org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnOrigin$Handler"],
   ["org.apache.calcite.rel.metadata.BuiltInMetadata$ExpressionLineage$Handler"],
+  ["org.apache.calcite.rel.metadata.BuiltInMetadata$FunctionalDependency$Handler"],
   ["org.apache.calcite.rel.metadata.BuiltInMetadata$TableReferences$Handler"],
   ["org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnUniqueness$Handler"],
   ["org.apache.calcite.rel.metadata.BuiltInMetadata$CumulativeCost$Handler"],

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -42,6 +42,7 @@ import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -60,6 +61,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -457,17 +459,17 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
         {
           assert modify.getTable() != null;
 
-          Expression condition;
-          if (modify.getInput() instanceof org.apache.calcite.rel.core.Filter) {
-            org.apache.calcite.rel.core.Filter filter =
-                (org.apache.calcite.rel.core.Filter) modify.getInput();
+          RelNode input = modify.getInput();
+          final Expression condition;
+          if (input instanceof org.apache.calcite.rel.core.Filter) {
+            org.apache.calcite.rel.core.Filter filter = (org.apache.calcite.rel.core.Filter) input;
             condition = toExpression(filter.getCondition());
           } else {
             condition = Expression.BoolLiteral.builder().nullable(false).value(true).build();
           }
 
           List<String> updateColumnNames = modify.getUpdateColumnList();
-          List<RexNode> sourceExpressions = modify.getSourceExpressionList();
+          List<RexNode> sourceExpressions = getSourceExpressions(modify);
           List<String> allTableColumnNames = modify.getTable().getRowType().getFieldNames();
           List<NamedUpdate.TransformExpression> transformations = new ArrayList<>();
 
@@ -501,6 +503,36 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
       default:
         return super.visit(modify);
     }
+  }
+
+  private List<RexNode> getSourceExpressions(TableModify modify) {
+    List<RexNode> results = modify.getSourceExpressionList();
+    if (results == null) {
+      return Collections.emptyList();
+    }
+
+    RelNode input = modify.getInput();
+    if (input instanceof org.apache.calcite.rel.core.Project) {
+      return resolveProjectedRefs(results, (org.apache.calcite.rel.core.Project) input);
+    }
+
+    return results;
+  }
+
+  private List<RexNode> resolveProjectedRefs(
+      List<RexNode> expressions, org.apache.calcite.rel.core.Project project) {
+    List<RexNode> projects = project.getProjects();
+    return expressions.stream()
+        .map(
+            expression -> {
+              if (expression instanceof RexInputRef) {
+                int refIndex = ((RexInputRef) expression).getIndex();
+                return projects.get(refIndex);
+              }
+
+              return expression;
+            })
+        .collect(Collectors.toList());
   }
 
   private NamedStruct getSchema(final RelNode queryRelRoot) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -22,6 +22,7 @@ import org.apache.calcite.rex.RexLambdaRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexLocalRef;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexNodeAndFieldIndex;
 import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.rex.RexPatternFieldRef;
 import org.apache.calcite.rex.RexRangeRef;
@@ -207,5 +208,10 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
   @Override
   public Expression visitLambdaRef(RexLambdaRef rexLambdaRef) {
     throw new UnsupportedOperationException("RexLambdaRef not supported");
+  }
+
+  @Override
+  public Expression visitNodeAndFieldIndex(RexNodeAndFieldIndex nodeAndFieldIndex) {
+    throw new UnsupportedOperationException("RexNodeAndFieldIndex not supported");
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlValidator.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlValidator.java
@@ -7,7 +7,7 @@ import org.apache.calcite.sql.validate.SqlValidatorImpl;
 
 public class SubstraitSqlValidator extends SqlValidatorImpl {
 
-  static SqlValidator.Config CONFIG = Config.DEFAULT;
+  static SqlValidator.Config CONFIG = Config.DEFAULT.withIdentifierExpansion(true);
 
   public SubstraitSqlValidator(Prepare.CatalogReader catalogReader) {
     super(SubstraitOperatorTable.INSTANCE, catalogReader, catalogReader.getTypeFactory(), CONFIG);

--- a/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
@@ -1,7 +1,6 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.plan.Plan;
 import java.io.IOException;
@@ -14,8 +13,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 /** TPC-DS test to convert SQL to Substrait and then convert those plans back to SQL. */
 public class TpcdsQueryTest extends PlanTestBase {
   private static final Set<Integer> alternateForms = Set.of(27, 36, 70, 86);
-  private static final Set<Integer> fromSubstraitPojoExclusions = Set.of(1, 30, 81);
-  private static final Set<Integer> fromSubstraitProtoExclusions = Set.of(1, 30, 81);
 
   static IntStream testCases() {
     return IntStream.rangeClosed(1, 99);
@@ -29,23 +26,11 @@ public class TpcdsQueryTest extends PlanTestBase {
   @MethodSource("testCases")
   public void testQuery(int query) throws IOException {
     String inputSql = asString(inputSqlFile(query));
-
     Plan plan = assertDoesNotThrow(() -> toSubstraitPlan(inputSql), "SQL to Substrait POJO");
-
-    if (!fromSubstraitPojoExclusions.contains(query)) {
-      assertDoesNotThrow(() -> toSql(plan), "Substrait POJO to SQL");
-    } else {
-      assertThrows(Throwable.class, () -> toSql(plan), "Substrait POJO to SQL");
-    }
-
+    assertDoesNotThrow(() -> toSql(plan), "Substrait POJO to SQL");
     io.substrait.proto.Plan proto =
         assertDoesNotThrow(() -> toProto(plan), "Substrait POJO to Substrait PROTO");
-
-    if (!fromSubstraitProtoExclusions.contains(query)) {
-      assertDoesNotThrow(() -> toSql(proto), "Substrait PROTO to SQL");
-    } else {
-      assertThrows(Throwable.class, () -> toSql(proto), "Substrait PROTO to SQL");
-    }
+    assertDoesNotThrow(() -> toSql(proto), "Substrait PROTO to SQL");
   }
 
   private String inputSqlFile(int query) {


### PR DESCRIPTION
TPC-DS queries 1, 30 and 81 can already be converted from SQL to a Substrait plan, but these Substrait plans cannot be successfully converted back to SQL.

This change updates the Calcite version to 1.41.0, which contains fixes that allow successful conversion of TPC-DS queries from Substrait back to SQL.

In order to work around a regression introduced in Calcite 1.41.0 ([CALCITE-7276](https://issues.apache.org/jira/browse/CALCITE-7276)), this change adds the `withIdentifierExpansion` SQL validator configuration option, and fixes Rex to Substrait conversion of SQL Update where the table modify has a project as its input.