### PR TITLE
feat(isthmus): add strptime_* function mappings

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -97,7 +97,10 @@ public class FunctionMappings {
               s(SqlLibraryOperators.LEFT, "left"),
               s(SqlLibraryOperators.RIGHT, "right"),
               s(SqlLibraryOperators.LPAD, "lpad"),
-              s(SqlLibraryOperators.RPAD, "rpad"))
+              s(SqlLibraryOperators.RPAD, "rpad"),
+              s(SqlLibraryOperators.PARSE_TIME, "strptime_time"),
+              s(SqlLibraryOperators.PARSE_TIMESTAMP, "strptime_timestamp"),
+              s(SqlLibraryOperators.PARSE_DATE, "strptime_date"))
           .build();
 
   public static final ImmutableList<Sig> AGGREGATE_SIGS =

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -47,7 +47,10 @@ public class ScalarFunctionConverter
             new TrimFunctionMapper(functions),
             new SqrtFunctionMapper(functions),
             new ExtractDateFunctionMapper(functions),
-            new PositionFunctionMapper(functions));
+            new PositionFunctionMapper(functions),
+            new StrptimeDateFunctionMapper(functions),
+            new StrptimeTimeFunctionMapper(functions),
+            new StrptimeTimestampFunctionMapper(functions));
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeDateFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeDateFunctionMapper.java
@@ -1,0 +1,60 @@
+package io.substrait.isthmus.expression;
+
+import io.substrait.expression.Expression.ScalarFunctionInvocation;
+import io.substrait.expression.FunctionArg;
+import io.substrait.extension.SimpleExtension.ScalarFunctionVariant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+
+/**
+ * Custom mapping for the Calcite {@code PARSE_DATE} function to the Substrait {@code strptime_date}
+ * function.
+ *
+ * <p>Calcite {@code PARSE_DATE} has <em>format</em> followed by <em>date_string</em> parameters,
+ * while Substrait {@code strptime_date} has <em>date_string</em> followed by <em>format</em>. When
+ * mapping between Calcite and Substrait, the parameters need to be reversed.
+ *
+ * <p>{@code PARSE_DATE(format, date_string)} maps to {@code strptime_date(date_string, format)}.
+ */
+public final class StrptimeDateFunctionMapper implements ScalarFunctionMapper {
+  private static final String STRPTIME_DATE_FUNCTION_NAME = "strptime_date";
+  private final List<ScalarFunctionVariant> strptimeDateFunctions;
+
+  public StrptimeDateFunctionMapper(List<ScalarFunctionVariant> functions) {
+    strptimeDateFunctions =
+        functions.stream()
+            .filter(f -> STRPTIME_DATE_FUNCTION_NAME.equals(f.name()))
+            .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  public Optional<SubstraitFunctionMapping> toSubstrait(RexCall call) {
+    if (!SqlLibraryOperators.PARSE_DATE.equals(call.op)) {
+      return Optional.empty();
+    }
+
+    List<RexNode> operands = new ArrayList<>(call.getOperands());
+    Collections.swap(operands, 0, 1);
+
+    return Optional.of(
+        new SubstraitFunctionMapping(STRPTIME_DATE_FUNCTION_NAME, operands, strptimeDateFunctions));
+  }
+
+  @Override
+  public Optional<List<FunctionArg>> getExpressionArguments(ScalarFunctionInvocation expression) {
+    if (!STRPTIME_DATE_FUNCTION_NAME.equals(expression.declaration().name())) {
+      return Optional.empty();
+    }
+
+    List<FunctionArg> arguments = new ArrayList<>(expression.arguments());
+    Collections.swap(arguments, 0, 1);
+
+    return Optional.of(arguments);
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimeFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimeFunctionMapper.java
@@ -1,0 +1,60 @@
+package io.substrait.isthmus.expression;
+
+import io.substrait.expression.Expression.ScalarFunctionInvocation;
+import io.substrait.expression.FunctionArg;
+import io.substrait.extension.SimpleExtension.ScalarFunctionVariant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+
+/**
+ * Custom mapping for the Calcite {@code PARSE_TIME} function to the Substrait {@code strptime_time}
+ * function.
+ *
+ * <p>Calcite {@code PARSE_TIME} has <em>format</em> followed by <em>time_string</em> parameters,
+ * while Substrait {@code strptime_time} has <em>time_string</em> followed by <em>format</em>. When
+ * mapping between Calcite and Substrait, the parameters need to be reversed.
+ *
+ * <p>{@code PARSE_TIME(format, time_string)} maps to {@code strptime_time(time_string, format)}.
+ */
+public final class StrptimeTimeFunctionMapper implements ScalarFunctionMapper {
+  private static final String STRPTIME_TIME_FUNCTION_NAME = "strptime_time";
+  private final List<ScalarFunctionVariant> strptimeTimeFunctions;
+
+  public StrptimeTimeFunctionMapper(List<ScalarFunctionVariant> functions) {
+    strptimeTimeFunctions =
+        functions.stream()
+            .filter(f -> STRPTIME_TIME_FUNCTION_NAME.equals(f.name()))
+            .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  public Optional<SubstraitFunctionMapping> toSubstrait(RexCall call) {
+    if (!SqlLibraryOperators.PARSE_TIME.equals(call.op)) {
+      return Optional.empty();
+    }
+
+    List<RexNode> operands = new ArrayList<>(call.getOperands());
+    Collections.swap(operands, 0, 1);
+
+    return Optional.of(
+        new SubstraitFunctionMapping(STRPTIME_TIME_FUNCTION_NAME, operands, strptimeTimeFunctions));
+  }
+
+  @Override
+  public Optional<List<FunctionArg>> getExpressionArguments(ScalarFunctionInvocation expression) {
+    if (!STRPTIME_TIME_FUNCTION_NAME.equals(expression.declaration().name())) {
+      return Optional.empty();
+    }
+
+    List<FunctionArg> arguments = new ArrayList<>(expression.arguments());
+    Collections.swap(arguments, 0, 1);
+
+    return Optional.of(arguments);
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimestampFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimestampFunctionMapper.java
@@ -1,0 +1,62 @@
+package io.substrait.isthmus.expression;
+
+import io.substrait.expression.Expression.ScalarFunctionInvocation;
+import io.substrait.expression.FunctionArg;
+import io.substrait.extension.SimpleExtension.ScalarFunctionVariant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
+
+/**
+ * Custom mapping for the Calcite {@code PARSE_TIMESTAMP} function to the Substrait {@code
+ * strptime_timestamp} function.
+ *
+ * <p>Calcite {@code PARSE_TIMESTAMP} has <em>format</em> followed by <em>timestamp_string</em>
+ * parameters, while Substrait {@code strptime_timestamp} has <em>timestamp_string</em> followed by
+ * <em>format</em>. When mapping between Calcite and Substrait, the parameters need to be reversed.
+ *
+ * <p>{@code PARSE_TIMESTAMP(format, timestamp_string)} maps to {@code
+ * strptime_timestamp(timestamp_string, format)}.
+ */
+public final class StrptimeTimestampFunctionMapper implements ScalarFunctionMapper {
+  private static final String STRPTIME_TIMESTAMP_FUNCTION_NAME = "strptime_timestamp";
+  private final List<ScalarFunctionVariant> strptimeTimestampFunctions;
+
+  public StrptimeTimestampFunctionMapper(List<ScalarFunctionVariant> functions) {
+    strptimeTimestampFunctions =
+        functions.stream()
+            .filter(f -> STRPTIME_TIMESTAMP_FUNCTION_NAME.equals(f.name()))
+            .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  public Optional<SubstraitFunctionMapping> toSubstrait(RexCall call) {
+    if (!SqlLibraryOperators.PARSE_TIMESTAMP.equals(call.op)) {
+      return Optional.empty();
+    }
+
+    List<RexNode> operands = new ArrayList<>(call.getOperands());
+    Collections.swap(operands, 0, 1);
+
+    return Optional.of(
+        new SubstraitFunctionMapping(
+            STRPTIME_TIMESTAMP_FUNCTION_NAME, operands, strptimeTimestampFunctions));
+  }
+
+  @Override
+  public Optional<List<FunctionArg>> getExpressionArguments(ScalarFunctionInvocation expression) {
+    if (!STRPTIME_TIMESTAMP_FUNCTION_NAME.equals(expression.declaration().name())) {
+      return Optional.empty();
+    }
+
+    List<FunctionArg> arguments = new ArrayList<>(expression.arguments());
+    Collections.swap(arguments, 0, 1);
+
+    return Optional.of(arguments);
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -301,8 +301,7 @@ class FunctionConversionTest extends PlanTestBase {
     assertEquals(SqlKind.OTHER_FUNCTION, calciteExpr.getKind());
     assertInstanceOf(RexCall.class, calciteExpr);
 
-    RexCall extract = (RexCall) calciteExpr;
-    assertEquals("PARSE_TIME('%H:%M:%S':VARCHAR, '12:34:56':VARCHAR)", extract.toString());
+    assertEquals("PARSE_TIME('%H:%M:%S':VARCHAR, '12:34:56':VARCHAR)", calciteExpr.toString());
 
     // tests the reverse Calcite -> Substrait
     Expression reverse = calciteExpr.accept(rexExpressionConverter);
@@ -329,10 +328,9 @@ class FunctionConversionTest extends PlanTestBase {
     assertEquals(SqlKind.OTHER_FUNCTION, calciteExpr.getKind());
     assertInstanceOf(RexCall.class, calciteExpr);
 
-    RexCall extract = (RexCall) calciteExpr;
     assertEquals(
         "PARSE_TIMESTAMP('%Y:%m:%dT%H:%M:%S':VARCHAR, '2026-01-29T12:34:56':VARCHAR)",
-        extract.toString());
+        calciteExpr.toString());
 
     // tests the reverse Calcite -> Substrait
     Expression reverse = calciteExpr.accept(rexExpressionConverter);
@@ -356,8 +354,7 @@ class FunctionConversionTest extends PlanTestBase {
     assertEquals(SqlKind.OTHER_FUNCTION, calciteExpr.getKind());
     assertInstanceOf(RexCall.class, calciteExpr);
 
-    RexCall extract = (RexCall) calciteExpr;
-    assertEquals("PARSE_DATE('%Y:%m:%d':VARCHAR, '2026-01-29':VARCHAR)", extract.toString());
+    assertEquals("PARSE_DATE('%Y:%m:%d':VARCHAR, '2026-01-29':VARCHAR)", calciteExpr.toString());
 
     // tests the reverse Calcite -> Substrait
     Expression reverse = calciteExpr.accept(rexExpressionConverter);


### PR DESCRIPTION
This adds Calcite mappings for the following 3 Substrait functions:

- `strptime_time` -> `PARSE_TIME`
- `strptime_timestamp` -> `PARSE_TIMESTAMP`
- `strptime_date` -> `PARSE_DATE`

I added the `ScalarFunctionConverter` into the `RexExpressionConverter` instance in `FunctionConversionTest` in order to round-trip test Substrait <-> Calcite expression mappings which also made the `subtractDateIDay` test case work.

The Calcite functions are Big Query specific variants which happen to be defined closest to the Substrait variants of this functions vs. other alternatives `TO_DATE` and `TO_TIMESTAMP`.