### PR TITLE
fix: add essential javadoc to remove warnings

### DIFF
--- a/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
@@ -2,91 +2,442 @@ package io.substrait.expression;
 
 import io.substrait.util.VisitationContext;
 
+/**
+ * Visitor for {@code Expression} nodes.
+ *
+ * @param <R> result type returned by each visit
+ * @param <C> visitation context type
+ * @param <E> throwable type that visit methods may throw
+ */
 public interface ExpressionVisitor<R, C extends VisitationContext, E extends Throwable> {
 
+  /**
+   * Visit a NULL literal.
+   *
+   * @param expr the NULL literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.NullLiteral expr, C context) throws E;
 
+  /**
+   * Visit a boolean literal.
+   *
+   * @param expr the boolean literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.BoolLiteral expr, C context) throws E;
 
+  /**
+   * Visit an 8-bit integer literal.
+   *
+   * @param expr the i8 literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.I8Literal expr, C context) throws E;
 
+  /**
+   * Visit a 16-bit integer literal.
+   *
+   * @param expr the i16 literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.I16Literal expr, C context) throws E;
 
+  /**
+   * Visit a 32-bit integer literal.
+   *
+   * @param expr the i32 literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.I32Literal expr, C context) throws E;
 
+  /**
+   * Visit a 64-bit integer literal.
+   *
+   * @param expr the i64 literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.I64Literal expr, C context) throws E;
 
+  /**
+   * Visit a 32-bit floating-point literal.
+   *
+   * @param expr the fp32 literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.FP32Literal expr, C context) throws E;
 
+  /**
+   * Visit a 64-bit floating-point literal.
+   *
+   * @param expr the fp64 literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.FP64Literal expr, C context) throws E;
 
+  /**
+   * Visit a string literal.
+   *
+   * @param expr the string literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.StrLiteral expr, C context) throws E;
 
+  /**
+   * Visit a binary literal.
+   *
+   * @param expr the binary literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.BinaryLiteral expr, C context) throws E;
 
+  /**
+   * Visit a time literal.
+   *
+   * @param expr the time literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.TimeLiteral expr, C context) throws E;
 
+  /**
+   * Visit a date literal.
+   *
+   * @param expr the date literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.DateLiteral expr, C context) throws E;
 
+  /**
+   * Visit a timestamp literal.
+   *
+   * @param expr the timestamp literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.TimestampLiteral expr, C context) throws E;
 
+  /**
+   * Visit a timestamp-with-timezone literal.
+   *
+   * @param expr the timestamp TZ literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.TimestampTZLiteral expr, C context) throws E;
 
+  /**
+   * Visit a precision timestamp literal.
+   *
+   * @param expr the precision timestamp literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.PrecisionTimestampLiteral expr, C context) throws E;
 
+  /**
+   * Visit a precision timestamp-with-timezone literal.
+   *
+   * @param expr the precision timestamp TZ literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.PrecisionTimestampTZLiteral expr, C context) throws E;
 
+  /**
+   * Visit a year/month interval literal.
+   *
+   * @param expr the interval (year) literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.IntervalYearLiteral expr, C context) throws E;
 
+  /**
+   * Visit a day/time interval literal.
+   *
+   * @param expr the interval (day) literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.IntervalDayLiteral expr, C context) throws E;
 
+  /**
+   * Visit a compound interval literal.
+   *
+   * @param expr the compound interval literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.IntervalCompoundLiteral expr, C context) throws E;
 
+  /**
+   * Visit a UUID literal.
+   *
+   * @param expr the UUID literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.UUIDLiteral expr, C context) throws E;
 
+  /**
+   * Visit a fixed-length char literal.
+   *
+   * @param expr the fixed char literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.FixedCharLiteral expr, C context) throws E;
 
+  /**
+   * Visit a variable-length char literal.
+   *
+   * @param expr the varchar literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.VarCharLiteral expr, C context) throws E;
 
+  /**
+   * Visit a fixed-length binary literal.
+   *
+   * @param expr the fixed binary literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.FixedBinaryLiteral expr, C context) throws E;
 
+  /**
+   * Visit a decimal literal.
+   *
+   * @param expr the decimal literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.DecimalLiteral expr, C context) throws E;
 
+  /**
+   * Visit a map literal.
+   *
+   * @param expr the map literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.MapLiteral expr, C context) throws E;
 
+  /**
+   * Visit an empty map literal.
+   *
+   * @param expr the empty map literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.EmptyMapLiteral expr, C context) throws E;
 
+  /**
+   * Visit a list literal.
+   *
+   * @param expr the list literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.ListLiteral expr, C context) throws E;
 
+  /**
+   * Visit an empty list literal.
+   *
+   * @param expr the empty list literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.EmptyListLiteral expr, C context) throws E;
 
+  /**
+   * Visit a struct literal.
+   *
+   * @param expr the struct literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.StructLiteral expr, C context) throws E;
 
+  /**
+   * Visit a nested struct.
+   *
+   * @param expr the nested struct
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.NestedStruct expr, C context) throws E;
 
+  /**
+   * Visit a user-defined literal.
+   *
+   * @param expr the user-defined literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.UserDefinedLiteral expr, C context) throws E;
 
+  /**
+   * Visit a switch expression.
+   *
+   * @param expr the switch expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.Switch expr, C context) throws E;
 
+  /**
+   * Visit an if-then expression.
+   *
+   * @param expr the if-then expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.IfThen expr, C context) throws E;
 
+  /**
+   * Visit a scalar function invocation.
+   *
+   * @param expr the scalar function invocation
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.ScalarFunctionInvocation expr, C context) throws E;
 
+  /**
+   * Visit a window function invocation.
+   *
+   * @param expr the window function invocation
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.WindowFunctionInvocation expr, C context) throws E;
 
+  /**
+   * Visit a cast.
+   *
+   * @param expr the cast expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.Cast expr, C context) throws E;
 
+  /**
+   * Visit a single-or-list expression.
+   *
+   * @param expr the single-or-list expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.SingleOrList expr, C context) throws E;
 
+  /**
+   * Visit a multi-or-list expression.
+   *
+   * @param expr the multi-or-list expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.MultiOrList expr, C context) throws E;
 
+  /**
+   * Visit a nested list.
+   *
+   * @param expr the nested list
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.NestedList expr, C context) throws E;
 
+  /**
+   * Visit a field reference.
+   *
+   * @param expr the field reference
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(FieldReference expr, C context) throws E;
 
+  /**
+   * Visit a set predicate.
+   *
+   * @param expr the set predicate
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.SetPredicate expr, C context) throws E;
 
+  /**
+   * Visit a scalar subquery.
+   *
+   * @param expr the scalar subquery
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.ScalarSubquery expr, C context) throws E;
 
+  /**
+   * Visit an IN predicate.
+   *
+   * @param expr the IN predicate
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   R visit(Expression.InPredicate expr, C context) throws E;
 }

--- a/core/src/main/java/io/substrait/extension/AdvancedExtension.java
+++ b/core/src/main/java/io/substrait/extension/AdvancedExtension.java
@@ -4,30 +4,57 @@ import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
 
+/**
+ * Represents advanced extensions that can include optimizations and enhancements.
+ *
+ * <p>Optimizations provide optional hints that do not affect semantics, while enhancements
+ * introduce semantic changes and must be honored by consumers.
+ *
+ * @param <O> type of optimization
+ * @param <E> type of enhancement
+ */
 @Value.Immutable
 public abstract class AdvancedExtension<
     O extends AdvancedExtension.Optimization, E extends AdvancedExtension.Enhancement> {
+
+  /**
+   * Returns the list of optimizations associated with this extension.
+   *
+   * @return list of optimizations
+   */
   public abstract List<O> getOptimizations();
 
+  /**
+   * Returns the optional enhancement associated with this extension.
+   *
+   * @return optional enhancement
+   */
   public abstract Optional<E> getEnhancement();
 
+  /**
+   * Creates a builder for {@link AdvancedExtension}.
+   *
+   * @param <O> type of optimization
+   * @param <E> type of enhancement
+   * @return builder instance
+   */
   public static <O extends AdvancedExtension.Optimization, E extends AdvancedExtension.Enhancement>
       ImmutableAdvancedExtension.Builder<O, E> builder() {
     return ImmutableAdvancedExtension.<O, E>builder();
   }
 
   /**
-   * Optimization associated with an {@link io.substrait.proto.AdvancedExtension}
+   * Represents an optimization associated with an {@link io.substrait.proto.AdvancedExtension}.
    *
-   * <p>An optimization is helpful information that doesn't influence semantics. May be ignored by a
-   * consumer.
+   * <p>An optimization provides helpful information that does not influence semantics and may be
+   * ignored by consumers.
    */
   public interface Optimization {}
 
   /**
-   * Enhancement associated with an {@link io.substrait.proto.AdvancedExtension}
+   * Represents an enhancement associated with an {@link io.substrait.proto.AdvancedExtension}.
    *
-   * <p>An enhancement alters semantics. Cannot be ignored by a consumer.
+   * <p>An enhancement alters semantics and cannot be ignored by consumers.
    */
   public interface Enhancement {}
 }

--- a/core/src/main/java/io/substrait/relation/AbstractDdlRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractDdlRel.java
@@ -6,32 +6,84 @@ import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import java.util.Optional;
 
+/**
+ * Base class for DDL relations with no inputs.
+ *
+ * <p>Defines schema/defaults, DDL object and operation, and optional view definition.
+ */
 public abstract class AbstractDdlRel extends ZeroInputRel implements HasExtension {
+
+  /**
+   * Returns the target table/view schema (names + types).
+   *
+   * @return target {@link NamedStruct}
+   */
   public abstract NamedStruct getTableSchema();
 
+  /**
+   * Returns default values for the table columns.
+   *
+   * @return defaults as {@link Expression.StructLiteral}
+   */
   public abstract Expression.StructLiteral getTableDefaults();
 
+  /**
+   * Returns the DDL object kind (table or view).
+   *
+   * @return DDL object
+   */
   public abstract DdlObject getObject();
 
+  /**
+   * Returns the DDL operation (create/alter/drop, etc.).
+   *
+   * @return DDL operation
+   */
   public abstract DdlOp getOperation();
 
+  /**
+   * Returns the view definition when the object is a view.
+   *
+   * @return optional view definition relation
+   */
   public abstract Optional<Rel> getViewDefinition();
 
+  /** DDL object kinds. */
   public enum DdlObject {
+    /** Unspecified object. */
     UNSPECIFIED(DdlRel.DdlObject.DDL_OBJECT_UNSPECIFIED),
+    /** Table DDL. */
     TABLE(DdlRel.DdlObject.DDL_OBJECT_TABLE),
+    /** View DDL. */
     VIEW(DdlRel.DdlObject.DDL_OBJECT_VIEW);
 
     private final DdlRel.DdlObject proto;
 
+    /**
+     * Creates a {@code DdlObject} bound to its protobuf value.
+     *
+     * @param proto protobuf enum value
+     */
     DdlObject(DdlRel.DdlObject proto) {
       this.proto = proto;
     }
 
+    /**
+     * Converts this enum to its protobuf counterpart.
+     *
+     * @return protobuf enum value
+     */
     public DdlRel.DdlObject toProto() {
       return proto;
     }
 
+    /**
+     * Maps a protobuf value to this enum.
+     *
+     * @param proto protobuf enum value
+     * @return matching {@code DdlObject}
+     * @throws IllegalArgumentException if unknown
+     */
     public static DdlObject fromProto(DdlRel.DdlObject proto) {
       for (DdlObject v : values()) {
         if (v.proto == proto) {
@@ -42,24 +94,48 @@ public abstract class AbstractDdlRel extends ZeroInputRel implements HasExtensio
     }
   }
 
+  /** DDL operations. */
   public enum DdlOp {
+    /** Unspecified operation. */
     UNSPECIFIED(DdlRel.DdlOp.DDL_OP_UNSPECIFIED),
+    /** Create a new object. */
     CREATE(DdlRel.DdlOp.DDL_OP_CREATE),
+    /** Create or replace the object. */
     CREATE_OR_REPLACE(DdlRel.DdlOp.DDL_OP_CREATE_OR_REPLACE),
+    /** Alter an existing object. */
     ALTER(DdlRel.DdlOp.DDL_OP_ALTER),
+    /** Drop an object. */
     DROP(DdlRel.DdlOp.DDL_OP_DROP),
+    /** Drop an object if it exists. */
     DROP_IF_EXIST(DdlRel.DdlOp.DDL_OP_DROP_IF_EXIST);
 
     private final DdlRel.DdlOp proto;
 
+    /**
+     * Creates a {@code DdlOp} bound to its protobuf value.
+     *
+     * @param proto protobuf enum value
+     */
     DdlOp(DdlRel.DdlOp proto) {
       this.proto = proto;
     }
 
+    /**
+     * Converts this enum to its protobuf counterpart.
+     *
+     * @return protobuf enum value
+     */
     public DdlRel.DdlOp toProto() {
       return proto;
     }
 
+    /**
+     * Maps a protobuf value to this enum.
+     *
+     * @param proto protobuf enum value
+     * @return matching {@code DdlOp}
+     * @throws IllegalArgumentException if unknown
+     */
     public static DdlOp fromProto(DdlRel.DdlOp proto) {
       for (DdlOp v : values()) {
         if (v.proto == proto) {
@@ -70,6 +146,11 @@ public abstract class AbstractDdlRel extends ZeroInputRel implements HasExtensio
     }
   }
 
+  /**
+   * Derives the output record type from the declared schema.
+   *
+   * @return {@link Type.Struct} from {@link #getTableSchema()}
+   */
   @Override
   public Type.Struct deriveRecordType() {
     return getTableSchema().struct();

--- a/core/src/main/java/io/substrait/relation/AbstractUpdate.java
+++ b/core/src/main/java/io/substrait/relation/AbstractUpdate.java
@@ -6,25 +6,67 @@ import io.substrait.type.Type;
 import java.util.List;
 import org.immutables.value.Value;
 
+/**
+ * Represents an update operation on a table.
+ *
+ * <p>Defines the target schema, update condition, and column transformations.
+ */
 public abstract class AbstractUpdate extends ZeroInputRel implements HasExtension {
 
+  /**
+   * Returns the schema of the target table.
+   *
+   * @return table schema as {@link NamedStruct}
+   */
   public abstract NamedStruct getTableSchema();
 
+  /**
+   * Returns the condition that determines which rows to update.
+   *
+   * @return update condition expression
+   */
   public abstract Expression getCondition();
 
+  /**
+   * Returns the list of column transformations to apply.
+   *
+   * @return list of {@link TransformExpression}
+   */
   public abstract List<TransformExpression> getTransformations();
 
+  /** Represents a transformation applied to a specific column during an update. */
   @Value.Immutable
   public abstract static class TransformExpression {
+
+    /**
+     * Returns the expression that computes the new value for the column.
+     *
+     * @return transformation expression
+     */
     public abstract Expression getTransformation();
 
+    /**
+     * Returns the index of the target column to update.
+     *
+     * @return column index
+     */
     public abstract int getColumnTarget();
 
+    /**
+     * Creates a builder for {@link TransformExpression}.
+     *
+     * @return builder instance
+     */
     public static ImmutableTransformExpression.Builder builder() {
       return ImmutableTransformExpression.builder();
     }
   }
 
+  /**
+   * Derives the output record type from the table schema.
+   *
+   * @return {@link Type.Struct} based on {@link #getTableSchema()}
+   */
   @Override
   public Type.Struct deriveRecordType() {
     return getTableSchema().struct();

--- a/core/src/main/java/io/substrait/relation/AbstractWriteRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractWriteRel.java
@@ -4,33 +4,81 @@ import io.substrait.proto.WriteRel;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 
+/**
+ * Base class for write relations with a single input.
+ *
+ * <p>Defines table schema, write operation, create mode, and output mode.
+ */
 public abstract class AbstractWriteRel extends SingleInputRel implements HasExtension {
 
+  /**
+   * Returns the target table schema (names + types).
+   *
+   * @return target table {@link NamedStruct}
+   */
   public abstract NamedStruct getTableSchema();
 
+  /**
+   * Returns the write operation (insert/delete/update/ctas).
+   *
+   * @return write operation
+   */
   public abstract WriteOp getOperation();
 
+  /**
+   * Returns the table creation behavior when the target exists.
+   *
+   * @return create mode
+   */
   public abstract CreateMode getCreateMode();
 
+  /**
+   * Returns the output behavior of the write (e.g., rows returned).
+   *
+   * @return output mode
+   */
   public abstract OutputMode getOutputMode();
 
+  /** Logical write operation kinds. */
   public enum WriteOp {
+    /** Unspecified operation. */
     UNSPECIFIED(WriteRel.WriteOp.WRITE_OP_UNSPECIFIED),
+    /** Insert rows into the target. */
     INSERT(WriteRel.WriteOp.WRITE_OP_INSERT),
+    /** Delete rows from the target. */
     DELETE(WriteRel.WriteOp.WRITE_OP_DELETE),
+    /** Update rows in the target. */
     UPDATE(WriteRel.WriteOp.WRITE_OP_UPDATE),
+    /** Create table as select (CTAS). */
     CTAS(WriteRel.WriteOp.WRITE_OP_CTAS);
 
     private final WriteRel.WriteOp proto;
 
+    /**
+     * Creates a {@code WriteOp} bound to its protobuf value.
+     *
+     * @param proto protobuf enum value
+     */
     WriteOp(WriteRel.WriteOp proto) {
       this.proto = proto;
     }
 
+    /**
+     * Converts this enum to its protobuf counterpart.
+     *
+     * @return protobuf enum value
+     */
     public WriteRel.WriteOp toProto() {
       return proto;
     }
 
+    /**
+     * Maps a protobuf value to this enum.
+     *
+     * @param proto protobuf enum value
+     * @return matching {@code WriteOp}
+     * @throws IllegalArgumentException if unknown
+     */
     public static WriteOp fromProto(WriteRel.WriteOp proto) {
       for (WriteOp v : values()) {
         if (v.proto == proto) {
@@ -41,23 +89,46 @@ public abstract class AbstractWriteRel extends SingleInputRel implements HasExte
     }
   }
 
+  /** Behavior when the target table already exists. */
   public enum CreateMode {
+    /** Unspecified mode. */
     UNSPECIFIED(WriteRel.CreateMode.CREATE_MODE_UNSPECIFIED),
+    /** Append to the existing table if it exists. */
     APPEND_IF_EXISTS(WriteRel.CreateMode.CREATE_MODE_APPEND_IF_EXISTS),
+    /** Replace the existing table if it exists. */
     REPLACE_IF_EXISTS(WriteRel.CreateMode.CREATE_MODE_REPLACE_IF_EXISTS),
+    /** Ignore the write if the table exists. */
     IGNORE_IF_EXISTS(WriteRel.CreateMode.CREATE_MODE_IGNORE_IF_EXISTS),
+    /** Error if the table exists. */
     ERROR_IF_EXISTS(WriteRel.CreateMode.CREATE_MODE_ERROR_IF_EXISTS);
 
     private final WriteRel.CreateMode proto;
 
+    /**
+     * Creates a {@code CreateMode} bound to its protobuf value.
+     *
+     * @param proto protobuf enum value
+     */
     CreateMode(WriteRel.CreateMode proto) {
       this.proto = proto;
     }
 
+    /**
+     * Converts this enum to its protobuf counterpart.
+     *
+     * @return protobuf enum value
+     */
     public WriteRel.CreateMode toProto() {
       return proto;
     }
 
+    /**
+     * Maps a protobuf value to this enum.
+     *
+     * @param proto protobuf enum value
+     * @return matching {@code CreateMode}
+     * @throws IllegalArgumentException if unknown
+     */
     public static CreateMode fromProto(WriteRel.CreateMode proto) {
       for (CreateMode v : values()) {
         if (v.proto == proto) {
@@ -68,21 +139,42 @@ public abstract class AbstractWriteRel extends SingleInputRel implements HasExte
     }
   }
 
+  /** Output behavior for write operations. */
   public enum OutputMode {
+    /** Unspecified output. */
     UNSPECIFIED(WriteRel.OutputMode.OUTPUT_MODE_UNSPECIFIED),
+    /** No rows are produced by the write. */
     NO_OUTPUT(WriteRel.OutputMode.OUTPUT_MODE_NO_OUTPUT),
+    /** Only modified records are produced. */
     MODIFIED_RECORDS(WriteRel.OutputMode.OUTPUT_MODE_MODIFIED_RECORDS);
 
     private final WriteRel.OutputMode proto;
 
+    /**
+     * Creates an {@code OutputMode} bound to its protobuf value.
+     *
+     * @param proto protobuf enum value
+     */
     OutputMode(WriteRel.OutputMode proto) {
       this.proto = proto;
     }
 
+    /**
+     * Converts this enum to its protobuf counterpart.
+     *
+     * @return protobuf enum value
+     */
     public WriteRel.OutputMode toProto() {
       return proto;
     }
 
+    /**
+     * Maps a protobuf value to this enum.
+     *
+     * @param proto protobuf enum value
+     * @return matching {@code OutputMode}
+     * @throws IllegalArgumentException if unknown
+     */
     public static OutputMode fromProto(WriteRel.OutputMode proto) {
       for (OutputMode v : values()) {
         if (v.proto == proto) {
@@ -93,6 +185,11 @@ public abstract class AbstractWriteRel extends SingleInputRel implements HasExte
     }
   }
 
+  /**
+   * Derives the output record type from the input relation.
+   *
+   * @return input record {@link Type.Struct}
+   */
   @Override
   public Type.Struct deriveRecordType() {
     return getInput().getRecordType();

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -10,66 +10,322 @@ import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
 import io.substrait.util.VisitationContext;
 
+/**
+ * Visitor for {@code Rel} nodes.
+ *
+ * @param <O> result type returned by each visit
+ * @param <C> visitation context type
+ * @param <E> exception type that visit methods may throw
+ */
 public interface RelVisitor<O, C extends VisitationContext, E extends Exception> {
+
+  /**
+   * Visit an aggregate relation.
+   *
+   * @param aggregate the aggregate node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Aggregate aggregate, C context) throws E;
 
+  /**
+   * Visit an empty scan relation.
+   *
+   * @param emptyScan the empty scan node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(EmptyScan emptyScan, C context) throws E;
 
+  /**
+   * Visit a fetch (limit/offset) relation.
+   *
+   * @param fetch the fetch node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Fetch fetch, C context) throws E;
 
+  /**
+   * Visit a filter relation.
+   *
+   * @param filter the filter node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Filter filter, C context) throws E;
 
+  /**
+   * Visit a logical join relation.
+   *
+   * @param join the join node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Join join, C context) throws E;
 
+  /**
+   * Visit a set operation relation (e.g., UNION/INTERSECT).
+   *
+   * @param set the set node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Set set, C context) throws E;
 
+  /**
+   * Visit a named scan relation.
+   *
+   * @param namedScan the named scan node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(NamedScan namedScan, C context) throws E;
 
+  /**
+   * Visit a local files scan relation.
+   *
+   * @param localFiles the local files node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(LocalFiles localFiles, C context) throws E;
 
+  /**
+   * Visit a project relation.
+   *
+   * @param project the project node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Project project, C context) throws E;
 
+  /**
+   * Visit an expand relation (e.g., generators).
+   *
+   * @param expand the expand node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Expand expand, C context) throws E;
 
+  /**
+   * Visit a sort relation.
+   *
+   * @param sort the sort node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Sort sort, C context) throws E;
 
+  /**
+   * Visit a cross product relation.
+   *
+   * @param cross the cross node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(Cross cross, C context) throws E;
 
+  /**
+   * Visit a virtual table scan relation.
+   *
+   * @param virtualTableScan the virtual table scan node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(VirtualTableScan virtualTableScan, C context) throws E;
 
+  /**
+   * Visit an extension leaf relation.
+   *
+   * @param extensionLeaf the extension leaf node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ExtensionLeaf extensionLeaf, C context) throws E;
 
+  /**
+   * Visit an extension single-input relation.
+   *
+   * @param extensionSingle the extension single node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ExtensionSingle extensionSingle, C context) throws E;
 
+  /**
+   * Visit an extension multi-input relation.
+   *
+   * @param extensionMulti the extension multi node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ExtensionMulti extensionMulti, C context) throws E;
 
+  /**
+   * Visit an extension table relation.
+   *
+   * @param extensionTable the extension table node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ExtensionTable extensionTable, C context) throws E;
 
+  /**
+   * Visit a physical hash join relation.
+   *
+   * @param hashJoin the hash join node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(HashJoin hashJoin, C context) throws E;
 
+  /**
+   * Visit a physical merge join relation.
+   *
+   * @param mergeJoin the merge join node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(MergeJoin mergeJoin, C context) throws E;
 
+  /**
+   * Visit a physical nested loop join relation.
+   *
+   * @param nestedLoopJoin the nested loop join node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(NestedLoopJoin nestedLoopJoin, C context) throws E;
 
+  /**
+   * Visit a consistent partition window relation.
+   *
+   * @param consistentPartitionWindow the window node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ConsistentPartitionWindow consistentPartitionWindow, C context) throws E;
 
+  /**
+   * Visit a named write relation.
+   *
+   * @param write the named write node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(NamedWrite write, C context) throws E;
 
+  /**
+   * Visit an extension write relation.
+   *
+   * @param write the extension write node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ExtensionWrite write, C context) throws E;
 
+  /**
+   * Visit a named DDL relation.
+   *
+   * @param ddl the named DDL node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(NamedDdl ddl, C context) throws E;
 
+  /**
+   * Visit an extension DDL relation.
+   *
+   * @param ddl the extension DDL node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ExtensionDdl ddl, C context) throws E;
 
+  /**
+   * Visit a named update relation.
+   *
+   * @param update the named update node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(NamedUpdate update, C context) throws E;
 
+  /**
+   * Visit a scatter exchange relation.
+   *
+   * @param exchange the scatter exchange node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(ScatterExchange exchange, C context) throws E;
 
+  /**
+   * Visit a single-bucket exchange relation.
+   *
+   * @param exchange the single-bucket exchange node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(SingleBucketExchange exchange, C context) throws E;
 
+  /**
+   * Visit a multi-bucket exchange relation.
+   *
+   * @param exchange the multi-bucket exchange node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(MultiBucketExchange exchange, C context) throws E;
 
+  /**
+   * Visit a round-robin exchange relation.
+   *
+   * @param exchange the round-robin exchange node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(RoundRobinExchange exchange, C context) throws E;
 
+  /**
+   * Visit a broadcast exchange relation.
+   *
+   * @param exchange the broadcast exchange node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
   O visit(BroadcastExchange exchange, C context) throws E;
 }


### PR DESCRIPTION
The number of JavaDoc warnings was getting 'annoying' so this PR is at least a start in removing the warnings. 
My preference would be to do in parts;  to try and keep things manageable. 