### PR TITLE
build(spark): set SPARK_LOCAL_IP env var for test execution

### DIFF
--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -144,5 +144,6 @@ tasks {
       "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/java.net=ALL-UNNAMED",
     )
+    environment("SPARK_LOCAL_IP", "127.0.0.1")
   }
 }


### PR DESCRIPTION
When running the full substrait-java build I frequently get the following error message for the Spark tests:

```
Cause: java.net.BindException: Can't assign requested address: Service 'sparkDriver' failed after 16 retries (on a random free port)! Consider explicitly setting the appropriate binding address for the service 'sparkDriver' (for example spark.driver.bindAddress for SparkDriver) to the correct binding address.
```

According to @andrew-coleman setting the following env variable can fix the issue: `SPARK_LOCAL_IP=127.0.0.1`

This PR sets the env variable by default for the Spark test execution.