### PR TITLE
build: re-enable core module test execution

### DIFF
--- a/spark/spark-3.4_2.12/build.gradle.kts
+++ b/spark/spark-3.4_2.12/build.gradle.kts
@@ -150,13 +150,6 @@ tasks {
     mustRunAfter(":core:compileJava")
   }
 
-  // Explicitly skip core test compilation for this build
-  gradle.taskGraph.whenReady {
-    allTasks
-      .filter { it.path.startsWith(":core:") && it.name.contains("Test") }
-      .forEach { it.enabled = false }
-  }
-
   jar {
     manifest {
       from("../../core/build/generated/sources/manifest/META-INF/MANIFEST.MF")


### PR DESCRIPTION
Fixes #725.

Removes the `gradle.taskGraph.whenReady` block in `spark/spark-3.4_2.12/build.gradle.kts` that was globally disabling all `:core:` test tasks.

### Evidence
Here is a random CI job which "passed" though it reports NO-SOURCE for `:core:test`: https://github.com/substrait-io/substrait-java/actions/runs/22715122770/job/65862746905?pr=721#step:5:878

Whereas here is a CI job from this PR which doesn't report NO-SOURCE: https://github.com/substrait-io/substrait-java/actions/runs/22731399731/job/65921121388?pr=726#step:5:888

See also #727, which adds a deliberately failing `fail()` test to core on `main` — CI passes anyway.