### PR TITLE
docs(core): add javadoc, excluding Expression

### DIFF
--- a/core/src/main/java/io/substrait/expression/EnumArg.java
+++ b/core/src/main/java/io/substrait/expression/EnumArg.java
@@ -14,8 +14,14 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 public interface EnumArg extends FunctionArg {
+  /** Constant representing an unspecified enum argument with no value. */
   EnumArg UNSPECIFIED_ENUM_ARG = builder().value(Optional.empty()).build();
 
+  /**
+   * Returns the enum option value.
+   *
+   * @return the option value, if present
+   */
   Optional<String> value();
 
   @Override
@@ -25,6 +31,15 @@ public interface EnumArg extends FunctionArg {
     return fnArgVisitor.visitEnumArg(fnDef, argIdx, this, context);
   }
 
+  /**
+   * Creates an EnumArg with the specified option value, validating it against the enum argument
+   * definition.
+   *
+   * @param enumArg the enum argument definition
+   * @param option the option value to use
+   * @return a new EnumArg instance
+   * @throws IllegalArgumentException if the option is not valid for the enum argument
+   */
   static EnumArg of(SimpleExtension.EnumArgument enumArg, String option) {
     if (!enumArg.options().contains(option)) {
       throw new IllegalArgumentException(
@@ -33,10 +48,21 @@ public interface EnumArg extends FunctionArg {
     return builder().value(Optional.of(option)).build();
   }
 
+  /**
+   * Creates an EnumArg with the specified value without validation.
+   *
+   * @param value the enum value
+   * @return a new EnumArg instance
+   */
   static EnumArg of(String value) {
     return builder().value(Optional.of(value)).build();
   }
 
+  /**
+   * Creates a new builder for constructing an EnumArg.
+   *
+   * @return a new builder instance
+   */
   static ImmutableEnumArg.Builder builder() {
     return ImmutableEnumArg.builder();
   }

--- a/core/src/main/java/io/substrait/expression/FunctionArg.java
+++ b/core/src/main/java/io/substrait/expression/FunctionArg.java
@@ -17,6 +17,19 @@ import io.substrait.util.VisitationContext;
  */
 public interface FunctionArg {
 
+  /**
+   * Accepts a visitor for this function argument.
+   *
+   * @param <R> the return type
+   * @param <C> the visitation context type
+   * @param <E> the exception type that may be thrown
+   * @param fnDef the function definition
+   * @param argIdx the argument index
+   * @param fnArgVisitor the visitor
+   * @param context the visitation context
+   * @return the result of the visit
+   * @throws E if the visit fails
+   */
   <R, C extends VisitationContext, E extends Throwable> R accept(
       SimpleExtension.Function fnDef, int argIdx, FuncArgVisitor<R, C, E> fnArgVisitor, C context)
       throws E;

--- a/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/AbstractExtensionLookup.java
@@ -2,10 +2,23 @@ package io.substrait.extension;
 
 import java.util.Map;
 
+/**
+ * Abstract base class for {@link ExtensionLookup} implementations that use maps to resolve
+ * extension references to their corresponding function and type anchors.
+ */
 public abstract class AbstractExtensionLookup implements ExtensionLookup {
+  /** Map of function reference IDs to their corresponding function anchors. */
   protected final Map<Integer, SimpleExtension.FunctionAnchor> functionAnchorMap;
+
+  /** Map of type reference IDs to their corresponding type anchors. */
   protected final Map<Integer, SimpleExtension.TypeAnchor> typeAnchorMap;
 
+  /**
+   * Constructs an AbstractExtensionLookup with the provided anchor maps.
+   *
+   * @param functionAnchorMap map of function reference IDs to function anchors
+   * @param typeAnchorMap map of type reference IDs to type anchors
+   */
   public AbstractExtensionLookup(
       Map<Integer, SimpleExtension.FunctionAnchor> functionAnchorMap,
       Map<Integer, SimpleExtension.TypeAnchor> typeAnchorMap) {

--- a/core/src/main/java/io/substrait/extension/ExtensionLookup.java
+++ b/core/src/main/java/io/substrait/extension/ExtensionLookup.java
@@ -6,14 +6,42 @@ package io.substrait.extension;
  * functions or types.
  */
 public interface ExtensionLookup {
+  /**
+   * Resolves a scalar function reference to its corresponding function variant.
+   *
+   * @param reference the function reference ID
+   * @param extensions the extension collection to search
+   * @return the scalar function variant
+   */
   SimpleExtension.ScalarFunctionVariant getScalarFunction(
       int reference, SimpleExtension.ExtensionCollection extensions);
 
+  /**
+   * Resolves a window function reference to its corresponding function variant.
+   *
+   * @param reference the function reference ID
+   * @param extensions the extension collection to search
+   * @return the window function variant
+   */
   SimpleExtension.WindowFunctionVariant getWindowFunction(
       int reference, SimpleExtension.ExtensionCollection extensions);
 
+  /**
+   * Resolves an aggregate function reference to its corresponding function variant.
+   *
+   * @param reference the function reference ID
+   * @param extensions the extension collection to search
+   * @return the aggregate function variant
+   */
   SimpleExtension.AggregateFunctionVariant getAggregateFunction(
       int reference, SimpleExtension.ExtensionCollection extensions);
 
+  /**
+   * Resolves a type reference to its corresponding type.
+   *
+   * @param reference the type reference ID
+   * @param extensions the extension collection to search
+   * @return the type
+   */
   SimpleExtension.Type getType(int reference, SimpleExtension.ExtensionCollection extensions);
 }

--- a/core/src/main/java/io/substrait/relation/AbstractReadRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractReadRel.java
@@ -5,12 +5,32 @@ import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import java.util.Optional;
 
+/**
+ * Abstract base class for read relations that scan data from various sources. Provides common
+ * functionality for schema definition and filtering.
+ */
 public abstract class AbstractReadRel extends ZeroInputRel implements HasExtension {
 
+  /**
+   * Returns the initial schema of the data being read.
+   *
+   * @return the named struct defining the schema
+   */
   public abstract NamedStruct getInitialSchema();
 
+  /**
+   * Returns an optional filter expression that must be applied during the read.
+   *
+   * @return the filter expression, if present
+   */
   public abstract Optional<Expression> getFilter();
 
+  /**
+   * Returns an optional best-effort filter to apply during the read. If the source doesn't support
+   * all operations, this filter may not be applied.
+   *
+   * @return the best-effort filter expression, if present
+   */
   public abstract Optional<Expression> getBestEffortFilter();
 
   // TODO:

--- a/core/src/main/java/io/substrait/relation/AbstractRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRel.java
@@ -4,6 +4,10 @@ import io.substrait.type.Type;
 import io.substrait.util.Util;
 import java.util.function.Supplier;
 
+/**
+ * Abstract base class for relations that provides common functionality for deriving and caching
+ * record types with optional remapping.
+ */
 public abstract class AbstractRel implements Rel {
 
   private Supplier<Type.Struct> recordType =
@@ -13,6 +17,11 @@ public abstract class AbstractRel implements Rel {
             return getRemap().map(r -> r.remap(s)).orElse(s);
           });
 
+  /**
+   * Derives the record type for this relation before any remapping is applied.
+   *
+   * @return the derived record type
+   */
   protected abstract Type.Struct deriveRecordType();
 
   @Override

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -10,8 +10,23 @@ import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
 import io.substrait.util.VisitationContext;
 
+/**
+ * Abstract base class for relation visitors that provides default implementations delegating all
+ * visit methods to a fallback method.
+ *
+ * @param <O> the return type of visit methods
+ * @param <C> the visitation context type
+ * @param <E> the exception type that may be thrown
+ */
 public abstract class AbstractRelVisitor<O, C extends VisitationContext, E extends Exception>
     implements RelVisitor<O, C, E> {
+  /**
+   * Fallback method called by default implementations of all visit methods.
+   *
+   * @param rel the relation to visit
+   * @param context the visitation context
+   * @return the result of the visit
+   */
   public abstract O visitFallback(Rel rel, C context);
 
   @Override

--- a/core/src/main/java/io/substrait/relation/Aggregate.java
+++ b/core/src/main/java/io/substrait/relation/Aggregate.java
@@ -12,11 +12,25 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
 
+/**
+ * Represents an aggregate relation that groups input rows and computes aggregate functions.
+ * Supports multiple grouping sets and measures.
+ */
 @Value.Immutable
 public abstract class Aggregate extends SingleInputRel implements HasExtension {
 
+  /**
+   * Returns the list of grouping sets for this aggregate.
+   *
+   * @return list of grouping sets
+   */
   public abstract List<Grouping> getGroupings();
 
+  /**
+   * Returns the list of aggregate measures to compute.
+   *
+   * @return list of measures
+   */
   public abstract List<Measure> getMeasures();
 
   @Override
@@ -71,26 +85,58 @@ public abstract class Aggregate extends SingleInputRel implements HasExtension {
     return visitor.visit(this, context);
   }
 
+  /** Represents a grouping set - a set of expressions to group by. */
   @Value.Immutable
   public abstract static class Grouping {
+    /**
+     * Returns the list of expressions in this grouping set.
+     *
+     * @return list of grouping expressions
+     */
     public abstract List<Expression> getExpressions();
 
+    /**
+     * Creates a new builder for constructing a Grouping.
+     *
+     * @return a new builder instance
+     */
     public static ImmutableGrouping.Builder builder() {
       return ImmutableGrouping.builder();
     }
   }
 
+  /** Represents an aggregate measure - an aggregate function to compute. */
   @Value.Immutable
   public abstract static class Measure {
+    /**
+     * Returns the aggregate function invocation for this measure.
+     *
+     * @return the aggregate function
+     */
     public abstract AggregateFunctionInvocation getFunction();
 
+    /**
+     * Returns an optional filter to apply before computing the aggregate.
+     *
+     * @return the pre-measure filter, if present
+     */
     public abstract Optional<Expression> getPreMeasureFilter();
 
+    /**
+     * Creates a new builder for constructing a Measure.
+     *
+     * @return a new builder instance
+     */
     public static ImmutableMeasure.Builder builder() {
       return ImmutableMeasure.builder();
     }
   }
 
+  /**
+   * Creates a new builder for constructing an Aggregate relation.
+   *
+   * @return a new builder instance
+   */
   public static ImmutableAggregate.Builder builder() {
     return ImmutableAggregate.builder();
   }

--- a/core/src/main/java/io/substrait/relation/AggregateFunctionProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/AggregateFunctionProtoConverter.java
@@ -22,12 +22,23 @@ public class AggregateFunctionProtoConverter {
   private final TypeProtoConverter typeProtoConverter;
   private final ExtensionCollector functionCollector;
 
+  /**
+   * Constructs a converter with the specified extension collector.
+   *
+   * @param functionCollector the extension collector for tracking function references
+   */
   public AggregateFunctionProtoConverter(ExtensionCollector functionCollector) {
     this.functionCollector = functionCollector;
     this.exprProtoConverter = new ExpressionProtoConverter(functionCollector, null);
     this.typeProtoConverter = new TypeProtoConverter(functionCollector);
   }
 
+  /**
+   * Converts an aggregate measure to its protobuf representation.
+   *
+   * @param measure the aggregate measure to convert
+   * @return the protobuf aggregate function
+   */
   public AggregateFunction toProto(Aggregate.Measure measure) {
     FunctionArg.FuncArgVisitor<FunctionArgument, EmptyVisitationContext, RuntimeException>
         argVisitor = FunctionArg.toProto(typeProtoConverter, exprProtoConverter);

--- a/core/src/main/java/io/substrait/relation/BiRel.java
+++ b/core/src/main/java/io/substrait/relation/BiRel.java
@@ -3,10 +3,21 @@ package io.substrait.relation;
 import java.util.Arrays;
 import java.util.List;
 
+/** Abstract base class for binary relations that have exactly two input relations. */
 public abstract class BiRel extends AbstractRel {
 
+  /**
+   * Returns the left input relation.
+   *
+   * @return the left input
+   */
   public abstract Rel getLeft();
 
+  /**
+   * Returns the right input relation.
+   *
+   * @return the right input
+   */
   public abstract Rel getRight();
 
   @Override

--- a/core/src/main/java/io/substrait/relation/CopyOnWriteUtils.java
+++ b/core/src/main/java/io/substrait/relation/CopyOnWriteUtils.java
@@ -37,6 +37,13 @@ public class CopyOnWriteUtils {
     }
   }
 
+  /**
+   * Functional interface for transforming values during copy-on-write operations.
+   *
+   * @param <T> the type of value to transform
+   * @param <C> the visitation context type
+   * @param <E> the exception type that may be thrown
+   */
   @FunctionalInterface
   public interface TransformFunction<T, C extends VisitationContext, E extends Exception> {
 

--- a/core/src/main/java/io/substrait/relation/Cross.java
+++ b/core/src/main/java/io/substrait/relation/Cross.java
@@ -6,6 +6,10 @@ import io.substrait.util.VisitationContext;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
 
+/**
+ * Represents a cross product (Cartesian product) relation that combines all rows from the left
+ * input with all rows from the right input.
+ */
 @Value.Immutable
 public abstract class Cross extends BiRel implements HasExtension {
 
@@ -23,6 +27,11 @@ public abstract class Cross extends BiRel implements HasExtension {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a new builder for constructing a Cross relation.
+   *
+   * @return a new builder instance
+   */
   public static ImmutableCross.Builder builder() {
     return ImmutableCross.builder();
   }

--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -19,8 +19,18 @@ public interface Rel {
    */
   Optional<AdvancedExtension> getCommonExtension();
 
+  /**
+   * Returns the record type (schema) produced by this relation.
+   *
+   * @return the struct type representing the output schema
+   */
   Type.Struct getRecordType();
 
+  /**
+   * Returns the input relations for this relation.
+   *
+   * @return list of input relations (empty for leaf relations)
+   */
   List<Rel> getInputs();
 
   Optional<Hint> getHint();
@@ -46,6 +56,17 @@ public interface Rel {
     }
   }
 
+  /**
+   * Accepts a visitor for this relation.
+   *
+   * @param <O> the return type
+   * @param <C> the visitation context type
+   * @param <E> the exception type that may be thrown
+   * @param visitor the visitor
+   * @param context the visitation context
+   * @return the result of the visit
+   * @throws E if the visit fails
+   */
   <O, C extends VisitationContext, E extends Exception> O accept(
       RelVisitor<O, C, E> visitor, C context) throws E;
 }

--- a/core/src/main/java/io/substrait/relation/ToProto.java
+++ b/core/src/main/java/io/substrait/relation/ToProto.java
@@ -2,6 +2,17 @@ package io.substrait.relation;
 
 import com.google.protobuf.Message;
 
+/**
+ * Interface for objects that can be converted to protobuf messages.
+ *
+ * @param <T> the protobuf message type
+ */
 public interface ToProto<T extends Message> {
+  /**
+   * Converts this object to its protobuf representation.
+   *
+   * @param converter the converter to use for nested conversions
+   * @return the protobuf message
+   */
   T toProto(RelProtoConverter converter);
 }

--- a/core/src/main/java/io/substrait/relation/physical/BroadcastExchange.java
+++ b/core/src/main/java/io/substrait/relation/physical/BroadcastExchange.java
@@ -4,6 +4,12 @@ import io.substrait.relation.RelVisitor;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/**
+ * Represents a broadcast exchange that sends all data from the input to all target nodes. This is
+ * typically used as a performance optimization to join a small dataset with a large dataset in a
+ * distributed data processing engine. A full copy of the small dataset is sent to all processing
+ * nodes to reduce network overheads.
+ */
 @Value.Immutable
 public abstract class BroadcastExchange extends AbstractExchangeRel {
   @Override
@@ -12,6 +18,11 @@ public abstract class BroadcastExchange extends AbstractExchangeRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a new builder for constructing a BroadcastExchange relation.
+   *
+   * @return a new builder instance
+   */
   public static ImmutableBroadcastExchange.Builder builder() {
     return ImmutableBroadcastExchange.builder();
   }

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -14,26 +14,48 @@ import io.substrait.type.parser.TypeStringParser;
 import java.io.IOException;
 import java.util.function.BiFunction;
 
+/**
+ * Provides Jackson deserializers for Substrait type-related classes. These deserializers parse JSON
+ * representations of types into their corresponding Java objects.
+ */
 public class Deserializers {
 
+  /** Deserializer for {@link ParameterizedType} from JSON representation. */
   public static final StdDeserializer<ParameterizedType> PARAMETERIZED_TYPE =
       new ParseDeserializer<>(ParameterizedType.class, ParseToPojo::parameterizedType);
+
+  /** Deserializer for {@link Type} from JSON representation. */
   public static final StdDeserializer<Type> TYPE =
       new ParseDeserializer<>(Type.class, ParseToPojo::type);
+
+  /** Deserializer for {@link TypeExpression} from JSON representation. */
   public static final StdDeserializer<TypeExpression> DERIVATION_EXPRESSION =
       new ParseDeserializer<>(TypeExpression.class, ParseToPojo::typeExpression);
 
+  /** Jackson module containing all type deserializers. */
   public static final SimpleModule MODULE =
       new SimpleModule()
           .addDeserializer(ParameterizedType.class, PARAMETERIZED_TYPE)
           .addDeserializer(TypeExpression.class, DERIVATION_EXPRESSION);
 
+  /**
+   * Generic deserializer that parses JSON representations of types using a provided converter
+   * function.
+   *
+   * @param <T> the type to deserialize
+   */
   public static class ParseDeserializer<T> extends StdDeserializer<T> {
 
     private static final long serialVersionUID = 2105956703553161270L;
 
     private final BiFunction<String, SubstraitTypeParser.StartRuleContext, T> converter;
 
+    /**
+     * Constructs a ParseDeserializer with the specified class and converter function.
+     *
+     * @param clazz the class to deserialize
+     * @param converter the function to convert parsed JSON to the target type
+     */
     public ParseDeserializer(
         Class<T> clazz, BiFunction<String, SubstraitTypeParser.StartRuleContext, T> converter) {
       super(clazz);

--- a/core/src/main/java/io/substrait/util/EmptyVisitationContext.java
+++ b/core/src/main/java/io/substrait/util/EmptyVisitationContext.java
@@ -1,5 +1,10 @@
 package io.substrait.util;
 
+/**
+ * A singleton implementation of {@link VisitationContext} that provides no additional context. This
+ * is useful as a default context when no specific visitation state needs to be maintained.
+ */
 public class EmptyVisitationContext implements VisitationContext {
+  /** Singleton instance of the empty visitation context. */
   public static final EmptyVisitationContext INSTANCE = new EmptyVisitationContext();
 }


### PR DESCRIPTION
This change adds missing Javadoc to address build warnings in all classes except for io.substrait.expression.Expression.