### PR TITLE
refactor(isthmus): simplify OuterReferenceResolver

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
@@ -29,15 +29,8 @@ public class OuterReferenceResolver extends RelNodeVisitor<RelNode, RuntimeExcep
     fieldAccessDepthMap = new IdentityHashMap<>();
   }
 
-  public int getStepsOut(RexFieldAccess fieldAccess) {
-    return fieldAccessDepthMap.get(fieldAccess);
-  }
-
-  public RelNode apply(RelNode r) {
-    return reverseAccept(r);
-  }
-
-  public Map<RexFieldAccess, Integer> getFieldAccessDepthMap() {
+  public Map<RexFieldAccess, Integer> apply(RelNode r) {
+    reverseAccept(r);
     return fieldAccessDepthMap;
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -609,8 +609,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
   protected void popFieldAccessDepthMap(RelNode root) {
     final OuterReferenceResolver resolver = new OuterReferenceResolver();
-    resolver.apply(root);
-    fieldAccessDepthMap = resolver.getFieldAccessDepthMap();
+    fieldAccessDepthMap = resolver.apply(root);
   }
 
   public Integer getFieldAccessDepth(RexFieldAccess fieldAccess) {

--- a/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
@@ -32,10 +32,7 @@ class OuterReferenceResolverTest extends PlanTestBase {
 
   private static Map<RexFieldAccess, Integer> buildOuterFieldRefMap(final RelNode root) {
     final OuterReferenceResolver resolver = new OuterReferenceResolver();
-    final Map<RexFieldAccess, Integer> fieldAccessDepthMap = resolver.getFieldAccessDepthMap();
-    Assertions.assertEquals(0, fieldAccessDepthMap.size());
-    resolver.apply(root);
-    return fieldAccessDepthMap;
+    return resolver.apply(root);
   }
 
   @Test


### PR DESCRIPTION
This simplifies the `OuterReferenceResolver` as identified in https://github.com/substrait-io/substrait-java/pull/645/files#r2672534015 

The way the `OuterReferenceResolver` is used in the code today does not encapsulate the `fieldAccessDepthMap` within the resolver but it gets used directly in `SubstraitRelVisitor` meaning that the `getStepsOut` method is never used. We could either try to encapsulate the map better within `OuterReferenceResolver` or we simply return the map as a result of the `OuterReferenceResolver` which this PR does:

- removes `getStepsOut` and `getFieldAccessDepthMap`
- returns `fieldAccessDepthMap` in `apply` method