### PR TITLE
fix(core): use new aggregate grouping behavior in RelProtoConverter

### DIFF
--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -215,6 +215,8 @@ public class RelProtoConverter
   private AggregateRel.Grouping toProto(
       Aggregate.Grouping grouping, List<Expression> uniqueGroupingExpressions) {
     return AggregateRel.Grouping.newBuilder()
+        .addAllGroupingExpressions(
+            grouping.getExpressions().stream().map(this::toProto).collect(Collectors.toList()))
         .addAllExpressionReferences(
             grouping.getExpressions().stream()
                 .map(e -> uniqueGroupingExpressions.indexOf(e))

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -155,12 +155,21 @@ public class RelProtoConverter
 
   @Override
   public Rel visit(Aggregate aggregate, EmptyVisitationContext context) throws RuntimeException {
-    AggregateRel.Builder builder =
+    final List<Expression> uniqueGroupingExpressions =
+        aggregate.getGroupings().stream()
+            .flatMap(g -> g.getExpressions().stream())
+            .distinct()
+            .collect(Collectors.toList());
+
+    final AggregateRel.Builder builder =
         AggregateRel.newBuilder()
             .setInput(toProto(aggregate.getInput()))
             .setCommon(common(aggregate))
+            .addAllGroupingExpressions(toProto(uniqueGroupingExpressions))
             .addAllGroupings(
-                aggregate.getGroupings().stream().map(this::toProto).collect(Collectors.toList()))
+                aggregate.getGroupings().stream()
+                    .map(g -> toProto(g, uniqueGroupingExpressions))
+                    .collect(Collectors.toList()))
             .addAllMeasures(
                 aggregate.getMeasures().stream().map(this::toProto).collect(Collectors.toList()));
 
@@ -203,9 +212,13 @@ public class RelProtoConverter
     return builder.build();
   }
 
-  private AggregateRel.Grouping toProto(Aggregate.Grouping grouping) {
+  private AggregateRel.Grouping toProto(
+      Aggregate.Grouping grouping, List<Expression> uniqueGroupingExpressions) {
     return AggregateRel.Grouping.newBuilder()
-        .addAllGroupingExpressions(toProto(grouping.getExpressions()))
+        .addAllExpressionReferences(
+            grouping.getExpressions().stream()
+                .map(e -> uniqueGroupingExpressions.indexOf(e))
+                .collect(Collectors.toList()))
         .build();
   }
 

--- a/core/src/test/java/io/substrait/relation/AggregateRelTest.java
+++ b/core/src/test/java/io/substrait/relation/AggregateRelTest.java
@@ -69,9 +69,7 @@ class AggregateRelTest extends TestBase {
    */
   private static List<List<Integer>> getExpressionReferences(AggregateRel aggregateRel) {
     return aggregateRel.getGroupingsList().stream()
-        .map(
-            grouping ->
-                grouping.getExpressionReferencesList().stream().collect(Collectors.toList()))
+        .map(AggregateRel.Grouping::getExpressionReferencesList)
         .collect(Collectors.toList());
   }
 
@@ -85,16 +83,6 @@ class AggregateRelTest extends TestBase {
     return aggregateRel.getGroupingsList().stream()
         .map(grouping -> grouping.getGroupingExpressionsList())
         .collect(Collectors.toList());
-  }
-
-  /**
-   * Helper method to extract aggregate-level grouping expressions from an AggregateRel.
-   *
-   * @param aggregateRel the AggregateRel to extract grouping expressions from
-   * @return a list of expressions at the aggregate level
-   */
-  private static List<Expression> getAggregateGroupingExpressions(AggregateRel aggregateRel) {
-    return aggregateRel.getGroupingExpressionsList();
   }
 
   @Test
@@ -140,7 +128,7 @@ class AggregateRelTest extends TestBase {
     // Verify backward compatibility: deprecated grouping_expressions field is also populated
     assertEquals(List.of(List.of(col1Ref, col2Ref)), getGroupingExpressions(roundtripAgg));
     // Verify aggregate-level grouping_expressions field is populated
-    assertEquals(List.of(col1Ref, col2Ref), getAggregateGroupingExpressions(roundtripAgg));
+    assertEquals(List.of(col1Ref, col2Ref), roundtripAgg.getGroupingExpressionsList());
   }
 
   @Test
@@ -188,7 +176,7 @@ class AggregateRelTest extends TestBase {
     // Verify backward compatibility: deprecated grouping_expressions field is also populated
     assertEquals(List.of(List.of(col1Ref, col2Ref)), getGroupingExpressions(roundtripAgg));
     // Verify aggregate-level grouping_expressions field is populated
-    assertEquals(List.of(col1Ref, col2Ref), getAggregateGroupingExpressions(roundtripAgg));
+    assertEquals(List.of(col1Ref, col2Ref), roundtripAgg.getGroupingExpressionsList());
   }
 
   @Test
@@ -242,6 +230,34 @@ class AggregateRelTest extends TestBase {
     assertEquals(
         List.of(List.of(col1Ref, col2Ref), List.of(col2Ref)), getGroupingExpressions(roundtripAgg));
     // Verify aggregate-level grouping_expressions field is populated
-    assertEquals(List.of(col1Ref, col2Ref), getAggregateGroupingExpressions(roundtripAgg));
+    assertEquals(List.of(col1Ref, col2Ref), roundtripAgg.getGroupingExpressionsList());
+  }
+
+  /**
+   * Tests deduplication of non-trivial grouping expressions by equals() (not identity), and that an
+   * empty grouping set is handled correctly alongside non-empty ones.
+   */
+  @Test
+  void testGroupingExpressionDeduplicationAndEmptyGroupingSet() {
+    NamedScan input = sb.namedScan(List.of("t"), List.of("a", "b"), List.of(R.I32, R.I32));
+
+    // Two independently constructed add(a, b) expressions — equal but not same instance.
+    io.substrait.expression.Expression addAB1 =
+        sb.add(sb.fieldReference(input, 0), sb.fieldReference(input, 1));
+    io.substrait.expression.Expression addAB2 =
+        sb.add(sb.fieldReference(input, 0), sb.fieldReference(input, 1));
+
+    Aggregate agg =
+        Aggregate.builder()
+            .input(input)
+            .addGroupings(sb.grouping(addAB1), sb.grouping(addAB2), sb.grouping())
+            .build();
+
+    Rel roundtripRel = relProtoConverter.visit(agg, EmptyVisitationContext.INSTANCE);
+    AggregateRel result = roundtripRel.getAggregate();
+
+    assertEquals(
+        List.of(expressionProtoConverter.toProto(addAB1)), result.getGroupingExpressionsList());
+    assertEquals(List.of(List.of(0), List.of(0), List.of()), getExpressionReferences(result));
   }
 }

--- a/core/src/test/java/io/substrait/relation/AggregateRelTest.java
+++ b/core/src/test/java/io/substrait/relation/AggregateRelTest.java
@@ -102,9 +102,9 @@ class AggregateRelTest extends TestBase {
         roundtripAgg.getGroupingExpressionsCount(),
         "grouping expressions count of aggregate should be 2");
     assertEquals(
-        0,
+        2,
         roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
-        "grouping expressions count of grouping should be 0");
+        "grouping expressions count of grouping should be 2");
     assertEquals(
         2,
         roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
@@ -157,9 +157,9 @@ class AggregateRelTest extends TestBase {
         roundtripAgg.getGroupingExpressionsCount(),
         "grouping expressions count of aggregate should be 2");
     assertEquals(
-        0,
+        2,
         roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
-        "grouping expressions count of grouping should be 0");
+        "grouping expressions count of grouping should be 2");
     assertEquals(
         2,
         roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
@@ -217,9 +217,9 @@ class AggregateRelTest extends TestBase {
         roundtripAgg.getGroupingExpressionsCount(),
         "grouping expressions count of aggregate should be 2");
     assertEquals(
-        0,
+        2,
         roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
-        "grouping expressions count of grouping should be 0");
+        "grouping expressions count of grouping should be 2");
     assertEquals(
         2,
         roundtripAgg.getGroupings(0).getExpressionReferencesCount(),

--- a/core/src/test/java/io/substrait/relation/AggregateRelTest.java
+++ b/core/src/test/java/io/substrait/relation/AggregateRelTest.java
@@ -12,6 +12,8 @@ import io.substrait.proto.Plan;
 import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
 import io.substrait.util.EmptyVisitationContext;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 class AggregateRelTest extends TestBase {
@@ -58,6 +60,43 @@ class AggregateRelTest extends TestBase {
     return Expression.newBuilder().setSelection(fieldRef1).build();
   }
 
+  /**
+   * Helper method to extract expression references from an AggregateRel.
+   *
+   * @param aggregateRel the AggregateRel to extract expression references from
+   * @return a list of lists, where each inner list contains the expression reference indices for a
+   *     grouping
+   */
+  private static List<List<Integer>> getExpressionReferences(AggregateRel aggregateRel) {
+    return aggregateRel.getGroupingsList().stream()
+        .map(
+            grouping ->
+                grouping.getExpressionReferencesList().stream().collect(Collectors.toList()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Helper method to extract deprecated grouping expressions from an AggregateRel.
+   *
+   * @param aggregateRel the AggregateRel to extract grouping expressions from
+   * @return a list of lists, where each inner list contains the grouping expressions for a grouping
+   */
+  private static List<List<Expression>> getGroupingExpressions(AggregateRel aggregateRel) {
+    return aggregateRel.getGroupingsList().stream()
+        .map(grouping -> grouping.getGroupingExpressionsList())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Helper method to extract aggregate-level grouping expressions from an AggregateRel.
+   *
+   * @param aggregateRel the AggregateRel to extract grouping expressions from
+   * @return a list of expressions at the aggregate level
+   */
+  private static List<Expression> getAggregateGroupingExpressions(AggregateRel aggregateRel) {
+    return aggregateRel.getGroupingExpressionsList();
+  }
+
   @Test
   void testDeprecatedGroupingExpressionConversion() {
     Expression col1Ref = createFieldReference(0);
@@ -96,19 +135,12 @@ class AggregateRelTest extends TestBase {
     assertTrue(roundtripRel.hasAggregate());
 
     AggregateRel roundtripAgg = roundtripRel.getAggregate();
-    assertEquals(1, roundtripAgg.getGroupingsCount(), "grouping count should be 1");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupingExpressionsCount(),
-        "grouping expressions count of aggregate should be 2");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
-        "grouping expressions count of grouping should be 2");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
-        "expression reference count of grouping should be 2");
+    // Verify new expression_references structure
+    assertEquals(List.of(List.of(0, 1)), getExpressionReferences(roundtripAgg));
+    // Verify backward compatibility: deprecated grouping_expressions field is also populated
+    assertEquals(List.of(List.of(col1Ref, col2Ref)), getGroupingExpressions(roundtripAgg));
+    // Verify aggregate-level grouping_expressions field is populated
+    assertEquals(List.of(col1Ref, col2Ref), getAggregateGroupingExpressions(roundtripAgg));
   }
 
   @Test
@@ -151,19 +183,12 @@ class AggregateRelTest extends TestBase {
     assertTrue(roundtripRel.hasAggregate());
 
     AggregateRel roundtripAgg = roundtripRel.getAggregate();
-    assertEquals(1, roundtripAgg.getGroupingsCount(), "grouping count should be 1");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupingExpressionsCount(),
-        "grouping expressions count of aggregate should be 2");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
-        "grouping expressions count of grouping should be 2");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
-        "expression reference count of grouping should be 2");
+    // Verify new expression_references structure
+    assertEquals(List.of(List.of(0, 1)), getExpressionReferences(roundtripAgg));
+    // Verify backward compatibility: deprecated grouping_expressions field is also populated
+    assertEquals(List.of(List.of(col1Ref, col2Ref)), getGroupingExpressions(roundtripAgg));
+    // Verify aggregate-level grouping_expressions field is populated
+    assertEquals(List.of(col1Ref, col2Ref), getAggregateGroupingExpressions(roundtripAgg));
   }
 
   @Test
@@ -211,22 +236,12 @@ class AggregateRelTest extends TestBase {
     assertTrue(roundtripRel.hasAggregate());
 
     AggregateRel roundtripAgg = roundtripRel.getAggregate();
-    assertEquals(2, roundtripAgg.getGroupingsCount(), "grouping count should be 2");
+    // Verify new expression_references structure
+    assertEquals(List.of(List.of(0, 1), List.of(1)), getExpressionReferences(roundtripAgg));
+    // Verify backward compatibility: deprecated grouping_expressions field is also populated
     assertEquals(
-        2,
-        roundtripAgg.getGroupingExpressionsCount(),
-        "grouping expressions count of aggregate should be 2");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
-        "grouping expressions count of grouping should be 2");
-    assertEquals(
-        2,
-        roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
-        "expression reference count of grouping should be 2");
-    assertEquals(
-        1,
-        roundtripAgg.getGroupings(1).getExpressionReferencesCount(),
-        "expression reference count of grouping should be 2");
+        List.of(List.of(col1Ref, col2Ref), List.of(col2Ref)), getGroupingExpressions(roundtripAgg));
+    // Verify aggregate-level grouping_expressions field is populated
+    assertEquals(List.of(col1Ref, col2Ref), getAggregateGroupingExpressions(roundtripAgg));
   }
 }

--- a/core/src/test/java/io/substrait/relation/AggregateRelTest.java
+++ b/core/src/test/java/io/substrait/relation/AggregateRelTest.java
@@ -95,19 +95,19 @@ class AggregateRelTest extends TestBase {
     Rel roundtripRel = relProtoConverter.visit(agg, EmptyVisitationContext.INSTANCE);
     assertTrue(roundtripRel.hasAggregate());
 
-    AggregateRel roundtripAggr = roundtripRel.getAggregate();
-    assertEquals(1, roundtripAggr.getGroupingsCount(), "grouping count should be 1");
+    AggregateRel roundtripAgg = roundtripRel.getAggregate();
+    assertEquals(1, roundtripAgg.getGroupingsCount(), "grouping count should be 1");
     assertEquals(
         2,
-        roundtripAggr.getGroupingExpressionsCount(),
+        roundtripAgg.getGroupingExpressionsCount(),
         "grouping expressions count of aggregate should be 2");
     assertEquals(
         0,
-        roundtripAggr.getGroupings(0).getGroupingExpressionsCount(),
+        roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
         "grouping expressions count of grouping should be 0");
     assertEquals(
         2,
-        roundtripAggr.getGroupings(0).getExpressionReferencesCount(),
+        roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
         "expression reference count of grouping should be 2");
   }
 

--- a/core/src/test/java/io/substrait/relation/AggregateRelTest.java
+++ b/core/src/test/java/io/substrait/relation/AggregateRelTest.java
@@ -11,6 +11,7 @@ import io.substrait.proto.Expression;
 import io.substrait.proto.Plan;
 import io.substrait.proto.ReadRel;
 import io.substrait.proto.Rel;
+import io.substrait.util.EmptyVisitationContext;
 import org.junit.jupiter.api.Test;
 
 class AggregateRelTest extends TestBase {
@@ -90,6 +91,24 @@ class AggregateRelTest extends TestBase {
     Aggregate agg = (Aggregate) resultRel;
     assertEquals(1, agg.getGroupings().size());
     assertEquals(2, agg.getGroupings().get(0).getExpressions().size());
+
+    Rel roundtripRel = relProtoConverter.visit(agg, EmptyVisitationContext.INSTANCE);
+    assertTrue(roundtripRel.hasAggregate());
+
+    AggregateRel roundtripAggr = roundtripRel.getAggregate();
+    assertEquals(1, roundtripAggr.getGroupingsCount(), "grouping count should be 1");
+    assertEquals(
+        2,
+        roundtripAggr.getGroupingExpressionsCount(),
+        "grouping expressions count of aggregate should be 2");
+    assertEquals(
+        0,
+        roundtripAggr.getGroupings(0).getGroupingExpressionsCount(),
+        "grouping expressions count of grouping should be 0");
+    assertEquals(
+        2,
+        roundtripAggr.getGroupings(0).getExpressionReferencesCount(),
+        "expression reference count of grouping should be 2");
   }
 
   @Test
@@ -127,6 +146,24 @@ class AggregateRelTest extends TestBase {
     Aggregate agg = (Aggregate) resultRel;
     assertEquals(1, agg.getGroupings().size());
     assertEquals(2, agg.getGroupings().get(0).getExpressions().size());
+
+    Rel roundtripRel = relProtoConverter.visit(agg, EmptyVisitationContext.INSTANCE);
+    assertTrue(roundtripRel.hasAggregate());
+
+    AggregateRel roundtripAgg = roundtripRel.getAggregate();
+    assertEquals(1, roundtripAgg.getGroupingsCount(), "grouping count should be 1");
+    assertEquals(
+        2,
+        roundtripAgg.getGroupingExpressionsCount(),
+        "grouping expressions count of aggregate should be 2");
+    assertEquals(
+        0,
+        roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
+        "grouping expressions count of grouping should be 0");
+    assertEquals(
+        2,
+        roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
+        "expression reference count of grouping should be 2");
   }
 
   @Test
@@ -169,5 +206,27 @@ class AggregateRelTest extends TestBase {
     assertEquals(2, agg.getGroupings().size());
     assertEquals(2, agg.getGroupings().get(0).getExpressions().size());
     assertEquals(1, agg.getGroupings().get(1).getExpressions().size());
+
+    Rel roundtripRel = relProtoConverter.visit(agg, EmptyVisitationContext.INSTANCE);
+    assertTrue(roundtripRel.hasAggregate());
+
+    AggregateRel roundtripAgg = roundtripRel.getAggregate();
+    assertEquals(2, roundtripAgg.getGroupingsCount(), "grouping count should be 2");
+    assertEquals(
+        2,
+        roundtripAgg.getGroupingExpressionsCount(),
+        "grouping expressions count of aggregate should be 2");
+    assertEquals(
+        0,
+        roundtripAgg.getGroupings(0).getGroupingExpressionsCount(),
+        "grouping expressions count of grouping should be 0");
+    assertEquals(
+        2,
+        roundtripAgg.getGroupings(0).getExpressionReferencesCount(),
+        "expression reference count of grouping should be 2");
+    assertEquals(
+        1,
+        roundtripAgg.getGroupings(1).getExpressionReferencesCount(),
+        "expression reference count of grouping should be 2");
   }
 }


### PR DESCRIPTION
changes RelProtoConverter to output the new and the old aggregate grouping proto structures

relates to https://github.com/substrait-io/substrait-java/issues/299 and https://github.com/substrait-io/substrait/pull/1002

This PR changes the `RelProtoConverter` to output the new and the old grouping behavior keeping the existing `io.substrait.relation.Aggregate` behavior the same.