### PR TITLE
feat(spark): support lpad and rpad functions

### DIFF
--- a/spark/spark_dialect.yaml
+++ b/spark/spark_dialect.yaml
@@ -611,6 +611,22 @@ supported_scalar_functions:
   - "str"
   - "vchar"
   - "fchar"
+- source: "string"
+  name: "lpad"
+  system_metadata:
+    name: "lpad"
+    notation: "FUNCTION"
+  supported_impls:
+  - "vchar_i32_vchar"
+  - "str_i32_str"
+- source: "string"
+  name: "rpad"
+  system_metadata:
+    name: "rpad"
+    notation: "FUNCTION"
+  supported_impls:
+  - "vchar_i32_vchar"
+  - "str_i32_str"
 - source: "arithmetic"
   name: "shift_left"
   system_metadata:

--- a/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/FunctionMappings.scala
@@ -158,6 +158,8 @@ class FunctionMappings {
     s[Substring]("substring"),
     s[Upper]("upper"),
     s[Lower]("lower"),
+    s[StringLPad]("lpad"),
+    s[StringRPad]("rpad"),
     s[Concat]("concat"),
     s[Coalesce]("coalesce"),
     s[ShiftLeft]("shift_left"),

--- a/spark/src/test/scala/io/substrait/spark/TPCHPlan.scala
+++ b/spark/src/test/scala/io/substrait/spark/TPCHPlan.scala
@@ -224,6 +224,16 @@ class TPCHPlan extends TPCHBase with SubstraitPlanTestBase {
     )
   }
 
+  test("pad") {
+    assertSqlSubstraitRelRoundTrip(
+      "select lpad(o_comment, 5), rpad(o_comment, 2) from orders"
+    )
+
+    assertSqlSubstraitRelRoundTrip(
+      "select lpad(o_comment, 5, '-'), rpad(o_comment, 2, '*') from orders"
+    )
+  }
+
   test("tpch_q1_variant") {
     // difference from tpch_q1 : 1) remove order by clause; 2) remove interval date literal
     assertSqlSubstraitRelRoundTrip(


### PR DESCRIPTION
Adds support for the LPAD ad RPAD functions to the spark/substrait converter.