### PR TITLE
build(core): fix Spotless failure following PR merge

### DIFF
--- a/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
+++ b/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
@@ -52,6 +52,8 @@ public class DefaultExtensionCatalog {
 
   /** Extension identifier for string functions. */
   public static final String FUNCTIONS_STRING = "extension:io.substrait:functions_string";
+
+  /** Identifier for extension types. */
   public static final String EXTENSION_TYPES = "extension:io.substrait:extension_types";
 
   /** Default collection of built-in extensions loaded from YAML resources. */


### PR DESCRIPTION
Commits 13309df and 5e2d0bb combined to produce a Spotless check failure. This change fixes the formatting and adds a missing Javadoc comment.