### PR TITLE
build(core): add direct guava test dependency

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -86,6 +86,7 @@ configurations[JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME].extendsFrom(sh
 dependencies {
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.protobuf.java.util)
+  testImplementation(libs.guava)
 
   testImplementation(libs.junit.jupiter)
   testRuntimeOnly(libs.junit.platform.launcher)


### PR DESCRIPTION
This unblocks the protobuf upgrade PR: https://github.com/substrait-io/substrait-java/pull/658

We are using the [`Resources`](https://guava.dev/releases/19.0/api/docs/com/google/common/io/Resources.html) from guava in [`TestBase`](https://github.com/substrait-io/substrait-java/blob/aad358e01c3b3ec59f5bba36df515e8a22d22c56/core/src/test/java/io/substrait/TestBase.java#L47) in `core`.

protobuf-java-util v4 has dropped the dependency on guava which means guava is no longer on the classpath when upgrading to v4. By declaring a direct test dependency on guava we make it clear that we are using guava during testing and can ensure the code still compiles when we upgrade to protobuf v4.