### PR TITLE
style: make JUnit 5 test classes and methods package private

### DIFF
--- a/build-logic/src/main/resources/substrait-pmd.xml
+++ b/build-logic/src/main/resources/substrait-pmd.xml
@@ -13,6 +13,7 @@
   <rule ref="category/java/codestyle.xml/UnnecessaryModifier" />
   <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" />
   <rule ref="category/java/codestyle.xml/UseExplicitTypes" />
+  <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" />
   <rule ref="category/java/bestpractices.xml/MissingOverride" />
   <rule ref="category/java/bestpractices.xml/UnusedAssignment" />
   <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />

--- a/core/src/test/java/io/substrait/extendedexpression/ExtendedExpressionRoundTripTest.java
+++ b/core/src/test/java/io/substrait/extendedexpression/ExtendedExpressionRoundTripTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class ExtendedExpressionRoundTripTest extends TestBase {
+class ExtendedExpressionRoundTripTest extends TestBase {
 
   private static Stream<Arguments> expressionReferenceProvider() {
     return Stream.of(
@@ -34,7 +34,7 @@ public class ExtendedExpressionRoundTripTest extends TestBase {
 
   @ParameterizedTest
   @MethodSource("expressionReferenceProvider")
-  public void testRoundTrip(ExtendedExpression.ExpressionReferenceBase expressionReference) {
+  void testRoundTrip(ExtendedExpression.ExpressionReferenceBase expressionReference) {
     List<ExtendedExpression.ExpressionReferenceBase> expressionReferences = new ArrayList<>();
     expressionReferences.add(expressionReference);
     NamedStruct namedStruct = getImmutableNamedStruct();
@@ -42,7 +42,7 @@ public class ExtendedExpressionRoundTripTest extends TestBase {
   }
 
   @Test
-  public void getNoExpressionDefined() {
+  void getNoExpressionDefined() {
     IllegalStateException illegalStateException =
         Assertions.assertThrows(
             IllegalStateException.class,
@@ -55,7 +55,7 @@ public class ExtendedExpressionRoundTripTest extends TestBase {
   }
 
   @Test
-  public void getNoAggregateFunctionDefined() {
+  void getNoAggregateFunctionDefined() {
     IllegalStateException illegalStateException =
         Assertions.assertThrows(
             IllegalStateException.class,

--- a/core/src/test/java/io/substrait/extension/ExtensionCollectionMergeTest.java
+++ b/core/src/test/java/io/substrait/extension/ExtensionCollectionMergeTest.java
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class ExtensionCollectionMergeTest {
+class ExtensionCollectionMergeTest {
 
   @Test
-  public void testMergeCollectionsWithDifferentUriUrnMappings() {
+  void testMergeCollectionsWithDifferentUriUrnMappings() {
     String yaml1 =
         "%YAML 1.2\n"
             + "---\n"
@@ -47,7 +47,7 @@ public class ExtensionCollectionMergeTest {
   }
 
   @Test
-  public void testMergeCollectionsWithIdenticalMappings() {
+  void testMergeCollectionsWithIdenticalMappings() {
     String yaml =
         "%YAML 1.2\n"
             + "---\n"
@@ -69,7 +69,7 @@ public class ExtensionCollectionMergeTest {
   }
 
   @Test
-  public void testMergeCollectionsWithConflictingMappings() {
+  void testMergeCollectionsWithConflictingMappings() {
     String yaml1 =
         "%YAML 1.2\n" + "---\n" + "urn: extension:conflict:urn1\n" + "scalar_functions: []\n";
 

--- a/core/src/test/java/io/substrait/extension/ExtensionCollectionUriUrnTest.java
+++ b/core/src/test/java/io/substrait/extension/ExtensionCollectionUriUrnTest.java
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class ExtensionCollectionUriUrnTest {
+class ExtensionCollectionUriUrnTest {
 
   @Test
-  public void testHasUrnAndHasUri() {
+  void testHasUrnAndHasUri() {
     String yamlContent =
         "%YAML 1.2\n"
             + "---\n"
@@ -28,7 +28,7 @@ public class ExtensionCollectionUriUrnTest {
   }
 
   @Test
-  public void testGetNonexistentMappings() {
+  void testGetNonexistentMappings() {
     String yamlContent =
         "%YAML 1.2\n" + "---\n" + "urn: extension:test:minimal\n" + "scalar_functions: []\n";
 
@@ -40,7 +40,7 @@ public class ExtensionCollectionUriUrnTest {
   }
 
   @Test
-  public void testEmptyUriThrowsException() {
+  void testEmptyUriThrowsException() {
     String yamlContent =
         "%YAML 1.2\n" + "---\n" + "urn: extension:test:empty\n" + "scalar_functions: []\n";
 
@@ -50,7 +50,7 @@ public class ExtensionCollectionUriUrnTest {
   }
 
   @Test
-  public void testNullUriThrowsException() {
+  void testNullUriThrowsException() {
     String yamlContent =
         "%YAML 1.2\n" + "---\n" + "urn: extension:test:null\n" + "scalar_functions: []\n";
 

--- a/core/src/test/java/io/substrait/extension/ExtensionCollectorUriUrnTest.java
+++ b/core/src/test/java/io/substrait/extension/ExtensionCollectorUriUrnTest.java
@@ -5,10 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.substrait.proto.Plan;
 import org.junit.jupiter.api.Test;
 
-public class ExtensionCollectorUriUrnTest {
+class ExtensionCollectorUriUrnTest {
 
   @Test
-  public void testExtensionCollectorScalarFuncWithoutURI() {
+  void testExtensionCollectorScalarFuncWithoutURI() {
     String uri = "test://uri";
     BidiMap<String, String> uriUrnMap = new BidiMap<String, String>();
     uriUrnMap.put(uri, "extension:test:basic");

--- a/core/src/test/java/io/substrait/extension/ImmutableExtensionLookupUriUrnTest.java
+++ b/core/src/test/java/io/substrait/extension/ImmutableExtensionLookupUriUrnTest.java
@@ -10,10 +10,10 @@ import io.substrait.proto.SimpleExtensionURI;
 import io.substrait.proto.SimpleExtensionURN;
 import org.junit.jupiter.api.Test;
 
-public class ImmutableExtensionLookupUriUrnTest {
+class ImmutableExtensionLookupUriUrnTest {
 
   @Test
-  public void testUrnResolutionWorks() {
+  void testUrnResolutionWorks() {
     // Create URN-only plan (normal case)
     SimpleExtensionURN urnProto =
         SimpleExtensionURN.newBuilder()
@@ -41,7 +41,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testUriToUrnFallbackWorks() {
+  void testUriToUrnFallbackWorks() {
     // Create an ExtensionCollection with URI/URN mapping
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/extensions/test", "extension:test:mapped");
@@ -77,7 +77,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testUriWithoutMappingThrowsError() {
+  void testUriWithoutMappingThrowsError() {
     // Create URI-only plan without mapping
     SimpleExtensionURI uriProto =
         SimpleExtensionURI.newBuilder()
@@ -111,7 +111,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testMissingUrnAndUriThrowsError() {
+  void testMissingUrnAndUriThrowsError() {
     // Create plan with missing URN/URI reference
     SimpleExtensionDeclaration.ExtensionFunction func =
         SimpleExtensionDeclaration.ExtensionFunction.newBuilder()
@@ -142,7 +142,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   // ==========================================================================
 
   @Test
-  public void testFunctionCase1_NonZeroUrnReference() {
+  void testFunctionCase1_NonZeroUrnReference() {
     // Case 1: Non-zero URN reference resolves
     SimpleExtensionURN urnProto =
         SimpleExtensionURN.newBuilder()
@@ -169,7 +169,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testFunctionCase2_NonZeroUriReference() {
+  void testFunctionCase2_NonZeroUriReference() {
     // Case 2: Non-zero URI reference resolves via mapping
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/case2", "extension:test:case2");
@@ -203,7 +203,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testFunctionCase3_ZeroBothResolveConsistent() {
+  void testFunctionCase3_ZeroBothResolveConsistent() {
     // Case 3: Both 0 references resolve to consistent URN
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/case3", "extension:test:case3");
@@ -249,7 +249,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testFunctionCase3_ZeroBothResolveConflict() {
+  void testFunctionCase3_ZeroBothResolveConflict() {
     // Case 3: Both 0 references resolve but to different URNs - should throw
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/conflict", "extension:test:different");
@@ -299,7 +299,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testFunctionCase4_ZeroUrnOnly() {
+  void testFunctionCase4_ZeroUrnOnly() {
     // Case 4: Only 0 URN reference resolves
     SimpleExtensionURN urnProto =
         SimpleExtensionURN.newBuilder()
@@ -327,7 +327,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testFunctionCase5_ZeroUriOnly() {
+  void testFunctionCase5_ZeroUriOnly() {
     // Case 5: Only 0 URI reference resolves
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/case5", "extension:test:case5");
@@ -366,7 +366,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   // ==========================================================================
 
   @Test
-  public void testTypeCase1_NonZeroUrnReference() {
+  void testTypeCase1_NonZeroUrnReference() {
     // Case 1: Non-zero URN reference resolves
     SimpleExtensionURN urnProto =
         SimpleExtensionURN.newBuilder()
@@ -393,7 +393,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testTypeCase2_NonZeroUriReference() {
+  void testTypeCase2_NonZeroUriReference() {
     // Case 2: Non-zero URI reference resolves via mapping
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/case2", "extension:test:case2");
@@ -427,7 +427,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testTypeCase3_ZeroBothResolveConsistent() {
+  void testTypeCase3_ZeroBothResolveConsistent() {
     // Case 3: Both 0 references resolve to consistent URN
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/case3", "extension:test:case3");
@@ -473,7 +473,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testTypeCase3_ZeroBothResolveConflict() {
+  void testTypeCase3_ZeroBothResolveConflict() {
     // Case 3: Both 0 references resolve but to different URNs - should throw
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/conflict", "extension:test:different");
@@ -523,7 +523,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testTypeCase4_ZeroUrnOnly() {
+  void testTypeCase4_ZeroUrnOnly() {
     // Case 4: Only 0 URN reference resolves
     SimpleExtensionURN urnProto =
         SimpleExtensionURN.newBuilder()
@@ -551,7 +551,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testTypeCase5_ZeroUriOnly() {
+  void testTypeCase5_ZeroUriOnly() {
     // Case 5: Only 0 URI reference resolves
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/case5", "extension:test:case5");
@@ -586,7 +586,7 @@ public class ImmutableExtensionLookupUriUrnTest {
   }
 
   @Test
-  public void testTypeUriToUrnFallbackWorks() {
+  void testTypeUriToUrnFallbackWorks() {
     // Test the same logic but for types instead of functions
     BidiMap<String, String> uriUrnMap = new BidiMap<>();
     uriUrnMap.put("http://example.com/types/test", "extension:types:mapped");

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
  *   <li>Roundtrip between POJO and Proto
  * </ul>
  */
-public class TypeExtensionTest {
+class TypeExtensionTest {
 
   static final TypeCreator R = TypeCreator.of(false);
 

--- a/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
+++ b/core/src/test/java/io/substrait/extension/UriUrnMigrationEndToEndTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * 3. Convert POJO -> proto using PlanProtoConverter 4. Verify output contains proper
  * extensioninformation
  */
-public class UriUrnMigrationEndToEndTest {
+class UriUrnMigrationEndToEndTest {
 
   /** Load a proto Plan from a JSON resource file using JsonFormat */
   private Plan loadPlanFromJson(String resourcePath) throws IOException {
@@ -45,7 +45,7 @@ public class UriUrnMigrationEndToEndTest {
   }
 
   @Test
-  public void testUriUrnMigrationEndToEnd() throws IOException {
+  void testUriUrnMigrationEndToEnd() throws IOException {
 
     // List of (inputPath, expectedPath, extensionCollection) tuples
     List<String[]> testCases =
@@ -91,7 +91,7 @@ public class UriUrnMigrationEndToEndTest {
   }
 
   @Test
-  public void testUnresolvableUriThrowsException() throws IOException {
+  void testUnresolvableUriThrowsException() throws IOException {
     Plan inputPlan = loadPlanFromJson("uri-urn-migration/unresolvable-uri-plan.json");
 
     ProtoPlanConverter protoToPojo =

--- a/core/src/test/java/io/substrait/extension/UrnValidationTest.java
+++ b/core/src/test/java/io/substrait/extension/UrnValidationTest.java
@@ -7,10 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class UrnValidationTest {
+class UrnValidationTest {
 
   @Test
-  public void testMissingUrnThrowsException() {
+  void testMissingUrnThrowsException() {
     String yamlWithoutUrn = "%YAML 1.2\n" + "---\n" + "scalar_functions:\n" + "  - name: test\n";
     IllegalArgumentException exception =
         assertThrows(
@@ -19,7 +19,7 @@ public class UrnValidationTest {
   }
 
   @Test
-  public void testInvalidUrnFormatThrowsException() {
+  void testInvalidUrnFormatThrowsException() {
     String yamlWithInvalidUrn =
         "%YAML 1.2\n"
             + "---\n"
@@ -35,7 +35,7 @@ public class UrnValidationTest {
   }
 
   @Test
-  public void testValidUrnWorks() {
+  void testValidUrnWorks() {
     String yamlWithValidUrn =
         "%YAML 1.2\n"
             + "---\n"
@@ -46,7 +46,7 @@ public class UrnValidationTest {
   }
 
   @Test
-  public void testUriUrnMapIsPopulated() {
+  void testUriUrnMapIsPopulated() {
     String yamlWithValidUrn =
         "%YAML 1.2\n"
             + "---\n"

--- a/core/src/test/java/io/substrait/relation/AggregateRelTest.java
+++ b/core/src/test/java/io/substrait/relation/AggregateRelTest.java
@@ -58,7 +58,7 @@ class AggregateRelTest extends TestBase {
   }
 
   @Test
-  public void testDeprecatedGroupingExpressionConversion() {
+  void testDeprecatedGroupingExpressionConversion() {
     Expression col1Ref = createFieldReference(0);
     Expression col2Ref = createFieldReference(1);
 
@@ -89,7 +89,7 @@ class AggregateRelTest extends TestBase {
   }
 
   @Test
-  public void testAggregateWithSingleGrouping() {
+  void testAggregateWithSingleGrouping() {
     Expression col1Ref = createFieldReference(0);
     Expression col2Ref = createFieldReference(1);
 
@@ -122,7 +122,7 @@ class AggregateRelTest extends TestBase {
   }
 
   @Test
-  public void testAggregateWithMultipleGroupings() {
+  void testAggregateWithMultipleGroupings() {
     Expression col1Ref = createFieldReference(0);
     Expression col2Ref = createFieldReference(1);
 

--- a/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/ProtoRelConverterTest.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public class ProtoRelConverterTest extends TestBase {
+class ProtoRelConverterTest extends TestBase {
 
   final NamedScan commonTable =
       b.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());

--- a/core/src/test/java/io/substrait/relation/SpecVersionTest.java
+++ b/core/src/test/java/io/substrait/relation/SpecVersionTest.java
@@ -7,9 +7,9 @@ import io.substrait.plan.Plan.Version;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
-public class SpecVersionTest {
+class SpecVersionTest {
   @Test
-  public void testSubstraitVersionDefaultValues() {
+  void testSubstraitVersionDefaultValues() {
     Version version = Version.DEFAULT_VERSION;
 
     assertNotNull(version.getMajor());

--- a/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
+++ b/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
@@ -8,7 +8,7 @@ import io.substrait.function.TypeExpressionCreator;
 import io.substrait.type.TypeCreator;
 import org.junit.jupiter.api.Test;
 
-public class TestTypeParser {
+class TestTypeParser {
 
   private final TypeCreator n = TypeCreator.NULLABLE;
   private final TypeCreator r = TypeCreator.REQUIRED;
@@ -20,47 +20,47 @@ public class TestTypeParser {
   private static final String URN = "test";
 
   @Test
-  public void basic() {
+  void basic() {
     simpleTests(ParseToPojo.Visitor.simple(URN));
   }
 
   @Test
-  public void compound() {
+  void compound() {
     compoundTests(ParseToPojo.Visitor.simple(URN));
   }
 
   @Test
-  public void parameterizedSimple() {
+  void parameterizedSimple() {
     simpleTests(ParseToPojo.Visitor.parameterized(URN));
   }
 
   @Test
-  public void parameterizedCompound() {
+  void parameterizedCompound() {
     compoundTests(ParseToPojo.Visitor.parameterized(URN));
   }
 
   @Test
-  public void parameterizedParameterized() {
+  void parameterizedParameterized() {
     parameterizedTests(ParseToPojo.Visitor.parameterized(URN));
   }
 
   @Test
-  public void derivationSimple() {
+  void derivationSimple() {
     simpleTests(ParseToPojo.Visitor.expression(URN));
   }
 
   @Test
-  public void derivationCompound() {
+  void derivationCompound() {
     compoundTests(ParseToPojo.Visitor.expression(URN));
   }
 
   @Test
-  public void derivationParameterized() {
+  void derivationParameterized() {
     parameterizedTests(ParseToPojo.Visitor.expression(URN));
   }
 
   @Test
-  public void derivationExpression() {
+  void derivationExpression() {
     test(
         ParseToPojo.Visitor.expression(URN),
         eo.fixedCharE(eo.plus(pr.parameter("L1"), pr.parameter("L2"))),

--- a/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/AggregateRoundtripTest.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class AggregateRoundtripTest extends TestBase {
+class AggregateRoundtripTest extends TestBase {
 
   private void assertAggregateRoundtrip(Expression.AggregationInvocation invocation) {
     Expression.DecimalLiteral expression = ExpressionCreator.decimal(false, BigDecimal.TEN, 10, 2);

--- a/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
@@ -13,7 +13,7 @@ import io.substrait.relation.Rel;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
-public class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
+class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
 
   @Test
   void consistentPartitionWindowRoundtripSingle() {

--- a/core/src/test/java/io/substrait/type/proto/DdlRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/DdlRelRoundtripTest.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-public class DdlRelRoundtripTest extends TestBase {
+class DdlRelRoundtripTest extends TestBase {
 
   @Test
   void create() {

--- a/core/src/test/java/io/substrait/type/proto/ExpandRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExpandRelRoundtripTest.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-public class ExpandRelRoundtripTest extends TestBase {
+class ExpandRelRoundtripTest extends TestBase {
   final Rel input =
       b.namedScan(
           Stream.of("a_table").collect(Collectors.toList()),

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
  * Verify that the various extension types in {@link io.substrait.relation.Extension} roundtrip
  * correctly.
  */
-public class ExtensionRoundtripTest extends TestBase {
+class ExtensionRoundtripTest extends TestBase {
 
   final ProtoRelConverter protoRelConverter =
       new StringHolderHandlingProtoRelConverter(functionCollector, defaultExtensionCollection);

--- a/core/src/test/java/io/substrait/type/proto/FieldReferenceRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/FieldReferenceRoundtripTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
  * Tests field reference roundtrip behavior through relations. Field references are tested as part
  * of the relation context since they require schema information for proper deserialization.
  */
-public class FieldReferenceRoundtripTest extends TestBase {
+class FieldReferenceRoundtripTest extends TestBase {
 
   final Rel baseTable =
       b.namedScan(

--- a/core/src/test/java/io/substrait/type/proto/FilterRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/FilterRelRoundtripTest.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class FilterRelRoundtripTest extends TestBase {
+class FilterRelRoundtripTest extends TestBase {
 
   final Rel baseTable =
       b.namedScan(

--- a/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class GenericRoundtripTest extends TestBase {
+class GenericRoundtripTest extends TestBase {
 
   static Random rand = new Random(123);
 
@@ -40,7 +40,7 @@ public class GenericRoundtripTest extends TestBase {
    * parameters. If the param generation has failed the {@link UnsupportedTypeGenerationException} e
    * is populated, and the test will be ignored (kept here for tracking).
    */
-  public void roundtripTest(Method m, List<Object> paramInst, UnsupportedTypeGenerationException e)
+  void roundtripTest(Method m, List<Object> paramInst, UnsupportedTypeGenerationException e)
       throws InvocationTargetException, IllegalAccessException {
 
     // If there is an UncoveredTypeGenerationException we  ignore this test

--- a/core/src/test/java/io/substrait/type/proto/IfThenRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/IfThenRoundtripTest.java
@@ -14,7 +14,7 @@ import io.substrait.util.EmptyVisitationContext;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
-public class IfThenRoundtripTest extends TestBase {
+class IfThenRoundtripTest extends TestBase {
 
   @Test
   void ifThenNotNullable() {

--- a/core/src/test/java/io/substrait/type/proto/JoinRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/JoinRoundtripTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class JoinRoundtripTest extends TestBase {
+class JoinRoundtripTest extends TestBase {
 
   final Rel leftTable =
       b.namedScan(

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -11,7 +11,7 @@ import io.substrait.util.EmptyVisitationContext;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 
-public class LiteralRoundtripTest extends TestBase {
+class LiteralRoundtripTest extends TestBase {
 
   @Test
   void decimal() {

--- a/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LocalFilesRoundtripTest.java
@@ -17,7 +17,7 @@ import io.substrait.type.TypeCreator;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
-public class LocalFilesRoundtripTest extends TestBase {
+class LocalFilesRoundtripTest extends TestBase {
 
   private void assertLocalFilesRoundtrip(FileOrFiles file) {
     io.substrait.relation.ImmutableLocalFiles.Builder builder =

--- a/core/src/test/java/io/substrait/type/proto/ProjectRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ProjectRelRoundtripTest.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class ProjectRelRoundtripTest extends TestBase {
+class ProjectRelRoundtripTest extends TestBase {
 
   final Rel baseTable =
       b.namedScan(

--- a/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ReadRelRoundtripTest.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-public class ReadRelRoundtripTest extends TestBase {
+class ReadRelRoundtripTest extends TestBase {
 
   @Test
   void namedScan() {

--- a/core/src/test/java/io/substrait/type/proto/SortRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/SortRelRoundtripTest.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
-public class SortRelRoundtripTest extends TestBase {
+class SortRelRoundtripTest extends TestBase {
 
   final Rel baseTable =
       b.namedScan(

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -9,7 +9,7 @@ import io.substrait.type.TypeCreator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class TestTypeRoundtrip {
+class TestTypeRoundtrip {
 
   private ExtensionCollector lookup = new ExtensionCollector();
   private TypeProtoConverter typeProtoConverter = new TypeProtoConverter(lookup);
@@ -19,7 +19,7 @@ public class TestTypeRoundtrip {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  public void roundtrip(boolean n) {
+  void roundtrip(boolean n) {
     t(creator(n).BOOLEAN);
     t(creator(n).I8);
     t(creator(n).I16);

--- a/core/src/test/java/io/substrait/type/proto/UpdateRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/UpdateRelRoundtripTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-public class UpdateRelRoundtripTest extends TestBase {
+class UpdateRelRoundtripTest extends TestBase {
 
   @Test
   void update() {

--- a/core/src/test/java/io/substrait/type/proto/WriteRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/WriteRelRoundtripTest.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
-public class WriteRelRoundtripTest extends TestBase {
+class WriteRelRoundtripTest extends TestBase {
 
   @Test
   void insert() {

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class AggregationFunctionsTest extends PlanTestBase {
+class AggregationFunctionsTest extends PlanTestBase {
 
   SubstraitBuilder b = new SubstraitBuilder(extensions);
 

--- a/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class ArithmeticFunctionTest extends PlanTestBase {
+class ArithmeticFunctionTest extends PlanTestBase {
 
   static String CREATES =
       "CREATE TABLE numbers (i8 TINYINT, i16 SMALLINT, i32 INT, i64 BIGINT, fp32 REAL, fp64 DOUBLE)";

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteCallTest.java
@@ -20,7 +20,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
-public class CalciteCallTest extends CalciteObjs {
+class CalciteCallTest extends CalciteObjs {
 
   private static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION =
       DefaultExtensionCatalog.DEFAULT_COLLECTION;
@@ -33,7 +33,7 @@ public class CalciteCallTest extends CalciteObjs {
       new ExpressionRexConverter(type, functionConverter, null, TypeConverter.DEFAULT);
 
   @Test
-  public void extract() {
+  void extract() {
     test(
         "extract:req_ts",
         rex.makeCall(
@@ -45,7 +45,7 @@ public class CalciteCallTest extends CalciteObjs {
   }
 
   @Test
-  public void coerceNumericOp() {
+  void coerceNumericOp() {
     test(
         "add:i64_i64",
         rex.makeCall(
@@ -63,7 +63,7 @@ public class CalciteCallTest extends CalciteObjs {
   }
 
   @Test
-  public void directMatchPlus() {
+  void directMatchPlus() {
     test(
         "add:i64_i64",
         rex.makeCall(SqlStdOperatorTable.PLUS, c(4, SqlTypeName.BIGINT), c(4, SqlTypeName.BIGINT)),
@@ -77,7 +77,7 @@ public class CalciteCallTest extends CalciteObjs {
   }
 
   @Test
-  public void directMatchAnd() {
+  void directMatchAnd() {
     test(
         "and:bool",
         rex.makeCall(
@@ -85,7 +85,7 @@ public class CalciteCallTest extends CalciteObjs {
   }
 
   @Test
-  public void directMatchOr() {
+  void directMatchOr() {
     test(
         "or:bool",
         rex.makeCall(
@@ -93,7 +93,7 @@ public class CalciteCallTest extends CalciteObjs {
   }
 
   @Test
-  public void not() {
+  void not() {
     test("not:bool", rex.makeCall(SqlStdOperatorTable.NOT, c(false, SqlTypeName.BOOLEAN)));
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteFieldSelectionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteFieldSelectionTest.java
@@ -1,9 +1,0 @@
-package io.substrait.isthmus;
-
-import org.junit.jupiter.api.Test;
-
-public class CalciteFieldSelectionTest {
-
-  @Test
-  public void simpleSelection() {}
-}

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -34,7 +34,7 @@ import org.apache.calcite.util.TimestampString;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class CalciteLiteralTest extends CalciteObjs {
+class CalciteLiteralTest extends CalciteObjs {
 
   private final ScalarFunctionConverter scalarFunctionConverter =
       new ScalarFunctionConverter(EXTENSION_COLLECTION.scalarFunctions(), type);

--- a/isthmus/src/test/java/io/substrait/isthmus/ComparisonFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComparisonFunctionsTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class ComparisonFunctionsTest extends PlanTestBase {
+class ComparisonFunctionsTest extends PlanTestBase {
   static String CREATES =
       "CREATE TABLE numbers (int_a INT, int_b INT, int_c INT, double_a DOUBLE, double_b DOUBLE, double_c DOUBLE)";
 

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 import org.apache.calcite.rel.RelNode;
 import org.junit.jupiter.api.Test;
 
-public class ComplexAggregateTest extends PlanTestBase {
+class ComplexAggregateTest extends PlanTestBase {
 
   final TypeCreator R = TypeCreator.of(false);
   SubstraitBuilder b = new SubstraitBuilder(extensions);

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
@@ -18,7 +18,7 @@ import org.apache.calcite.util.Pair;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
-public class ComplexSortTest extends PlanTestBase {
+class ComplexSortTest extends PlanTestBase {
 
   final TypeCreator R = TypeCreator.of(false);
   SubstraitBuilder b = new SubstraitBuilder(extensions);

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -40,7 +40,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 /** Verify that custom functions can convert from Substrait to Calcite and back. */
-public class CustomFunctionTest extends PlanTestBase {
+class CustomFunctionTest extends PlanTestBase {
 
   // Define custom functions in a "functions_custom.yaml" extension
   static final String URN = "extension:substrait:functions_custom";

--- a/isthmus/src/test/java/io/substrait/isthmus/DmlRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DmlRoundtripTest.java
@@ -5,7 +5,7 @@ import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
-public class DmlRoundtripTest extends PlanTestBase {
+class DmlRoundtripTest extends PlanTestBase {
 
   final Prepare.CatalogReader catalogReader =
       SubstraitCreateStatementParser.processCreateStatementsToCatalog(

--- a/isthmus/src/test/java/io/substrait/isthmus/EmptyArrayLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/EmptyArrayLiteralTest.java
@@ -10,7 +10,7 @@ import io.substrait.type.TypeCreator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class EmptyArrayLiteralTest extends PlanTestBase {
+class EmptyArrayLiteralTest extends PlanTestBase {
   private static final TypeCreator N = TypeCreator.of(true);
 
   private final SubstraitBuilder b = new SubstraitBuilder(extensions);

--- a/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
@@ -29,7 +29,7 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
 /** Tests which test that an expression can be converted to and from Calcite expressions. */
-public class ExpressionConvertabilityTest extends PlanTestBase {
+class ExpressionConvertabilityTest extends PlanTestBase {
 
   static final TypeCreator R = TypeCreator.of(false);
   static final TypeCreator N = TypeCreator.of(true);
@@ -54,24 +54,24 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
       b.namedScan(List.of("example"), List.of("a", "b", "c", "d"), commonTableType);
 
   @Test
-  public void listLiteral() throws IOException, SqlParseException {
+  void listLiteral() throws IOException, SqlParseException {
     assertFullRoundTrip("select ARRAY[1,2,3] from ORDERS");
   }
 
   @Test
-  public void mapLiteral() throws IOException, SqlParseException {
+  void mapLiteral() throws IOException, SqlParseException {
     assertFullRoundTrip("select MAP[1, 'hello'] from ORDERS");
   }
 
   @Test
-  public void inPredicate() throws IOException, SqlParseException {
+  void inPredicate() throws IOException, SqlParseException {
     assertFullRoundTrip(
         "select L_PARTKEY from LINEITEM where L_PARTKEY in "
             + "(SELECT L_SUPPKEY from LINEITEM where L_SUPPKEY < L_ORDERKEY)");
   }
 
   @Test
-  public void singleOrList() {
+  void singleOrList() {
     Expression singleOrList = b.singleOrList(b.fieldReference(commonTable, 0), b.i32(5), b.i32(10));
     RexNode rexNode = singleOrList.accept(converter, Context.newContext());
     Expression substraitExpression =
@@ -89,7 +89,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
   }
 
   @Test
-  public void switchExpression() {
+  void switchExpression() {
     Expression switchExpression =
         b.switchExpression(
             b.fieldReference(commonTable, 0),
@@ -112,7 +112,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
   }
 
   @Test
-  public void castFailureCondition() {
+  void castFailureCondition() {
     Rel rel =
         b.project(
             input ->
@@ -138,7 +138,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
   }
 
   @Test
-  public void supportedPrecisionForPrecisionTimestampLiteral() {
+  void supportedPrecisionForPrecisionTimestampLiteral() {
     assertPrecisionTimestampLiteral(0);
     assertPrecisionTimestampLiteral(3);
     assertPrecisionTimestampLiteral(6);
@@ -155,7 +155,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
   }
 
   @Test
-  public void supportedPrecisionForPrecisionTimestampTZLiteral() {
+  void supportedPrecisionForPrecisionTimestampTZLiteral() {
     assertPrecisionTimestampTZLiteral(0);
     assertPrecisionTimestampTZLiteral(3);
     assertPrecisionTimestampTZLiteral(6);
@@ -172,7 +172,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
   }
 
   @Test
-  public void unsupportedPrecisionForPrecisionTimestampLiteral() {
+  void unsupportedPrecisionForPrecisionTimestampLiteral() {
     // test different edge case precision values
     assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(-1);
     assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(1);
@@ -203,7 +203,7 @@ public class ExpressionConvertabilityTest extends PlanTestBase {
   }
 
   @Test
-  public void unsupportedPrecisionPrecisionTimestampTZLiteral() {
+  void unsupportedPrecisionPrecisionTimestampTZLiteral() {
     // test different edge case precision values
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(-1);
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(1);

--- a/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
@@ -6,7 +6,7 @@ import io.substrait.type.TypeCreator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class FetchTest extends PlanTestBase {
+class FetchTest extends PlanTestBase {
 
   static final TypeCreator R = TypeCreator.of(false);
 

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Verify that "problematic" Substrait functions can be converted to Calcite and back successfully
  */
-public class FunctionConversionTest extends PlanTestBase {
+class FunctionConversionTest extends PlanTestBase {
 
   final SubstraitBuilder b = new SubstraitBuilder(extensions);
 
@@ -46,7 +46,7 @@ public class FunctionConversionTest extends PlanTestBase {
           TypeConverter.DEFAULT);
 
   @Test
-  public void subtractDateIDay() {
+  void subtractDateIDay() {
     // When this function is converted to Calcite, if the Calcite type derivation is used an
     // java.lang.ArrayIndexOutOfBoundsException is thrown. It is quite likely that this is being
     // mapped to the wrong
@@ -70,7 +70,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void extractTimestampTzScalarFunction() {
+  void extractTimestampTzScalarFunction() {
     ScalarFunctionInvocation reqTstzFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -91,7 +91,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void extractPrecisionTimestampTzScalarFunction() {
+  void extractPrecisionTimestampTzScalarFunction() {
     ScalarFunctionInvocation reqPtstzFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -112,7 +112,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void extractTimestampScalarFunction() {
+  void extractTimestampScalarFunction() {
     ScalarFunctionInvocation reqTsFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -130,7 +130,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void extractPrecisionTimestampScalarFunction() {
+  void extractPrecisionTimestampScalarFunction() {
     ScalarFunctionInvocation reqPtsFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -148,7 +148,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void extractDateScalarFunction() {
+  void extractDateScalarFunction() {
     ScalarFunctionInvocation reqDateFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -166,7 +166,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void extractTimeScalarFunction() {
+  void extractTimeScalarFunction() {
     ScalarFunctionInvocation reqTimeFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -184,7 +184,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void unsupportedExtractTimestampTzWithIndexing() {
+  void unsupportedExtractTimestampTzWithIndexing() {
     ScalarFunctionInvocation reqReqTstzFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -201,7 +201,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void unsupportedExtractPrecisionTimestampTzWithIndexing() {
+  void unsupportedExtractPrecisionTimestampTzWithIndexing() {
     ScalarFunctionInvocation reqReqPtstzFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -218,7 +218,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void unsupportedExtractTimestampWithIndexing() {
+  void unsupportedExtractTimestampWithIndexing() {
     ScalarFunctionInvocation reqReqTsFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -234,7 +234,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void unsupportedExtractPrecisionTimestampWithIndexing() {
+  void unsupportedExtractPrecisionTimestampWithIndexing() {
     ScalarFunctionInvocation reqReqPtsFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -250,7 +250,7 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void unsupportedExtractDateWithIndexing() {
+  void unsupportedExtractDateWithIndexing() {
     ScalarFunctionInvocation reqReqDateFn =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -266,17 +266,17 @@ public class FunctionConversionTest extends PlanTestBase {
   }
 
   @Test
-  public void concatStringLiteralAndVarchar() throws Exception {
+  void concatStringLiteralAndVarchar() throws Exception {
     assertProtoPlanRoundrip("select 'part_'||P_NAME from PART");
   }
 
   @Test
-  public void concatCharAndVarchar() throws Exception {
+  void concatCharAndVarchar() throws Exception {
     assertProtoPlanRoundrip("select P_BRAND||P_NAME from PART");
   }
 
   @Test
-  public void concatStringLiteralAndChar() throws Exception {
+  void concatStringLiteralAndChar() throws Exception {
     assertProtoPlanRoundrip("select 'brand_'||P_BRAND from PART");
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/KeyConstraintsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/KeyConstraintsTest.java
@@ -5,11 +5,11 @@ import org.apache.calcite.prepare.Prepare;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class KeyConstraintsTest extends PlanTestBase {
+class KeyConstraintsTest extends PlanTestBase {
 
   @ParameterizedTest
   @ValueSource(ints = {7})
-  public void tpcds(int query) throws Exception {
+  void tpcds(int query) throws Exception {
     SqlToSubstrait s = new SqlToSubstrait();
     String values = asString("keyconstraints_schema.sql");
     Prepare.CatalogReader catalog =

--- a/isthmus/src/test/java/io/substrait/isthmus/LogarithmicFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/LogarithmicFunctionTest.java
@@ -3,7 +3,7 @@ package io.substrait.isthmus;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class LogarithmicFunctionTest extends PlanTestBase {
+class LogarithmicFunctionTest extends PlanTestBase {
 
   static String CREATES =
       "CREATE TABLE numbers (i8 TINYINT, i16 SMALLINT, i32 INT, i64 BIGINT, fp32 REAL, fp64 DOUBLE)";

--- a/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NameRoundtripTest.java
@@ -11,7 +11,7 @@ import java.util.List;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.junit.jupiter.api.Test;
 
-public class NameRoundtripTest extends PlanTestBase {
+class NameRoundtripTest extends PlanTestBase {
 
   @Test
   void preserveNamesFromSql() throws Exception {

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedStructQueryTest.java
@@ -21,7 +21,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Pair;
 import org.junit.jupiter.api.Test;
 
-public class NestedStructQueryTest extends PlanTestBase {
+class NestedStructQueryTest extends PlanTestBase {
   private class TypeHelper {
     private final RelDataTypeFactory factory;
 
@@ -72,7 +72,7 @@ public class NestedStructQueryTest extends PlanTestBase {
   }
 
   @Test
-  public void testNestedStruct() throws SqlParseException, IOException {
+  void testNestedStruct() throws SqlParseException, IOException {
     final Table table =
         new AbstractTable() {
           @Override
@@ -101,7 +101,7 @@ public class NestedStructQueryTest extends PlanTestBase {
   }
 
   @Test
-  public void testNestedStruct2() throws SqlParseException, IOException {
+  void testNestedStruct2() throws SqlParseException, IOException {
     final Table table =
         new AbstractTable() {
           @Override
@@ -138,7 +138,7 @@ public class NestedStructQueryTest extends PlanTestBase {
   }
 
   @Test
-  public void testNestedStruct3() throws SqlParseException, IOException {
+  void testNestedStruct3() throws SqlParseException, IOException {
     final Table table =
         new AbstractTable() {
           @Override
@@ -180,7 +180,7 @@ public class NestedStructQueryTest extends PlanTestBase {
   }
 
   @Test
-  public void testNestedList() throws SqlParseException, IOException {
+  void testNestedList() throws SqlParseException, IOException {
     final Table table =
         new AbstractTable() {
           @Override
@@ -216,7 +216,7 @@ public class NestedStructQueryTest extends PlanTestBase {
   }
 
   @Test
-  public void testNestedList2() throws SqlParseException, IOException {
+  void testNestedList2() throws SqlParseException, IOException {
     final Table table =
         new AbstractTable() {
           @Override
@@ -266,7 +266,7 @@ public class NestedStructQueryTest extends PlanTestBase {
   }
 
   @Test
-  public void testProtobufDoc() throws SqlParseException, IOException {
+  void testProtobufDoc() throws SqlParseException, IOException {
 
     final Table table =
         new AbstractTable() {

--- a/isthmus/src/test/java/io/substrait/isthmus/OptimizerIntegrationTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OptimizerIntegrationTest.java
@@ -14,7 +14,7 @@ import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
-public class OptimizerIntegrationTest extends PlanTestBase {
+class OptimizerIntegrationTest extends PlanTestBase {
 
   @Test
   void conversionHandlesBuiltInSum0CallAddedByRule() throws SqlParseException, IOException {

--- a/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ProtoPlanConverterTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class ProtoPlanConverterTest extends PlanTestBase {
+class ProtoPlanConverterTest extends PlanTestBase {
 
   private io.substrait.proto.Plan getProtoPlan(String query1) throws SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
@@ -26,12 +26,12 @@ public class ProtoPlanConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void aggregate() throws IOException, SqlParseException {
+  void aggregate() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select count(L_ORDERKEY),sum(L_ORDERKEY) from lineitem");
   }
 
   @Test
-  public void simpleSelect() throws IOException, SqlParseException {
+  void simpleSelect() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select l_orderkey,l_extendedprice from lineitem");
   }
 
@@ -49,7 +49,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void distinctCount() throws IOException, SqlParseException {
+  void distinctCount() throws IOException, SqlParseException {
     String distinctQuery = "select count(DISTINCT L_ORDERKEY) from lineitem";
     io.substrait.proto.Plan protoPlan = getProtoPlan(distinctQuery);
     assertAggregateInvocationDistinct(protoPlan);
@@ -57,12 +57,12 @@ public class ProtoPlanConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void filter() throws IOException, SqlParseException {
+  void filter() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select L_ORDERKEY from lineitem WHERE L_ORDERKEY + 1 > 10");
   }
 
   @Test
-  public void crossJoin() throws IOException, SqlParseException {
+  void crossJoin() throws IOException, SqlParseException {
     int[] counter = new int[1];
     RelCopyOnWriteVisitor<RuntimeException> crossJoinCountingVisitor =
         new RelCopyOnWriteVisitor<RuntimeException>() {
@@ -105,7 +105,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void joinAggSortLimit() throws IOException, SqlParseException {
+  void joinAggSortLimit() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select\n"
             + "  l.l_orderkey,\n"
@@ -137,36 +137,36 @@ public class ProtoPlanConverterTest extends PlanTestBase {
 
   @ParameterizedTest
   @MethodSource("io.substrait.isthmus.utils.SetUtils#setTestConfig")
-  public void setTest(Set.SetOp op, boolean multi) throws Exception {
+  void setTest(Set.SetOp op, boolean multi) throws Exception {
     assertProtoPlanRoundrip(SetUtils.getSetQuery(op, multi));
   }
 
   @Test
-  public void existsCorrelatedSubquery() throws IOException, SqlParseException {
+  void existsCorrelatedSubquery() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select l_partkey from lineitem where exists (select o_orderdate from orders where o_orderkey = l_orderkey)");
   }
 
   @Test
-  public void uniqueCorrelatedSubquery() throws IOException, SqlParseException {
+  void uniqueCorrelatedSubquery() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select l_partkey from lineitem where unique (select o_orderdate from orders where o_orderkey = l_orderkey)");
   }
 
   @Test
-  public void inPredicateCorrelatedSubQuery() throws IOException, SqlParseException {
+  void inPredicateCorrelatedSubQuery() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select l_orderkey from lineitem where l_partkey in (select p_partkey from part where p_partkey = l_partkey)");
   }
 
   @Test
-  public void notInPredicateCorrelatedSubquery() throws IOException, SqlParseException {
+  void notInPredicateCorrelatedSubquery() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select l_orderkey from lineitem where l_partkey not in (select p_partkey from part where p_partkey = l_partkey)");
   }
 
   @Test
-  public void existsNestedCorrelatedSubquery() throws IOException, SqlParseException {
+  void existsNestedCorrelatedSubquery() throws IOException, SqlParseException {
     String sql =
         "SELECT p_partkey\n"
             + "FROM part p\n"
@@ -183,7 +183,7 @@ public class ProtoPlanConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void nestedScalarCorrelatedSubquery() throws IOException, SqlParseException {
+  void nestedScalarCorrelatedSubquery() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(asString("subquery/nested_scalar_subquery_in_filter.sql"));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -25,7 +25,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
-public class RelCopyOnWriteVisitorTest extends PlanTestBase {
+class RelCopyOnWriteVisitorTest extends PlanTestBase {
 
   public static SimpleExtension.FunctionAnchor APPROX_COUNT_DISTINCT =
       SimpleExtension.FunctionAnchor.of(
@@ -82,7 +82,7 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
   }
 
   @Test
-  public void hasTableReference() throws IOException, SqlParseException {
+  void hasTableReference() throws IOException, SqlParseException {
     Plan plan =
         buildPlanFromQuery(
             "SELECT p_partkey\n"
@@ -104,13 +104,13 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
   }
 
   @Test
-  public void countCountDistincts() throws IOException, SqlParseException {
+  void countCountDistincts() throws IOException, SqlParseException {
     Plan plan = buildPlanFromQuery(COUNT_DISTINCT_SUBBQUERY);
     assertEquals(2, new CountCountDistinct().getCountDistincts(plan));
   }
 
   @Test
-  public void replaceCountDistincts() throws IOException, SqlParseException {
+  void replaceCountDistincts() throws IOException, SqlParseException {
     Plan oldPlan = buildPlanFromQuery(COUNT_DISTINCT_SUBBQUERY);
     assertEquals(2, new CountCountDistinct().getCountDistincts(oldPlan));
     assertEquals(0, new CountApproxCountDistinct().getApproxCountDistincts(oldPlan));
@@ -122,7 +122,7 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
   }
 
   @Test
-  public void approximateCountDistinct() throws IOException, SqlParseException {
+  void approximateCountDistinct() throws IOException, SqlParseException {
     Plan oldPlan =
         buildPlanFromQuery(
             "select count(distinct l_discount), count(distinct l_tax) from lineitem");
@@ -142,13 +142,13 @@ public class RelCopyOnWriteVisitorTest extends PlanTestBase {
   }
 
   @Test
-  public void countCountDistinctsUnion() throws IOException, SqlParseException {
+  void countCountDistinctsUnion() throws IOException, SqlParseException {
     Plan plan = buildPlanFromQuery(UNION_DISTINCT_COUNT_QUERY);
     assertEquals(2, new CountCountDistinct().getCountDistincts(plan));
   }
 
   @Test
-  public void replaceCountDistinctsInUnion() throws IOException, SqlParseException {
+  void replaceCountDistinctsInUnion() throws IOException, SqlParseException {
     Plan oldPlan = buildPlanFromQuery(UNION_DISTINCT_COUNT_QUERY);
     assertEquals(2, new CountCountDistinct().getCountDistincts(oldPlan));
     assertEquals(0, new CountApproxCountDistinct().getApproxCountDistincts(oldPlan));

--- a/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelExtensionRoundtripTest.java
@@ -41,7 +41,7 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.tools.RelBuilder;
 import org.junit.jupiter.api.Test;
 
-public class RelExtensionRoundtripTest extends PlanTestBase {
+class RelExtensionRoundtripTest extends PlanTestBase {
   @Test
   void extensionLeafRelDetailTest() {
     ColumnAppendDetail detail = new ColumnAppendDetail(substraitBuilder.i32(1));

--- a/isthmus/src/test/java/io/substrait/isthmus/RoundingFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RoundingFunctionTest.java
@@ -3,7 +3,7 @@ package io.substrait.isthmus;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class RoundingFunctionTest extends PlanTestBase {
+class RoundingFunctionTest extends PlanTestBase {
 
   static String CREATES =
       "CREATE TABLE numbers (i8 TINYINT, i16 SMALLINT, i32 INT, i64 BIGINT, fp32 REAL, fp64 DOUBLE)";

--- a/isthmus/src/test/java/io/substrait/isthmus/SchemaCollectorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SchemaCollectorTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.junit.jupiter.api.Test;
 
-public class SchemaCollectorTest extends PlanTestBase {
+class SchemaCollectorTest extends PlanTestBase {
 
   SubstraitBuilder b = substraitBuilder;
   SchemaCollector schemaCollector = new SchemaCollector(typeFactory, TypeConverter.DEFAULT);

--- a/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
+class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
 
   private static Stream<Arguments> expressionTypeProvider() {
     return Stream.of(
@@ -26,14 +26,14 @@ public class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
 
   @ParameterizedTest
   @MethodSource("expressionTypeProvider")
-  public void testExtendedExpressionsRoundTrip(String sqlExpression)
+  void testExtendedExpressionsRoundTrip(String sqlExpression)
       throws SqlParseException, IOException {
     assertProtoExtendedExpressionRoundtrip(sqlExpression);
   }
 
   @ParameterizedTest
   @MethodSource("expressionTypeProvider")
-  public void testExtendedExpressionsDuplicateColumnIdentifierRoundTrip(String sqlExpression) {
+  void testExtendedExpressionsDuplicateColumnIdentifierRoundTrip(String sqlExpression) {
     IllegalArgumentException illegalArgumentException =
         assertThrows(
             IllegalArgumentException.class,
@@ -45,8 +45,7 @@ public class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
   }
 
   @Test
-  public void testExtendedExpressionsListExpressionRoundTrip()
-      throws SqlParseException, IOException {
+  void testExtendedExpressionsListExpressionRoundTrip() throws SqlParseException, IOException {
     String[] expressions = {
       "2",
       "L_ORDERKEY",

--- a/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimplePlansTest.java
@@ -4,59 +4,59 @@ import java.io.IOException;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
-public class SimplePlansTest extends PlanTestBase {
+class SimplePlansTest extends PlanTestBase {
 
   @Test
-  public void aggFilter() throws IOException, SqlParseException {
+  void aggFilter() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select sum(L_ORDERKEY) filter(WHERE L_ORDERKEY > 10) from lineitem ");
   }
 
   @Test
-  public void cd() throws IOException, SqlParseException {
+  void cd() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select l_partkey, sum(distinct L_ORDERKEY) from lineitem group by l_partkey ");
   }
 
   @Test
-  public void filter() throws IOException, SqlParseException {
+  void filter() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select * from lineitem WHERE L_ORDERKEY > 10");
   }
 
   @Test
-  public void in() throws IOException, SqlParseException {
+  void in() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select * from lineitem WHERE L_ORDERKEY IN (10, 20)");
   }
 
   @Test
-  public void joinWithMultiDDLInOneString() throws IOException, SqlParseException {
+  void joinWithMultiDDLInOneString() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select * from lineitem l, orders o WHERE o.o_orderkey = l.l_orderkey  and L_ORDERKEY > 10");
   }
 
   @Test
-  public void trailingSemicolon() throws IOException, SqlParseException {
+  void trailingSemicolon() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select * from lineitem WHERE L_ORDERKEY > 10;");
   }
 
   @Test
-  public void isNotNull() throws IOException, SqlParseException {
+  void isNotNull() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select L_ORDERKEY from lineitem WHERE L_ORDERKEY is not null;");
   }
 
   @Test
-  public void isNull() throws IOException, SqlParseException {
+  void isNull() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("select L_ORDERKEY from lineitem WHERE L_ORDERKEY is null;");
   }
 
   @Test
-  public void multiStatement() throws IOException, SqlParseException {
+  void multiStatement() throws IOException, SqlParseException {
     assertProtoPlanRoundrip(
         "select l_orderkey from lineitem; select l_partkey from lineitem WHERE L_ORDERKEY > 20;",
         new SqlToSubstrait());
   }
 
   @Test
-  public void virtualTable() throws IOException, SqlParseException {
+  void virtualTable() throws IOException, SqlParseException {
     assertProtoPlanRoundrip("SELECT  1");
     assertProtoPlanRoundrip(
         "SELECT  * FROM    ( " + "        VALUES (1), (3) " + "        ) AS q (col1)");

--- a/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public final class StringFunctionTest extends PlanTestBase {
+final class StringFunctionTest extends PlanTestBase {
 
   static String CREATES = "CREATE TABLE strings (c16 CHAR(16), vc32 VARCHAR(32), vc VARCHAR)";
   static String REPLACE_CREATES =

--- a/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
@@ -13,12 +13,12 @@ import java.io.IOException;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
-public class SubqueryPlanTest extends PlanTestBase {
+class SubqueryPlanTest extends PlanTestBase {
   // TODO: Add a roundtrip test once the ProtoRelConverter is committed and updated to support
   // subqueries
 
   @Test
-  public void existsCorrelatedSubquery() throws SqlParseException {
+  void existsCorrelatedSubquery() throws SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     Plan plan =
         toProto(
@@ -58,7 +58,7 @@ public class SubqueryPlanTest extends PlanTestBase {
   }
 
   @Test
-  public void uniqueCorrelatedSubquery() throws IOException, SqlParseException {
+  void uniqueCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     Plan plan =
         toProto(
@@ -101,7 +101,7 @@ public class SubqueryPlanTest extends PlanTestBase {
   }
 
   @Test
-  public void inPredicateCorrelatedSubQuery() throws IOException, SqlParseException {
+  void inPredicateCorrelatedSubQuery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String sql =
         "select l_orderkey from lineitem where l_partkey in (select p_partkey from part where p_partkey = l_partkey)";
@@ -139,7 +139,7 @@ public class SubqueryPlanTest extends PlanTestBase {
   }
 
   @Test
-  public void notInPredicateCorrelatedSubquery() throws IOException, SqlParseException {
+  void notInPredicateCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String sql =
         "select l_orderkey from lineitem where l_partkey not in (select p_partkey from part where p_partkey = l_partkey)";
@@ -179,7 +179,7 @@ public class SubqueryPlanTest extends PlanTestBase {
   }
 
   @Test
-  public void existsNestedCorrelatedSubquery() throws IOException, SqlParseException {
+  void existsNestedCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String sql =
         "SELECT p_partkey\n"
@@ -260,7 +260,7 @@ public class SubqueryPlanTest extends PlanTestBase {
   }
 
   @Test
-  public void nestedScalarCorrelatedSubquery() throws IOException, SqlParseException {
+  void nestedScalarCorrelatedSubquery() throws IOException, SqlParseException {
     SqlToSubstrait s = new SqlToSubstrait();
     String sql = asString("subquery/nested_scalar_subquery_in_filter.sql");
     Plan plan = toProto(s.convert(sql, TPCH_CATALOG));
@@ -335,7 +335,7 @@ public class SubqueryPlanTest extends PlanTestBase {
   }
 
   @Test
-  public void correlatedScalarSubQueryInSelect() throws Exception {
+  void correlatedScalarSubQueryInSelect() throws Exception {
     String sql = asString("subquery/nested_scalar_subquery_in_select.sql");
     assertSqlSubstraitRelRoundTrip(sql);
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/Substrait2SqlTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class Substrait2SqlTest extends PlanTestBase {
+class Substrait2SqlTest extends PlanTestBase {
   private void assertSqlRoundTripViaPojoAndProto(String inputSql) {
     Plan plan =
         assertDoesNotThrow(() -> toSubstraitPlan(inputSql, TPCH_CATALOG), "SQL to Substrait POJO");
@@ -26,20 +26,20 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleTest() throws Exception {
+  void simpleTest() throws Exception {
     String query = "select p_size  from part where p_partkey > cast(100 as bigint)";
     assertSqlSubstraitRelRoundTrip(query);
   }
 
   @Test
-  public void simpleTest2() throws Exception {
+  void simpleTest2() throws Exception {
     String query =
         "select l_partkey, l_discount from lineitem where l_orderkey > cast(100 as bigint)";
     assertSqlSubstraitRelRoundTrip(query);
   }
 
   @Test
-  public void simpleTestDateInterval() throws Exception {
+  void simpleTestDateInterval() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey + l_orderkey, l_shipdate from lineitem where l_shipdate < date '1998-01-01' ");
     assertSqlSubstraitRelRoundTrip(
@@ -51,13 +51,13 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleTestDecimal() throws Exception {
+  void simpleTestDecimal() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey + l_orderkey, l_extendedprice * 0.1 + 100.0 from lineitem where l_shipdate < date '1998-01-01' ");
   }
 
   @Test
-  public void simpleJoin() throws Exception {
+  void simpleJoin() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey + l_orderkey, l_extendedprice * 0.1 + 100.0, o_orderkey from lineitem join orders on l_orderkey = o_orderkey where l_shipdate < date '1998-01-01' ");
     assertSqlSubstraitRelRoundTrip(
@@ -69,7 +69,7 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleTestAgg() throws Exception {
+  void simpleTestAgg() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey, count(l_tax), COUNT(distinct l_discount) from lineitem group by l_partkey");
 
@@ -79,7 +79,7 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleTestGroupingSets() throws Exception {
+  void simpleTestGroupingSets() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select sum(l_discount) from lineitem group by grouping sets ((l_orderkey, L_COMMITDATE), l_shipdate)");
     assertSqlSubstraitRelRoundTrip(
@@ -109,7 +109,7 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleTestAggFilter() throws Exception {
+  void simpleTestAggFilter() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select sum(l_tax) filter(WHERE l_orderkey > l_partkey) from lineitem");
     // cast is added to avoid the difference by implicit cast
@@ -118,30 +118,30 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleTestAggNoGB() throws Exception {
+  void simpleTestAggNoGB() throws Exception {
     assertSqlSubstraitRelRoundTrip("select count(l_tax), count(distinct l_discount) from lineitem");
   }
 
   @Test
-  public void simpleTestAgg2() throws Exception {
+  void simpleTestAgg2() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey, sum(l_tax), sum(distinct l_tax), avg(l_discount), avg(distinct l_discount) from lineitem group by l_partkey");
   }
 
   @Test
-  public void simpleTestAgg3() throws Exception {
+  void simpleTestAgg3() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey, sum(l_extendedprice * (1.0 - l_discount)) from lineitem group by l_partkey");
   }
 
   @ParameterizedTest
   @MethodSource("io.substrait.isthmus.utils.SetUtils#setTestConfig")
-  public void setTest(Set.SetOp op, boolean multi) throws Exception {
+  void setTest(Set.SetOp op, boolean multi) throws Exception {
     assertSqlSubstraitRelRoundTrip(SetUtils.getSetQuery(op, multi));
   }
 
   @Test
-  public void tpch_q1_variant() throws Exception {
+  void tpch_q1_variant() throws Exception {
     // difference from tpch_q1 : 1) remove order by clause; 2) remove interval date literal
     assertSqlSubstraitRelRoundTrip(
         "select\n"
@@ -165,7 +165,7 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleTestApproxCountDistinct() throws Exception {
+  void simpleTestApproxCountDistinct() throws Exception {
     String query = "select approx_count_distinct(l_tax)  from lineitem";
     RelRoot relRoot = assertSqlSubstraitRelRoundTrip(query);
     RelNode relNode = relRoot.project();
@@ -179,7 +179,7 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleOrderByClause() throws Exception {
+  void simpleOrderByClause() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select l_partkey from lineitem where l_shipdate < date '1998-01-01' order by l_shipdate, l_discount");
     assertSqlSubstraitRelRoundTrip(
@@ -197,7 +197,7 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void simpleStringOpTest() throws Exception {
+  void simpleStringOpTest() throws Exception {
     assertSqlSubstraitRelRoundTrip("select substring(l_comment, 1, 5) from lineitem");
 
     assertSqlSubstraitRelRoundTrip("select lower(l_comment) from lineitem");
@@ -210,7 +210,7 @@ public class Substrait2SqlTest extends PlanTestBase {
   }
 
   @Test
-  public void caseWhenTest() throws Exception {
+  void caseWhenTest() throws Exception {
     assertSqlSubstraitRelRoundTrip(
         "select case when p_size > 100 then 'large' when p_size > 50 then 'medium' else 'small' end from part");
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -26,7 +26,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.junit.jupiter.api.Test;
 
-public class SubstraitExpressionConverterTest extends PlanTestBase {
+class SubstraitExpressionConverterTest extends PlanTestBase {
 
   static final TypeCreator R = TypeCreator.of(false);
   static final TypeCreator N = TypeCreator.of(true);
@@ -54,7 +54,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void switchExpression() {
+  void switchExpression() {
     Switch expr =
         b.switchExpression(
             b.fieldReference(commonTable, 0),
@@ -66,7 +66,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void scalarSubQuery() {
+  void scalarSubQuery() {
     Rel subQueryRel = createSubQueryRel();
 
     Expression.ScalarSubquery expr =
@@ -84,7 +84,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void existsSetPredicate() {
+  void existsSetPredicate() {
     Rel subQueryRel = createSubQueryRel();
 
     Expression.SetPredicate expr =
@@ -105,7 +105,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void uniqueSetPredicate() {
+  void uniqueSetPredicate() {
     Rel subQueryRel = createSubQueryRel();
 
     Expression.SetPredicate expr =
@@ -126,7 +126,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void unspecifiedSetPredicate() {
+  void unspecifiedSetPredicate() {
     Rel subQueryRel = createSubQueryRel();
 
     Expression.SetPredicate expr =
@@ -165,7 +165,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void useSubstraitReturnTypeDuringScalarFunctionConversion() {
+  void useSubstraitReturnTypeDuringScalarFunctionConversion() {
     Expression.ScalarFunctionInvocation expr =
         b.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
@@ -181,7 +181,7 @@ public class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
-  public void useSubstraitReturnTypeDuringWindowFunctionConversion() {
+  void useSubstraitReturnTypeDuringWindowFunctionConversion() {
     Expression.WindowFunctionInvocation expr =
         b.windowFn(
             DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -16,7 +16,7 @@ import org.apache.calcite.rel.RelNode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public class SubstraitRelNodeConverterTest extends PlanTestBase {
+class SubstraitRelNodeConverterTest extends PlanTestBase {
 
   static final TypeCreator R = TypeCreator.of(false);
   static final TypeCreator N = TypeCreator.of(true);
@@ -36,7 +36,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Aggregate {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root =
           b.root(
               b.aggregate(
@@ -49,7 +49,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root =
           b.root(
               b.aggregate(
@@ -66,7 +66,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Cross {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root = b.root(b.cross(commonTable, commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -74,7 +74,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root = b.root(b.cross(commonTable, commonTable, b.remap(0, 1, 4, 6)));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -85,7 +85,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Fetch {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root = b.root(b.fetch(20, 40, commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -93,7 +93,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root = b.root(b.fetch(20, 40, b.remap(0, 2), commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -104,7 +104,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Filter {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root = b.root(b.filter(input -> b.bool(true), commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -112,7 +112,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root = b.root(b.filter(input -> b.bool(true), b.remap(0, 2), commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -123,7 +123,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Join {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root = b.root(b.innerJoin(input -> b.bool(true), commonTable, commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -131,7 +131,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root =
           b.root(b.innerJoin(input -> b.bool(true), b.remap(0, 6), commonTable, commonTable));
 
@@ -140,7 +140,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void leftJoin() {
+    void leftJoin() {
       final List<Type> joinTableType = List.of(R.STRING, R.FP64, R.BINARY);
       final Rel joinTable = b.namedScan(List.of("join"), List.of("a", "b", "c"), joinTableType);
 
@@ -156,7 +156,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void rightJoin() {
+    void rightJoin() {
       final List<Type> joinTableType = List.of(R.STRING, R.FP64, R.BINARY);
       final Rel joinTable = b.namedScan(List.of("join"), List.of("a", "b", "c"), joinTableType);
 
@@ -172,7 +172,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void outerJoin() {
+    void outerJoin() {
       final List<Type> joinTableType = List.of(R.STRING, R.FP64, R.BINARY);
       final Rel joinTable = b.namedScan(List.of("join"), List.of("a", "b", "c"), joinTableType);
 
@@ -191,7 +191,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class NamedScan {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root =
           b.root(b.namedScan(List.of("example"), List.of("a", "b"), List.of(R.I32, R.FP32)));
 
@@ -200,7 +200,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root =
           b.root(
               b.namedScan(
@@ -214,7 +214,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Project {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root = b.root(b.project(input -> b.fieldReferences(input, 1, 0, 2), commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -223,7 +223,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root =
           b.root(
               b.project(
@@ -237,7 +237,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Set {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root = b.root(b.set(SetOp.UNION_ALL, commonTable, commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -245,7 +245,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root = b.root(b.set(SetOp.UNION_ALL, b.remap(0, 2), commonTable, commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -256,7 +256,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   @Nested
   class Sort {
     @Test
-    public void direct() {
+    void direct() {
       Plan.Root root = b.root(b.sort(input -> b.sortFields(input, 0, 1, 2), commonTable));
 
       RelNode relNode = converter.convert(root.getInput());
@@ -264,7 +264,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Plan.Root root =
           b.root(b.sort(input -> b.sortFields(input, 0, 1, 2), b.remap(0, 2), commonTable));
 
@@ -277,7 +277,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
   class EmptyScan {
 
     @Test
-    public void direct() {
+    void direct() {
       Rel emptyScan =
           io.substrait.relation.EmptyScan.builder()
               .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct(R.I32, N.STRING)))
@@ -289,7 +289,7 @@ public class SubstraitRelNodeConverterTest extends PlanTestBase {
     }
 
     @Test
-    public void emit() {
+    void emit() {
       Rel emptyScanWithRemap =
           io.substrait.relation.EmptyScan.builder()
               .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct(R.I32, N.STRING)))

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitToCalciteTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitToCalciteTest.java
@@ -12,7 +12,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
-public class SubstraitToCalciteTest extends PlanTestBase {
+class SubstraitToCalciteTest extends PlanTestBase {
   final SubstraitToCalcite converter = new SubstraitToCalcite(extensions, typeFactory);
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpcdsQueryTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /** TPC-DS test to convert SQL to Substrait and then convert those plans back to SQL. */
-public class TpcdsQueryTest extends PlanTestBase {
+class TpcdsQueryTest extends PlanTestBase {
   private static final Set<Integer> alternateForms = Set.of(27, 36, 70, 86);
 
   static IntStream testCases() {
@@ -24,7 +24,7 @@ public class TpcdsQueryTest extends PlanTestBase {
    */
   @ParameterizedTest
   @MethodSource("testCases")
-  public void testQuery(int query) throws IOException {
+  void testQuery(int query) throws IOException {
     String inputSql = asString(inputSqlFile(query));
     Plan plan = assertDoesNotThrow(() -> toSubstraitPlan(inputSql), "SQL to Substrait POJO");
     assertDoesNotThrow(() -> toSql(plan), "Substrait POJO to SQL");

--- a/isthmus/src/test/java/io/substrait/isthmus/TpchQueryTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/TpchQueryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /** TPC-H test to convert SQL to Substrait and then convert those plans back to SQL. */
-public class TpchQueryTest extends PlanTestBase {
+class TpchQueryTest extends PlanTestBase {
   static IntStream testCases() {
     return IntStream.rangeClosed(1, 22);
   }
@@ -21,7 +21,7 @@ public class TpchQueryTest extends PlanTestBase {
    */
   @ParameterizedTest
   @MethodSource("testCases")
-  public void testQuery(int query) throws IOException {
+  void testQuery(int query) throws IOException {
     String inputSql = asString(String.format("tpch/queries/%02d.sql", query));
 
     Plan plan = assertDoesNotThrow(() -> toSubstraitPlan(inputSql), "SQL to Substrait POJO");

--- a/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/WindowFunctionTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class WindowFunctionTest extends PlanTestBase {
+class WindowFunctionTest extends PlanTestBase {
 
   @Nested
   class WindowFunctionInvocations {

--- a/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/expression/AggregateFunctionConverterTest.java
@@ -13,7 +13,7 @@ import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
-public class AggregateFunctionConverterTest extends PlanTestBase {
+class AggregateFunctionConverterTest extends PlanTestBase {
 
   @Test
   void testFunctionFinderMatch() {


### PR DESCRIPTION
This PR makes all JUnit 5 test classes and methods package private. Further, it enables the PMD rule [`JUnit5TestShouldBePackagePrivate`](https://pmd.github.io/pmd/pmd_rules_java_bestpractices.html#junit5testshouldbepackageprivate) which enforces going forward that all new JUnit 5 test classes and test methods are package private.

I also remove a no-op test class: `isthmus/src/test/java/io/substrait/isthmus/CalciteFieldSelectionTest.java`