### PR TITLE
feat: add plan execution behavior

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -16,7 +16,9 @@ import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.function.ToTypeString;
+import io.substrait.plan.ImmutableExecutionBehavior;
 import io.substrait.plan.Plan;
+import io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode;
 import io.substrait.relation.AbstractWriteRel;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.Aggregate.Measure;
@@ -1540,13 +1542,54 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates a plan from a plan root.
+   * Creates a plan from a plan root with default execution behavior.
+   *
+   * <p>The plan is created with {@link VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN} as
+   * the default variable evaluation mode. To specify a custom execution behavior, use {@link
+   * #plan(Plan.ExecutionBehavior, Plan.Root)} instead.
    *
    * @param root the plan root
    * @return a new {@link Plan}
    */
   public Plan plan(Plan.Root root) {
-    return Plan.builder().addRoots(root).build();
+    return plan(
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .build(),
+        root);
+  }
+
+  /**
+   * Creates a plan from a plan root with custom execution behavior.
+   *
+   * @param executionBehavior the execution behavior for the plan
+   * @param root the plan root
+   * @return a new {@link Plan}
+   */
+  public Plan plan(Plan.ExecutionBehavior executionBehavior, Plan.Root root) {
+    return Plan.builder().executionBehavior(executionBehavior).addRoots(root).build();
+  }
+
+  /**
+   * Creates a plan from multiple plan roots with custom execution behavior.
+   *
+   * @param executionBehavior the execution behavior for the plan
+   * @param roots the plan roots
+   * @return a new {@link Plan}
+   */
+  public Plan plan(Plan.ExecutionBehavior executionBehavior, Plan.Root... roots) {
+    return Plan.builder().executionBehavior(executionBehavior).roots(Arrays.asList(roots)).build();
+  }
+
+  /**
+   * Creates a plan from multiple plan roots with custom execution behavior.
+   *
+   * @param executionBehavior the execution behavior for the plan
+   * @param roots the plan roots as an iterable
+   * @return a new {@link Plan}
+   */
+  public Plan plan(Plan.ExecutionBehavior executionBehavior, Iterable<Plan.Root> roots) {
+    return Plan.builder().executionBehavior(executionBehavior).roots(roots).build();
   }
 
   /**

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -1544,8 +1544,8 @@ public class SubstraitBuilder {
   /**
    * Creates a plan from a plan root with default execution behavior.
    *
-   * <p>The plan is created with {@link VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN} as
-   * the default variable evaluation mode. To specify a custom execution behavior, use {@link
+   * <p>The plan is created with {@link VariableEvaluationMode#PER_PLAN} as the default variable
+   * evaluation mode. To specify a custom execution behavior, use {@link
    * #plan(Plan.ExecutionBehavior, Plan.Root)} instead.
    *
    * @param root the plan root
@@ -1554,7 +1554,7 @@ public class SubstraitBuilder {
   public Plan plan(Plan.Root root) {
     return plan(
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .variableEvaluationMode(VariableEvaluationMode.PER_PLAN)
             .build(),
         root);
   }

--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -21,6 +21,38 @@ public abstract class Plan {
 
   public abstract Optional<AdvancedExtension> getAdvancedExtension();
 
+  public abstract Optional<ExecutionBehavior> getExecutionBehavior();
+
+  /**
+   * Validates that the execution behavior is properly configured.
+   *
+   * <p>This validation method ensures that:
+   *
+   * <ul>
+   *   <li>The {@link ExecutionBehavior} field is present (not null or empty) - ExecutionBehavior is
+   *       a required field
+   *   <li>The {@link ExecutionBehavior.VariableEvaluationMode} is set to a valid value (not {@link
+   *       ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED})
+   * </ul>
+   *
+   * @throws IllegalArgumentException if the execution behavior is not present, or if the variable
+   *     evaluation mode is set to {@link
+   *     ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED}
+   */
+  @Value.Check
+  protected void check() {
+    if (!getExecutionBehavior().isPresent()) {
+      throw new IllegalArgumentException("ExecutionBehavior is required but was not set");
+    }
+    ExecutionBehavior behavior = getExecutionBehavior().get();
+    if (behavior.getVariableEvaluationMode()
+        == ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED) {
+      throw new IllegalArgumentException(
+          "ExecutionBehavior requires a specified VariableEvaluationMode, but got: "
+              + behavior.getVariableEvaluationMode());
+    }
+  }
+
   public static ImmutablePlan.Builder builder() {
     return ImmutablePlan.builder();
   }
@@ -67,6 +99,21 @@ public abstract class Plan {
 
     public static ImmutableRoot.Builder builder() {
       return ImmutableRoot.builder();
+    }
+  }
+
+  @Value.Immutable
+  public abstract static class ExecutionBehavior {
+    public abstract VariableEvaluationMode getVariableEvaluationMode();
+
+    public static ImmutableExecutionBehavior.Builder builder() {
+      return ImmutableExecutionBehavior.builder();
+    }
+
+    public enum VariableEvaluationMode {
+      VARIABLE_EVALUATION_MODE_UNSPECIFIED,
+      VARIABLE_EVALUATION_MODE_PER_PLAN,
+      VARIABLE_EVALUATION_MODE_PER_RECORD
     }
   }
 }

--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -32,18 +32,17 @@ public abstract class Plan {
    *   <li>The {@link ExecutionBehavior} field is present (not null or empty) - ExecutionBehavior is
    *       a required field
    *   <li>The {@link ExecutionBehavior.VariableEvaluationMode} is set to a valid value (not {@link
-   *       ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED})
+   *       ExecutionBehavior.VariableEvaluationMode#UNSPECIFIED})
    * </ul>
    *
    * @throws IllegalArgumentException if the execution behavior is not present, or if the variable
-   *     evaluation mode is set to {@link
-   *     ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED}
+   *     evaluation mode is set to {@link ExecutionBehavior.VariableEvaluationMode#UNSPECIFIED}
    */
   @Value.Check
   protected void check() {
     ExecutionBehavior behavior = getExecutionBehavior();
     if (behavior.getVariableEvaluationMode()
-        == ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED) {
+        == ExecutionBehavior.VariableEvaluationMode.UNSPECIFIED) {
       throw new IllegalArgumentException(
           "ExecutionBehavior requires a specified VariableEvaluationMode, but got: "
               + behavior.getVariableEvaluationMode());
@@ -108,9 +107,30 @@ public abstract class Plan {
     }
 
     public enum VariableEvaluationMode {
-      VARIABLE_EVALUATION_MODE_UNSPECIFIED,
-      VARIABLE_EVALUATION_MODE_PER_PLAN,
-      VARIABLE_EVALUATION_MODE_PER_RECORD
+      UNSPECIFIED(
+          io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+              .VARIABLE_EVALUATION_MODE_UNSPECIFIED),
+      PER_PLAN(
+          io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+              .VARIABLE_EVALUATION_MODE_PER_PLAN),
+      PER_RECORD(
+          io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+              .VARIABLE_EVALUATION_MODE_PER_RECORD);
+
+      private final io.substrait.proto.ExecutionBehavior.VariableEvaluationMode proto;
+
+      VariableEvaluationMode(io.substrait.proto.ExecutionBehavior.VariableEvaluationMode proto) {
+        this.proto = proto;
+      }
+
+      /**
+       * Converts this variable evaluation mode to its protobuf representation.
+       *
+       * @return the protobuf representation
+       */
+      public io.substrait.proto.ExecutionBehavior.VariableEvaluationMode toProto() {
+        return proto;
+      }
     }
   }
 }

--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -35,22 +35,14 @@ public abstract class Plan {
    *       ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED})
    * </ul>
    *
-   * <p>The validation is currently triggered when the Plan gets serialized into protobuf in {@link
-   * PlanProtoConverter#toProto(Plan)}.
-   *
-   * <p>TODO: After the grace period of introducing this breaking change is over, the validation
-   * should also be triggered when the Plan gets deserialized from protobuf by adding the {@link
-   * Value.Check} annotation to this method and removing the call from {@link
-   * PlanProtoConverter#toProto(Plan)}.
-   *
    * @throws IllegalArgumentException if the execution behavior is not present, or if the variable
    *     evaluation mode is set to {@link
    *     ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED}
    */
-  protected void validate() {
+  @Value.Check
+  protected void check() {
     if (!getExecutionBehavior().isPresent()) {
-      throw new IllegalArgumentException(
-          "ExecutionBehavior is required since Substrait v0.87.0 but was not set");
+      throw new IllegalArgumentException("ExecutionBehavior is required but was not set");
     }
     ExecutionBehavior behavior = getExecutionBehavior().get();
     if (behavior.getVariableEvaluationMode()

--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -21,7 +21,7 @@ public abstract class Plan {
 
   public abstract Optional<AdvancedExtension> getAdvancedExtension();
 
-  public abstract Optional<ExecutionBehavior> getExecutionBehavior();
+  public abstract ExecutionBehavior getExecutionBehavior();
 
   /**
    * Validates that the execution behavior is properly configured.
@@ -41,10 +41,7 @@ public abstract class Plan {
    */
   @Value.Check
   protected void check() {
-    if (!getExecutionBehavior().isPresent()) {
-      throw new IllegalArgumentException("ExecutionBehavior is required but was not set");
-    }
-    ExecutionBehavior behavior = getExecutionBehavior().get();
+    ExecutionBehavior behavior = getExecutionBehavior();
     if (behavior.getVariableEvaluationMode()
         == ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED) {
       throw new IllegalArgumentException(

--- a/core/src/main/java/io/substrait/plan/Plan.java
+++ b/core/src/main/java/io/substrait/plan/Plan.java
@@ -35,14 +35,22 @@ public abstract class Plan {
    *       ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED})
    * </ul>
    *
+   * <p>The validation is currently triggered when the Plan gets serialized into protobuf in {@link
+   * PlanProtoConverter#toProto(Plan)}.
+   *
+   * <p>TODO: After the grace period of introducing this breaking change is over, the validation
+   * should also be triggered when the Plan gets deserialized from protobuf by adding the {@link
+   * Value.Check} annotation to this method and removing the call from {@link
+   * PlanProtoConverter#toProto(Plan)}.
+   *
    * @throws IllegalArgumentException if the execution behavior is not present, or if the variable
    *     evaluation mode is set to {@link
    *     ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED}
    */
-  @Value.Check
-  protected void check() {
+  protected void validate() {
     if (!getExecutionBehavior().isPresent()) {
-      throw new IllegalArgumentException("ExecutionBehavior is required but was not set");
+      throw new IllegalArgumentException(
+          "ExecutionBehavior is required since Substrait v0.87.0 but was not set");
     }
     ExecutionBehavior behavior = getExecutionBehavior().get();
     if (behavior.getVariableEvaluationMode()

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -4,6 +4,8 @@ import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.ExtensionProtoConverter;
 import io.substrait.extension.SimpleExtension.ExtensionCollection;
+import io.substrait.proto.ExecutionBehavior;
+import io.substrait.proto.ExecutionBehavior.VariableEvaluationMode;
 import io.substrait.proto.Plan;
 import io.substrait.proto.PlanRel;
 import io.substrait.proto.Rel;
@@ -61,6 +63,26 @@ public class PlanProtoConverter {
     this.extensionProtoConverter = extensionProtoConverter;
   }
 
+  /**
+   * Converts a {@link io.substrait.plan.Plan} object to its protobuf representation.
+   *
+   * <p>This method performs a complete conversion of the Plan object, including:
+   *
+   * <ul>
+   *   <li>All plan roots and their associated relations
+   *   <li>Extension functions and types used in the plan
+   *   <li>Version information
+   *   <li>Advanced extensions if present
+   *   <li>Execution behavior configuration if present
+   * </ul>
+   *
+   * <p>The execution behavior is optional. If present, it will be converted using {@link
+   * #toProtoExecutionBehavior(io.substrait.plan.Plan.ExecutionBehavior)}.
+   *
+   * @param plan the Plan object to convert, must not be null
+   * @return the protobuf Plan representation
+   * @throws IllegalArgumentException if the plan contains invalid data
+   */
   public Plan toProto(final io.substrait.plan.Plan plan) {
     final List<PlanRel> planRels = new ArrayList<>();
     final ExtensionCollector functionCollector = new ExtensionCollector(extensionCollection);
@@ -97,6 +119,65 @@ public class PlanProtoConverter {
 
     builder.setVersion(versionBuilder);
 
+    // Set execution behavior if present
+    if (plan.getExecutionBehavior().isPresent()) {
+      builder.setExecutionBehavior(toProtoExecutionBehavior(plan.getExecutionBehavior().get()));
+    }
+
     return builder.build();
+  }
+
+  /**
+   * Converts an {@link io.substrait.plan.Plan.ExecutionBehavior} to its protobuf representation.
+   *
+   * <p>This method converts the execution behavior configuration, including the variable evaluation
+   * mode, from the POJO representation to the protobuf format.
+   *
+   * @param executionBehavior the ExecutionBehavior to convert, must not be null
+   * @return the protobuf ExecutionBehavior representation
+   * @throws IllegalArgumentException if the variable evaluation mode is unknown
+   */
+  private ExecutionBehavior toProtoExecutionBehavior(
+      final io.substrait.plan.Plan.ExecutionBehavior executionBehavior) {
+    return ExecutionBehavior.newBuilder()
+        .setVariableEvalMode(
+            toProtoVariableEvaluationMode(executionBehavior.getVariableEvaluationMode()))
+        .build();
+  }
+
+  /**
+   * Converts a {@link io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode} to its
+   * protobuf representation.
+   *
+   * <p>Supported modes:
+   *
+   * <ul>
+   *   <li>{@link
+   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED}
+   *       - Unspecified mode (should be avoided in valid plans)
+   *   <li>{@link
+   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN}
+   *       - Variables are evaluated once per plan execution
+   *   <li>{@link
+   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_RECORD}
+   *       - Variables are evaluated for each record
+   * </ul>
+   *
+   * @param mode the VariableEvaluationMode to convert, must not be null
+   * @return the protobuf VariableEvaluationMode representation
+   * @throws IllegalArgumentException if the mode is unknown or not supported
+   */
+  private VariableEvaluationMode toProtoVariableEvaluationMode(
+      final io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode mode) {
+    switch (mode) {
+      case VARIABLE_EVALUATION_MODE_UNSPECIFIED:
+        return VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED;
+      case VARIABLE_EVALUATION_MODE_PER_PLAN:
+        return VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN;
+      case VARIABLE_EVALUATION_MODE_PER_RECORD:
+        return VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD;
+      default:
+        throw new IllegalArgumentException("Unknown VariableEvaluationMode: " + mode);
+    }
   }
 }

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -66,7 +66,6 @@ public class PlanProtoConverter {
   /**
    * Converts a {@link io.substrait.plan.Plan} object to its protobuf representation.
    *
-   *
    * @param plan the Plan object to convert, must not be null
    * @return the protobuf Plan representation
    * @throws IllegalArgumentException if the plan contains invalid data

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -5,7 +5,6 @@ import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.ExtensionProtoConverter;
 import io.substrait.extension.SimpleExtension.ExtensionCollection;
 import io.substrait.proto.ExecutionBehavior;
-import io.substrait.proto.ExecutionBehavior.VariableEvaluationMode;
 import io.substrait.proto.Plan;
 import io.substrait.proto.PlanRel;
 import io.substrait.proto.Rel;
@@ -125,44 +124,7 @@ public class PlanProtoConverter {
   private ExecutionBehavior toProtoExecutionBehavior(
       final io.substrait.plan.Plan.ExecutionBehavior executionBehavior) {
     return ExecutionBehavior.newBuilder()
-        .setVariableEvalMode(
-            toProtoVariableEvaluationMode(executionBehavior.getVariableEvaluationMode()))
+        .setVariableEvalMode(executionBehavior.getVariableEvaluationMode().toProto())
         .build();
-  }
-
-  /**
-   * Converts a {@link io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode} to its
-   * protobuf representation.
-   *
-   * <p>Supported modes:
-   *
-   * <ul>
-   *   <li>{@link
-   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED}
-   *       - Unspecified mode (should be avoided in valid plans)
-   *   <li>{@link
-   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN}
-   *       - Variables are evaluated once per plan execution
-   *   <li>{@link
-   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_RECORD}
-   *       - Variables are evaluated for each record
-   * </ul>
-   *
-   * @param mode the VariableEvaluationMode to convert, must not be null
-   * @return the protobuf VariableEvaluationMode representation
-   * @throws IllegalArgumentException if the mode is unknown or not supported
-   */
-  private VariableEvaluationMode toProtoVariableEvaluationMode(
-      final io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode mode) {
-    switch (mode) {
-      case VARIABLE_EVALUATION_MODE_UNSPECIFIED:
-        return VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED;
-      case VARIABLE_EVALUATION_MODE_PER_PLAN:
-        return VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN;
-      case VARIABLE_EVALUATION_MODE_PER_RECORD:
-        return VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD;
-      default:
-        throw new IllegalArgumentException("Unknown VariableEvaluationMode: " + mode);
-    }
   }
 }

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -84,9 +84,6 @@ public class PlanProtoConverter {
    * @throws IllegalArgumentException if the plan contains invalid data
    */
   public Plan toProto(final io.substrait.plan.Plan plan) {
-    // validate Plan is valid with current specification
-    plan.validate();
-
     final List<PlanRel> planRels = new ArrayList<>();
     final ExtensionCollector functionCollector = new ExtensionCollector(extensionCollection);
     for (final io.substrait.plan.Plan.Root root : plan.getRoots()) {

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -84,6 +84,9 @@ public class PlanProtoConverter {
    * @throws IllegalArgumentException if the plan contains invalid data
    */
   public Plan toProto(final io.substrait.plan.Plan plan) {
+    // validate Plan is valid with current specification
+    plan.validate();
+
     final List<PlanRel> planRels = new ArrayList<>();
     final ExtensionCollector functionCollector = new ExtensionCollector(extensionCollection);
     for (final io.substrait.plan.Plan.Root root : plan.getRoots()) {

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -106,10 +106,8 @@ public class PlanProtoConverter {
 
     builder.setVersion(versionBuilder);
 
-    // Set execution behavior if present
-    if (plan.getExecutionBehavior().isPresent()) {
-      builder.setExecutionBehavior(toProtoExecutionBehavior(plan.getExecutionBehavior().get()));
-    }
+    // Set execution behavior
+    builder.setExecutionBehavior(toProtoExecutionBehavior(plan.getExecutionBehavior()));
 
     return builder.build();
   }

--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -66,18 +66,6 @@ public class PlanProtoConverter {
   /**
    * Converts a {@link io.substrait.plan.Plan} object to its protobuf representation.
    *
-   * <p>This method performs a complete conversion of the Plan object, including:
-   *
-   * <ul>
-   *   <li>All plan roots and their associated relations
-   *   <li>Extension functions and types used in the plan
-   *   <li>Version information
-   *   <li>Advanced extensions if present
-   *   <li>Execution behavior configuration if present
-   * </ul>
-   *
-   * <p>The execution behavior is optional. If present, it will be converted using {@link
-   * #toProtoExecutionBehavior(io.substrait.plan.Plan.ExecutionBehavior)}.
    *
    * @param plan the Plan object to convert, must not be null
    * @return the protobuf Plan representation

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -66,6 +66,29 @@ public class ProtoPlanConverter {
     return new ProtoRelConverter(functionLookup, this.extensionCollection, protoExtensionConverter);
   }
 
+  /**
+   * Converts a protobuf {@link io.substrait.proto.Plan} to a {@link Plan} POJO.
+   *
+   * <p>This method performs a complete conversion from the protobuf representation, including:
+   *
+   * <ul>
+   *   <li>All plan relations and their roots
+   *   <li>Extension functions and types lookup
+   *   <li>Version information (major, minor, patch, git hash, producer)
+   *   <li>Advanced extensions if present
+   *   <li>Execution behavior configuration if present
+   * </ul>
+   *
+   * <p><b>Note:</b> While execution behavior is optional in the protobuf message, the Plan
+   * validation will still fail if ExecutionBehavior is not set or if it contains
+   * VARIABLE_EVALUATION_MODE_UNSPECIFIED. Ensure the protobuf Plan has a valid execution behavior
+   * before conversion.
+   *
+   * @param plan the protobuf Plan to convert, must not be null
+   * @return the converted Plan POJO
+   * @throws IllegalArgumentException if the plan contains invalid data or if the execution behavior
+   *     validation fails
+   */
   public Plan from(io.substrait.proto.Plan plan) {
     ExtensionLookup functionLookup = ImmutableExtensionLookup.builder().from(plan).build();
     ProtoRelConverter relConverter = getProtoRelConverter(functionLookup);
@@ -92,15 +115,81 @@ public class ProtoPlanConverter {
       versionBuilder.producer(Optional.of(plan.getVersion().getProducer()));
     }
 
-    return Plan.builder()
-        .roots(roots)
-        .expectedTypeUrls(plan.getExpectedTypeUrlsList())
-        .advancedExtension(
-            Optional.ofNullable(
-                plan.hasAdvancedExtensions()
-                    ? protoExtensionConverter.fromProto(plan.getAdvancedExtensions())
-                    : null))
-        .version(versionBuilder.build())
+    ImmutablePlan.Builder planBuilder =
+        Plan.builder()
+            .roots(roots)
+            .expectedTypeUrls(plan.getExpectedTypeUrlsList())
+            .advancedExtension(
+                Optional.ofNullable(
+                    plan.hasAdvancedExtensions()
+                        ? protoExtensionConverter.fromProto(plan.getAdvancedExtensions())
+                        : null))
+            .version(versionBuilder.build());
+
+    // Set execution behavior if present
+    if (plan.hasExecutionBehavior()) {
+      planBuilder.executionBehavior(fromProtoExecutionBehavior(plan.getExecutionBehavior()));
+    }
+
+    return planBuilder.build();
+  }
+
+  /**
+   * Converts a protobuf {@link io.substrait.proto.ExecutionBehavior} to its POJO representation.
+   *
+   * <p>This method converts the execution behavior configuration from the protobuf format to the
+   * POJO representation, including the variable evaluation mode.
+   *
+   * @param executionBehavior the protobuf ExecutionBehavior to convert, must not be null
+   * @return the POJO ExecutionBehavior representation
+   * @throws IllegalArgumentException if the variable evaluation mode is unknown or UNRECOGNIZED
+   */
+  private io.substrait.plan.Plan.ExecutionBehavior fromProtoExecutionBehavior(
+      final io.substrait.proto.ExecutionBehavior executionBehavior) {
+    return io.substrait.plan.Plan.ExecutionBehavior.builder()
+        .variableEvaluationMode(
+            fromProtoVariableEvaluationMode(executionBehavior.getVariableEvalMode()))
         .build();
+  }
+
+  /**
+   * Converts a protobuf {@link io.substrait.proto.ExecutionBehavior.VariableEvaluationMode} to its
+   * POJO representation.
+   *
+   * <p>Supported modes:
+   *
+   * <ul>
+   *   <li>{@link
+   *       io.substrait.proto.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_UNSPECIFIED}
+   *       - Unspecified mode (will cause validation failure in Plan)
+   *   <li>{@link
+   *       io.substrait.proto.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN}
+   *       - Variables are evaluated once per plan execution
+   *   <li>{@link
+   *       io.substrait.proto.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_RECORD}
+   *       - Variables are evaluated for each record
+   * </ul>
+   *
+   * @param mode the protobuf VariableEvaluationMode to convert, must not be null
+   * @return the POJO VariableEvaluationMode representation
+   * @throws IllegalArgumentException if the mode is UNRECOGNIZED or not supported
+   */
+  private io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
+      fromProtoVariableEvaluationMode(
+          final io.substrait.proto.ExecutionBehavior.VariableEvaluationMode mode) {
+    switch (mode) {
+      case VARIABLE_EVALUATION_MODE_UNSPECIFIED:
+        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
+            .VARIABLE_EVALUATION_MODE_UNSPECIFIED;
+      case VARIABLE_EVALUATION_MODE_PER_PLAN:
+        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
+            .VARIABLE_EVALUATION_MODE_PER_PLAN;
+      case VARIABLE_EVALUATION_MODE_PER_RECORD:
+        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
+            .VARIABLE_EVALUATION_MODE_PER_RECORD;
+      case UNRECOGNIZED:
+      default:
+        throw new IllegalArgumentException("Unknown VariableEvaluationMode: " + mode);
+    }
   }
 }

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -74,16 +74,9 @@ public class ProtoPlanConverter {
    * <p><b>Note:</b> Execution behavior is optional in the protobuf message, but the {@link Plan}
    * POJO requires it. Conversion handles a missing execution behavior based on the plan version:
    *
-   * <ul>
-   *   <li>For plans older than Substrait 0.87.0 (the version that introduced execution behavior), a
-   *       missing execution behavior is defaulted to {@link
-   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN}.
-   *       Note that a plan without a version is treated as version 0.0.0, and therefore as older
-   *       than 0.87.0.
-   *   <li>For plans at or after 0.87.0, a missing execution behavior is left unset and Plan
-   *       validation will fail. The validation also fails if the execution behavior is present but
-   *       contains {@code VARIABLE_EVALUATION_MODE_UNSPECIFIED}.
-   * </ul>
+   * <p><b>Note:</b> If {@Code Plan.ExecutionBehavior.VariableEvaluationMode} is not set, it will be
+   * defaulted to {@code VARIABLE_EVALUATION_MODE_PER_PLAN}. Once other producers populate this
+   * field correctly, this compatibility workaround will be removed.
    *
    * @param plan the protobuf Plan to convert, must not be null
    * @return the converted Plan POJO
@@ -127,11 +120,11 @@ public class ProtoPlanConverter {
                         : null))
             .version(versionBuilder.build());
 
-    // Set execution behavior if present
+    // Set execution behavior (required field)
     if (plan.hasExecutionBehavior()) {
       planBuilder.executionBehavior(fromProtoExecutionBehavior(plan.getExecutionBehavior()));
     } else {
-      // set default ExecutionBehavior for older plans
+      // Set default ExecutionBehavior for older plans that don't have it
       planBuilder.executionBehavior(
           ExecutionBehavior.builder()
               .variableEvaluationMode(VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -74,7 +74,7 @@ public class ProtoPlanConverter {
    * <p><b>Note:</b> Execution behavior is optional in the protobuf message, but the {@link Plan}
    * POJO requires it. Conversion handles a missing execution behavior based on the plan version:
    *
-   * <p><b>Note:</b> If {@Code Plan.ExecutionBehavior.VariableEvaluationMode} is not set, it will be
+   * <p><b>Note:</b> If {@code Plan.ExecutionBehavior.VariableEvaluationMode} is not set, it will be
    * defaulted to {@code VARIABLE_EVALUATION_MODE_PER_PLAN}. Once other producers populate this
    * field correctly, this compatibility workaround will be removed.
    *

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -5,6 +5,8 @@ import io.substrait.extension.ExtensionLookup;
 import io.substrait.extension.ImmutableExtensionLookup;
 import io.substrait.extension.ProtoExtensionConverter;
 import io.substrait.extension.SimpleExtension.ExtensionCollection;
+import io.substrait.plan.Plan.ExecutionBehavior;
+import io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode;
 import io.substrait.proto.PlanRel;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
@@ -128,6 +130,12 @@ public class ProtoPlanConverter {
     // Set execution behavior if present
     if (plan.hasExecutionBehavior()) {
       planBuilder.executionBehavior(fromProtoExecutionBehavior(plan.getExecutionBehavior()));
+    } else {
+      // set default ExecutionBehavior for older plans
+      planBuilder.executionBehavior(
+          ExecutionBehavior.builder()
+              .variableEvaluationMode(VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+              .build());
     }
 
     return planBuilder.build();

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -125,41 +125,12 @@ public class ProtoPlanConverter {
                         : null))
             .version(versionBuilder.build());
 
-    // Set execution behavior if present. For plans produced before Substrait 0.87.0 the
-    // execution behavior did not exist, so default it to per-plan variable evaluation.
+    // Set execution behavior if present
     if (plan.hasExecutionBehavior()) {
       planBuilder.executionBehavior(fromProtoExecutionBehavior(plan.getExecutionBehavior()));
-    } else if (isOlderThan(plan.getVersion(), 0, 87, 0)) {
-      planBuilder.executionBehavior(
-          io.substrait.plan.Plan.ExecutionBehavior.builder()
-              .variableEvaluationMode(
-                  io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
-                      .VARIABLE_EVALUATION_MODE_PER_PLAN)
-              .build());
     }
 
     return planBuilder.build();
-  }
-
-  /**
-   * Determines whether the given protobuf {@link io.substrait.proto.Version} is older than the
-   * provided major/minor/patch version.
-   *
-   * @param version the protobuf Version to check
-   * @param major the major version to compare against
-   * @param minor the minor version to compare against
-   * @param patch the patch version to compare against
-   * @return {@code true} if {@code version} is strictly older than {@code major.minor.patch}
-   */
-  private static boolean isOlderThan(
-      final io.substrait.proto.Version version, final int major, final int minor, final int patch) {
-    if (version.getMajorNumber() != major) {
-      return version.getMajorNumber() < major;
-    }
-    if (version.getMinorNumber() != minor) {
-      return version.getMinorNumber() < minor;
-    }
-    return version.getPatchNumber() < patch;
   }
 
   /**

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -126,12 +126,41 @@ public class ProtoPlanConverter {
                         : null))
             .version(versionBuilder.build());
 
-    // Set execution behavior if present
+    // Set execution behavior if present. For plans produced before Substrait 0.87.0 the
+    // execution behavior did not exist, so default it to per-plan variable evaluation.
     if (plan.hasExecutionBehavior()) {
       planBuilder.executionBehavior(fromProtoExecutionBehavior(plan.getExecutionBehavior()));
+    } else if (isOlderThan(plan.getVersion(), 0, 87, 0)) {
+      planBuilder.executionBehavior(
+          io.substrait.plan.Plan.ExecutionBehavior.builder()
+              .variableEvaluationMode(
+                  io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
+                      .VARIABLE_EVALUATION_MODE_PER_PLAN)
+              .build());
     }
 
     return planBuilder.build();
+  }
+
+  /**
+   * Determines whether the given protobuf {@link io.substrait.proto.Version} is older than the
+   * provided major/minor/patch version.
+   *
+   * @param version the protobuf Version to check
+   * @param major the major version to compare against
+   * @param minor the minor version to compare against
+   * @param patch the patch version to compare against
+   * @return {@code true} if {@code version} is strictly older than {@code major.minor.patch}
+   */
+  private static boolean isOlderThan(
+      final io.substrait.proto.Version version, final int major, final int minor, final int patch) {
+    if (version.getMajorNumber() != major) {
+      return version.getMajorNumber() < major;
+    }
+    if (version.getMinorNumber() != minor) {
+      return version.getMinorNumber() < minor;
+    }
+    return version.getPatchNumber() < patch;
   }
 
   /**

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -69,11 +69,19 @@ public class ProtoPlanConverter {
   /**
    * Converts a protobuf {@link io.substrait.proto.Plan} to a {@link Plan} POJO.
    *
+   * <p><b>Note:</b> Execution behavior is optional in the protobuf message, but the {@link Plan}
+   * POJO requires it. Conversion handles a missing execution behavior based on the plan version:
    *
-   * <p><b>Note:</b> While execution behavior is optional in the protobuf message, the Plan
-   * validation will still fail if ExecutionBehavior is not set or if it contains
-   * VARIABLE_EVALUATION_MODE_UNSPECIFIED. Ensure the protobuf Plan has a valid execution behavior
-   * before conversion.
+   * <ul>
+   *   <li>For plans older than Substrait 0.87.0 (the version that introduced execution behavior), a
+   *       missing execution behavior is defaulted to {@link
+   *       io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN}.
+   *       Note that a plan without a version is treated as version 0.0.0, and therefore as older
+   *       than 0.87.0.
+   *   <li>For plans at or after 0.87.0, a missing execution behavior is left unset and Plan
+   *       validation will fail. The validation also fails if the execution behavior is present but
+   *       contains {@code VARIABLE_EVALUATION_MODE_UNSPECIFIED}.
+   * </ul>
    *
    * @param plan the protobuf Plan to convert, must not be null
    * @return the converted Plan POJO

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -69,15 +69,6 @@ public class ProtoPlanConverter {
   /**
    * Converts a protobuf {@link io.substrait.proto.Plan} to a {@link Plan} POJO.
    *
-   * <p>This method performs a complete conversion from the protobuf representation, including:
-   *
-   * <ul>
-   *   <li>All plan relations and their roots
-   *   <li>Extension functions and types lookup
-   *   <li>Version information (major, minor, patch, git hash, producer)
-   *   <li>Advanced extensions if present
-   *   <li>Execution behavior configuration if present
-   * </ul>
    *
    * <p><b>Note:</b> While execution behavior is optional in the protobuf message, the Plan
    * validation will still fail if ExecutionBehavior is not set or if it contains

--- a/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
+++ b/core/src/main/java/io/substrait/plan/ProtoPlanConverter.java
@@ -127,7 +127,7 @@ public class ProtoPlanConverter {
       // Set default ExecutionBehavior for older plans that don't have it
       planBuilder.executionBehavior(
           ExecutionBehavior.builder()
-              .variableEvaluationMode(VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+              .variableEvaluationMode(VariableEvaluationMode.PER_PLAN)
               .build());
     }
 
@@ -179,14 +179,11 @@ public class ProtoPlanConverter {
           final io.substrait.proto.ExecutionBehavior.VariableEvaluationMode mode) {
     switch (mode) {
       case VARIABLE_EVALUATION_MODE_UNSPECIFIED:
-        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
-            .VARIABLE_EVALUATION_MODE_UNSPECIFIED;
+        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode.UNSPECIFIED;
       case VARIABLE_EVALUATION_MODE_PER_PLAN:
-        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
-            .VARIABLE_EVALUATION_MODE_PER_PLAN;
+        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN;
       case VARIABLE_EVALUATION_MODE_PER_RECORD:
-        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
-            .VARIABLE_EVALUATION_MODE_PER_RECORD;
+        return io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD;
       case UNRECOGNIZED:
       default:
         throw new IllegalArgumentException("Unknown VariableEvaluationMode: " + mode);

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -1,7 +1,11 @@
 package io.substrait.plan;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
@@ -21,13 +25,25 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class PlanConverterTest {
+  private final PlanProtoConverter toProtoConverter = new PlanProtoConverter();
+  private final ProtoPlanConverter fromProtoConverter = new ProtoPlanConverter();
+
+  private static Plan.ExecutionBehavior defaultExecutionBehavior() {
+    return ImmutableExecutionBehavior.builder()
+        .variableEvaluationMode(
+            Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+        .build();
+  }
+
   @Test
   void emptyAdvancedExtensionTest() {
-    final Plan plan = Plan.builder().advancedExtension(AdvancedExtension.builder().build()).build();
-    final PlanProtoConverter toProtoConverter = new PlanProtoConverter();
+    final Plan plan =
+        Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
+            .advancedExtension(AdvancedExtension.builder().build())
+            .build();
     final io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
 
-    final ProtoPlanConverter fromProtoConverter = new ProtoPlanConverter();
     final Plan plan2 = fromProtoConverter.from(protoPlan);
 
     assertEquals(plan, plan2);
@@ -39,9 +55,9 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .advancedExtension(AdvancedExtension.builder().enhancement(enhanced).build())
             .build();
-    final PlanProtoConverter toProtoConverter = new PlanProtoConverter();
 
     assertThrows(
         UnsupportedOperationException.class,
@@ -55,13 +71,13 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .advancedExtension(AdvancedExtension.builder().enhancement(enhanced).build())
             .build();
     final PlanProtoConverter toProtoConverter =
         new PlanProtoConverter(new StringHolderHandlingExtensionProtoConverter());
     final io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
 
-    final ProtoPlanConverter fromProtoConverter = new ProtoPlanConverter();
     assertThrows(
         UnsupportedOperationException.class,
         () -> fromProtoConverter.from(protoPlan),
@@ -74,6 +90,7 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .advancedExtension(AdvancedExtension.builder().enhancement(enhanced).build())
             .build();
     final PlanProtoConverter toProtoConverter =
@@ -93,9 +110,9 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .advancedExtension(AdvancedExtension.builder().addOptimizations(optimized).build())
             .build();
-    final PlanProtoConverter toProtoConverter = new PlanProtoConverter();
 
     assertThrows(
         UnsupportedOperationException.class,
@@ -109,13 +126,13 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .advancedExtension(AdvancedExtension.builder().addOptimizations(optimized).build())
             .build();
     final PlanProtoConverter toProtoConverter =
         new PlanProtoConverter(new StringHolderHandlingExtensionProtoConverter());
     final io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
 
-    final ProtoPlanConverter fromProtoConverter = new ProtoPlanConverter();
     assertThrows(
         UnsupportedOperationException.class,
         () -> fromProtoConverter.from(protoPlan),
@@ -128,6 +145,7 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .advancedExtension(AdvancedExtension.builder().addOptimizations(optimized).build())
             .build();
     final PlanProtoConverter toProtoConverter =
@@ -148,6 +166,7 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .advancedExtension(
                 AdvancedExtension.builder()
                     .enhancement(enhanced)
@@ -172,6 +191,7 @@ class PlanConverterTest {
 
     final Plan plan =
         Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
             .addRoots(
                 Root.builder()
                     .input(
@@ -304,9 +324,12 @@ class PlanConverterTest {
                     false, nullablePointLiteral, pointLiteral, vectorOfPointLiteral))
             .build();
 
-    Plan plan = Plan.builder().addRoots(Root.builder().input(virtualTable).build()).build();
+    Plan plan =
+        Plan.builder()
+            .executionBehavior(defaultExecutionBehavior())
+            .addRoots(Root.builder().input(virtualTable).build())
+            .build();
 
-    PlanProtoConverter toProtoConverter = new PlanProtoConverter();
     io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
 
     assertEquals(1, protoPlan.getExtensionUrnsCount(), "Should have exactly 1 extension URN");
@@ -318,5 +341,317 @@ class PlanConverterTest {
     ProtoPlanConverter fromProtoConverter = new ProtoPlanConverter(extensions);
     Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
     assertEquals(plan, roundTrippedPlan, "Plan should roundtrip correctly");
+  }
+
+  /**
+   * Conversion of Plan with VARIABLE_EVALUATION_MODE_PER_PLAN to protobuf.
+   *
+   * <p>Verifies that a Plan with ExecutionBehavior set to PER_PLAN mode is correctly converted to
+   * protobuf format, including the execution behavior field.
+   */
+  @Test
+  void testToProtoWithExecutionBehaviorPerPlan() {
+    // Create a Plan with ExecutionBehavior set to PER_PLAN
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .build();
+
+    Plan plan =
+        ImmutablePlan.builder()
+            .executionBehavior(executionBehavior)
+            .roots(Collections.emptyList())
+            .expectedTypeUrls(Collections.emptyList())
+            .build();
+
+    // Convert to protobuf
+    io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
+
+    // Verify the protobuf has execution behavior
+    assertTrue(protoPlan.hasExecutionBehavior(), "Protobuf Plan should have ExecutionBehavior");
+    assertEquals(
+        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+            .VARIABLE_EVALUATION_MODE_PER_PLAN,
+        protoPlan.getExecutionBehavior().getVariableEvalMode(),
+        "Variable evaluation mode should be PER_PLAN");
+  }
+
+  /**
+   * Conversion of Plan with VARIABLE_EVALUATION_MODE_PER_RECORD to protobuf.
+   *
+   * <p>Verifies that a Plan with ExecutionBehavior set to PER_RECORD mode is correctly converted to
+   * protobuf format.
+   */
+  @Test
+  void testToProtoWithExecutionBehaviorPerRecord() {
+    // Create a Plan with ExecutionBehavior set to PER_RECORD
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD)
+            .build();
+
+    Plan plan =
+        ImmutablePlan.builder()
+            .executionBehavior(executionBehavior)
+            .roots(Collections.emptyList())
+            .expectedTypeUrls(Collections.emptyList())
+            .build();
+
+    // Convert to protobuf
+    io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
+
+    // Verify the protobuf has execution behavior
+    assertTrue(protoPlan.hasExecutionBehavior(), "Protobuf Plan should have ExecutionBehavior");
+    assertEquals(
+        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+            .VARIABLE_EVALUATION_MODE_PER_RECORD,
+        protoPlan.getExecutionBehavior().getVariableEvalMode(),
+        "Variable evaluation mode should be PER_RECORD");
+  }
+
+  /**
+   * Conversion from protobuf Plan with ExecutionBehavior to POJO.
+   *
+   * <p>Verifies that a protobuf Plan with ExecutionBehavior is correctly converted to the POJO
+   * representation.
+   */
+  @Test
+  void testFromProtoWithExecutionBehaviorPerPlan() {
+    // Create a protobuf Plan with ExecutionBehavior
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder()
+            .setExecutionBehavior(
+                io.substrait.proto.ExecutionBehavior.newBuilder()
+                    .setVariableEvalMode(
+                        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+                            .VARIABLE_EVALUATION_MODE_PER_PLAN)
+                    .build())
+            .build();
+
+    // Convert to POJO
+    Plan plan = fromProtoConverter.from(protoPlan);
+
+    // Verify the POJO has execution behavior
+    assertTrue(
+        plan.getExecutionBehavior().isPresent(), "Plan should have ExecutionBehavior present");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Variable evaluation mode should be PER_PLAN");
+  }
+
+  /**
+   * Conversion from protobuf Plan with PER_RECORD mode to POJO.
+   *
+   * <p>Verifies that a protobuf Plan with PER_RECORD execution behavior is correctly converted.
+   */
+  @Test
+  void testFromProtoWithExecutionBehaviorPerRecord() {
+    // Create a protobuf Plan with ExecutionBehavior set to PER_RECORD
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder()
+            .setExecutionBehavior(
+                io.substrait.proto.ExecutionBehavior.newBuilder()
+                    .setVariableEvalMode(
+                        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+                            .VARIABLE_EVALUATION_MODE_PER_RECORD)
+                    .build())
+            .build();
+
+    // Convert to POJO
+    Plan plan = fromProtoConverter.from(protoPlan);
+
+    // Verify the POJO has execution behavior
+    assertTrue(
+        plan.getExecutionBehavior().isPresent(), "Plan should have ExecutionBehavior present");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
+        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Variable evaluation mode should be PER_RECORD");
+  }
+
+  /**
+   * Conversion from protobuf Plan without ExecutionBehavior.
+   *
+   * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan that fails
+   * validation (since ExecutionBehavior is required).
+   */
+  @Test
+  void testFromProtoWithoutExecutionBehaviorFailsValidation() {
+    // Create a protobuf Plan without ExecutionBehavior
+    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
+
+    // Attempt to convert to POJO - should fail validation
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> fromProtoConverter.from(protoPlan),
+        "Conversion should fail when ExecutionBehavior is not set");
+  }
+
+  /**
+   * Test case 6: Conversion from protobuf Plan with UNSPECIFIED mode fails validation.
+   *
+   * <p>Verifies that a protobuf Plan with VARIABLE_EVALUATION_MODE_UNSPECIFIED results in a
+   * validation failure when converted to POJO.
+   */
+  @Test
+  void testFromProtoWithUnspecifiedModeFailsValidation() {
+    // Create a protobuf Plan with UNSPECIFIED mode
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder()
+            .setExecutionBehavior(
+                io.substrait.proto.ExecutionBehavior.newBuilder()
+                    .setVariableEvalMode(
+                        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+                            .VARIABLE_EVALUATION_MODE_UNSPECIFIED)
+                    .build())
+            .build();
+
+    // Attempt to convert to POJO - should fail validation
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> fromProtoConverter.from(protoPlan),
+            "Conversion should fail when VariableEvaluationMode is UNSPECIFIED");
+
+    assertTrue(
+        exception.getMessage().contains("VariableEvaluationMode"),
+        "Error message should mention VariableEvaluationMode");
+  }
+
+  /**
+   * Round-trip conversion with PER_PLAN mode.
+   *
+   * <p>Verifies that converting a Plan to protobuf and back preserves all data, including the
+   * execution behavior with PER_PLAN mode.
+   */
+  @Test
+  void testRoundTripWithExecutionBehaviorPerPlan() {
+    // Create original Plan
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .build();
+
+    Plan originalPlan =
+        ImmutablePlan.builder()
+            .executionBehavior(executionBehavior)
+            .roots(Collections.emptyList())
+            .expectedTypeUrls(Collections.emptyList())
+            .build();
+
+    // Convert to protobuf and back
+    io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(originalPlan);
+    Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
+
+    // Verify data integrity
+    assertTrue(
+        roundTrippedPlan.getExecutionBehavior().isPresent(),
+        "Round-tripped Plan should have ExecutionBehavior");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        roundTrippedPlan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Variable evaluation mode should be preserved");
+    assertEquals(
+        originalPlan.getRoots().size(),
+        roundTrippedPlan.getRoots().size(),
+        "Number of roots should be preserved");
+    assertEquals(
+        originalPlan.getExpectedTypeUrls().size(),
+        roundTrippedPlan.getExpectedTypeUrls().size(),
+        "Number of expected type URLs should be preserved");
+  }
+
+  /**
+   * Round-trip conversion with PER_RECORD mode.
+   *
+   * <p>Verifies that converting a Plan with PER_RECORD mode to protobuf and back preserves the
+   * execution behavior correctly.
+   */
+  @Test
+  void testRoundTripWithExecutionBehaviorPerRecord() {
+    // Create original Plan
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD)
+            .build();
+
+    Plan originalPlan =
+        ImmutablePlan.builder()
+            .executionBehavior(executionBehavior)
+            .roots(Collections.emptyList())
+            .expectedTypeUrls(Collections.emptyList())
+            .build();
+
+    // Convert to protobuf and back
+    io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(originalPlan);
+    Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
+
+    // Verify data integrity
+    assertTrue(
+        roundTrippedPlan.getExecutionBehavior().isPresent(),
+        "Round-tripped Plan should have ExecutionBehavior");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
+        roundTrippedPlan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Variable evaluation mode should be preserved");
+  }
+
+  /**
+   * Empty plan with only execution behavior.
+   *
+   * <p>Verifies that a minimal Plan with only execution behavior (no roots, no type URLs) can be
+   * successfully converted.
+   */
+  @Test
+  void testRoundTripEmptyPlanWithExecutionBehavior() {
+    // Create minimal Plan
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .build();
+
+    Plan originalPlan =
+        ImmutablePlan.builder()
+            .executionBehavior(executionBehavior)
+            .roots(Collections.emptyList())
+            .expectedTypeUrls(Collections.emptyList())
+            .build();
+
+    // Verify conversion succeeds
+    assertDoesNotThrow(
+        () -> {
+          io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(originalPlan);
+          Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
+          assertNotNull(roundTrippedPlan, "Round-tripped Plan should not be null");
+        },
+        "Empty plan with execution behavior should convert successfully");
+  }
+
+  /**
+   * Verify that protobuf without execution behavior field is handled.
+   *
+   * <p>Tests the edge case where a protobuf Plan doesn't have the execution behavior field set at
+   * all.
+   */
+  @Test
+  void testFromProtoMissingExecutionBehaviorField() {
+    // Create protobuf Plan without setting execution behavior
+    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
+
+    // Verify hasExecutionBehavior returns false
+    assertFalse(
+        protoPlan.hasExecutionBehavior(), "Protobuf Plan should not have execution behavior field");
+
+    // Conversion should fail validation
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> fromProtoConverter.from(protoPlan),
+        "Conversion should fail when execution behavior is missing");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -434,11 +434,10 @@ class PlanConverterTest {
     Plan plan = fromProtoConverter.from(protoPlan);
 
     // Verify the POJO has execution behavior
-    assertTrue(
-        plan.getExecutionBehavior().isPresent(), "Plan should have ExecutionBehavior present");
+    assertNotNull(plan.getExecutionBehavior(), "Plan should have ExecutionBehavior");
     assertEquals(
         Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
-        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be PER_PLAN");
   }
 
@@ -464,11 +463,10 @@ class PlanConverterTest {
     Plan plan = fromProtoConverter.from(protoPlan);
 
     // Verify the POJO has execution behavior
-    assertTrue(
-        plan.getExecutionBehavior().isPresent(), "Plan should have ExecutionBehavior present");
+    assertNotNull(plan.getExecutionBehavior(), "Plan should have ExecutionBehavior");
     assertEquals(
         Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
-        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be PER_RECORD");
   }
 
@@ -486,12 +484,10 @@ class PlanConverterTest {
     // Convert to POJO - should succeed with a default ExecutionBehavior
     Plan plan = fromProtoConverter.from(protoPlan);
 
-    assertTrue(
-        plan.getExecutionBehavior().isPresent(),
-        "Plan should have a default ExecutionBehavior present");
+    assertNotNull(plan.getExecutionBehavior(), "Plan should have a default ExecutionBehavior");
     assertEquals(
         Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
-        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Default variable evaluation mode should be PER_PLAN");
   }
 
@@ -553,12 +549,12 @@ class PlanConverterTest {
     Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
 
     // Verify data integrity
-    assertTrue(
-        roundTrippedPlan.getExecutionBehavior().isPresent(),
+    assertNotNull(
+        roundTrippedPlan.getExecutionBehavior(),
         "Round-tripped Plan should have ExecutionBehavior");
     assertEquals(
         Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
-        roundTrippedPlan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        roundTrippedPlan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be preserved");
     assertEquals(
         originalPlan.getRoots().size(),
@@ -597,12 +593,12 @@ class PlanConverterTest {
     Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
 
     // Verify data integrity
-    assertTrue(
-        roundTrippedPlan.getExecutionBehavior().isPresent(),
+    assertNotNull(
+        roundTrippedPlan.getExecutionBehavior(),
         "Round-tripped Plan should have ExecutionBehavior");
     assertEquals(
         Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
-        roundTrippedPlan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        roundTrippedPlan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be preserved");
   }
 
@@ -656,12 +652,10 @@ class PlanConverterTest {
     // Conversion should succeed with a default ExecutionBehavior of PER_PLAN
     Plan plan = fromProtoConverter.from(protoPlan);
 
-    assertTrue(
-        plan.getExecutionBehavior().isPresent(),
-        "Plan should have a default ExecutionBehavior present");
+    assertNotNull(plan.getExecutionBehavior(), "Plan should have a default ExecutionBehavior");
     assertEquals(
         Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
-        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Default variable evaluation mode should be PER_PLAN");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -480,11 +480,8 @@ class PlanConverterTest {
    */
   @Test
   void testFromProtoWithoutExecutionBehaviorFailsValidation() {
-    // Create a protobuf Plan without ExecutionBehavior at a version that requires it (>= 0.87.0)
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder()
-            .setVersion(io.substrait.proto.Version.newBuilder().setMinorNumber(87).build())
-            .build();
+    // Create a protobuf Plan without ExecutionBehavior
+    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
 
     // Attempt to convert to POJO - should fail validation
     assertThrows(
@@ -644,11 +641,8 @@ class PlanConverterTest {
    */
   @Test
   void testFromProtoMissingExecutionBehaviorField() {
-    // Create protobuf Plan without setting execution behavior at a version that requires it
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder()
-            .setVersion(io.substrait.proto.Version.newBuilder().setMinorNumber(87).build())
-            .build();
+    // Create protobuf Plan without setting execution behavior
+    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
 
     // Verify hasExecutionBehavior returns false
     assertFalse(

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -475,8 +475,8 @@ class PlanConverterTest {
   /**
    * Conversion from protobuf Plan without ExecutionBehavior.
    *
-   * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan with a default
-   * ExecutionBehavior of PER_PLAN, supporting older plans that predate the field.
+   * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan with a
+   * default ExecutionBehavior of PER_PLAN, supporting older plans that predate the field.
    */
   @Test
   void testFromProtoWithoutExecutionBehaviorUsesDefault() {

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -475,30 +475,33 @@ class PlanConverterTest {
   /**
    * Conversion from protobuf Plan without ExecutionBehavior.
    *
-   * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan that fails
-   * validation (since ExecutionBehavior is required).
+   * <p>Verifies that converting a protobuf Plan without ExecutionBehavior to POJO succeeds, but
+   * serializing that POJO via
+   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
+   * fails validation because ExecutionBehavior is required.
    */
   @Test
   void testFromProtoWithoutExecutionBehaviorFailsValidation() {
-    // Create a protobuf Plan without ExecutionBehavior
     io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
 
-    // Attempt to convert to POJO - should fail validation
+    Plan plan = fromProtoConverter.from(protoPlan);
+
     assertThrows(
         IllegalArgumentException.class,
-        () -> fromProtoConverter.from(protoPlan),
-        "Conversion should fail when ExecutionBehavior is not set");
+        () -> toProtoConverter.toProto(plan),
+        "Serialization should fail when ExecutionBehavior is not set");
   }
 
   /**
    * Test case 6: Conversion from protobuf Plan with UNSPECIFIED mode fails validation.
    *
-   * <p>Verifies that a protobuf Plan with VARIABLE_EVALUATION_MODE_UNSPECIFIED results in a
-   * validation failure when converted to POJO.
+   * <p>Verifies that converting a protobuf Plan with VARIABLE_EVALUATION_MODE_UNSPECIFIED to POJO
+   * succeeds, but serializing that POJO via
+   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
+   * fails validation.
    */
   @Test
   void testFromProtoWithUnspecifiedModeFailsValidation() {
-    // Create a protobuf Plan with UNSPECIFIED mode
     io.substrait.proto.Plan protoPlan =
         io.substrait.proto.Plan.newBuilder()
             .setExecutionBehavior(
@@ -509,12 +512,13 @@ class PlanConverterTest {
                     .build())
             .build();
 
-    // Attempt to convert to POJO - should fail validation
+    Plan plan = fromProtoConverter.from(protoPlan);
+
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> fromProtoConverter.from(protoPlan),
-            "Conversion should fail when VariableEvaluationMode is UNSPECIFIED");
+            () -> toProtoConverter.toProto(plan),
+            "Serialization should fail when VariableEvaluationMode is UNSPECIFIED");
 
     assertTrue(
         exception.getMessage().contains("VariableEvaluationMode"),
@@ -637,21 +641,22 @@ class PlanConverterTest {
    * Verify that protobuf without execution behavior field is handled.
    *
    * <p>Tests the edge case where a protobuf Plan doesn't have the execution behavior field set at
-   * all.
+   * all. Conversion to POJO should succeed, but serialization via
+   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
+   * should fail.
    */
   @Test
   void testFromProtoMissingExecutionBehaviorField() {
-    // Create protobuf Plan without setting execution behavior
     io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
 
-    // Verify hasExecutionBehavior returns false
     assertFalse(
         protoPlan.hasExecutionBehavior(), "Protobuf Plan should not have execution behavior field");
 
-    // Conversion should fail validation
+    Plan plan = fromProtoConverter.from(protoPlan);
+
     assertThrows(
         IllegalArgumentException.class,
-        () -> fromProtoConverter.from(protoPlan),
-        "Conversion should fail when execution behavior is missing");
+        () -> toProtoConverter.toProto(plan),
+        "Serialization should fail when execution behavior is missing");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -480,8 +480,11 @@ class PlanConverterTest {
    */
   @Test
   void testFromProtoWithoutExecutionBehaviorFailsValidation() {
-    // Create a protobuf Plan without ExecutionBehavior
-    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
+    // Create a protobuf Plan without ExecutionBehavior at a version that requires it (>= 0.87.0)
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder()
+            .setVersion(io.substrait.proto.Version.newBuilder().setMinorNumber(87).build())
+            .build();
 
     // Attempt to convert to POJO - should fail validation
     assertThrows(
@@ -641,8 +644,11 @@ class PlanConverterTest {
    */
   @Test
   void testFromProtoMissingExecutionBehaviorField() {
-    // Create protobuf Plan without setting execution behavior
-    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
+    // Create protobuf Plan without setting execution behavior at a version that requires it
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder()
+            .setVersion(io.substrait.proto.Version.newBuilder().setMinorNumber(87).build())
+            .build();
 
     // Verify hasExecutionBehavior returns false
     assertFalse(

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -475,33 +475,30 @@ class PlanConverterTest {
   /**
    * Conversion from protobuf Plan without ExecutionBehavior.
    *
-   * <p>Verifies that converting a protobuf Plan without ExecutionBehavior to POJO succeeds, but
-   * serializing that POJO via
-   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
-   * fails validation because ExecutionBehavior is required.
+   * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan that fails
+   * validation (since ExecutionBehavior is required).
    */
   @Test
   void testFromProtoWithoutExecutionBehaviorFailsValidation() {
+    // Create a protobuf Plan without ExecutionBehavior
     io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
 
-    Plan plan = fromProtoConverter.from(protoPlan);
-
+    // Attempt to convert to POJO - should fail validation
     assertThrows(
         IllegalArgumentException.class,
-        () -> toProtoConverter.toProto(plan),
-        "Serialization should fail when ExecutionBehavior is not set");
+        () -> fromProtoConverter.from(protoPlan),
+        "Conversion should fail when ExecutionBehavior is not set");
   }
 
   /**
    * Test case 6: Conversion from protobuf Plan with UNSPECIFIED mode fails validation.
    *
-   * <p>Verifies that converting a protobuf Plan with VARIABLE_EVALUATION_MODE_UNSPECIFIED to POJO
-   * succeeds, but serializing that POJO via
-   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
-   * fails validation.
+   * <p>Verifies that a protobuf Plan with VARIABLE_EVALUATION_MODE_UNSPECIFIED results in a
+   * validation failure when converted to POJO.
    */
   @Test
   void testFromProtoWithUnspecifiedModeFailsValidation() {
+    // Create a protobuf Plan with UNSPECIFIED mode
     io.substrait.proto.Plan protoPlan =
         io.substrait.proto.Plan.newBuilder()
             .setExecutionBehavior(
@@ -512,13 +509,12 @@ class PlanConverterTest {
                     .build())
             .build();
 
-    Plan plan = fromProtoConverter.from(protoPlan);
-
+    // Attempt to convert to POJO - should fail validation
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> toProtoConverter.toProto(plan),
-            "Serialization should fail when VariableEvaluationMode is UNSPECIFIED");
+            () -> fromProtoConverter.from(protoPlan),
+            "Conversion should fail when VariableEvaluationMode is UNSPECIFIED");
 
     assertTrue(
         exception.getMessage().contains("VariableEvaluationMode"),
@@ -641,22 +637,21 @@ class PlanConverterTest {
    * Verify that protobuf without execution behavior field is handled.
    *
    * <p>Tests the edge case where a protobuf Plan doesn't have the execution behavior field set at
-   * all. Conversion to POJO should succeed, but serialization via
-   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
-   * should fail.
+   * all.
    */
   @Test
   void testFromProtoMissingExecutionBehaviorField() {
+    // Create protobuf Plan without setting execution behavior
     io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
 
+    // Verify hasExecutionBehavior returns false
     assertFalse(
         protoPlan.hasExecutionBehavior(), "Protobuf Plan should not have execution behavior field");
 
-    Plan plan = fromProtoConverter.from(protoPlan);
-
+    // Conversion should fail validation
     assertThrows(
         IllegalArgumentException.class,
-        () -> toProtoConverter.toProto(plan),
-        "Serialization should fail when execution behavior is missing");
+        () -> fromProtoConverter.from(protoPlan),
+        "Conversion should fail when execution behavior is missing");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -1,6 +1,5 @@
 package io.substrait.plan;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -23,6 +22,8 @@ import io.substrait.utils.StringHolderHandlingProtoExtensionConverter;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class PlanConverterTest {
   private final PlanProtoConverter toProtoConverter = new PlanProtoConverter();
@@ -343,131 +344,6 @@ class PlanConverterTest {
   }
 
   /**
-   * Conversion of Plan with VARIABLE_EVALUATION_MODE_PER_PLAN to protobuf.
-   *
-   * <p>Verifies that a Plan with ExecutionBehavior set to PER_PLAN mode is correctly converted to
-   * protobuf format, including the execution behavior field.
-   */
-  @Test
-  void testToProtoWithExecutionBehaviorPerPlan() {
-    // Create a Plan with ExecutionBehavior set to PER_PLAN
-    Plan.ExecutionBehavior executionBehavior =
-        ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
-            .build();
-
-    Plan plan =
-        ImmutablePlan.builder()
-            .executionBehavior(executionBehavior)
-            .roots(Collections.emptyList())
-            .expectedTypeUrls(Collections.emptyList())
-            .build();
-
-    // Convert to protobuf
-    io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
-
-    // Verify the protobuf has execution behavior
-    assertTrue(protoPlan.hasExecutionBehavior(), "Protobuf Plan should have ExecutionBehavior");
-    assertEquals(
-        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
-            .VARIABLE_EVALUATION_MODE_PER_PLAN,
-        protoPlan.getExecutionBehavior().getVariableEvalMode(),
-        "Variable evaluation mode should be PER_PLAN");
-  }
-
-  /**
-   * Conversion of Plan with VARIABLE_EVALUATION_MODE_PER_RECORD to protobuf.
-   *
-   * <p>Verifies that a Plan with ExecutionBehavior set to PER_RECORD mode is correctly converted to
-   * protobuf format.
-   */
-  @Test
-  void testToProtoWithExecutionBehaviorPerRecord() {
-    // Create a Plan with ExecutionBehavior set to PER_RECORD
-    Plan.ExecutionBehavior executionBehavior =
-        ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD)
-            .build();
-
-    Plan plan =
-        ImmutablePlan.builder()
-            .executionBehavior(executionBehavior)
-            .roots(Collections.emptyList())
-            .expectedTypeUrls(Collections.emptyList())
-            .build();
-
-    // Convert to protobuf
-    io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(plan);
-
-    // Verify the protobuf has execution behavior
-    assertTrue(protoPlan.hasExecutionBehavior(), "Protobuf Plan should have ExecutionBehavior");
-    assertEquals(
-        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
-            .VARIABLE_EVALUATION_MODE_PER_RECORD,
-        protoPlan.getExecutionBehavior().getVariableEvalMode(),
-        "Variable evaluation mode should be PER_RECORD");
-  }
-
-  /**
-   * Conversion from protobuf Plan with ExecutionBehavior to POJO.
-   *
-   * <p>Verifies that a protobuf Plan with ExecutionBehavior is correctly converted to the POJO
-   * representation.
-   */
-  @Test
-  void testFromProtoWithExecutionBehaviorPerPlan() {
-    // Create a protobuf Plan with ExecutionBehavior
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder()
-            .setExecutionBehavior(
-                io.substrait.proto.ExecutionBehavior.newBuilder()
-                    .setVariableEvalMode(
-                        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
-                            .VARIABLE_EVALUATION_MODE_PER_PLAN)
-                    .build())
-            .build();
-
-    // Convert to POJO
-    Plan plan = fromProtoConverter.from(protoPlan);
-
-    // Verify the POJO has execution behavior
-    assertNotNull(plan.getExecutionBehavior(), "Plan should have ExecutionBehavior");
-    assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN,
-        plan.getExecutionBehavior().getVariableEvaluationMode(),
-        "Variable evaluation mode should be PER_PLAN");
-  }
-
-  /**
-   * Conversion from protobuf Plan with PER_RECORD mode to POJO.
-   *
-   * <p>Verifies that a protobuf Plan with PER_RECORD execution behavior is correctly converted.
-   */
-  @Test
-  void testFromProtoWithExecutionBehaviorPerRecord() {
-    // Create a protobuf Plan with ExecutionBehavior set to PER_RECORD
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder()
-            .setExecutionBehavior(
-                io.substrait.proto.ExecutionBehavior.newBuilder()
-                    .setVariableEvalMode(
-                        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
-                            .VARIABLE_EVALUATION_MODE_PER_RECORD)
-                    .build())
-            .build();
-
-    // Convert to POJO
-    Plan plan = fromProtoConverter.from(protoPlan);
-
-    // Verify the POJO has execution behavior
-    assertNotNull(plan.getExecutionBehavior(), "Plan should have ExecutionBehavior");
-    assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD,
-        plan.getExecutionBehavior().getVariableEvaluationMode(),
-        "Variable evaluation mode should be PER_RECORD");
-  }
-
-  /**
    * Conversion from protobuf Plan without ExecutionBehavior.
    *
    * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan with a
@@ -477,6 +353,8 @@ class PlanConverterTest {
   void testFromProtoWithoutExecutionBehaviorUsesDefault() {
     // Create a protobuf Plan without ExecutionBehavior
     io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
+    assertFalse(
+        protoPlan.hasExecutionBehavior(), "Protobuf Plan should not have execution behavior field");
 
     // Convert to POJO - should succeed with a default ExecutionBehavior
     Plan plan = fromProtoConverter.from(protoPlan);
@@ -489,7 +367,7 @@ class PlanConverterTest {
   }
 
   /**
-   * Test case 6: Conversion from protobuf Plan with UNSPECIFIED mode fails validation.
+   * Conversion from protobuf Plan with UNSPECIFIED mode fails validation.
    *
    * <p>Verifies that a protobuf Plan with VARIABLE_EVALUATION_MODE_UNSPECIFIED results in a
    * validation failure when converted to POJO.
@@ -520,18 +398,19 @@ class PlanConverterTest {
   }
 
   /**
-   * Round-trip conversion with PER_PLAN mode.
+   * Round-trip conversion preserves the execution behavior.
    *
    * <p>Verifies that converting a Plan to protobuf and back preserves all data, including the
-   * execution behavior with PER_PLAN mode.
+   * execution behavior, for every valid {@link Plan.ExecutionBehavior.VariableEvaluationMode}.
    */
-  @Test
-  void testRoundTripWithExecutionBehaviorPerPlan() {
+  @ParameterizedTest
+  @EnumSource(
+      value = Plan.ExecutionBehavior.VariableEvaluationMode.class,
+      names = {"PER_PLAN", "PER_RECORD"})
+  void testRoundTripWithExecutionBehavior(Plan.ExecutionBehavior.VariableEvaluationMode mode) {
     // Create original Plan
     Plan.ExecutionBehavior executionBehavior =
-        ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
-            .build();
+        ImmutableExecutionBehavior.builder().variableEvaluationMode(mode).build();
 
     Plan originalPlan =
         ImmutablePlan.builder()
@@ -549,7 +428,7 @@ class PlanConverterTest {
         roundTrippedPlan.getExecutionBehavior(),
         "Round-tripped Plan should have ExecutionBehavior");
     assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN,
+        mode,
         roundTrippedPlan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be preserved");
     assertEquals(
@@ -560,96 +439,5 @@ class PlanConverterTest {
         originalPlan.getExpectedTypeUrls().size(),
         roundTrippedPlan.getExpectedTypeUrls().size(),
         "Number of expected type URLs should be preserved");
-  }
-
-  /**
-   * Round-trip conversion with PER_RECORD mode.
-   *
-   * <p>Verifies that converting a Plan with PER_RECORD mode to protobuf and back preserves the
-   * execution behavior correctly.
-   */
-  @Test
-  void testRoundTripWithExecutionBehaviorPerRecord() {
-    // Create original Plan
-    Plan.ExecutionBehavior executionBehavior =
-        ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD)
-            .build();
-
-    Plan originalPlan =
-        ImmutablePlan.builder()
-            .executionBehavior(executionBehavior)
-            .roots(Collections.emptyList())
-            .expectedTypeUrls(Collections.emptyList())
-            .build();
-
-    // Convert to protobuf and back
-    io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(originalPlan);
-    Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
-
-    // Verify data integrity
-    assertNotNull(
-        roundTrippedPlan.getExecutionBehavior(),
-        "Round-tripped Plan should have ExecutionBehavior");
-    assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD,
-        roundTrippedPlan.getExecutionBehavior().getVariableEvaluationMode(),
-        "Variable evaluation mode should be preserved");
-  }
-
-  /**
-   * Empty plan with only execution behavior.
-   *
-   * <p>Verifies that a minimal Plan with only execution behavior (no roots, no type URLs) can be
-   * successfully converted.
-   */
-  @Test
-  void testRoundTripEmptyPlanWithExecutionBehavior() {
-    // Create minimal Plan
-    Plan.ExecutionBehavior executionBehavior =
-        ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
-            .build();
-
-    Plan originalPlan =
-        ImmutablePlan.builder()
-            .executionBehavior(executionBehavior)
-            .roots(Collections.emptyList())
-            .expectedTypeUrls(Collections.emptyList())
-            .build();
-
-    // Verify conversion succeeds
-    assertDoesNotThrow(
-        () -> {
-          io.substrait.proto.Plan protoPlan = toProtoConverter.toProto(originalPlan);
-          Plan roundTrippedPlan = fromProtoConverter.from(protoPlan);
-          assertNotNull(roundTrippedPlan, "Round-tripped Plan should not be null");
-        },
-        "Empty plan with execution behavior should convert successfully");
-  }
-
-  /**
-   * Verify that protobuf without execution behavior field is handled.
-   *
-   * <p>Tests the edge case where a protobuf Plan doesn't have the execution behavior field set at
-   * all. Such older plans receive a default ExecutionBehavior of PER_PLAN.
-   */
-  @Test
-  void testFromProtoMissingExecutionBehaviorField() {
-    // Create protobuf Plan without setting execution behavior
-    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
-
-    // Verify hasExecutionBehavior returns false
-    assertFalse(
-        protoPlan.hasExecutionBehavior(), "Protobuf Plan should not have execution behavior field");
-
-    // Conversion should succeed with a default ExecutionBehavior of PER_PLAN
-    Plan plan = fromProtoConverter.from(protoPlan);
-
-    assertNotNull(plan.getExecutionBehavior(), "Plan should have a default ExecutionBehavior");
-    assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN,
-        plan.getExecutionBehavior().getVariableEvaluationMode(),
-        "Default variable evaluation mode should be PER_PLAN");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -30,8 +30,7 @@ class PlanConverterTest {
 
   private static Plan.ExecutionBehavior defaultExecutionBehavior() {
     return ImmutableExecutionBehavior.builder()
-        .variableEvaluationMode(
-            Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+        .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
         .build();
   }
 
@@ -354,8 +353,7 @@ class PlanConverterTest {
     // Create a Plan with ExecutionBehavior set to PER_PLAN
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
             .build();
 
     Plan plan =
@@ -388,8 +386,7 @@ class PlanConverterTest {
     // Create a Plan with ExecutionBehavior set to PER_RECORD
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD)
             .build();
 
     Plan plan =
@@ -436,7 +433,7 @@ class PlanConverterTest {
     // Verify the POJO has execution behavior
     assertNotNull(plan.getExecutionBehavior(), "Plan should have ExecutionBehavior");
     assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN,
         plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be PER_PLAN");
   }
@@ -465,7 +462,7 @@ class PlanConverterTest {
     // Verify the POJO has execution behavior
     assertNotNull(plan.getExecutionBehavior(), "Plan should have ExecutionBehavior");
     assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
+        Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD,
         plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be PER_RECORD");
   }
@@ -486,7 +483,7 @@ class PlanConverterTest {
 
     assertNotNull(plan.getExecutionBehavior(), "Plan should have a default ExecutionBehavior");
     assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN,
         plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Default variable evaluation mode should be PER_PLAN");
   }
@@ -533,8 +530,7 @@ class PlanConverterTest {
     // Create original Plan
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
             .build();
 
     Plan originalPlan =
@@ -553,7 +549,7 @@ class PlanConverterTest {
         roundTrippedPlan.getExecutionBehavior(),
         "Round-tripped Plan should have ExecutionBehavior");
     assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN,
         roundTrippedPlan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be preserved");
     assertEquals(
@@ -577,8 +573,7 @@ class PlanConverterTest {
     // Create original Plan
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD)
             .build();
 
     Plan originalPlan =
@@ -597,7 +592,7 @@ class PlanConverterTest {
         roundTrippedPlan.getExecutionBehavior(),
         "Round-tripped Plan should have ExecutionBehavior");
     assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
+        Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD,
         roundTrippedPlan.getExecutionBehavior().getVariableEvaluationMode(),
         "Variable evaluation mode should be preserved");
   }
@@ -613,8 +608,7 @@ class PlanConverterTest {
     // Create minimal Plan
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
             .build();
 
     Plan originalPlan =
@@ -654,7 +648,7 @@ class PlanConverterTest {
 
     assertNotNull(plan.getExecutionBehavior(), "Plan should have a default ExecutionBehavior");
     assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN,
         plan.getExecutionBehavior().getVariableEvaluationMode(),
         "Default variable evaluation mode should be PER_PLAN");
   }

--- a/core/src/test/java/io/substrait/plan/PlanConverterTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanConverterTest.java
@@ -475,19 +475,24 @@ class PlanConverterTest {
   /**
    * Conversion from protobuf Plan without ExecutionBehavior.
    *
-   * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan that fails
-   * validation (since ExecutionBehavior is required).
+   * <p>Verifies that a protobuf Plan without ExecutionBehavior results in a POJO Plan with a default
+   * ExecutionBehavior of PER_PLAN, supporting older plans that predate the field.
    */
   @Test
-  void testFromProtoWithoutExecutionBehaviorFailsValidation() {
+  void testFromProtoWithoutExecutionBehaviorUsesDefault() {
     // Create a protobuf Plan without ExecutionBehavior
     io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
 
-    // Attempt to convert to POJO - should fail validation
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> fromProtoConverter.from(protoPlan),
-        "Conversion should fail when ExecutionBehavior is not set");
+    // Convert to POJO - should succeed with a default ExecutionBehavior
+    Plan plan = fromProtoConverter.from(protoPlan);
+
+    assertTrue(
+        plan.getExecutionBehavior().isPresent(),
+        "Plan should have a default ExecutionBehavior present");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Default variable evaluation mode should be PER_PLAN");
   }
 
   /**
@@ -637,7 +642,7 @@ class PlanConverterTest {
    * Verify that protobuf without execution behavior field is handled.
    *
    * <p>Tests the edge case where a protobuf Plan doesn't have the execution behavior field set at
-   * all.
+   * all. Such older plans receive a default ExecutionBehavior of PER_PLAN.
    */
   @Test
   void testFromProtoMissingExecutionBehaviorField() {
@@ -648,10 +653,15 @@ class PlanConverterTest {
     assertFalse(
         protoPlan.hasExecutionBehavior(), "Protobuf Plan should not have execution behavior field");
 
-    // Conversion should fail validation
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> fromProtoConverter.from(protoPlan),
-        "Conversion should fail when execution behavior is missing");
+    // Conversion should succeed with a default ExecutionBehavior of PER_PLAN
+    Plan plan = fromProtoConverter.from(protoPlan);
+
+    assertTrue(
+        plan.getExecutionBehavior().isPresent(),
+        "Plan should have a default ExecutionBehavior present");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Default variable evaluation mode should be PER_PLAN");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -1,0 +1,120 @@
+package io.substrait.plan;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for the Plan validation method that ensures ExecutionBehavior is properly configured.
+ */
+class PlanValidationTest {
+
+  /**
+   * Test case 1: Valid execution behavior with proper variable evaluation mode.
+   *
+   * <p>This test verifies that a Plan with a properly configured ExecutionBehavior (with
+   * VariableEvaluationMode set to a valid value other than UNSPECIFIED) is successfully created
+   * without throwing any exceptions.
+   */
+  @Test
+  void testValidExecutionBehavior_PerPlan() {
+    // Create a valid ExecutionBehavior with VARIABLE_EVALUATION_MODE_PER_PLAN
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .build();
+
+    // Create a Plan with the valid ExecutionBehavior
+    assertDoesNotThrow(
+        () -> {
+          ImmutablePlan.builder().executionBehavior(executionBehavior).build();
+        },
+        "Plan creation should succeed with valid ExecutionBehavior");
+  }
+
+  /**
+   * Test case 1b: Valid execution behavior with VARIABLE_EVALUATION_MODE_PER_RECORD.
+   *
+   * <p>This test verifies that a Plan with ExecutionBehavior set to
+   * VARIABLE_EVALUATION_MODE_PER_RECORD is also valid.
+   */
+  @Test
+  void testValidExecutionBehavior_PerRecord() {
+    // Create a valid ExecutionBehavior with VARIABLE_EVALUATION_MODE_PER_RECORD
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD)
+            .build();
+
+    // Create a Plan with the valid ExecutionBehavior
+    assertDoesNotThrow(
+        () -> {
+          ImmutablePlan.builder().executionBehavior(executionBehavior).build();
+        },
+        "Plan creation should succeed with valid ExecutionBehavior");
+  }
+
+  /**
+   * Test case 2: Missing execution behavior (empty Optional).
+   *
+   * <p>This test verifies that attempting to create a Plan without setting the ExecutionBehavior
+   * field throws an IllegalArgumentException with an appropriate error message indicating that
+   * ExecutionBehavior is required.
+   */
+  @Test
+  void testMissingExecutionBehavior() {
+    // Attempt to create a Plan without ExecutionBehavior
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              ImmutablePlan.builder().build();
+            },
+            "Plan creation should fail when ExecutionBehavior is not set");
+
+    // Verify the error message
+    assertEquals(
+        "ExecutionBehavior is required but was not set",
+        exception.getMessage(),
+        "Error message should indicate ExecutionBehavior is required");
+  }
+
+  /**
+   * Test case 3: Execution behavior with unspecified variable evaluation mode.
+   *
+   * <p>This test verifies that attempting to create a Plan with an ExecutionBehavior that has its
+   * VariableEvaluationMode set to VARIABLE_EVALUATION_MODE_UNSPECIFIED throws an
+   * IllegalArgumentException with an appropriate error message.
+   */
+  @Test
+  void testUnspecifiedVariableEvaluationMode() {
+    // Create an ExecutionBehavior with VARIABLE_EVALUATION_MODE_UNSPECIFIED
+    Plan.ExecutionBehavior executionBehavior =
+        ImmutableExecutionBehavior.builder()
+            .variableEvaluationMode(
+                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED)
+            .build();
+
+    // Attempt to create a Plan with the invalid ExecutionBehavior
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              ImmutablePlan.builder().executionBehavior(executionBehavior).build();
+            },
+            "Plan creation should fail when VariableEvaluationMode is UNSPECIFIED");
+
+    // Verify the error message contains the expected information
+    String expectedMessage =
+        "ExecutionBehavior requires a specified VariableEvaluationMode, but got: "
+            + "VARIABLE_EVALUATION_MODE_UNSPECIFIED";
+    assertEquals(
+        expectedMessage,
+        exception.getMessage(),
+        "Error message should indicate VariableEvaluationMode cannot be UNSPECIFIED");
+  }
+}

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -24,8 +24,7 @@ class PlanValidationTest {
     // Create a valid ExecutionBehavior with VARIABLE_EVALUATION_MODE_PER_PLAN
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
             .build();
 
     // Create a Plan with the valid ExecutionBehavior
@@ -47,8 +46,7 @@ class PlanValidationTest {
     // Create a valid ExecutionBehavior with VARIABLE_EVALUATION_MODE_PER_RECORD
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD)
             .build();
 
     // Create a Plan with the valid ExecutionBehavior
@@ -95,8 +93,7 @@ class PlanValidationTest {
     // Create an ExecutionBehavior with VARIABLE_EVALUATION_MODE_UNSPECIFIED
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(
-                Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED)
+            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.UNSPECIFIED)
             .build();
 
     // Attempt to create a Plan with the invalid ExecutionBehavior

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * Test cases for the Plan validation method that ensures ExecutionBehavior is properly configured.
@@ -13,19 +15,20 @@ import org.junit.jupiter.api.Test;
 class PlanValidationTest {
 
   /**
-   * Test case 1: Valid execution behavior with proper variable evaluation mode.
+   * Valid execution behavior with a specified variable evaluation mode.
    *
    * <p>This test verifies that a Plan with a properly configured ExecutionBehavior (with
    * VariableEvaluationMode set to a valid value other than UNSPECIFIED) is successfully created
    * without throwing any exceptions.
    */
-  @Test
-  void testValidExecutionBehavior_PerPlan() {
-    // Create a valid ExecutionBehavior with VARIABLE_EVALUATION_MODE_PER_PLAN
+  @ParameterizedTest
+  @EnumSource(
+      value = Plan.ExecutionBehavior.VariableEvaluationMode.class,
+      names = {"PER_PLAN", "PER_RECORD"})
+  void testValidExecutionBehavior(Plan.ExecutionBehavior.VariableEvaluationMode mode) {
+    // Create a valid ExecutionBehavior
     Plan.ExecutionBehavior executionBehavior =
-        ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
-            .build();
+        ImmutableExecutionBehavior.builder().variableEvaluationMode(mode).build();
 
     // Create a Plan with the valid ExecutionBehavior
     assertDoesNotThrow(
@@ -36,29 +39,7 @@ class PlanValidationTest {
   }
 
   /**
-   * Test case 1b: Valid execution behavior with VARIABLE_EVALUATION_MODE_PER_RECORD.
-   *
-   * <p>This test verifies that a Plan with ExecutionBehavior set to
-   * VARIABLE_EVALUATION_MODE_PER_RECORD is also valid.
-   */
-  @Test
-  void testValidExecutionBehavior_PerRecord() {
-    // Create a valid ExecutionBehavior with VARIABLE_EVALUATION_MODE_PER_RECORD
-    Plan.ExecutionBehavior executionBehavior =
-        ImmutableExecutionBehavior.builder()
-            .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_RECORD)
-            .build();
-
-    // Create a Plan with the valid ExecutionBehavior
-    assertDoesNotThrow(
-        () -> {
-          ImmutablePlan.builder().executionBehavior(executionBehavior).build();
-        },
-        "Plan creation should succeed with valid ExecutionBehavior");
-  }
-
-  /**
-   * Test case 2: Missing execution behavior.
+   * Missing execution behavior.
    *
    * <p>This test verifies that attempting to create a Plan without setting the ExecutionBehavior
    * field throws an IllegalStateException (from Immutables) with an appropriate error message
@@ -82,7 +63,7 @@ class PlanValidationTest {
   }
 
   /**
-   * Test case 3: Execution behavior with unspecified variable evaluation mode.
+   * Execution behavior with unspecified variable evaluation mode.
    *
    * <p>This test verifies that attempting to create a Plan with an ExecutionBehavior that has its
    * VariableEvaluationMode set to VARIABLE_EVALUATION_MODE_UNSPECIFIED throws an

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -3,6 +3,7 @@ package io.substrait.plan;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,28 +60,27 @@ class PlanValidationTest {
   }
 
   /**
-   * Test case 2: Missing execution behavior (empty Optional).
+   * Test case 2: Missing execution behavior.
    *
    * <p>This test verifies that attempting to create a Plan without setting the ExecutionBehavior
-   * field throws an IllegalArgumentException with an appropriate error message indicating that
-   * ExecutionBehavior is required.
+   * field throws an IllegalStateException (from Immutables) with an appropriate error message
+   * indicating that ExecutionBehavior is required.
    */
   @Test
   void testMissingExecutionBehavior() {
     // Attempt to create a Plan without ExecutionBehavior
-    IllegalArgumentException exception =
+    IllegalStateException exception =
         assertThrows(
-            IllegalArgumentException.class,
+            IllegalStateException.class,
             () -> {
               ImmutablePlan.builder().build();
             },
             "Plan creation should fail when ExecutionBehavior is not set");
 
-    // Verify the error message
-    assertEquals(
-        "ExecutionBehavior is required but was not set",
-        exception.getMessage(),
-        "Error message should indicate ExecutionBehavior is required");
+    // Verify the error message mentions the required field
+    assertTrue(
+        exception.getMessage().contains("executionBehavior"),
+        "Error message should mention executionBehavior field");
   }
 
   /**

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -107,8 +107,7 @@ class PlanValidationTest {
 
     // Verify the error message contains the expected information
     String expectedMessage =
-        "ExecutionBehavior requires a specified VariableEvaluationMode, but got: "
-            + "VARIABLE_EVALUATION_MODE_UNSPECIFIED";
+        "ExecutionBehavior requires a specified VariableEvaluationMode, but got: " + "UNSPECIFIED";
     assertEquals(
         expectedMessage,
         exception.getMessage(),

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -3,6 +3,7 @@ package io.substrait.plan;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,16 @@ import org.junit.jupiter.api.Test;
  * Test cases for the Plan validation method that ensures ExecutionBehavior is properly configured.
  */
 class PlanValidationTest {
+
+  private final ProtoPlanConverter fromProtoConverter = new ProtoPlanConverter();
+
+  private static io.substrait.proto.Version protoVersion(int major, int minor, int patch) {
+    return io.substrait.proto.Version.newBuilder()
+        .setMajorNumber(major)
+        .setMinorNumber(minor)
+        .setPatchNumber(patch)
+        .build();
+  }
 
   /**
    * Test case 1: Valid execution behavior with proper variable evaluation mode.
@@ -116,5 +127,108 @@ class PlanValidationTest {
         expectedMessage,
         exception.getMessage(),
         "Error message should indicate VariableEvaluationMode cannot be UNSPECIFIED");
+  }
+
+  /**
+   * Test case 4: Missing execution behavior on a pre-0.87.0 plan defaults to PER_PLAN.
+   *
+   * <p>ExecutionBehavior did not exist before Substrait 0.87.0, so converting a protobuf Plan that
+   * explicitly declares an older version and omits execution behavior should default the variable
+   * evaluation mode to PER_PLAN rather than failing validation.
+   */
+  @Test
+  void testMissingExecutionBehaviorOnOldVersionDefaultsToPerPlan() {
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder().setVersion(protoVersion(0, 86, 0)).build();
+
+    Plan plan = assertDoesNotThrow(() -> fromProtoConverter.from(protoPlan));
+
+    assertTrue(
+        plan.getExecutionBehavior().isPresent(),
+        "Pre-0.87.0 plan should have a defaulted ExecutionBehavior");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Pre-0.87.0 plan should default to PER_PLAN");
+  }
+
+  /**
+   * Test case 5: Missing execution behavior at exactly 0.87.0 still fails validation.
+   *
+   * <p>ExecutionBehavior is required from Substrait 0.87.0 onward, so a plan at that version with
+   * no execution behavior must fail validation rather than being defaulted.
+   */
+  @Test
+  void testMissingExecutionBehaviorAtCutoffVersionFails() {
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder().setVersion(protoVersion(0, 87, 0)).build();
+
+    IllegalArgumentException exception =
+        assertThrows(IllegalArgumentException.class, () -> fromProtoConverter.from(protoPlan));
+    assertEquals(
+        "ExecutionBehavior is required but was not set",
+        exception.getMessage(),
+        "Plans at or after 0.87.0 require ExecutionBehavior");
+  }
+
+  /**
+   * Test case 6: Missing execution behavior on a newer plan still fails validation.
+   *
+   * <p>Verifies the requirement also holds for versions beyond the 0.87.0 cutoff.
+   */
+  @Test
+  void testMissingExecutionBehaviorOnNewerVersionFails() {
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder().setVersion(protoVersion(1, 0, 0)).build();
+
+    assertThrows(IllegalArgumentException.class, () -> fromProtoConverter.from(protoPlan));
+  }
+
+  /**
+   * Test case 7: A version-less plan reads as the protobuf default 0.0.0.
+   *
+   * <p>A protobuf Plan that does not declare a version at all has the default version 0.0.0, which
+   * is older than 0.87.0, so a missing execution behavior is defaulted to PER_PLAN.
+   */
+  @Test
+  void testMissingExecutionBehaviorWithoutVersionDefaultsToPerPlan() {
+    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
+
+    Plan plan = assertDoesNotThrow(() -> fromProtoConverter.from(protoPlan));
+
+    assertTrue(
+        plan.getExecutionBehavior().isPresent(),
+        "Version-less plan (0.0.0) should have a defaulted ExecutionBehavior");
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
+        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Version-less plan (0.0.0) should default to PER_PLAN");
+  }
+
+  /**
+   * Test case 8: An explicit execution behavior on an old plan is not overridden.
+   *
+   * <p>When a pre-0.87.0 plan does provide an execution behavior, the provided value must be used
+   * instead of the PER_PLAN default.
+   */
+  @Test
+  void testExplicitExecutionBehaviorOnOldVersionIsPreserved() {
+    io.substrait.proto.Plan protoPlan =
+        io.substrait.proto.Plan.newBuilder()
+            .setVersion(protoVersion(0, 86, 0))
+            .setExecutionBehavior(
+                io.substrait.proto.ExecutionBehavior.newBuilder()
+                    .setVariableEvalMode(
+                        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
+                            .VARIABLE_EVALUATION_MODE_PER_RECORD)
+                    .build())
+            .build();
+
+    Plan plan = fromProtoConverter.from(protoPlan);
+
+    assertEquals(
+        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
+        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
+        "Explicit execution behavior should not be overridden by the default");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -61,24 +61,22 @@ class PlanValidationTest {
   /**
    * Test case 2: Missing execution behavior (empty Optional).
    *
-   * <p>This test verifies that attempting to create a Plan without setting the ExecutionBehavior
-   * field throws an IllegalArgumentException with an appropriate error message indicating that
-   * ExecutionBehavior is required.
+   * <p>This test verifies that a Plan can be built without ExecutionBehavior, but serialization via
+   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
+   * fails with an IllegalArgumentException indicating that ExecutionBehavior is required.
    */
   @Test
   void testMissingExecutionBehavior() {
-    // Attempt to create a Plan without ExecutionBehavior
+    Plan plan = ImmutablePlan.builder().build();
+
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> {
-              ImmutablePlan.builder().build();
-            },
-            "Plan creation should fail when ExecutionBehavior is not set");
+            () -> new PlanProtoConverter().toProto(plan),
+            "Plan serialization should fail when ExecutionBehavior is not set");
 
-    // Verify the error message
     assertEquals(
-        "ExecutionBehavior is required but was not set",
+        "ExecutionBehavior is required since Substrait v0.87.0 but was not set",
         exception.getMessage(),
         "Error message should indicate ExecutionBehavior is required");
   }
@@ -86,29 +84,27 @@ class PlanValidationTest {
   /**
    * Test case 3: Execution behavior with unspecified variable evaluation mode.
    *
-   * <p>This test verifies that attempting to create a Plan with an ExecutionBehavior that has its
-   * VariableEvaluationMode set to VARIABLE_EVALUATION_MODE_UNSPECIFIED throws an
-   * IllegalArgumentException with an appropriate error message.
+   * <p>This test verifies that a Plan can be built with an ExecutionBehavior whose
+   * VariableEvaluationMode is VARIABLE_EVALUATION_MODE_UNSPECIFIED, but serialization via
+   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
+   * fails with an IllegalArgumentException.
    */
   @Test
   void testUnspecifiedVariableEvaluationMode() {
-    // Create an ExecutionBehavior with VARIABLE_EVALUATION_MODE_UNSPECIFIED
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
             .variableEvaluationMode(
                 Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED)
             .build();
 
-    // Attempt to create a Plan with the invalid ExecutionBehavior
+    Plan plan = ImmutablePlan.builder().executionBehavior(executionBehavior).build();
+
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> {
-              ImmutablePlan.builder().executionBehavior(executionBehavior).build();
-            },
-            "Plan creation should fail when VariableEvaluationMode is UNSPECIFIED");
+            () -> new PlanProtoConverter().toProto(plan),
+            "Plan serialization should fail when VariableEvaluationMode is UNSPECIFIED");
 
-    // Verify the error message contains the expected information
     String expectedMessage =
         "ExecutionBehavior requires a specified VariableEvaluationMode, but got: "
             + "VARIABLE_EVALUATION_MODE_UNSPECIFIED";

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -3,7 +3,6 @@ package io.substrait.plan;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,16 +10,6 @@ import org.junit.jupiter.api.Test;
  * Test cases for the Plan validation method that ensures ExecutionBehavior is properly configured.
  */
 class PlanValidationTest {
-
-  private final ProtoPlanConverter fromProtoConverter = new ProtoPlanConverter();
-
-  private static io.substrait.proto.Version protoVersion(int major, int minor, int patch) {
-    return io.substrait.proto.Version.newBuilder()
-        .setMajorNumber(major)
-        .setMinorNumber(minor)
-        .setPatchNumber(patch)
-        .build();
-  }
 
   /**
    * Test case 1: Valid execution behavior with proper variable evaluation mode.
@@ -127,108 +116,5 @@ class PlanValidationTest {
         expectedMessage,
         exception.getMessage(),
         "Error message should indicate VariableEvaluationMode cannot be UNSPECIFIED");
-  }
-
-  /**
-   * Test case 4: Missing execution behavior on a pre-0.87.0 plan defaults to PER_PLAN.
-   *
-   * <p>ExecutionBehavior did not exist before Substrait 0.87.0, so converting a protobuf Plan that
-   * explicitly declares an older version and omits execution behavior should default the variable
-   * evaluation mode to PER_PLAN rather than failing validation.
-   */
-  @Test
-  void testMissingExecutionBehaviorOnOldVersionDefaultsToPerPlan() {
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder().setVersion(protoVersion(0, 86, 0)).build();
-
-    Plan plan = assertDoesNotThrow(() -> fromProtoConverter.from(protoPlan));
-
-    assertTrue(
-        plan.getExecutionBehavior().isPresent(),
-        "Pre-0.87.0 plan should have a defaulted ExecutionBehavior");
-    assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
-        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
-        "Pre-0.87.0 plan should default to PER_PLAN");
-  }
-
-  /**
-   * Test case 5: Missing execution behavior at exactly 0.87.0 still fails validation.
-   *
-   * <p>ExecutionBehavior is required from Substrait 0.87.0 onward, so a plan at that version with
-   * no execution behavior must fail validation rather than being defaulted.
-   */
-  @Test
-  void testMissingExecutionBehaviorAtCutoffVersionFails() {
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder().setVersion(protoVersion(0, 87, 0)).build();
-
-    IllegalArgumentException exception =
-        assertThrows(IllegalArgumentException.class, () -> fromProtoConverter.from(protoPlan));
-    assertEquals(
-        "ExecutionBehavior is required but was not set",
-        exception.getMessage(),
-        "Plans at or after 0.87.0 require ExecutionBehavior");
-  }
-
-  /**
-   * Test case 6: Missing execution behavior on a newer plan still fails validation.
-   *
-   * <p>Verifies the requirement also holds for versions beyond the 0.87.0 cutoff.
-   */
-  @Test
-  void testMissingExecutionBehaviorOnNewerVersionFails() {
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder().setVersion(protoVersion(1, 0, 0)).build();
-
-    assertThrows(IllegalArgumentException.class, () -> fromProtoConverter.from(protoPlan));
-  }
-
-  /**
-   * Test case 7: A version-less plan reads as the protobuf default 0.0.0.
-   *
-   * <p>A protobuf Plan that does not declare a version at all has the default version 0.0.0, which
-   * is older than 0.87.0, so a missing execution behavior is defaulted to PER_PLAN.
-   */
-  @Test
-  void testMissingExecutionBehaviorWithoutVersionDefaultsToPerPlan() {
-    io.substrait.proto.Plan protoPlan = io.substrait.proto.Plan.newBuilder().build();
-
-    Plan plan = assertDoesNotThrow(() -> fromProtoConverter.from(protoPlan));
-
-    assertTrue(
-        plan.getExecutionBehavior().isPresent(),
-        "Version-less plan (0.0.0) should have a defaulted ExecutionBehavior");
-    assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN,
-        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
-        "Version-less plan (0.0.0) should default to PER_PLAN");
-  }
-
-  /**
-   * Test case 8: An explicit execution behavior on an old plan is not overridden.
-   *
-   * <p>When a pre-0.87.0 plan does provide an execution behavior, the provided value must be used
-   * instead of the PER_PLAN default.
-   */
-  @Test
-  void testExplicitExecutionBehaviorOnOldVersionIsPreserved() {
-    io.substrait.proto.Plan protoPlan =
-        io.substrait.proto.Plan.newBuilder()
-            .setVersion(protoVersion(0, 86, 0))
-            .setExecutionBehavior(
-                io.substrait.proto.ExecutionBehavior.newBuilder()
-                    .setVariableEvalMode(
-                        io.substrait.proto.ExecutionBehavior.VariableEvaluationMode
-                            .VARIABLE_EVALUATION_MODE_PER_RECORD)
-                    .build())
-            .build();
-
-    Plan plan = fromProtoConverter.from(protoPlan);
-
-    assertEquals(
-        Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_RECORD,
-        plan.getExecutionBehavior().get().getVariableEvaluationMode(),
-        "Explicit execution behavior should not be overridden by the default");
   }
 }

--- a/core/src/test/java/io/substrait/plan/PlanValidationTest.java
+++ b/core/src/test/java/io/substrait/plan/PlanValidationTest.java
@@ -61,22 +61,24 @@ class PlanValidationTest {
   /**
    * Test case 2: Missing execution behavior (empty Optional).
    *
-   * <p>This test verifies that a Plan can be built without ExecutionBehavior, but serialization via
-   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
-   * fails with an IllegalArgumentException indicating that ExecutionBehavior is required.
+   * <p>This test verifies that attempting to create a Plan without setting the ExecutionBehavior
+   * field throws an IllegalArgumentException with an appropriate error message indicating that
+   * ExecutionBehavior is required.
    */
   @Test
   void testMissingExecutionBehavior() {
-    Plan plan = ImmutablePlan.builder().build();
-
+    // Attempt to create a Plan without ExecutionBehavior
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new PlanProtoConverter().toProto(plan),
-            "Plan serialization should fail when ExecutionBehavior is not set");
+            () -> {
+              ImmutablePlan.builder().build();
+            },
+            "Plan creation should fail when ExecutionBehavior is not set");
 
+    // Verify the error message
     assertEquals(
-        "ExecutionBehavior is required since Substrait v0.87.0 but was not set",
+        "ExecutionBehavior is required but was not set",
         exception.getMessage(),
         "Error message should indicate ExecutionBehavior is required");
   }
@@ -84,27 +86,29 @@ class PlanValidationTest {
   /**
    * Test case 3: Execution behavior with unspecified variable evaluation mode.
    *
-   * <p>This test verifies that a Plan can be built with an ExecutionBehavior whose
-   * VariableEvaluationMode is VARIABLE_EVALUATION_MODE_UNSPECIFIED, but serialization via
-   * [`PlanProtoConverter.toProto()`](core/src/main/java/io/substrait/plan/PlanProtoConverter.java:86)
-   * fails with an IllegalArgumentException.
+   * <p>This test verifies that attempting to create a Plan with an ExecutionBehavior that has its
+   * VariableEvaluationMode set to VARIABLE_EVALUATION_MODE_UNSPECIFIED throws an
+   * IllegalArgumentException with an appropriate error message.
    */
   @Test
   void testUnspecifiedVariableEvaluationMode() {
+    // Create an ExecutionBehavior with VARIABLE_EVALUATION_MODE_UNSPECIFIED
     Plan.ExecutionBehavior executionBehavior =
         ImmutableExecutionBehavior.builder()
             .variableEvaluationMode(
                 Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_UNSPECIFIED)
             .build();
 
-    Plan plan = ImmutablePlan.builder().executionBehavior(executionBehavior).build();
-
+    // Attempt to create a Plan with the invalid ExecutionBehavior
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new PlanProtoConverter().toProto(plan),
-            "Plan serialization should fail when VariableEvaluationMode is UNSPECIFIED");
+            () -> {
+              ImmutablePlan.builder().executionBehavior(executionBehavior).build();
+            },
+            "Plan creation should fail when VariableEvaluationMode is UNSPECIFIED");
 
+    // Verify the error message contains the expected information
     String expectedMessage =
         "ExecutionBehavior requires a specified VariableEvaluationMode, but got: "
             + "VARIABLE_EVALUATION_MODE_UNSPECIFIED";

--- a/core/src/test/resources/plan-roundtrip/complex-expected-plan.json
+++ b/core/src/test/resources/plan-roundtrip/complex-expected-plan.json
@@ -148,6 +148,9 @@
     }
   ],
   "version": {
-    "minorNumber": 75
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
   }
 }

--- a/core/src/test/resources/plan-roundtrip/complex-input-plan.json
+++ b/core/src/test/resources/plan-roundtrip/complex-input-plan.json
@@ -133,6 +133,9 @@
     }
   ],
   "version": {
-    "minorNumber": 75
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
   }
 }

--- a/core/src/test/resources/plan-roundtrip/simple-expected-plan.json
+++ b/core/src/test/resources/plan-roundtrip/simple-expected-plan.json
@@ -120,6 +120,9 @@
     }
   ],
   "version": {
-    "minorNumber": 75
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
   }
 }

--- a/core/src/test/resources/plan-roundtrip/simple-input-plan.json
+++ b/core/src/test/resources/plan-roundtrip/simple-input-plan.json
@@ -105,6 +105,9 @@
     }
   ],
   "version": {
-    "minorNumber": 75
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
   }
 }

--- a/core/src/test/resources/plan-roundtrip/zero-anchor-expected-plan.json
+++ b/core/src/test/resources/plan-roundtrip/zero-anchor-expected-plan.json
@@ -92,6 +92,9 @@
     }
   ],
   "version": {
-    "minorNumber": 75
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
   }
 }

--- a/core/src/test/resources/plan-roundtrip/zero-anchor-input-plan.json
+++ b/core/src/test/resources/plan-roundtrip/zero-anchor-input-plan.json
@@ -79,6 +79,9 @@
     }
   ],
   "version": {
-    "minorNumber": 75
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -12,6 +12,8 @@ import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.SqlArrayValueConstructorCallConverter;
 import io.substrait.isthmus.expression.SqlMapValueConstructorCallConverter;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
+import io.substrait.plan.ImmutableExecutionBehavior;
+import io.substrait.plan.Plan;
 import io.substrait.relation.Rel;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +66,8 @@ public class ConverterProvider {
   /** Converter for Substrait types to Calcite types and vice versa. */
   protected TypeConverter typeConverter;
 
+  protected final Plan.ExecutionBehavior executionBehavior;
+
   /**
    * Creates a ConverterProvider with default extension collection and type factory. Uses {@link
    * DefaultExtensionCatalog#DEFAULT_COLLECTION} and {@link SubstraitTypeSystem#TYPE_FACTORY}.
@@ -115,12 +119,36 @@ public class ConverterProvider {
       AggregateFunctionConverter afc,
       WindowFunctionConverter wfc,
       TypeConverter tc) {
+    this(typeFactory, extensions, sfc, afc, wfc, tc, createDefaultExecutionBehavior());
+  }
+
+  public ConverterProvider(
+      RelDataTypeFactory typeFactory,
+      SimpleExtension.ExtensionCollection extensions,
+      ScalarFunctionConverter sfc,
+      AggregateFunctionConverter afc,
+      WindowFunctionConverter wfc,
+      TypeConverter tc,
+      Plan.ExecutionBehavior executionBehavior) {
     this.typeFactory = typeFactory;
     this.extensions = extensions;
     this.scalarFunctionConverter = sfc;
     this.aggregateFunctionConverter = afc;
     this.windowFunctionConverter = wfc;
     this.typeConverter = tc;
+    this.executionBehavior = executionBehavior;
+  }
+
+  /**
+   * Creates the default execution behavior with PER_PLAN variable evaluation mode.
+   *
+   * @return the default execution behavior
+   */
+  private static Plan.ExecutionBehavior createDefaultExecutionBehavior() {
+    return ImmutableExecutionBehavior.builder()
+        .variableEvaluationMode(
+            Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+        .build();
   }
 
   // SQL to Calcite Processing
@@ -350,5 +378,19 @@ public class ConverterProvider {
    */
   public TypeConverter getTypeConverter() {
     return typeConverter;
+  }
+
+  /**
+   * Returns the execution behavior for plans created by this converter.
+   *
+   * <p>The default execution behavior uses {@link
+   * Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN}, which
+   * evaluates variables once per plan execution. This can be customized by providing a different
+   * execution behavior through the constructor.
+   *
+   * @return the execution behavior to use when creating plans
+   */
+  public Plan.ExecutionBehavior getExecutionBehavior() {
+    return executionBehavior;
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -66,6 +66,7 @@ public class ConverterProvider {
   /** Converter for Substrait types to Calcite types and vice versa. */
   protected TypeConverter typeConverter;
 
+  /** The execution behavior configuration for plans created by this converter. */
   protected final Plan.ExecutionBehavior executionBehavior;
 
   /**
@@ -122,6 +123,17 @@ public class ConverterProvider {
     this(typeFactory, extensions, sfc, afc, wfc, tc, createDefaultExecutionBehavior());
   }
 
+  /**
+   * Creates a ConverterProvider with full customization including execution behavior.
+   *
+   * @param typeFactory the Calcite type factory to use
+   * @param extensions the Substrait extension collection to use
+   * @param sfc the scalar function converter to use
+   * @param afc the aggregate function converter to use
+   * @param wfc the window function converter to use
+   * @param tc the type converter to use
+   * @param executionBehavior the execution behavior to use for plans
+   */
   public ConverterProvider(
       RelDataTypeFactory typeFactory,
       SimpleExtension.ExtensionCollection extensions,

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -158,8 +158,7 @@ public class ConverterProvider {
    */
   private static Plan.ExecutionBehavior createDefaultExecutionBehavior() {
     return ImmutableExecutionBehavior.builder()
-        .variableEvaluationMode(
-            Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+        .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
         .build();
   }
 
@@ -396,9 +395,9 @@ public class ConverterProvider {
    * Returns the execution behavior for plans created by this converter.
    *
    * <p>The default execution behavior uses {@link
-   * Plan.ExecutionBehavior.VariableEvaluationMode#VARIABLE_EVALUATION_MODE_PER_PLAN}, which
-   * evaluates variables once per plan execution. This can be customized by providing a different
-   * execution behavior through the constructor.
+   * Plan.ExecutionBehavior.VariableEvaluationMode#PER_PLAN}, which evaluates variables once per
+   * plan execution. This can be customized by providing a different execution behavior through the
+   * constructor.
    *
    * @return the execution behavior to use when creating plans
    */

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlToSubstrait.java
@@ -47,6 +47,7 @@ public class SqlToSubstrait extends SqlConverterBase {
       throws SqlParseException {
     Builder builder = io.substrait.plan.Plan.builder();
     builder.version(Version.builder().from(Version.DEFAULT_VERSION).producer("isthmus").build());
+    builder.executionBehavior(converterProvider.getExecutionBehavior());
 
     // TODO: consider case in which one sql passes conversion while others don't
     SubstraitSqlToCalcite.convertQueries(sqlStatements, catalogReader, operatorTable).stream()
@@ -73,6 +74,7 @@ public class SqlToSubstrait extends SqlConverterBase {
       throws SqlParseException {
     Builder builder = io.substrait.plan.Plan.builder();
     builder.version(Version.builder().from(Version.DEFAULT_VERSION).producer("isthmus").build());
+    builder.executionBehavior(converterProvider.getExecutionBehavior());
 
     final SqlParser.Config sqlParserConfig =
         sqlDialect.configureParser(

--- a/isthmus/src/test/java/io/substrait/isthmus/AutomaticDynamicFunctionMappingRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AutomaticDynamicFunctionMappingRoundtripTest.java
@@ -63,13 +63,9 @@ class AutomaticDynamicFunctionMappingRoundtripTest extends PlanTestBase {
             sb.remap(2, 3), // The inputs are indices 0, 1. The two scalarFn outputs are 2, 3.
             table);
 
-    // Build plan with output field names
+    // Build plan with output field names and default execution behavior
     Plan plan =
-        Plan.builder()
-            .roots(
-                List.of(
-                    Plan.Root.builder().input(project).names(List.of("ts_str", "dt_str")).build()))
-            .build();
+        sb.plan(Plan.Root.builder().input(project).names(List.of("ts_str", "dt_str")).build());
 
     // Use PlanTestBase helper method for comprehensive roundtrip testing
     assertFullRoundTrip(plan.getRoots().get(0));

--- a/isthmus/src/test/resources/lambdas/basic-lambda.json
+++ b/isthmus/src/test/resources/lambdas/basic-lambda.json
@@ -1,7 +1,9 @@
 {
   "version": {
-    "majorNumber": 0,
-    "minorNumber": 79
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
   },
   "extensionUrns": [
     {

--- a/isthmus/src/test/resources/lambdas/lambda-field-ref.json
+++ b/isthmus/src/test/resources/lambdas/lambda-field-ref.json
@@ -1,4 +1,10 @@
 {
+  "version": {
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
+  },
   "extensionUrns": [
     {
       "extensionUrnAnchor": 1,

--- a/isthmus/src/test/resources/lambdas/lambda-with-function.json
+++ b/isthmus/src/test/resources/lambdas/lambda-with-function.json
@@ -1,4 +1,10 @@
 {
+  "version": {
+    "minorNumber": 87
+  },
+  "executionBehavior": {
+    "variableEvalMode": "VARIABLE_EVALUATION_MODE_PER_PLAN"
+  },
   "extensionUrns": [
     {
       "extensionUrnAnchor": 1,

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -47,7 +47,8 @@ import io.substrait.expression.{Expression => SExpression, ExpressionCreator}
 import io.substrait.expression.Expression.StructLiteral
 import io.substrait.extension.ExtensionCollector
 import io.substrait.hint.Hint
-import io.substrait.plan.Plan
+import io.substrait.plan.{ImmutableExecutionBehavior, Plan}
+import io.substrait.plan.Plan.ExecutionBehavior.VariableEvaluationMode
 import io.substrait.relation.AbstractDdlRel.{DdlObject, DdlOp}
 import io.substrait.relation.AbstractWriteRel.{CreateMode, OutputMode, WriteOp}
 import io.substrait.relation.RelProtoConverter
@@ -706,6 +707,10 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
           .builder()
           .from(Plan.Version.DEFAULT_VERSION)
           .producer("substrait-spark")
+          .build())
+      .executionBehavior(
+        ImmutableExecutionBehavior.builder()
+          .variableEvaluationMode(VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
           .build())
       .roots(
         Collections.singletonList(

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -710,7 +710,7 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
           .build())
       .executionBehavior(
         ImmutableExecutionBehavior.builder()
-          .variableEvaluationMode(VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+          .variableEvaluationMode(VariableEvaluationMode.PER_PLAN)
           .build())
       .roots(
         Collections.singletonList(

--- a/spark/src/test/scala/io/substrait/spark/AggregateWithJoinSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/AggregateWithJoinSuite.scala
@@ -244,7 +244,7 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
       .addRoots(root)
       .executionBehavior(
         Plan.ExecutionBehavior.builder()
-          .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+          .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
           .build()
       )
       .build()

--- a/spark/src/test/scala/io/substrait/spark/AggregateWithJoinSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/AggregateWithJoinSuite.scala
@@ -242,6 +242,11 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
 
     val plan = Plan.builder()
       .addRoots(root)
+      .executionBehavior(
+        Plan.ExecutionBehavior.builder()
+          .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.VARIABLE_EVALUATION_MODE_PER_PLAN)
+          .build()
+      )
       .build()
 
     val converter = new ToLogicalPlan(spark)


### PR DESCRIPTION
- Updates substrait Git submodule to v0.87.0
- Adds ExecutionBehavior field to Plan with VariableEvaluationMode enum
- Enhances SubstraitBuilder with overloaded plan() methods accepting custom execution behavior
- Updates SqlToSubstrait and Spark converters to set default execution behavior (VARIABLE_EVALUATION_MODE_PER_PLAN)

fixes https://github.com/substrait-io/substrait-java/issues/801