### PR TITLE
build: add workaround for VS Code detection of immutables classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,11 @@ gen
 *.iml
 out/**
 *.iws
-.vscode
 .pmdCache
 
-*/bin
+# VS Code ignores
+.vscode
+bin
 .metals
 .bloop
 .project

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   id("java-library")
   id("idea")
   id("antlr")
+  id("eclipse")
   alias(libs.plugins.protobuf)
   alias(libs.plugins.spotless)
   alias(libs.plugins.shadow)
@@ -387,4 +388,22 @@ tasks.named<Jar>("javadocJar") {
 
   // Handle duplicate files (e.g., allclasses-index.html) from multiple javadoc tasks
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// workaround for Eclipse/VS Code bug handling annotationProcessor sources
+// https://github.com/redhat-developer/vscode-java/issues/2981
+eclipse {
+  classpath {
+    containers("org.eclipse.buildship.core.gradleclasspathcontainer")
+    file.whenMerged {
+      if (this is org.gradle.plugins.ide.eclipse.model.Classpath) {
+        entries.add(
+          org.gradle.plugins.ide.eclipse.model.SourceFolder(
+            "build/generated/sources/annotationProcessor/java/main",
+            null,
+          )
+        )
+      }
+    }
+  }
 }

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -2,6 +2,7 @@ import java.nio.charset.StandardCharsets
 
 plugins {
   id("idea")
+  id("eclipse")
   id("application")
   alias(libs.plugins.graal)
   alias(libs.plugins.spotless)
@@ -103,4 +104,22 @@ tasks.named<Javadoc>("javadoc") {
 
   val isthmusVersionClass = layout.buildDirectory.file("generated/sources").get().getAsFile()
   exclude { spec -> spec.file.toPath().startsWith(isthmusVersionClass.toPath()) }
+}
+
+// workaround for Eclipse/VS Code bug handling annotationProcessor sources
+// https://github.com/redhat-developer/vscode-java/issues/2981
+eclipse {
+  classpath {
+    containers("org.eclipse.buildship.core.gradleclasspathcontainer")
+    file.whenMerged {
+      if (this is org.gradle.plugins.ide.eclipse.model.Classpath) {
+        entries.add(
+          org.gradle.plugins.ide.eclipse.model.SourceFolder(
+            "build/generated/sources/annotationProcessor/java/main",
+            null,
+          )
+        )
+      }
+    }
+  }
 }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   signing
   id("java-library")
   id("idea")
+  id("eclipse")
   alias(libs.plugins.shadow)
   alias(libs.plugins.spotless)
   alias(libs.plugins.protobuf)
@@ -174,4 +175,22 @@ tasks.named<Jar>("javadocJar") {
   // Ensure javadoc tasks have produced output
   // Handle duplicate files (e.g., allclasses-index.html) from multiple javadoc tasks
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// workaround for Eclipse/VS Code bug handling annotationProcessor sources
+// https://github.com/redhat-developer/vscode-java/issues/2981
+eclipse {
+  classpath {
+    containers("org.eclipse.buildship.core.gradleclasspathcontainer")
+    file.whenMerged {
+      if (this is org.gradle.plugins.ide.eclipse.model.Classpath) {
+        entries.add(
+          org.gradle.plugins.ide.eclipse.model.SourceFolder(
+            "build/generated/sources/annotationProcessor/java/main",
+            null,
+          )
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
If you are a user of a VS Code based IDE then you may have been noticing that the IDE started having trouble recognizing the immutables generated classes. This is a known issue with VS Code / Eclipse and one workaround is to add additional Gradle configuration using the Eclipse plugin: https://github.com/redhat-developer/vscode-java/issues/2981

This PR adds the corresponding Gradle configuration for the Gradle modules using `annotationProcessor`.

Also fixes the .gitignore for Eclipse / VS Code `bin` directory since the current pattern is too specific missing `bin` directories in subfolders.