### PR TITLE
build(spotless): align google-java-format versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,10 +57,14 @@ allprojects {
 
   plugins.withType<SpotlessPlugin>().configureEach {
     configure<SpotlessExtension> {
-      kotlinGradle { ktfmt().googleStyle() }
+      // latest ktfmt version is 0.61
+      // https://github.com/facebook/ktfmt/releases
+      kotlinGradle { ktfmt("0.61").googleStyle() }
       java {
         target("src/*/java/**/*.java")
-        googleJavaFormat()
+        // since kfmt also brings in google-java-format we need to sync versions
+        // https://github.com/facebook/ktfmt/blob/v0.61/gradle/libs.versions.toml#L7
+        googleJavaFormat("1.23.0")
         removeUnusedImports()
         trimTrailingWhitespace()
         forbidWildcardImports()


### PR DESCRIPTION
Not sure if I'm the only one getting such spotless linting errors:

```
* What went wrong:
Execution failed for task ':examples:substrait-spark:spotlessJavaCheck'.
> There were 10 lint error(s), they must be fixed or suppressed.
  src/main/java/io/substrait/examples/App.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/SparkConsumeSubstrait.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/SparkDataset.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/SparkHelper.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/SparkSQL.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/util/ExpressionStringify.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/util/FunctionArgStringify.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/util/ParentStringify.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/util/SubstraitStringify.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  src/main/java/io/substrait/examples/util/TypeStringify.java:LINE_UNDEFINED google-java-format(java.lang.NoClassDefFoundError) com/google/common/collect/Iterables$4 (...)
  Resolve these lints or suppress with `suppressLintsFor`
```

I found out this is due to `kfmt` and the `java` formatting in spotless using different `google-java-foramt` versions. This PR aligns the `google-java-format` versions which fixes these "lint" errors.