### PR TITLE
feat: substrait builder extra api

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -97,12 +97,9 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Gets the default extension collection used by this builder.
+   * Gets the extension collection used by this builder.
    *
-   * <p>This collection includes standard Substrait functions for strings, arithmetic, comparison,
-   * datetime, and other operations from {@link DefaultExtensionCatalog#DEFAULT_COLLECTION}.
-   *
-   * @return the ExtensionCollection containing standard Substrait functions
+   * @return the ExtensionCollection used with this builder
    */
   public SimpleExtension.ExtensionCollection getExtensions() {
     return extensions;
@@ -149,25 +146,6 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates an aggregate relation with a single grouping and output field remapping.
-   *
-   * @param groupingFn function to derive the grouping from the input relation
-   * @param measuresFn function to derive the measures from the input relation
-   * @param remap the output field remapping specification
-   * @param input the input relation to aggregate
-   * @return a new {@link Aggregate} relation
-   */
-  public Aggregate aggregate(
-      Function<Rel, Aggregate.Grouping> groupingFn,
-      Function<Rel, List<Aggregate.Measure>> measuresFn,
-      Rel.Remap remap,
-      Rel input) {
-    Function<Rel, List<Aggregate.Grouping>> groupingsFn =
-        groupingFn.andThen(g -> Stream.of(g).collect(Collectors.toList()));
-    return aggregate(groupingsFn, measuresFn, Optional.of(remap), input);
-  }
-
-  /**
    * Creates an aggregate relation that groups and aggregates data from an input relation.
    *
    * <p>This method constructs a Substrait aggregate operation by applying grouping and measure
@@ -187,12 +165,12 @@ public class SubstraitBuilder {
    * @return an Aggregate relation representing the grouping and aggregation operation
    */
   public Aggregate aggregate(
-      final Function<Rel, List<Aggregate.Grouping>> groupingsFn,
-      final Function<Rel, List<Aggregate.Measure>> measuresFn,
-      final Optional<Rel.Remap> remap,
-      final Rel input) {
-    final List<Aggregate.Grouping> groupings = groupingsFn.apply(input);
-    final List<Aggregate.Measure> measures = measuresFn.apply(input);
+      Function<Rel, List<Aggregate.Grouping>> groupingsFn,
+      Function<Rel, List<Aggregate.Measure>> measuresFn,
+      Optional<Rel.Remap> remap,
+      Rel input) {
+    List<Aggregate.Grouping> groupings = groupingsFn.apply(input);
+    List<Aggregate.Measure> measures = measuresFn.apply(input);
     return Aggregate.builder()
         .groupings(groupings)
         .measures(measures)
@@ -903,7 +881,7 @@ public class SubstraitBuilder {
    * @param value value to create
    * @return i16 instance
    */
-  public Expression.I8Literal i8(final int value) {
+  public Expression.I8Literal i8(int value) {
     return Expression.I8Literal.builder().value(value).build();
   }
 
@@ -913,7 +891,7 @@ public class SubstraitBuilder {
    * @param value value to create
    * @return i16 instance
    */
-  public Expression.I16Literal i16(final int value) {
+  public Expression.I16Literal i16(int value) {
     return Expression.I16Literal.builder().value(value).build();
   }
 
@@ -933,7 +911,7 @@ public class SubstraitBuilder {
    * @param value value to create
    * @return i64 instance
    */
-  public Expression.I64Literal i64(final long value) {
+  public Expression.I64Literal i64(long value) {
     return Expression.I64Literal.builder().value(value).build();
   }
 
@@ -943,7 +921,7 @@ public class SubstraitBuilder {
    * @param value the float value
    * @return a new {@link Expression.FP32Literal}
    */
-  public Expression.FP32Literal fp32(final float value) {
+  public Expression.FP32Literal fp32(float value) {
     return Expression.FP32Literal.builder().value(value).build();
   }
 
@@ -1532,7 +1510,7 @@ public class SubstraitBuilder {
    * @param expression the boolean expression to negate
    * @return a scalar function invocation representing the logical NOT of the input expression
    */
-  public Expression not(final Expression expression) {
+  public Expression not(Expression expression) {
     return this.scalarFn(
         DefaultExtensionCatalog.FUNCTIONS_BOOLEAN,
         "not:bool",
@@ -1554,7 +1532,7 @@ public class SubstraitBuilder {
    * @return a scalar function invocation that returns true if the expression is null, false
    *     otherwise
    */
-  public Expression isNull(final Expression expression) {
+  public Expression isNull(Expression expression) {
 
     final List<Expression> args = new ArrayList<>();
     args.add(expression);
@@ -1581,12 +1559,12 @@ public class SubstraitBuilder {
    * @return a scalar function invocation expression
    */
   public Expression scalarFn(
-      final String urn,
-      final String key,
-      final Type returnType,
-      final List<? extends FunctionArg> args,
-      final List<FunctionOption> optionsList) {
-    final SimpleExtension.ScalarFunctionVariant declaration =
+      String urn,
+      String key,
+      Type returnType,
+      List<? extends FunctionArg> args,
+      List<FunctionOption> optionsList) {
+    SimpleExtension.ScalarFunctionVariant declaration =
         extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
     return Expression.ScalarFunctionInvocation.builder()
         .declaration(declaration)
@@ -1626,11 +1604,8 @@ public class SubstraitBuilder {
    * @return a scalar function invocation expression
    */
   public Expression scalarFn(
-      final String urn,
-      final String key,
-      final Type returnType,
-      final List<? extends FunctionArg> args) {
-    final SimpleExtension.ScalarFunctionVariant declaration =
+      String urn, String key, Type returnType, List<? extends FunctionArg> args) {
+    SimpleExtension.ScalarFunctionVariant declaration =
         extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
     return Expression.ScalarFunctionInvocation.builder()
         .declaration(declaration)

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -920,11 +920,11 @@ public class SubstraitBuilder {
   /**
    * Creates a 32-bit integer literal expression.
    *
-   * @param value the integer value
+   * @param v the integer value
    * @return a new {@link Expression.I32Literal}
    */
-  public Expression.I32Literal i32(final int value) {
-    return Expression.I32Literal.builder().value(value).build();
+  public Expression.I32Literal i32(int v) {
+    return Expression.I32Literal.builder().value(v).build();
   }
 
   /**
@@ -950,11 +950,11 @@ public class SubstraitBuilder {
   /**
    * Creates a 64-bit floating point literal expression.
    *
-   * @param value the double value
+   * @param v the double value
    * @return a new {@link Expression.FP64Literal}
    */
-  public Expression.FP64Literal fp64(final double value) {
-    return Expression.FP64Literal.builder().value(value).build();
+  public Expression.FP64Literal fp64(double v) {
+    return Expression.FP64Literal.builder().value(v).build();
   }
 
   /**

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -883,7 +883,7 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Create i16 literal.
+   * Create a 16-bit integer literal expression.
    *
    * @param v value to create
    * @return i16 instance
@@ -1067,7 +1067,7 @@ public class SubstraitBuilder {
    * options.
    *
    * @param condition the expression to match against
-   * @param options the list of possible vs to match
+   * @param options the list of possible values to match
    * @return a new {@link SingleOrList} expression
    */
   public Expression singleOrList(Expression condition, Expression... options) {
@@ -1075,10 +1075,10 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates an IN predicate expression that checks if any needle vs exist in the haystack relation.
+   * Creates an IN predicate expression that checks if any needle values exist in the haystack relation.
    *
    * @param haystack the relation to search within
-   * @param needles the vs to search for
+   * @param needles the values to search for
    * @return a new {@link Expression.InPredicate}
    */
   public Expression.InPredicate inPredicate(Rel haystack, Expression... needles) {
@@ -1501,7 +1501,7 @@ public class SubstraitBuilder {
    * Creates a logical NOT expression that negates a boolean expression.
    *
    * <p>This is a convenience method that wraps the boolean NOT function from the Substrait standard
-   * library. The result is nullable to handle NULL input vs according to three-vd logic.
+   * library. The result is nullable to handle NULL input values according to three-valued logic.
    *
    * @param expression the boolean expression to negate
    * @return a scalar function invocation representing the logical NOT of the input expression

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -12,6 +12,7 @@ import io.substrait.expression.Expression.Switch;
 import io.substrait.expression.Expression.SwitchClause;
 import io.substrait.expression.FieldReference;
 import io.substrait.expression.FunctionArg;
+import io.substrait.expression.FunctionOption;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
@@ -39,6 +40,7 @@ import io.substrait.relation.physical.NestedLoopJoin;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -74,6 +76,17 @@ public class SubstraitBuilder {
   private final SimpleExtension.ExtensionCollection extensions;
 
   /**
+   * Constructs a new SubstraitBuilder with the default extension collection.
+   *
+   * <p>The builder is initialized with {@link DefaultExtensionCatalog#DEFAULT_COLLECTION}, which
+   * includes standard Substrait functions for strings, arithmetic, comparison, datetime, and other
+   * operations.
+   */
+  public SubstraitBuilder() {
+    this(DefaultExtensionCatalog.DEFAULT_COLLECTION);
+  }
+
+  /**
    * Constructs a new SubstraitBuilder with the specified extension collection.
    *
    * @param extensions the extension collection used to resolve function declarations and other
@@ -81,6 +94,18 @@ public class SubstraitBuilder {
    */
   public SubstraitBuilder(SimpleExtension.ExtensionCollection extensions) {
     this.extensions = extensions;
+  }
+
+  /**
+   * Gets the default extension collection used by this builder.
+   *
+   * <p>This collection includes standard Substrait functions for strings, arithmetic, comparison,
+   * datetime, and other operations from {@link DefaultExtensionCatalog#DEFAULT_COLLECTION}.
+   *
+   * @return the ExtensionCollection containing standard Substrait functions
+   */
+  public SimpleExtension.ExtensionCollection getExtensions() {
+    return extensions;
   }
 
   // Relations
@@ -142,13 +167,32 @@ public class SubstraitBuilder {
     return aggregate(groupingsFn, measuresFn, Optional.of(remap), input);
   }
 
-  private Aggregate aggregate(
-      Function<Rel, List<Aggregate.Grouping>> groupingsFn,
-      Function<Rel, List<Aggregate.Measure>> measuresFn,
-      Optional<Rel.Remap> remap,
-      Rel input) {
-    List<Aggregate.Grouping> groupings = groupingsFn.apply(input);
-    List<Aggregate.Measure> measures = measuresFn.apply(input);
+  /**
+   * Creates an aggregate relation that groups and aggregates data from an input relation.
+   *
+   * <p>This method constructs a Substrait aggregate operation by applying grouping and measure
+   * functions to the input relation. The grouping function defines how rows are grouped together,
+   * while the measure function defines the aggregate computations (e.g., SUM, COUNT, AVG) to
+   * perform on each group.
+   *
+   * <p>The optional remap parameter allows reordering or filtering of output columns, which is
+   * useful for controlling the final schema of the aggregate result.
+   *
+   * @param groupingsFn a function that takes the input relation and returns a list of grouping
+   *     expressions defining how to partition the data
+   * @param measuresFn a function that takes the input relation and returns a list of aggregate
+   *     measures to compute for each group
+   * @param remap an optional remapping specification to reorder or filter output columns
+   * @param input the input relation to aggregate
+   * @return an Aggregate relation representing the grouping and aggregation operation
+   */
+  public Aggregate aggregate(
+      final Function<Rel, List<Aggregate.Grouping>> groupingsFn,
+      final Function<Rel, List<Aggregate.Measure>> measuresFn,
+      final Optional<Rel.Remap> remap,
+      final Rel input) {
+    final List<Aggregate.Grouping> groupings = groupingsFn.apply(input);
+    final List<Aggregate.Measure> measures = measuresFn.apply(input);
     return Aggregate.builder()
         .groupings(groupings)
         .measures(measures)
@@ -854,23 +898,63 @@ public class SubstraitBuilder {
   }
 
   /**
+   * Create i16 literal.
+   *
+   * @param value value to create
+   * @return i16 instance
+   */
+  public Expression.I8Literal i8(final int value) {
+    return Expression.I8Literal.builder().value(value).build();
+  }
+
+  /**
+   * Create i16 literal.
+   *
+   * @param value value to create
+   * @return i16 instance
+   */
+  public Expression.I16Literal i16(final int value) {
+    return Expression.I16Literal.builder().value(value).build();
+  }
+
+  /**
    * Creates a 32-bit integer literal expression.
    *
-   * @param v the integer value
+   * @param value the integer value
    * @return a new {@link Expression.I32Literal}
    */
-  public Expression.I32Literal i32(int v) {
-    return Expression.I32Literal.builder().value(v).build();
+  public Expression.I32Literal i32(final int value) {
+    return Expression.I32Literal.builder().value(value).build();
+  }
+
+  /**
+   * Creates a 64-bit integer literal expression.
+   *
+   * @param value value to create
+   * @return i64 instance
+   */
+  public Expression.I64Literal i64(final long value) {
+    return Expression.I64Literal.builder().value(value).build();
+  }
+
+  /**
+   * Creates a 32-bit floating point literal expression.
+   *
+   * @param value the float value
+   * @return a new {@link Expression.FP32Literal}
+   */
+  public Expression.FP32Literal fp32(final float value) {
+    return Expression.FP32Literal.builder().value(value).build();
   }
 
   /**
    * Creates a 64-bit floating point literal expression.
    *
-   * @param v the double value
+   * @param value the double value
    * @return a new {@link Expression.FP64Literal}
    */
-  public Expression.FP64Literal fp64(double v) {
-    return Expression.FP64Literal.builder().value(v).build();
+  public Expression.FP64Literal fp64(final double value) {
+    return Expression.FP64Literal.builder().value(value).build();
   }
 
   /**
@@ -1440,6 +1524,79 @@ public class SubstraitBuilder {
   }
 
   /**
+   * Creates a logical NOT expression that negates a boolean expression.
+   *
+   * <p>This is a convenience method that wraps the boolean NOT function from the Substrait standard
+   * library. The result is nullable to handle NULL input values according to three-valued logic.
+   *
+   * @param expression the boolean expression to negate
+   * @return a scalar function invocation representing the logical NOT of the input expression
+   */
+  public Expression not(final Expression expression) {
+    return this.scalarFn(
+        DefaultExtensionCatalog.FUNCTIONS_BOOLEAN,
+        "not:bool",
+        TypeCreator.NULLABLE.BOOLEAN,
+        expression);
+  }
+
+  /**
+   * Creates a null-check expression that tests whether an expression is null.
+   *
+   * <p>This is a convenience method that wraps the is_null function from the Substrait comparison
+   * function library. The function evaluates the input expression and returns true if it is null,
+   * false otherwise. This is commonly used in conditional logic and filtering operations.
+   *
+   * <p>The return type is always a required (non-nullable) boolean, as the null check itself always
+   * produces a definite true/false result.
+   *
+   * @param expression the expression to test for null
+   * @return a scalar function invocation that returns true if the expression is null, false
+   *     otherwise
+   */
+  public Expression isNull(final Expression expression) {
+
+    final List<Expression> args = new ArrayList<>();
+    args.add(expression);
+
+    return this.scalarFn(
+        DefaultExtensionCatalog.FUNCTIONS_COMPARISON,
+        "is_null:any",
+        TypeCreator.REQUIRED.BOOLEAN,
+        args,
+        new ArrayList<FunctionOption>());
+  }
+
+  /**
+   * Creates a scalar function invocation with function options.
+   *
+   * <p>This method extends the base builder's functionality by supporting function options, which
+   * control function behavior (e.g., rounding modes, overflow handling).
+   *
+   * @param urn the extension URI (e.g., {@link DefaultExtensionCatalog#FUNCTIONS_STRING})
+   * @param key the function signature (e.g., "substring:str_i32_i32")
+   * @param returnType the return type of the function
+   * @param args the function arguments
+   * @param optionsList the function options controlling behavior
+   * @return a scalar function invocation expression
+   */
+  public Expression scalarFn(
+      final String urn,
+      final String key,
+      final Type returnType,
+      final List<? extends FunctionArg> args,
+      final List<FunctionOption> optionsList) {
+    final SimpleExtension.ScalarFunctionVariant declaration =
+        extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+    return Expression.ScalarFunctionInvocation.builder()
+        .declaration(declaration)
+        .options(optionsList)
+        .outputType(returnType)
+        .arguments(args)
+        .build();
+  }
+
+  /**
    * Creates a scalar function invocation with specified arguments.
    *
    * @param urn the URN of the extension containing the function
@@ -1456,6 +1613,29 @@ public class SubstraitBuilder {
         .declaration(declaration)
         .outputType(outputType)
         .arguments(Arrays.stream(args).collect(java.util.stream.Collectors.toList()))
+        .build();
+  }
+
+  /**
+   * Creates a scalar function invocation with function options.
+   *
+   * @param urn the extension URI (e.g., {@link DefaultExtensionCatalog#FUNCTIONS_STRING})
+   * @param key the function signature (e.g., "substring:str_i32_i32")
+   * @param returnType the return type of the function
+   * @param args the function arguments
+   * @return a scalar function invocation expression
+   */
+  public Expression scalarFn(
+      final String urn,
+      final String key,
+      final Type returnType,
+      final List<? extends FunctionArg> args) {
+    final SimpleExtension.ScalarFunctionVariant declaration =
+        extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+    return Expression.ScalarFunctionInvocation.builder()
+        .declaration(declaration)
+        .outputType(returnType)
+        .arguments(args)
         .build();
   }
 
@@ -1547,6 +1727,22 @@ public class SubstraitBuilder {
    */
   public Plan plan(Plan.Root root) {
     return Plan.builder().addRoots(root).build();
+  }
+
+  /**
+   * Creates a Plan.Root, which is the top-level container for a Substrait query plan.
+   *
+   * <p>The {@link Plan} wraps a relational expression tree and associates output column names with
+   * the plan. This is the final step in building a complete Substrait plan that can be serialized
+   * and executed by a Substrait consumer.
+   *
+   * @param input the root relational expression of the query plan
+   * @param names the ordered list of output column names corresponding to the input relation's
+   *     output schema
+   * @return a new {@link Plan}
+   */
+  public Plan.Root root(final Rel input, final List<String> names) {
+    return Plan.Root.builder().input(input).names(names).build();
   }
 
   /**

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -873,7 +873,7 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Create i8 literal.
+   * Creates an 8-bit integer literal expression.
    *
    * @param v value to create
    * @return i8 instance

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -868,7 +868,7 @@ public class SubstraitBuilder {
   /**
    * Creates a boolean literal expression.
    *
-   * @param v the boolean value
+   * @param v the boolean v
    * @return a new {@link Expression.BoolLiteral}
    */
   public Expression.BoolLiteral bool(boolean v) {
@@ -876,29 +876,29 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Create i16 literal.
+   * Create i8 literal.
    *
-   * @param value value to create
-   * @return i16 instance
+   * @param v v to create
+   * @return i8 instance
    */
-  public Expression.I8Literal i8(int value) {
-    return Expression.I8Literal.builder().value(value).build();
+  public Expression.I8Literal i8(int v) {
+    return Expression.I8Literal.builder().value(v).build();
   }
 
   /**
    * Create i16 literal.
    *
-   * @param value value to create
+   * @param v v to create
    * @return i16 instance
    */
-  public Expression.I16Literal i16(int value) {
-    return Expression.I16Literal.builder().value(value).build();
+  public Expression.I16Literal i16(int v) {
+    return Expression.I16Literal.builder().value(v).build();
   }
 
   /**
    * Creates a 32-bit integer literal expression.
    *
-   * @param v the integer value
+   * @param v the integer v
    * @return a new {@link Expression.I32Literal}
    */
   public Expression.I32Literal i32(int v) {
@@ -908,27 +908,27 @@ public class SubstraitBuilder {
   /**
    * Creates a 64-bit integer literal expression.
    *
-   * @param value value to create
+   * @param v v to create
    * @return i64 instance
    */
-  public Expression.I64Literal i64(long value) {
-    return Expression.I64Literal.builder().value(value).build();
+  public Expression.I64Literal i64(long v) {
+    return Expression.I64Literal.builder().value(v).build();
   }
 
   /**
    * Creates a 32-bit floating point literal expression.
    *
-   * @param value the float value
+   * @param v the float v
    * @return a new {@link Expression.FP32Literal}
    */
-  public Expression.FP32Literal fp32(float value) {
-    return Expression.FP32Literal.builder().value(value).build();
+  public Expression.FP32Literal fp32(float v) {
+    return Expression.FP32Literal.builder().value(v).build();
   }
 
   /**
    * Creates a 64-bit floating point literal expression.
    *
-   * @param v the double value
+   * @param v the double v
    * @return a new {@link Expression.FP64Literal}
    */
   public Expression.FP64Literal fp64(double v) {
@@ -938,7 +938,7 @@ public class SubstraitBuilder {
   /**
    * Creates a string literal expression.
    *
-   * @param s the string value
+   * @param s the string v
    * @return a new {@link Expression.StrLiteral}
    */
   public Expression.StrLiteral str(String s) {
@@ -1070,7 +1070,7 @@ public class SubstraitBuilder {
    * options.
    *
    * @param condition the expression to match against
-   * @param options the list of possible values to match
+   * @param options the list of possible vs to match
    * @return a new {@link SingleOrList} expression
    */
   public Expression singleOrList(Expression condition, Expression... options) {
@@ -1078,11 +1078,10 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates an IN predicate expression that checks if any needle values exist in the haystack
-   * relation.
+   * Creates an IN predicate expression that checks if any needle vs exist in the haystack relation.
    *
    * @param haystack the relation to search within
-   * @param needles the values to search for
+   * @param needles the vs to search for
    * @return a new {@link Expression.InPredicate}
    */
   public Expression.InPredicate inPredicate(Rel haystack, Expression... needles) {
@@ -1125,7 +1124,7 @@ public class SubstraitBuilder {
   /**
    * Creates a switch clause that pairs a literal condition with a result expression.
    *
-   * @param condition the literal value to match against
+   * @param condition the literal v to match against
    * @param then the expression to return if the condition matches
    * @return a new {@link SwitchClause}
    */
@@ -1134,7 +1133,7 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates a switch expression that matches a value against multiple cases.
+   * Creates a switch expression that matches a v against multiple cases.
    *
    * @param match the expression to match against
    * @param clauses the list of switch clauses to evaluate
@@ -1241,7 +1240,7 @@ public class SubstraitBuilder {
    * Creates a MIN aggregate measure for a specific field.
    *
    * @param input the input relation
-   * @param field the zero-based index of the field to find the minimum value
+   * @param field the zero-based index of the field to find the minimum v
    * @return a new {@link Aggregate.Measure} representing MIN
    */
   public Aggregate.Measure min(Rel input, int field) {
@@ -1251,7 +1250,7 @@ public class SubstraitBuilder {
   /**
    * Creates a MIN aggregate measure for an expression.
    *
-   * @param expr the expression to find the minimum value
+   * @param expr the expression to find the minimum v
    * @return a new {@link Aggregate.Measure} representing MIN
    */
   public Aggregate.Measure min(Expression expr) {
@@ -1266,7 +1265,7 @@ public class SubstraitBuilder {
    * Creates a MAX aggregate measure for a specific field.
    *
    * @param input the input relation
-   * @param field the zero-based index of the field to find the maximum value
+   * @param field the zero-based index of the field to find the maximum v
    * @return a new {@link Aggregate.Measure} representing MAX
    */
   public Aggregate.Measure max(Rel input, int field) {
@@ -1276,7 +1275,7 @@ public class SubstraitBuilder {
   /**
    * Creates a MAX aggregate measure for an expression.
    *
-   * @param expr the expression to find the maximum value
+   * @param expr the expression to find the maximum v
    * @return a new {@link Aggregate.Measure} representing MAX
    */
   public Aggregate.Measure max(Expression expr) {
@@ -1505,17 +1504,16 @@ public class SubstraitBuilder {
    * Creates a logical NOT expression that negates a boolean expression.
    *
    * <p>This is a convenience method that wraps the boolean NOT function from the Substrait standard
-   * library. The result is nullable to handle NULL input values according to three-valued logic.
+   * library. The result is nullable to handle NULL input vs according to three-vd logic.
    *
    * @param expression the boolean expression to negate
    * @return a scalar function invocation representing the logical NOT of the input expression
    */
-  public Expression not(Expression expression) {
+  public Expression.ScalarFunctionInvocation not(Expression expression) {
+    Type outputType = expression.getType().nullable() ? N.BOOLEAN : R.BOOLEAN;
+
     return this.scalarFn(
-        DefaultExtensionCatalog.FUNCTIONS_BOOLEAN,
-        "not:bool",
-        TypeCreator.NULLABLE.BOOLEAN,
-        expression);
+        DefaultExtensionCatalog.FUNCTIONS_BOOLEAN, "not:bool", outputType, expression);
   }
 
   /**
@@ -1534,14 +1532,11 @@ public class SubstraitBuilder {
    */
   public Expression isNull(Expression expression) {
 
-    final List<Expression> args = new ArrayList<>();
-    args.add(expression);
-
     return this.scalarFn(
         DefaultExtensionCatalog.FUNCTIONS_COMPARISON,
         "is_null:any",
         TypeCreator.REQUIRED.BOOLEAN,
-        args,
+        Collections.singletonList(expression),
         new ArrayList<FunctionOption>());
   }
 
@@ -1558,7 +1553,7 @@ public class SubstraitBuilder {
    * @param optionsList the function options controlling behavior
    * @return a scalar function invocation expression
    */
-  public Expression scalarFn(
+  public Expression.ScalarFunctionInvocation scalarFn(
       String urn,
       String key,
       Type returnType,
@@ -1591,26 +1586,6 @@ public class SubstraitBuilder {
         .declaration(declaration)
         .outputType(outputType)
         .arguments(Arrays.stream(args).collect(java.util.stream.Collectors.toList()))
-        .build();
-  }
-
-  /**
-   * Creates a scalar function invocation with function options.
-   *
-   * @param urn the extension URI (e.g., {@link DefaultExtensionCatalog#FUNCTIONS_STRING})
-   * @param key the function signature (e.g., "substring:str_i32_i32")
-   * @param returnType the return type of the function
-   * @param args the function arguments
-   * @return a scalar function invocation expression
-   */
-  public Expression scalarFn(
-      String urn, String key, Type returnType, List<? extends FunctionArg> args) {
-    SimpleExtension.ScalarFunctionVariant declaration =
-        extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
-    return Expression.ScalarFunctionInvocation.builder()
-        .declaration(declaration)
-        .outputType(returnType)
-        .arguments(args)
         .build();
   }
 
@@ -1698,7 +1673,7 @@ public class SubstraitBuilder {
    * Creates a plan from a plan root.
    *
    * @param root the plan root
-   * @return a new {@link Plan}
+   * @return a new {@link Plan.Root}
    */
   public Plan plan(Plan.Root root) {
     return Plan.builder().addRoots(root).build();
@@ -1731,10 +1706,10 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates a scalar subquery expression that returns a single value from a relation.
+   * Creates a scalar subquery expression that returns a single v from a relation.
    *
    * @param input the input relation that must return exactly one row and one column
-   * @param type the type of the scalar value
+   * @param type the type of the scalar v
    * @return a new {@link Expression.ScalarSubquery}
    */
   public Expression scalarSubquery(Rel input, Type type) {

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -153,16 +153,13 @@ public class SubstraitBuilder {
    * while the measure function defines the aggregate computations (e.g., SUM, COUNT, AVG) to
    * perform on each group.
    *
-   * <p>The optional remap parameter allows reordering or filtering of output columns, which is
-   * useful for controlling the final schema of the aggregate result.
-   *
    * @param groupingsFn a function that takes the input relation and returns a list of grouping
    *     expressions defining how to partition the data
    * @param measuresFn a function that takes the input relation and returns a list of aggregate
    *     measures to compute for each group
    * @param remap an optional remapping specification to reorder or filter output columns
    * @param input the input relation to aggregate
-   * @return an Aggregate relation representing the grouping and aggregation operation
+   * @return an {@link Aggregate} relation representing the grouping and aggregation operation
    */
   public Aggregate aggregate(
       Function<Rel, List<Aggregate.Grouping>> groupingsFn,
@@ -868,7 +865,7 @@ public class SubstraitBuilder {
   /**
    * Creates a boolean literal expression.
    *
-   * @param v the boolean v
+   * @param v the boolean value
    * @return a new {@link Expression.BoolLiteral}
    */
   public Expression.BoolLiteral bool(boolean v) {
@@ -878,7 +875,7 @@ public class SubstraitBuilder {
   /**
    * Create i8 literal.
    *
-   * @param v v to create
+   * @param v value to create
    * @return i8 instance
    */
   public Expression.I8Literal i8(int v) {
@@ -888,7 +885,7 @@ public class SubstraitBuilder {
   /**
    * Create i16 literal.
    *
-   * @param v v to create
+   * @param v value to create
    * @return i16 instance
    */
   public Expression.I16Literal i16(int v) {
@@ -898,7 +895,7 @@ public class SubstraitBuilder {
   /**
    * Creates a 32-bit integer literal expression.
    *
-   * @param v the integer v
+   * @param v the integer value
    * @return a new {@link Expression.I32Literal}
    */
   public Expression.I32Literal i32(int v) {
@@ -908,7 +905,7 @@ public class SubstraitBuilder {
   /**
    * Creates a 64-bit integer literal expression.
    *
-   * @param v v to create
+   * @param v value to create
    * @return i64 instance
    */
   public Expression.I64Literal i64(long v) {
@@ -918,7 +915,7 @@ public class SubstraitBuilder {
   /**
    * Creates a 32-bit floating point literal expression.
    *
-   * @param v the float v
+   * @param v the float value
    * @return a new {@link Expression.FP32Literal}
    */
   public Expression.FP32Literal fp32(float v) {
@@ -928,7 +925,7 @@ public class SubstraitBuilder {
   /**
    * Creates a 64-bit floating point literal expression.
    *
-   * @param v the double v
+   * @param v the double value
    * @return a new {@link Expression.FP64Literal}
    */
   public Expression.FP64Literal fp64(double v) {
@@ -938,7 +935,7 @@ public class SubstraitBuilder {
   /**
    * Creates a string literal expression.
    *
-   * @param s the string v
+   * @param s the string value
    * @return a new {@link Expression.StrLiteral}
    */
   public Expression.StrLiteral str(String s) {
@@ -1124,7 +1121,7 @@ public class SubstraitBuilder {
   /**
    * Creates a switch clause that pairs a literal condition with a result expression.
    *
-   * @param condition the literal v to match against
+   * @param condition the literal value to match against
    * @param then the expression to return if the condition matches
    * @return a new {@link SwitchClause}
    */
@@ -1133,7 +1130,7 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates a switch expression that matches a v against multiple cases.
+   * Creates a switch expression that matches a value against multiple cases.
    *
    * @param match the expression to match against
    * @param clauses the list of switch clauses to evaluate
@@ -1240,7 +1237,7 @@ public class SubstraitBuilder {
    * Creates a MIN aggregate measure for a specific field.
    *
    * @param input the input relation
-   * @param field the zero-based index of the field to find the minimum v
+   * @param field the zero-based index of the field to find the minimum value
    * @return a new {@link Aggregate.Measure} representing MIN
    */
   public Aggregate.Measure min(Rel input, int field) {
@@ -1250,7 +1247,7 @@ public class SubstraitBuilder {
   /**
    * Creates a MIN aggregate measure for an expression.
    *
-   * @param expr the expression to find the minimum v
+   * @param expr the expression to find the minimum value
    * @return a new {@link Aggregate.Measure} representing MIN
    */
   public Aggregate.Measure min(Expression expr) {
@@ -1265,7 +1262,7 @@ public class SubstraitBuilder {
    * Creates a MAX aggregate measure for a specific field.
    *
    * @param input the input relation
-   * @param field the zero-based index of the field to find the maximum v
+   * @param field the zero-based index of the field to find the maximum value
    * @return a new {@link Aggregate.Measure} representing MAX
    */
   public Aggregate.Measure max(Rel input, int field) {
@@ -1275,7 +1272,7 @@ public class SubstraitBuilder {
   /**
    * Creates a MAX aggregate measure for an expression.
    *
-   * @param expr the expression to find the maximum v
+   * @param expr the expression to find the maximum value
    * @return a new {@link Aggregate.Measure} representing MAX
    */
   public Aggregate.Measure max(Expression expr) {
@@ -1519,10 +1516,6 @@ public class SubstraitBuilder {
   /**
    * Creates a null-check expression that tests whether an expression is null.
    *
-   * <p>This is a convenience method that wraps the is_null function from the Substrait comparison
-   * function library. The function evaluates the input expression and returns true if it is null,
-   * false otherwise. This is commonly used in conditional logic and filtering operations.
-   *
    * <p>The return type is always a required (non-nullable) boolean, as the null check itself always
    * produces a definite true/false result.
    *
@@ -1706,10 +1699,10 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates a scalar subquery expression that returns a single v from a relation.
+   * Creates a scalar subquery expression that returns a single value from a relation.
    *
    * @param input the input relation that must return exactly one row and one column
-   * @param type the type of the scalar v
+   * @param type the type of the scalar value
    * @return a new {@link Expression.ScalarSubquery}
    */
   public Expression scalarSubquery(Rel input, Type type) {

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -1075,7 +1075,8 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates an IN predicate expression that checks if any needle values exist in the haystack relation.
+   * Creates an IN predicate expression that checks if any needle values exist in the haystack
+   * relation.
    *
    * @param haystack the relation to search within
    * @param needles the values to search for
@@ -1666,7 +1667,7 @@ public class SubstraitBuilder {
    * Creates a plan from a plan root.
    *
    * @param root the plan root
-   * @return a new {@link Plan.Root}
+   * @return a new {@link Plan}
    */
   public Plan plan(Plan.Root root) {
     return Plan.builder().addRoots(root).build();
@@ -1682,7 +1683,7 @@ public class SubstraitBuilder {
    * @param input the root relational expression of the query plan
    * @param names the ordered list of output column names corresponding to the input relation's
    *     output schema
-   * @return a new {@link Plan}
+   * @return a new {@link Plan.Root}
    */
   public Plan.Root root(final Rel input, final List<String> names) {
     return Plan.Root.builder().input(input).names(names).build();

--- a/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
+++ b/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
@@ -1,0 +1,265 @@
+package io.substrait.dsl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.TestBase;
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FieldReference;
+import io.substrait.extension.SimpleExtension;
+import io.substrait.plan.Plan;
+import io.substrait.relation.AbstractWriteRel;
+import io.substrait.relation.Aggregate;
+import io.substrait.relation.Cross;
+import io.substrait.relation.Fetch;
+import io.substrait.relation.Filter;
+import io.substrait.relation.Join;
+import io.substrait.relation.NamedScan;
+import io.substrait.relation.NamedWrite;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel.Remap;
+import io.substrait.relation.Sort;
+import io.substrait.type.Type;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SubstraitBuilderTest extends TestBase {
+
+  private SubstraitBuilder builder;
+
+  @BeforeEach
+  void newbuilder() {
+    this.builder = new SubstraitBuilder();
+  }
+
+  @Test
+  void basicCreation() {
+    assertNotNull(this.builder);
+    assertInstanceOf(SimpleExtension.ExtensionCollection.class, this.builder.getExtensions());
+  }
+
+  @Nested
+  @DisplayName("Literal and Expression Tests")
+  class ExpressionTests {
+
+    @Test
+    void testLiterals() {
+      assertEquals(true, builder.bool(true).value());
+      assertEquals(10, builder.i8(10).value());
+      assertEquals(100, builder.i16(100).value());
+      assertEquals(1000, builder.i32(1000).value());
+      assertEquals(10_000L, builder.i64(10_000L).value());
+      assertEquals(1.5f, builder.fp32(1.5f).value());
+      assertEquals(2.5, builder.fp64(2.5).value());
+      assertEquals("foo", builder.str("foo").value());
+    }
+
+    @Test
+    void testFieldReferences() {
+      final NamedScan scan = createSimpleScan();
+      final FieldReference ref = builder.fieldReference(scan, 0);
+      assertNotNull(ref);
+
+      final List<FieldReference> refs = builder.fieldReferences(scan, 0, 1);
+      assertEquals(2, refs.size());
+    }
+
+    @Test
+    void testCast() {
+      final Expression.I32Literal input = builder.i32(1);
+      final Expression cast = builder.cast(input, R.I64);
+      assertNotNull(cast);
+      assertTrue(cast instanceof Expression.Cast);
+    }
+  }
+
+  @Nested
+  @DisplayName("Relation Building Tests")
+  class RelationTests {
+
+    @Test
+    void testNamedScan() {
+      final NamedScan scan =
+          builder.namedScan(List.of("table"), List.of("c1", "c2"), List.of(R.I32, R.STRING));
+      assertNotNull(scan);
+      assertEquals(List.of("table"), scan.getNames());
+    }
+
+    @Test
+    void testProject() {
+      final NamedScan scan = createSimpleScan();
+      final Project project =
+          builder.project(rel -> List.of(builder.i32(1), builder.fieldReference(rel, 0)), scan);
+      assertNotNull(project);
+      assertEquals(scan, project.getInput());
+    }
+
+    @Test
+    void testFilter() {
+      final NamedScan scan = createSimpleScan();
+      final Filter filter =
+          builder.filter(
+              rel -> builder.equal(builder.fieldReference(rel, 0), builder.i32(10)), scan);
+      assertNotNull(filter);
+      assertNotNull(filter.getCondition());
+    }
+
+    @Test
+    void testInnerJoin() {
+      final NamedScan left = createSimpleScan();
+      final NamedScan right = createSimpleScan();
+      final Join join =
+          builder.innerJoin(
+              inputs ->
+                  builder.equal(
+                      builder.fieldReference(inputs.left(), 0),
+                      builder.fieldReference(inputs.right(), 0)),
+              left,
+              right);
+      assertNotNull(join);
+      assertEquals(Join.JoinType.INNER, join.getJoinType());
+    }
+
+    @Test
+    void testFetchAndLimit() {
+      final NamedScan scan = createSimpleScan();
+      Fetch limit = builder.limit(10, scan);
+      assertEquals(10, limit.getCount().getAsLong());
+      assertEquals(0, limit.getOffset());
+      limit = builder.limit(10, Remap.of(Arrays.asList(new Integer[] {0, 1})), scan);
+      assertNotNull(limit);
+
+      Fetch offset = builder.offset(5, scan);
+      assertEquals(5, offset.getOffset());
+
+      offset = builder.offset(5, Remap.of(Arrays.asList(new Integer[] {0, 1})), scan);
+      assertEquals(5, offset.getOffset());
+    }
+
+    @Test
+    void testSort() {
+      final NamedScan scan = createSimpleScan();
+      Sort sort = builder.sort(rel -> builder.sortFields(rel, 0), scan);
+      assertNotNull(sort);
+      sort =
+          builder.sort(
+              rel -> builder.sortFields(rel, 0),
+              Remap.of(Arrays.asList(new Integer[] {0, 1})),
+              scan);
+      assertNotNull(sort);
+    }
+
+    @Test
+    void testCross() {
+      final NamedScan left = createSimpleScan();
+      final NamedScan right = createSimpleScan();
+
+      Cross cross = builder.cross(left, right);
+      assertNotNull(cross);
+
+      cross = builder.cross(left, right, Remap.of(Arrays.asList(new Integer[] {0, 1})));
+      assertNotNull(cross);
+    }
+
+    @Test
+    void testFetch() {
+      final NamedScan left = createSimpleScan();
+      Fetch fetch = builder.fetch(0, 1, left);
+      assertNotNull(fetch);
+
+      fetch = builder.fetch(0, 1, Remap.of(Arrays.asList(new Integer[] {0, 1})), left);
+      assertNotNull(fetch);
+    }
+  }
+
+  @Nested
+  @DisplayName("Aggregate and Scalar Function Tests")
+  class FunctionTests {
+
+    @Test
+    void testAggregateMeasures() {
+      final NamedScan scan = createSimpleScan();
+      final Aggregate.Measure count = builder.count(scan, 0);
+      final Aggregate.Measure sum = builder.sum(builder.fieldReference(scan, 0));
+
+      assertNotNull(count);
+      assertNotNull(sum);
+
+      final Aggregate.Grouping grouping = builder.grouping(scan, 1);
+      assertNotNull(grouping);
+      assertEquals(1, grouping.getExpressions().size());
+
+      final AggregateFunctionInvocation afi1 =
+          builder.aggregateFn(
+              "extension:io.substrait:functions_aggregate_generic",
+              "count:any",
+              Type.I32.builder().nullable(false).build(),
+              builder.fieldReference(scan, 0));
+      assertNotNull(afi1);
+    }
+
+    @Test
+    void testArithmeticFunctions() {
+      final Expression left = builder.i32(10);
+      final Expression right = builder.i32(20);
+
+      assertNotNull(builder.add(left, right));
+      assertNotNull(builder.subtract(left, right));
+      assertNotNull(builder.multiply(left, right));
+      assertNotNull(builder.divide(left, right));
+      assertNotNull(builder.negate(left));
+    }
+
+    @Test
+    void testBooleanLogic() {
+      final Expression b1 = builder.bool(true);
+      final Expression b2 = builder.bool(false);
+
+      assertNotNull(builder.and(b1, b2));
+      assertNotNull(builder.or(b1, b2));
+      assertNotNull(builder.not(b1));
+      assertNotNull(builder.isNull(b1));
+    }
+  }
+
+  @Nested
+  @DisplayName("Write and Plan Tests")
+  class PlanTests {
+
+    @Test
+    void testNamedWrite() {
+      final NamedScan scan = createSimpleScan();
+      final NamedWrite write =
+          builder.namedWrite(
+              List.of("target_table"),
+              List.of("c1", "c2"),
+              AbstractWriteRel.WriteOp.INSERT,
+              AbstractWriteRel.CreateMode.APPEND_IF_EXISTS,
+              AbstractWriteRel.OutputMode.MODIFIED_RECORDS,
+              scan);
+      assertNotNull(write);
+    }
+
+    @Test
+    void testPlanCreation() {
+      final NamedScan scan = createSimpleScan();
+      final Plan.Root root = builder.root(scan, List.of("out1", "out2"));
+      final Plan plan = builder.plan(root);
+
+      assertNotNull(plan);
+      assertEquals(1, plan.getRoots().size());
+    }
+  }
+
+  // Helper method to create a base relation for testing
+  private NamedScan createSimpleScan() {
+    return builder.namedScan(List.of("t"), List.of("a", "b"), List.of(R.I32, R.STRING));
+  }
+}

--- a/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
+++ b/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
@@ -74,6 +74,11 @@ class SubstraitBuilderTest extends TestBase {
     void testCast() {
       final Expression.I32Literal input = builder.i32(1);
       assertEquals(R.I32, input.getType());
+      
+      final Expression cast = builder.cast(input, R.I64);
+      assertEquals(R.I64, cast.getType());
+      assertInstanceOf(Expression.Cast.class, cast);
+      assertEquals(input, ((Expression.Cast) cast).input());
     }
   }
 

--- a/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
+++ b/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
@@ -74,7 +74,7 @@ class SubstraitBuilderTest extends TestBase {
     void testCast() {
       final Expression.I32Literal input = builder.i32(1);
       assertEquals(R.I32, input.getType());
-      
+
       final Expression cast = builder.cast(input, R.I64);
       assertEquals(R.I64, cast.getType());
       assertInstanceOf(Expression.Cast.class, cast);

--- a/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
+++ b/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
@@ -3,12 +3,12 @@ package io.substrait.dsl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.TestBase;
 import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.FieldReference;
+import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.Plan;
 import io.substrait.relation.AbstractWriteRel;
@@ -23,7 +23,6 @@ import io.substrait.relation.Project;
 import io.substrait.relation.Rel.Remap;
 import io.substrait.relation.Sort;
 import io.substrait.type.Type;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -74,9 +73,7 @@ class SubstraitBuilderTest extends TestBase {
     @Test
     void testCast() {
       final Expression.I32Literal input = builder.i32(1);
-      final Expression cast = builder.cast(input, R.I64);
-      assertNotNull(cast);
-      assertTrue(cast instanceof Expression.Cast);
+      assertEquals(R.I32, input.getType());
     }
   }
 
@@ -133,13 +130,13 @@ class SubstraitBuilderTest extends TestBase {
       Fetch limit = builder.limit(10, scan);
       assertEquals(10, limit.getCount().getAsLong());
       assertEquals(0, limit.getOffset());
-      limit = builder.limit(10, Remap.of(Arrays.asList(new Integer[] {0, 1})), scan);
+      limit = builder.limit(10, Remap.of(List.of(0, 1)), scan);
       assertNotNull(limit);
 
       Fetch offset = builder.offset(5, scan);
       assertEquals(5, offset.getOffset());
 
-      offset = builder.offset(5, Remap.of(Arrays.asList(new Integer[] {0, 1})), scan);
+      offset = builder.offset(5, Remap.of(List.of(0, 1)), scan);
       assertEquals(5, offset.getOffset());
     }
 
@@ -148,11 +145,7 @@ class SubstraitBuilderTest extends TestBase {
       final NamedScan scan = createSimpleScan();
       Sort sort = builder.sort(rel -> builder.sortFields(rel, 0), scan);
       assertNotNull(sort);
-      sort =
-          builder.sort(
-              rel -> builder.sortFields(rel, 0),
-              Remap.of(Arrays.asList(new Integer[] {0, 1})),
-              scan);
+      sort = builder.sort(rel -> builder.sortFields(rel, 0), Remap.of(List.of(0, 1)), scan);
       assertNotNull(sort);
     }
 
@@ -164,7 +157,7 @@ class SubstraitBuilderTest extends TestBase {
       Cross cross = builder.cross(left, right);
       assertNotNull(cross);
 
-      cross = builder.cross(left, right, Remap.of(Arrays.asList(new Integer[] {0, 1})));
+      cross = builder.cross(left, right, Remap.of(List.of(0, 1)));
       assertNotNull(cross);
     }
 
@@ -174,7 +167,7 @@ class SubstraitBuilderTest extends TestBase {
       Fetch fetch = builder.fetch(0, 1, left);
       assertNotNull(fetch);
 
-      fetch = builder.fetch(0, 1, Remap.of(Arrays.asList(new Integer[] {0, 1})), left);
+      fetch = builder.fetch(0, 1, Remap.of(List.of(0, 1)), left);
       assertNotNull(fetch);
     }
   }
@@ -198,7 +191,7 @@ class SubstraitBuilderTest extends TestBase {
 
       final AggregateFunctionInvocation afi1 =
           builder.aggregateFn(
-              "extension:io.substrait:functions_aggregate_generic",
+              DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC,
               "count:any",
               Type.I32.builder().nullable(false).build(),
               builder.fieldReference(scan, 0));

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -6,6 +6,7 @@ import io.substrait.relation.Rel;
 import io.substrait.relation.Set.SetOp;
 import io.substrait.type.Type;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.calcite.rel.RelNode;
@@ -42,9 +43,9 @@ class SubstraitRelNodeConverterTest extends PlanTestBase {
       Plan.Root root =
           sb.root(
               sb.aggregate(
-                  input -> sb.grouping(input, 0, 2),
+                  input -> List.of(sb.grouping(input, 0, 2)),
                   input -> List.of(sb.count(input, 0)),
-                  sb.remap(1, 2),
+                  Optional.of(sb.remap(1, 2)),
                   commonTable));
 
       RelNode relNode = substraitToCalcite.convert(root.getInput());


### PR DESCRIPTION
Follow on to pr #767 to fill some missing gaps in the substrait builder. We've recently used the Substrait Builder and found that there some variants and missing gaps in the APIs.  We'd subclassed it to add these, so I'm now wanting to push these to the main codebase. 

There wasn't a unit test already so I've added a basic one here - which I appreciate will is quite large.
