### PR TITLE
fix(core): enforce NullLiteral nullable invariant

### DIFF
--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -46,6 +46,20 @@ public interface Expression extends FunctionArg {
   abstract class NullLiteral implements Literal {
     public abstract Type type();
 
+    /** A null literal is inherently nullable. You cannot have a null of a non nullable type. */
+    @Override
+    public boolean nullable() {
+      return true;
+    }
+
+    @Value.Check
+    protected void check() {
+      if (!type().nullable()) {
+        throw new IllegalArgumentException(
+            "NullLiteral requires a nullable type, but got: " + type());
+      }
+    }
+
     @Override
     public Type getType() {
       return type();

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -2,6 +2,7 @@ package io.substrait.type.proto;
 
 import static io.substrait.expression.proto.ProtoExpressionConverter.EMPTY_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.Any;
 import io.substrait.TestBase;
@@ -286,5 +287,15 @@ class LiteralRoundtripTest extends TestBase {
             java.util.Arrays.asList(ExpressionCreator.i32(false, 42)));
 
     verifyNestedTypesRoundTrip(multiParam);
+  }
+
+  /** Verifies that NullLiteral rejects non nullable types. See issue #685. */
+  @Test
+  void nullLiteralRejectsNonNullableType() {
+    io.substrait.type.Type nonNullableType =
+        io.substrait.type.Type.I32.builder().nullable(false).build();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> ExpressionCreator.typedNull(nonNullableType));
   }
 }


### PR DESCRIPTION
A null literal is inherently nullable so `NullLiteral.nullable()` now always returns true and construction validates the type is nullable.

Closes #685