### PR TITLE
fix(isthmus): correct strpos parameter order

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/PositionFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/PositionFunctionMapper.java
@@ -1,0 +1,59 @@
+package io.substrait.isthmus.expression;
+
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionArg;
+import io.substrait.extension.SimpleExtension.ScalarFunctionVariant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+/**
+ * Custom mapping for the Calcite {@code POSITION} function to the Substrait {@code strpos}
+ * function. Calcite also represents the SQL {@code STRPOS} function as {@code POSITION}.
+ *
+ * <p>Calcite {@code POSITION} has <em>substring</em> followed by <em>input</em> parameters, while
+ * Substrait {@code strpos} has <em>input</em> followed by <em>substring</em>. When mapping between
+ * Calcite and Substrait, the parameters need to be reversed
+ *
+ * <p>{@code POSITION(substring IN input)} maps to {@code strpos(input, substring)}.
+ */
+final class PositionFunctionMapper implements ScalarFunctionMapper {
+  private static final String strposFunctionName = "strpos";
+  private final List<ScalarFunctionVariant> strposFunctions;
+
+  public PositionFunctionMapper(List<ScalarFunctionVariant> functions) {
+    strposFunctions =
+        functions.stream()
+            .filter(f -> strposFunctionName.equals(f.name()))
+            .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  public Optional<SubstraitFunctionMapping> toSubstrait(final RexCall call) {
+    if (!SqlStdOperatorTable.POSITION.equals(call.op)) {
+      return Optional.empty();
+    }
+
+    List<RexNode> operands = new ArrayList<>(call.getOperands());
+    Collections.swap(operands, 0, 1);
+
+    return Optional.of(new SubstraitFunctionMapping(strposFunctionName, operands, strposFunctions));
+  }
+
+  @Override
+  public Optional<List<FunctionArg>> getExpressionArguments(
+      final Expression.ScalarFunctionInvocation expression) {
+    if (!strposFunctionName.equals(expression.declaration().name())) {
+      return Optional.empty();
+    }
+
+    List<FunctionArg> args = new ArrayList<>(expression.arguments());
+    Collections.swap(args, 0, 1);
+    return Optional.of(args);
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -46,7 +46,8 @@ public class ScalarFunctionConverter
         List.of(
             new TrimFunctionMapper(functions),
             new SqrtFunctionMapper(functions),
-            new ExtractDateFunctionMapper(functions));
+            new ExtractDateFunctionMapper(functions),
+            new PositionFunctionMapper(functions));
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionMapper.java
@@ -7,13 +7,14 @@ import java.util.Optional;
 import org.apache.calcite.rex.RexCall;
 
 /**
- * Provides custom conversion for a Calcite call to corresponding Substrait functions and arguments.
+ * Provides custom conversion between a Calcite call and corresponding Substrait functions and
+ * arguments.
  */
 interface ScalarFunctionMapper {
 
   /**
-   * If the supplied call is applicable to this mapper, get the custom mapping to the corresponding
-   * Substrait function.
+   * If the supplied Calcite call is applicable to this mapper, get the custom mapping to the
+   * corresponding Substrait function.
    *
    * @param call a Calcite call.
    * @return a custom function mapping, or an empty Optional if no mapping exists.
@@ -21,8 +22,8 @@ interface ScalarFunctionMapper {
   Optional<SubstraitFunctionMapping> toSubstrait(RexCall call);
 
   /**
-   * If the supplied expression is applicable to this mapper, get the function arguments that should
-   * be used for the Substrait function call.
+   * If the supplied Substrait expression is applicable to this mapper, get the function arguments
+   * that should be used when mapping to the corresponding Calcite function.
    *
    * @param expression an expression.
    * @return a list of function arguments, or an empty Optional if no mapping exists.


### PR DESCRIPTION
Both SQL STRPOS and POSITION functions are modelled by Calcite as Position. Parameters are substring followed by the input to be searched. This maps to the Substrait strpos function, which has the parameters of input to be searched followed by substring. The default mapping retains the argument order, which results in SQL being translated to incorrect Substrait, and correct Substrait translated to incorrect SQL. Round-trip between Substrait and SQL still works since the parameter order is reversed in both directions, resulting in the correct order again.

This change adds a custom function mapper to reverse the order of the first two parameters when converting between Calcite Position and Substrait strpos functions.

Closes #662