### PR TITLE
fix: add missing serialVersionUIDs

### DIFF
--- a/build-logic/src/main/resources/substrait-pmd.xml
+++ b/build-logic/src/main/resources/substrait-pmd.xml
@@ -20,4 +20,5 @@
   <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
   <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
   <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" />
+  <rule ref="category/java/errorprone.xml/MissingSerialVersionUID" />
 </ruleset>

--- a/core/src/main/java/io/substrait/function/ParameterizedType.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedType.java
@@ -11,6 +11,9 @@ import org.immutables.value.Value;
 public interface ParameterizedType extends TypeExpression {
 
   class RequiredParameterizedVisitorException extends RuntimeException {
+
+    private static final long serialVersionUID = 5009974222890249956L;
+
     @Override
     public synchronized Throwable fillInStackTrace() {
       return this;

--- a/core/src/main/java/io/substrait/function/TypeExpression.java
+++ b/core/src/main/java/io/substrait/function/TypeExpression.java
@@ -6,7 +6,9 @@ import org.immutables.value.Value;
 @Value.Enclosing
 public interface TypeExpression {
 
-  class RequiredTypeExpressionVisitorException extends RuntimeException {}
+  class RequiredTypeExpressionVisitorException extends RuntimeException {
+    private static final long serialVersionUID = 8381558691397737963L;
+  }
 
   <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E;
 

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -30,6 +30,8 @@ public class Deserializers {
 
   public static class ParseDeserializer<T> extends StdDeserializer<T> {
 
+    private static final long serialVersionUID = 2105956703553161270L;
+
     private final BiFunction<String, SubstraitTypeParser.StartContext, T> converter;
 
     public ParseDeserializer(

--- a/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
+++ b/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
@@ -65,6 +65,9 @@ public class TypeStringParser {
   }
 
   public static class ParseError extends RuntimeException {
+
+    private static final long serialVersionUID = -6831467523614033666L;
+
     public ParseError(final String message, final Throwable cause) {
       super(message, cause);
     }

--- a/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/GenericRoundtripTest.java
@@ -143,6 +143,9 @@ class GenericRoundtripTest extends TestBase {
 
   // Class used to propagate type generation errors from param generator to test cases
   private static class UnsupportedTypeGenerationException extends Exception {
+
+    private static final long serialVersionUID = -8627552468610061245L;
+
     public UnsupportedTypeGenerationException(String s) {
       super(s);
     }


### PR DESCRIPTION
This PR adds missing serialVersionUIDs and adds a PMD check to ensure the serialVersionUID is present whenever new serializable classes are added.