### PR TITLE
DO NOT MERGE: proof that core tests are not running (#725)

### DIFF
--- a/core/src/test/java/io/substrait/SanityCheckTest.java
+++ b/core/src/test/java/io/substrait/SanityCheckTest.java
@@ -1,0 +1,12 @@
+package io.substrait;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+public class SanityCheckTest {
+  @Test
+  public void thisTestShouldFail() {
+    fail("This test should fail - sanity check");
+  }
+}


### PR DESCRIPTION
This PR adds a deliberately failing test to `core` to demonstrate #725. CI should pass despite the test containing `fail()`, proving that core tests are silently skipped.

Do not merge — close after CI completes.