### PR TITLE
build(isthmus-cli): fix javadoc warnings

### DIFF
--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -97,3 +97,14 @@ tasks.register("writeIsthmusVersion") {
 }
 
 tasks.named("compileJava") { dependsOn("writeIsthmusVersion") }
+
+tasks.named<Javadoc>("javadoc") {
+  description = "Generate Javadoc for main source files (excluding generated)."
+
+  val generatedSources = layout.buildDirectory.file("generated/sources").get().getAsFile()
+  exclude { spec -> spec.file.toPath().startsWith(generatedSources.toPath()) }
+  options {
+    require(this is CoreJavadocOptions)
+    addBooleanOption("Xwerror", true)
+  }
+}

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/IsthmusEntryPoint.java
@@ -23,6 +23,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
+/** Isthmus CLI entry point. */
 @Command(
     name = "isthmus",
     versionProvider = io.substrait.isthmus.cli.IsthmusCliVersion.class,
@@ -61,6 +62,11 @@ public class IsthmusEntryPoint implements Callable<Integer> {
       description = "Calcite's casing policy for unquoted identifiers: ${COMPLETION-CANDIDATES}")
   private Casing unquotedCasing = Casing.TO_UPPER;
 
+  /**
+   * Standard Java Main method invoked by the isthmus CLI command.
+   *
+   * @param args Isthmus CLI arguments.
+   */
   public static void main(String... args) {
     CommandLine commandLine = new CommandLine(new IsthmusEntryPoint());
     commandLine.setCaseInsensitiveEnumValuesAllowed(true);

--- a/isthmus-cli/src/main/java/io/substrait/isthmus/cli/RegisterAtRuntime.java
+++ b/isthmus-cli/src/main/java/io/substrait/isthmus/cli/RegisterAtRuntime.java
@@ -45,6 +45,10 @@ import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.immutables.value.Value;
 
+/**
+ * GraalVM {@link Feature} used during native image generation which registers classes for
+ * reflection at runtime using {@link RuntimeReflection}.
+ */
 public final class RegisterAtRuntime implements Feature {
   @Override
   public void beforeAnalysis(BeforeAnalysisAccess access) {


### PR DESCRIPTION
Change the isthmus-cli build to fail on warnings if they are introduced in the future.