### PR TITLE
build: fix examples/isthmus-api/.gitignore

### DIFF
--- a/examples/isthmus-api/.gitignore
+++ b/examples/isthmus-api/.gitignore
@@ -1,5 +1,5 @@
 _apps
 _data
-**/*/bin
+bin
 build
 substrait.plan


### PR DESCRIPTION
The current gitignore setting for `bin` does not work properly on my machine. The `bin` folder is being introduced if you are using VS Code only so it won't affect all users.