### PR TITLE
fix: properly deprecate Time(stamp) in favor of PrecisionTime(stamp)

### DIFF
--- a/core/src/main/java/io/substrait/expression/AbstractExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/AbstractExpressionVisitor.java
@@ -166,6 +166,19 @@ public abstract class AbstractExpressionVisitor<O, C extends VisitationContext, 
   }
 
   /**
+   * Visits a precision time literal.
+   *
+   * @param expr the precision time literal
+   * @param context the visitation context
+   * @return the visit result
+   * @throws E if visitation fails
+   */
+  @Override
+  public O visit(Expression.PrecisionTimeLiteral expr, C context) throws E {
+    return visitFallback(expr, context);
+  }
+
+  /**
    * Visits a date literal.
    *
    * @param expr the date literal

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -271,7 +271,12 @@ public interface Expression extends FunctionArg {
     }
   }
 
+  /**
+   * @deprecated {@link TimestampLiteral} is deprecated in favor of {@link
+   *     PrecisionTimestampLiteral}
+   */
   @Value.Immutable
+  @Deprecated
   abstract class TimestampLiteral implements Literal {
     public abstract long value();
 
@@ -291,7 +296,11 @@ public interface Expression extends FunctionArg {
     }
   }
 
+  /**
+   * @deprecated {@link TimeLiteral} is deprecated in favor of {@link PrecisionTimeLiteral}
+   */
   @Value.Immutable
+  @Deprecated
   abstract class TimeLiteral implements Literal {
     public abstract long value();
 
@@ -302,6 +311,28 @@ public interface Expression extends FunctionArg {
 
     public static ImmutableExpression.TimeLiteral.Builder builder() {
       return ImmutableExpression.TimeLiteral.builder();
+    }
+
+    @Override
+    public <R, C extends VisitationContext, E extends Throwable> R accept(
+        ExpressionVisitor<R, C, E> visitor, C context) throws E {
+      return visitor.visit(this, context);
+    }
+  }
+
+  @Value.Immutable
+  abstract class PrecisionTimeLiteral implements Literal {
+    public abstract long value();
+
+    public abstract int precision();
+
+    @Override
+    public Type getType() {
+      return Type.withNullability(nullable()).precisionTimestamp(precision());
+    }
+
+    public static ImmutableExpression.PrecisionTimeLiteral.Builder builder() {
+      return ImmutableExpression.PrecisionTimeLiteral.builder();
     }
 
     @Override
@@ -331,7 +362,12 @@ public interface Expression extends FunctionArg {
     }
   }
 
+  /**
+   * @deprecated {@link TimestampTZLiteral} is deprecated in favor of {@link
+   *     PrecisionTimestampTZLiteral}
+   */
   @Value.Immutable
+  @Deprecated
   abstract class TimestampTZLiteral implements Literal {
     public abstract long value();
 

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -72,8 +72,21 @@ public class ExpressionCreator {
     return Expression.DateLiteral.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * @deprecated Time is deprecated in favor of PrecisionTime
+   */
+  @Deprecated
   public static Expression.TimeLiteral time(boolean nullable, long value) {
     return Expression.TimeLiteral.builder().nullable(nullable).value(value).build();
+  }
+
+  public static Expression.PrecisionTimeLiteral precisionTime(
+      boolean nullable, long value, int precision) {
+    return Expression.PrecisionTimeLiteral.builder()
+        .nullable(nullable)
+        .value(value)
+        .precision(precision)
+        .build();
   }
 
   /**

--- a/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
@@ -122,6 +122,16 @@ public interface ExpressionVisitor<R, C extends VisitationContext, E extends Thr
   R visit(Expression.TimeLiteral expr, C context) throws E;
 
   /**
+   * Visit a precision time literal.
+   *
+   * @param expr the precision time literal
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
+  R visit(Expression.PrecisionTimeLiteral expr, C context) throws E;
+
+  /**
    * Visit a date literal.
    *
    * @param expr the date literal

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -141,6 +141,20 @@ public class ExpressionProtoConverter
 
   @Override
   public Expression visit(
+      io.substrait.expression.Expression.PrecisionTimeLiteral expr,
+      EmptyVisitationContext context) {
+    return lit(
+        bldr ->
+            bldr.setNullable(expr.nullable())
+                .setPrecisionTime(
+                    Expression.Literal.PrecisionTime.newBuilder()
+                        .setValue(expr.value())
+                        .setPrecision(expr.precision())
+                        .build()));
+  }
+
+  @Override
+  public Expression visit(
       io.substrait.expression.Expression.DateLiteral expr, EmptyVisitationContext context) {
     return lit(bldr -> bldr.setNullable(expr.nullable()).setDate(expr.value()));
   }

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -413,6 +413,11 @@ public class ProtoExpressionConverter {
         return ExpressionCreator.date(literal.getNullable(), literal.getDate());
       case TIME:
         return ExpressionCreator.time(literal.getNullable(), literal.getTime());
+      case PRECISION_TIME:
+        return ExpressionCreator.precisionTime(
+            literal.getNullable(),
+            literal.getPrecisionTime().getValue(),
+            literal.getPrecisionTime().getPrecision());
       case INTERVAL_YEAR_TO_MONTH:
         return ExpressionCreator.intervalYear(
             literal.getNullable(),

--- a/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
@@ -4,6 +4,7 @@ import static io.substrait.relation.CopyOnWriteUtils.allEmpty;
 import static io.substrait.relation.CopyOnWriteUtils.transformList;
 
 import io.substrait.expression.Expression;
+import io.substrait.expression.Expression.PrecisionTimeLiteral;
 import io.substrait.expression.ExpressionVisitor;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.FunctionArg;
@@ -91,6 +92,12 @@ public class ExpressionCopyOnWriteVisitor<E extends Exception>
 
   @Override
   public Optional<Expression> visit(Expression.TimeLiteral expr, EmptyVisitationContext context)
+      throws E {
+    return visitLiteral(expr);
+  }
+
+  @Override
+  public Optional<Expression> visit(PrecisionTimeLiteral expr, EmptyVisitationContext context)
       throws E {
     return visitLiteral(expr);
   }

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -164,6 +164,7 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   }
 
   @Value.Immutable
+  @Deprecated
   abstract class Time implements Type {
     public static ImmutableType.Time.Builder builder() {
       return ImmutableType.Time.builder();

--- a/core/src/main/java/io/substrait/type/TypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/TypeVisitor.java
@@ -21,6 +21,7 @@ public interface TypeVisitor<R, E extends Throwable> {
 
   R visit(Type.Date type) throws E;
 
+  @Deprecated
   R visit(Type.Time type) throws E;
 
   @Deprecated

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
@@ -25,6 +25,7 @@ import io.substrait.expression.Expression.ListLiteral;
 import io.substrait.expression.Expression.MapLiteral;
 import io.substrait.expression.Expression.MultiOrList;
 import io.substrait.expression.Expression.NullLiteral;
+import io.substrait.expression.Expression.PrecisionTimeLiteral;
 import io.substrait.expression.Expression.PrecisionTimestampLiteral;
 import io.substrait.expression.Expression.PrecisionTimestampTZLiteral;
 import io.substrait.expression.Expression.ScalarFunctionInvocation;
@@ -110,6 +111,12 @@ public class ExpressionStringify extends ParentStringify
   @Override
   public String visit(TimeLiteral expr, EmptyVisitationContext context) throws RuntimeException {
     return "<TimeLiteral " + expr.value() + ">";
+  }
+
+  @Override
+  public String visit(PrecisionTimeLiteral expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<PrecisionTimeLiteral " + expr.value() + ">";
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -7,6 +7,7 @@ import io.substrait.expression.AbstractExpressionVisitor;
 import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.FailureBehavior;
+import io.substrait.expression.Expression.PrecisionTimeLiteral;
 import io.substrait.expression.Expression.PrecisionTimestampLiteral;
 import io.substrait.expression.Expression.PrecisionTimestampTZLiteral;
 import io.substrait.expression.Expression.ScalarSubquery;
@@ -205,19 +206,48 @@ public class ExpressionRexConverter
 
   @Override
   public RexNode visit(Expression.TimeLiteral expr, Context context) throws RuntimeException {
-    // Expression.TimeLiteral is Microseconds
-    // Construct a TimeString :
-    // 1. Truncate microseconds to seconds
-    // 2. Get the fraction seconds in precision of nanoseconds.
-    // 3. Construct TimeString :  seconds  + fraction_seconds part.
-    long microSec = expr.value();
-    long seconds = TimeUnit.MICROSECONDS.toSeconds(microSec);
-    int fracSecondsInNano =
-        (int) (TimeUnit.MICROSECONDS.toNanos(microSec) - TimeUnit.SECONDS.toNanos(seconds));
-    TimeString timeString =
-        TimeString.fromMillisOfDay((int) TimeUnit.SECONDS.toMillis(seconds))
-            .withNanos(fracSecondsInNano);
-    return rexBuilder.makeLiteral(timeString, typeConverter.toCalcite(typeFactory, expr.getType()));
+    return rexBuilder.makeLiteral(
+        createTimeString(expr.value(), 6), typeConverter.toCalcite(typeFactory, expr.getType()));
+  }
+
+  @Override
+  public RexNode visit(PrecisionTimeLiteral expr, Context context) throws RuntimeException {
+    return rexBuilder.makeLiteral(
+        createTimeString(expr.value(), expr.precision()),
+        typeConverter.toCalcite(typeFactory, expr.getType()));
+  }
+
+  protected TimeString createTimeString(long value, int precision) {
+    switch (precision) {
+      case 0:
+        return TimeString.fromMillisOfDay((int) TimeUnit.SECONDS.toMillis(value));
+      case 3:
+        {
+          long seconds = TimeUnit.MILLISECONDS.toSeconds(value);
+          int fracSecondsInNano =
+              (int) (TimeUnit.MILLISECONDS.toNanos(value) - TimeUnit.SECONDS.toNanos(seconds));
+          return TimeString.fromMillisOfDay((int) TimeUnit.SECONDS.toMillis(seconds))
+              .withNanos(fracSecondsInNano);
+        }
+      case 6:
+        {
+          long seconds = TimeUnit.MICROSECONDS.toSeconds(value);
+          int fracSecondsInNano =
+              (int) (TimeUnit.MICROSECONDS.toNanos(value) - TimeUnit.SECONDS.toNanos(seconds));
+          return TimeString.fromMillisOfDay((int) TimeUnit.SECONDS.toMillis(seconds))
+              .withNanos(fracSecondsInNano);
+        }
+      case 9:
+        {
+          long seconds = TimeUnit.NANOSECONDS.toSeconds(value);
+          int fracSecondsInNano = (int) (value - TimeUnit.SECONDS.toNanos(seconds));
+          return TimeString.fromMillisOfDay((int) TimeUnit.SECONDS.toMillis(seconds))
+              .withNanos(fracSecondsInNano);
+        }
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Cannot handle PrecisionTime with precision %d.", precision));
+    }
   }
 
   @Override

--- a/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
@@ -44,6 +44,7 @@ class IgnoreNullableAndParameters(val typeToMatch: ParameterizedType)
 
   override def visit(`type`: Type.Date): Boolean = typeToMatch.isInstanceOf[Type.Date]
 
+  @nowarn
   override def visit(`type`: Type.Time): Boolean = typeToMatch.isInstanceOf[Type.Time]
 
   @nowarn


### PR DESCRIPTION
`Time` was originally deprecated in Substrait via https://github.com/substrait-io/substrait/pull/788 but was not marked properly as deprecated. Similarly the deprecation in substrait-java has not been implemented properly.

There are multiple places where the new `PrecisionTime` type has not been introduced, the deprecated `Time` type not being marked as deprecated and places where the even further back deprecated `Timestamp` types were not marked as deprecated.