### PR TITLE
feat(spark): upgrade scala compiler to 2.13.18

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ nmcp = "1.4.4"
 picocli = "4.7.7"
 protobuf-plugin = "0.9.6"
 protobuf = "3.25.8"
-scala-library = "2.12.21"
+scala-library = "2.13.18"
 scalatest = "3.2.19"
 scalatestplus-junit5 = "3.2.19.0"
 shadow = "9.3.1"
@@ -60,14 +60,14 @@ protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "p
 protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf" }
 protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 scala-library = { module = "org.scala-lang:scala-library", version.ref = "scala-library" }
-scalatest = { module = "org.scalatest:scalatest_2.12", version.ref = "scalatest" }
-scalatestplus-junit5 = { module = "org.scalatestplus:junit-5-13_2.12", version.ref = "scalatestplus-junit5" }
+scalatest = { module = "org.scalatest:scalatest_2.13", version.ref = "scalatest" }
+scalatestplus-junit5 = { module = "org.scalatestplus:junit-5-13_2.13", version.ref = "scalatestplus-junit5" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-jdk14 = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }
-spark-catalyst = { module = "org.apache.spark:spark-catalyst_2.12", version.ref = "spark" }
-spark-core = { module = "org.apache.spark:spark-core_2.12", version.ref = "spark" }
-spark-hive = { module = "org.apache.spark:spark-hive_2.12", version.ref = "spark" }
-spark-sql = { module = "org.apache.spark:spark-sql_2.12", version.ref = "spark" }
+spark-catalyst = { module = "org.apache.spark:spark-catalyst_2.13", version.ref = "spark" }
+spark-core = { module = "org.apache.spark:spark-core_2.13", version.ref = "spark" }
+spark-hive = { module = "org.apache.spark:spark-hive_2.13", version.ref = "spark" }
+spark-sql = { module = "org.apache.spark:spark-sql_2.13", version.ref = "spark" }
 
 [bundles]
 jackson = [ "jackson-databind", "jackson-annotations", "jackson-datatype-jdk8", "jackson-dataformat-yaml" ]

--- a/spark/spark_dialect.yaml
+++ b/spark/spark_dialect.yaml
@@ -423,13 +423,6 @@ supported_scalar_functions:
     notation: "FUNCTION"
   supported_impls:
   - "bool"
-- source: "comparison"
-  name: "lt"
-  system_metadata:
-    name: "<"
-    notation: "INFIX"
-  supported_impls:
-  - "any_any"
 - source: "datetime"
   name: "lt"
   system_metadata:
@@ -444,9 +437,9 @@ supported_scalar_functions:
   - "iday_iday"
   - "iyear_iyear"
 - source: "comparison"
-  name: "lte"
+  name: "lt"
   system_metadata:
-    name: "<="
+    name: "<"
     notation: "INFIX"
   supported_impls:
   - "any_any"
@@ -464,9 +457,9 @@ supported_scalar_functions:
   - "iday_iday"
   - "iyear_iyear"
 - source: "comparison"
-  name: "gt"
+  name: "lte"
   system_metadata:
-    name: ">"
+    name: "<="
     notation: "INFIX"
   supported_impls:
   - "any_any"
@@ -484,9 +477,9 @@ supported_scalar_functions:
   - "iday_iday"
   - "iyear_iyear"
 - source: "comparison"
-  name: "gte"
+  name: "gt"
   system_metadata:
-    name: ">="
+    name: ">"
     notation: "INFIX"
   supported_impls:
   - "any_any"
@@ -503,6 +496,13 @@ supported_scalar_functions:
   - "date_date"
   - "iday_iday"
   - "iyear_iyear"
+- source: "comparison"
+  name: "gte"
+  system_metadata:
+    name: ">="
+    notation: "INFIX"
+  supported_impls:
+  - "any_any"
 - source: "comparison"
   name: "equal"
   system_metadata:

--- a/spark/src/main/scala/io/substrait/debug/ExpressionToString.scala
+++ b/spark/src/main/scala/io/substrait/debug/ExpressionToString.scala
@@ -26,7 +26,7 @@ import io.substrait.function.ToTypeString
 import io.substrait.util.DecimalUtil
 import io.substrait.util.EmptyVisitationContext
 
-import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.jdk.CollectionConverters._
 
 class ExpressionToString extends DefaultExpressionVisitor[String] {
 

--- a/spark/src/main/scala/io/substrait/debug/TreePrinter.scala
+++ b/spark/src/main/scala/io/substrait/debug/TreePrinter.scala
@@ -23,7 +23,7 @@ import RelToVerboseString.{verboseString, verboseStringWithSuffix}
 import io.substrait.relation
 import io.substrait.relation.Rel
 
-import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.jdk.CollectionConverters._
 
 trait TreePrinter[T] {
   def tree(t: T): String

--- a/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
+++ b/spark/src/main/scala/io/substrait/spark/SparkExtension.scala
@@ -22,8 +22,7 @@ import io.substrait.extension.{DefaultExtensionCatalog, SimpleExtension}
 
 import java.util.Collections
 
-import scala.collection.JavaConverters
-import scala.collection.JavaConverters.asScalaBufferConverter
+import scala.jdk.CollectionConverters._
 
 object SparkExtension {
   final val file = "/spark.yml"
@@ -40,13 +39,13 @@ object SparkExtension {
     val ret = new collection.mutable.ArrayBuffer[SimpleExtension.ScalarFunctionVariant]()
     ret.appendAll(EXTENSION_COLLECTION.scalarFunctions().asScala)
     ret.appendAll(SparkImpls.scalarFunctions().asScala)
-    ret
+    ret.toSeq
   }
 
   val toAggregateFunction: ToAggregateFunction = ToAggregateFunction(
-    JavaConverters.asScalaBuffer(EXTENSION_COLLECTION.aggregateFunctions()))
+    EXTENSION_COLLECTION.aggregateFunctions().asScala.toSeq)
 
   val toWindowFunction: ToWindowFunction = ToWindowFunction(
-    JavaConverters.asScalaBuffer(EXTENSION_COLLECTION.windowFunctions())
+    EXTENSION_COLLECTION.windowFunctions().asScala.toSeq
   )
 }

--- a/spark/src/main/scala/io/substrait/spark/expression/ToAggregateFunction.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToAggregateFunction.scala
@@ -25,7 +25,7 @@ import io.substrait.extension.SimpleExtension
 
 import java.util.Collections
 
-import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters._
 
 abstract class ToAggregateFunction(functions: Seq[SimpleExtension.AggregateFunctionVariant])
   extends FunctionConverter[SimpleExtension.AggregateFunctionVariant, AggregateFunctionInvocation](
@@ -45,7 +45,7 @@ abstract class ToAggregateFunction(functions: Seq[SimpleExtension.AggregateFunct
       ToAggregateFunction.fromSpark(sparkAggregate.mode),
       Collections.emptyList[SExpression.SortField](),
       ToAggregateFunction.fromSpark(sparkAggregate.isDistinct),
-      JavaConverters.asJavaIterable(arguments)
+      arguments.asJava
     )
   }
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToScalarFunction.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToScalarFunction.scala
@@ -22,7 +22,7 @@ import io.substrait.`type`.Type
 import io.substrait.expression.{Expression => SExpression, FunctionArg}
 import io.substrait.extension.SimpleExtension
 
-import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters._
 
 abstract class ToScalarFunction(functions: Seq[SimpleExtension.ScalarFunctionVariant])
   extends FunctionConverter[SimpleExtension.ScalarFunctionVariant, SExpression](functions) {
@@ -36,7 +36,7 @@ abstract class ToScalarFunction(functions: Seq[SimpleExtension.ScalarFunctionVar
       .builder()
       .outputType(outputType)
       .declaration(function)
-      .addAllArguments(JavaConverters.asJavaIterable(arguments))
+      .addAllArguments(arguments.asJava)
       .build()
   }
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
@@ -29,7 +29,7 @@ import io.substrait.expression.Expression.FailureBehavior
 
 import java.util.Optional
 
-import scala.collection.JavaConverters.asJavaIterableConverter
+import scala.jdk.CollectionConverters._
 
 /** The builder to generate substrait expressions from catalyst expressions. */
 abstract class ToSubstraitExpression extends HasOutputStack[Seq[Attribute]] {

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitLiteral.scala
@@ -27,7 +27,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import io.substrait.expression.{Expression => SExpression}
 import io.substrait.expression.ExpressionCreator._
 
-import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters._
 
 class ToSubstraitLiteral {
 
@@ -50,7 +50,7 @@ class ToSubstraitLiteral {
     if (elements.isEmpty) {
       emptyList(nullable, ToSubstraitType.convert(elementType, nullable = containsNull).get)
     } else {
-      list(nullable, JavaConverters.asJavaIterable(elements))
+      list(nullable, elements.toSeq.asJava)
     }
   }
 
@@ -69,7 +69,7 @@ class ToSubstraitLiteral {
         ToSubstraitType.convert(keyType, nullable = false).get,
         ToSubstraitType.convert(valueType, nullable = valueContainsNull).get)
     } else {
-      map(nullable, JavaConverters.mapAsJavaMap(keys.zip(values).toMap))
+      map(nullable, keys.zip(values).toMap.asJava)
     }
   }
 
@@ -79,9 +79,11 @@ class ToSubstraitLiteral {
       nullable: Boolean): SExpression.Literal = {
     struct(
       nullable,
-      JavaConverters.asJavaIterable(fields.zip(structData.values).map {
-        case (field, any) => apply(Literal(any, field.dataType), Some(field.nullable))
-      }))
+      fields
+        .zip(structData.values)
+        .map { case (field, any) => apply(Literal(any, field.dataType), Some(field.nullable)) }
+        .toSeq
+        .asJava)
   }
 
   private def convertWithValue(literal: Literal, nullable: Boolean): Option[SExpression.Literal] = {

--- a/spark/src/main/scala/io/substrait/spark/expression/ToWindowFunction.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToWindowFunction.scala
@@ -29,7 +29,7 @@ import io.substrait.expression.WindowBound.{CURRENT_ROW, UNBOUNDED, WindowBoundV
 import io.substrait.extension.SimpleExtension
 import io.substrait.relation.ConsistentPartitionWindow.WindowRelFunctionInvocation
 
-import scala.collection.JavaConverters
+import scala.jdk.CollectionConverters._
 
 abstract class ToWindowFunction(functions: Seq[SimpleExtension.WindowFunctionVariant])
   extends FunctionConverter[SimpleExtension.WindowFunctionVariant, WindowRelFunctionInvocation](
@@ -64,7 +64,7 @@ abstract class ToWindowFunction(functions: Seq[SimpleExtension.WindowFunctionVar
       frameType,
       lower,
       upper,
-      JavaConverters.asJavaIterable(arguments)
+      arguments.asJava
     )
   }
 

--- a/spark/src/main/scala/io/substrait/spark/utils/Util.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/Util.scala
@@ -52,7 +52,7 @@ object Util {
       (list, elemsToAppend) => elemsToAppend.map(e => appendElementToList(list, e))
 
     val firstListToJoin = lists.head
-    val startProduct = appendAndGen(new ArrayBuffer[T], firstListToJoin)
+    val startProduct = appendAndGen(new ArrayBuffer[T].toSeq, firstListToJoin)
 
     /** ([ [a, b], [c, d] ], [1, 2]) -> [a, b, 1], [a, b, 2], [c, d, 1], [c, d, 2] */
     val appendAndGenLists: (Seq[Seq[T]], Seq[T]) => Seq[Seq[T]] =

--- a/spark/src/test/scala/io/substrait/spark/LocalFiles.scala
+++ b/spark/src/test/scala/io/substrait/spark/LocalFiles.scala
@@ -61,7 +61,7 @@ class LocalFiles extends SharedSparkSession {
     val result = DatasetUtil.fromLogicalPlan(spark, sparkPlan2)
 
     assertResult(data.columns)(result.columns)
-    assertResult(data.count)(result.count)
+    assertResult(data.count())(result.count())
     data.collect().zip(result.collect()).foreach {
       case (before, after) => assertResult(before)(after)
     }


### PR DESCRIPTION
Scala 2.13.18 is the latest current relese of the 2.x dialect of the scala language. Although 2.12.x is still in maintenance, the 4.x versions of Spark are only supported with scala 2.13.x. Hence this is a pre-req of future Spark upgrades.