### PR TITLE
fix: release of spark variants failed

### DIFF
--- a/spark/spark-3.4_2.12/build.gradle.kts
+++ b/spark/spark-3.4_2.12/build.gradle.kts
@@ -40,6 +40,12 @@ publishing {
             url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
           }
         }
+        developers {
+          developer {
+            id = "andrew-coleman"
+            name = "Andrew Coleman"
+          }
+        }
         scm {
           connection.set("scm:git:git://github.com:substrait-io/substrait-java.git")
           developerConnection.set("scm:git:ssh://github.com:substrait-io/substrait-java")

--- a/spark/spark-3.5_2.12/build.gradle.kts
+++ b/spark/spark-3.5_2.12/build.gradle.kts
@@ -40,6 +40,12 @@ publishing {
             url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
           }
         }
+        developers {
+          developer {
+            id = "andrew-coleman"
+            name = "Andrew Coleman"
+          }
+        }
         scm {
           connection.set("scm:git:git://github.com:substrait-io/substrait-java.git")
           developerConnection.set("scm:git:ssh://github.com:substrait-io/substrait-java")

--- a/spark/spark-4.0_2.13/build.gradle.kts
+++ b/spark/spark-4.0_2.13/build.gradle.kts
@@ -40,6 +40,12 @@ publishing {
             url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
           }
         }
+        developers {
+          developer {
+            id = "andrew-coleman"
+            name = "Andrew Coleman"
+          }
+        }
         scm {
           connection.set("scm:git:git://github.com:substrait-io/substrait-java.git")
           developerConnection.set("scm:git:ssh://github.com:substrait-io/substrait-java")


### PR DESCRIPTION
The release stage of the new spark variants build scrips are missing the ‘developers’ information in the pom descriptor, which cases the maven publication to fail.
This PR adds that information.