### PR TITLE
build: remove redundant examples build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,26 +63,6 @@ jobs:
           git submodule foreach 'git fetch --unshallow || true'
 
           ./gradlew build --rerun-tasks
-  examples:
-    name: Build Examples
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - uses: extractions/setup-just@v3
-      - name: substrait-spark
-        shell: bash
-        run: |
-          pwd
-          ls -lart
-          just -f ./examples/substrait-spark/justfile buildapp
-
   isthmus-native-image-mac-linux:
     name: Build Isthmus Native Image
     needs: java


### PR DESCRIPTION
The Substrait Spark examples are already being included in the default Gradle build:
https://github.com/substrait-io/substrait-java/blob/631df9d16a64cb0826d9988f72879ba20a44d9a8/settings.gradle.kts#L14

The additional examples build in Github Actions essentially also just runs the regular Gradle build besides creating a couple directories and copying files around:
https://github.com/substrait-io/substrait-java/blob/631df9d16a64cb0826d9988f72879ba20a44d9a8/examples/substrait-spark/justfile#L18-L30

I think we can remove the redundant examples build step from Github Actions and shorten the build time.