### PR TITLE
feat(isthmus): mapping of positional scalar fns

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
@@ -47,7 +47,13 @@ public class SubstraitOperatorTable implements SqlOperatorTable {
   // functions
   private static final SqlOperatorTable LIBRARY_OPERATOR_TABLE =
       SqlLibraryOperatorTableFactory.INSTANCE.getOperatorTable(
-          EnumSet.of(SqlLibrary.HIVE, SqlLibrary.SPARK, SqlLibrary.ALL));
+          EnumSet.of(
+              SqlLibrary.HIVE,
+              SqlLibrary.SPARK,
+              SqlLibrary.ALL,
+              SqlLibrary.BIG_QUERY,
+              SqlLibrary.SNOWFLAKE,
+              SqlLibrary.STANDARD));
 
   private static final SqlOperatorTable STANDARD_OPERATOR_TABLE = SqlStdOperatorTable.instance();
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -12,6 +12,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 public class FunctionMappings {
   // Static list of signature mapping between Calcite SQL operators and Substrait base function
   // names.
+
   public static final ImmutableList<Sig> SCALAR_SIGS =
       ImmutableList.<Sig>builder()
           .add(
@@ -88,7 +89,11 @@ public class FunctionMappings {
               s(SqlLibraryOperators.LEAST, "least"),
               s(SqlLibraryOperators.GREATEST, "greatest"),
               s(SqlStdOperatorTable.BIT_LEFT_SHIFT, "shift_left"),
-              s(SqlStdOperatorTable.LEFTSHIFT, "shift_left"))
+              s(SqlStdOperatorTable.LEFTSHIFT, "shift_left"),
+              s(SqlLibraryOperators.STARTS_WITH, "starts_with"),
+              s(SqlLibraryOperators.ENDS_WITH, "ends_with"),
+              s(SqlLibraryOperators.CONTAINS_SUBSTR, "contains"),
+              s(SqlStdOperatorTable.POSITION, "strpos"))
           .build();
 
   public static final ImmutableList<Sig> AGGREGATE_SIGS =

--- a/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import io.substrait.plan.Plan;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public final class StringFunctionTest extends PlanTestBase {
@@ -136,5 +137,137 @@ public final class StringFunctionTest extends PlanTestBase {
   private void assertSqlRoundTrip(String sql) throws SqlParseException {
     Plan plan = assertProtoPlanRoundrip(sql, new SqlToSubstrait(), CREATES);
     assertDoesNotThrow(() -> toSql(plan), "Substrait plan to SQL");
+  }
+
+  @ParameterizedTest
+  @CsvSource({"c16, c16", "c16, vc32", "c16, vc", "vc32, vc32", "vc32, vc", "vc, vc"})
+  void testStarts_With(String left, String right) throws Exception {
+
+    String query = String.format("SELECT STARTS_WITH(%s, %s) FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"'start', vc", "vc, 'end'"},
+      quoteCharacter = '`')
+  void testStarts_WithLiteral(String left, String right) throws Exception {
+    String query = String.format("SELECT STARTS_WITH(%s, %s) FROM strings", left, right);
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"c16, c16", "c16, vc32", "c16, vc", "vc32, vc32", "vc32, vc", "vc, vc"})
+  void testStartsWith(String left, String right) throws Exception {
+
+    String query = String.format("SELECT STARTSWITH(%s, %s) FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"'start', vc", "vc, 'end'"},
+      quoteCharacter = '`')
+  void testStartsWithLiteral(String left, String right) throws Exception {
+    String query = String.format("SELECT STARTSWITH(%s, %s) FROM strings", left, right);
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"c16, c16", "c16, vc32", "c16, vc", "vc32, vc32", "vc32, vc", "vc, vc"})
+  void testEnds_With(String left, String right) throws Exception {
+
+    String query = String.format("SELECT ENDS_WITH(%s, %s) FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"'start', vc", "vc, 'end'"},
+      quoteCharacter = '`')
+  void testEnds_WithLiteral(String left, String right) throws Exception {
+    String query = String.format("SELECT ENDS_WITH(%s, %s) FROM strings", left, right);
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"c16, c16", "c16, vc32", "c16, vc", "vc32, vc32", "vc32, vc", "vc, vc"})
+  void testEndsWith(String left, String right) throws Exception {
+
+    String query = String.format("SELECT ENDSWITH(%s, %s) FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"'start', vc", "vc, 'end'"},
+      quoteCharacter = '`')
+  void testEndsWithLiteral(String left, String right) throws Exception {
+    String query = String.format("SELECT ENDSWITH(%s, %s) FROM strings", left, right);
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"c16, c16", "c16, vc32", "c16, vc", "vc32, vc32", "vc32, vc", "vc, vc"})
+  void testContains(String left, String right) throws Exception {
+
+    String query = String.format("SELECT CONTAINS_SUBSTR(%s, %s) FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"'start', vc", "vc, 'end'"},
+      quoteCharacter = '`')
+  void testContainsWithLiteral(String left, String right) throws Exception {
+
+    String query = String.format("SELECT CONTAINS_SUBSTR(%s, %s) FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"c16, c16", "c16, vc32", "c16, vc", "vc32, vc32", "vc32, vc", "vc, vc"})
+  void testPosition(String left, String right) throws Exception {
+
+    String query = String.format("SELECT POSITION(%s IN %s) > 0 FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"'start', vc", "vc, 'end'"},
+      quoteCharacter = '`')
+  void testPositionWithLiteral(String left, String right) throws Exception {
+
+    String query = String.format("SELECT POSITION(%s IN %s) > 0 FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"c16, c16", "c16, vc32", "c16, vc", "vc32, vc32", "vc32, vc", "vc, vc"})
+  void testStrpos(String left, String right) throws Exception {
+
+    String query = String.format("SELECT STRPOS(%s, %s) > 0 FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"'start', vc", "vc, 'end'"},
+      quoteCharacter = '`')
+  void testStrposWithLiteral(String left, String right) throws Exception {
+
+    String query = String.format("SELECT STRPOS(%s, %s) > 0 FROM strings", left, right);
+
+    assertSqlRoundTrip(query);
   }
 }


### PR DESCRIPTION
-Added mappings for `STARTS_WITH`, `ENDS_WITH`, `CONTAINS` and `POSITION` to `FunctionMappings.java`
-Added extra libraries to enable the included operators in `SubstraitOperatorTable.java`
-Added passing tests to `StringFunctionTest.java` including `STARTSWITH`, `ENDSWITH`, `STRPOS` and literals