### PR TITLE
build: enable Gradle caching / remove setup-gradle

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+          cache: 'gradle'
       - name: Scan
         run: make component=${{ matrix.project }} scan
   java:
@@ -55,8 +54,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+          cache: 'gradle'
       - name: Build with Gradle
         run: |
           # fetch submodule tags since actions/checkout@v6 does not
@@ -75,6 +73,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'gradle'
       - uses: extractions/setup-just@v3
       - name: substrait-spark
         shell: bash
@@ -98,8 +97,7 @@ jobs:
       with:
         java-version: 25
         distribution: graalvm
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+        cache: 'gradle'
     - name: Report Java Version
       run: java -version
     - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
         with:
           java-version: 25
           distribution: graalvm
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+          cache: 'gradle'
       - name: Report Java Version
         run: java -version
       - name: Build with Gradle
@@ -71,11 +70,10 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
+          cache: 'gradle'
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
       - name: Download isthmus-ubuntu-latest binary
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
I've been seeing build failures recently where Maven Central responds with a 403 while fetching dependencies. This could be due to some Github Actions workers causing excessive traffic for Maven Central and being blocked: https://central.sonatype.org/faq/403-error-central/

This PR enables Gradle caching on Github Actions to limit traffic to Maven Central: https://github.com/actions/setup-java?tab=readme-ov-file#caching-gradle-dependencies

Further since we are using the Gradle wrapper I don't think we need the `setup-gradle` Github Actions task so I'm removing it which should also speed up the builds a little.