### PR TITLE
docs(isthmus): fix remaining javadoc warnings

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -303,7 +303,8 @@ tasks.register<Javadoc>("javadocProto") {
   dependsOn("generateProto")
 
   // Suppress warnings/doclint for protobuf pass
-  (options as StandardJavadocDocletOptions).apply {
+  options {
+    require(this is StandardJavadocDocletOptions)
     // Disable doclint entirely
     addBooleanOption("Xdoclint:none", true)
     // Be quiet
@@ -336,7 +337,8 @@ tasks.register<Javadoc>("javadocImmutable") {
   setDestinationDir(rootProject.layout.buildDirectory.dir("docs/${version}/immutable").get().asFile)
 
   // Suppress warnings/doclint for protobuf pass
-  (options as StandardJavadocDocletOptions).apply {
+  options {
+    require(this is StandardJavadocDocletOptions)
     // Disable doclint entirely
     addBooleanOption("Xdoclint:none", true)
     // Be quiet
@@ -366,7 +368,9 @@ tasks.named<Javadoc>("javadoc") {
   source(fileTree(immuteableJavaDir) { include("**/*.java") })
 
   // Keep normal behavior for main javadoc (warnings allowed to show/fail if you want)
-  (options as StandardJavadocDocletOptions).apply {
+  options {
+    require(this is StandardJavadocDocletOptions)
+    addBooleanOption("Xdoclint:all", true)
     encoding = "UTF-8"
     setDestinationDir(rootProject.layout.buildDirectory.dir("docs/${version}/core").get().asFile)
     addStringOption("overview", "${rootProject.projectDir}/core/src/main/javadoc/overview.html")

--- a/isthmus-cli/build.gradle.kts
+++ b/isthmus-cli/build.gradle.kts
@@ -104,6 +104,11 @@ tasks.named<Javadoc>("javadoc") {
 
   val isthmusVersionClass = layout.buildDirectory.file("generated/sources").get().getAsFile()
   exclude { spec -> spec.file.toPath().startsWith(isthmusVersionClass.toPath()) }
+  options {
+    require(this is StandardJavadocDocletOptions)
+    addBooleanOption("Xdoclint:all", true)
+    addBooleanOption("Xwerror", true)
+  }
 }
 
 // workaround for Eclipse/VS Code bug handling annotationProcessor sources

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -155,10 +155,13 @@ tasks.named<Javadoc>("javadoc") {
   description = "Generate Javadoc for main sources."
 
   // Keep normal behavior for main javadoc (warnings allowed to show/fail if you want)
-  (options as StandardJavadocDocletOptions).apply {
+  options {
+    require(this is StandardJavadocDocletOptions)
     encoding = "UTF-8"
     setDestinationDir(rootProject.layout.buildDirectory.dir("docs/${version}/isthmus").get().asFile)
     addStringOption("overview", "${rootProject.projectDir}/isthmus/src/main/javadoc/overview.html")
+    addBooleanOption("Xdoclint:all", true)
+    addBooleanOption("Xwerror", true)
     links("../core-proto/")
     links("../core/")
     links("https://calcite.apache.org/javadocAggregate/")

--- a/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SchemaCollector.java
@@ -37,6 +37,11 @@ public class SchemaCollector {
     this.typeConverter = typeConverter;
   }
 
+  /**
+   * Creates a SchemaCollector using configuration from the provider.
+   *
+   * @param converterProvider the converter provider containing type factory and type converter
+   */
   public SchemaCollector(ConverterProvider converterProvider) {
     this.typeFactory = converterProvider.getTypeFactory();
     this.typeConverter = converterProvider.getTypeConverter();

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -22,6 +22,7 @@ import org.apache.calcite.sql2rel.SqlToRelConverter;
  * shared setup.
  */
 public class SqlConverterBase {
+  /** The converter provider containing configuration. */
   protected final ConverterProvider converterProvider;
 
   /** Default Calcite connection config (case-insensitive). */

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitToCalcite.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitToCalcite.java
@@ -25,10 +25,20 @@ import org.apache.calcite.util.Pair;
  */
 public class SubstraitToCalcite {
 
+  /** The Calcite type factory for creating relational data types. */
   protected final RelDataTypeFactory typeFactory;
+
+  /** The Calcite catalog reader for schema resolution. */
   protected final Prepare.CatalogReader catalogReader;
+
+  /** The converter provider containing configuration. */
   protected ConverterProvider converterProvider;
 
+  /**
+   * Creates a Substrait-to-Calcite converter using configuration from the provider.
+   *
+   * @param converterProvider the converter provider containing configuration and converters
+   */
   public SubstraitToCalcite(ConverterProvider converterProvider) {
     this(converterProvider, null);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
@@ -18,18 +18,31 @@ import org.apache.calcite.sql.SqlDialect;
  */
 public class SubstraitToSql extends SqlConverterBase {
 
+  /** The Substrait-to-Calcite converter. */
   protected SubstraitToCalcite substraitToCalcite;
 
+  /** Creates a SubstraitToSql converter with default configuration and extensions. */
   public SubstraitToSql() {
     this(new ConverterProvider());
   }
 
-  /** Deprecated, use {@link #SubstraitToSql(ConverterProvider)} instead */
+  /**
+   * Creates a SubstraitToSql converter with default configuration and the specified extensions.
+   *
+   * @param extensions the extension collection to use
+   * @deprecated use {@link #SubstraitToSql(ConverterProvider)} instead
+   */
   @Deprecated
   public SubstraitToSql(SimpleExtension.ExtensionCollection extensions) {
     this(new ConverterProvider(extensions));
   }
 
+  /**
+   * Creates a SubstraitToSql converter with configuration and extensions specified by the converter
+   * provider.
+   *
+   * @param converterProvider the converter provider containing configuration
+   */
   public SubstraitToSql(ConverterProvider converterProvider) {
     super(converterProvider);
     substraitToCalcite = converterProvider.getSubstraitToCalcite();

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
@@ -7,6 +7,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 
+/** Represents a CREATE TABLE DDL operation in Calcite's relational algebra. */
 public class CreateTable extends SingleRel {
 
   private final List<String> tableName;

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
@@ -7,6 +7,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
 
+/** Represents a CREATE VIEW DDL operation in Calcite's relational algebra. */
 public class CreateView extends SingleRel {
   private final List<String> viewName;
 
@@ -16,6 +17,12 @@ public class CreateView extends SingleRel {
     this.viewName = viewName;
   }
 
+  /**
+   * CreateView Constructor.
+   *
+   * @param viewName view name components
+   * @param input RelNode input
+   */
   public CreateView(List<String> viewName, RelNode input) {
     this(input.getCluster(), input.getTraitSet(), viewName, input);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -252,6 +252,23 @@ public class ExpressionRexConverter
         createTimeString(expr.value(), expr.precision()), expr.precision());
   }
 
+  /**
+   * Creates a TimeString from a time value with the specified precision.
+   *
+   * <p>The time unit for the value is dictated by the supplied precision, with the following valid
+   * values:
+   *
+   * <ul>
+   *   <li>0 - seconds
+   *   <li>3 - milliseconds
+   *   <li>6 - microseconds
+   *   <li>9 - nanoseconds
+   * </ul>
+   *
+   * @param value the time value in the appropriate unit based on precision
+   * @param precision the precision level
+   * @return a TimeString representing the time value
+   */
   protected TimeString createTimeString(long value, int precision) {
     switch (precision) {
       case 0:

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExtractIndexing.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExtractIndexing.java
@@ -6,6 +6,8 @@ package io.substrait.isthmus.expression;
  * <p>Controls if the number used for example in months is 0 or 1 based.
  */
 public enum ExtractIndexing {
+  /** One-based indexing (January = 1). */
   ONE,
+  /** Zero-based indexing (January = 0). */
   ZERO
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -738,6 +738,7 @@ public abstract class FunctionConverter<
   /**
    * Identifies functions that are not mapped in the provided Sig list.
    *
+   * @param <F> the type of function extending SimpleExtension.Function
    * @param functions the list of function variants to check
    * @param sigs the list of mapped Sig signatures
    * @return a list of functions that are not found in the Sig mappings (case-insensitive name

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
@@ -21,6 +21,7 @@ import org.apache.calcite.sql.fun.SqlMapValueConstructor;
  */
 public class SqlMapValueConstructorCallConverter implements CallConverter {
 
+  /** Default constructor. */
   public SqlMapValueConstructorCallConverter() {}
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeDateFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeDateFunctionMapper.java
@@ -12,6 +12,11 @@ import org.apache.calcite.sql.fun.SqlLibraryOperators;
 public final class StrptimeDateFunctionMapper extends AbstractStrptimeFunctionMapper {
   private static final String STRPTIME_DATE_FUNCTION_NAME = "strptime_date";
 
+  /**
+   * Constructor.
+   *
+   * @param functions the list of scalar function variants
+   */
   public StrptimeDateFunctionMapper(List<ScalarFunctionVariant> functions) {
     super(STRPTIME_DATE_FUNCTION_NAME, SqlLibraryOperators.PARSE_DATE, functions);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimeFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimeFunctionMapper.java
@@ -12,6 +12,11 @@ import org.apache.calcite.sql.fun.SqlLibraryOperators;
 public final class StrptimeTimeFunctionMapper extends AbstractStrptimeFunctionMapper {
   private static final String STRPTIME_TIME_FUNCTION_NAME = "strptime_time";
 
+  /**
+   * Constructor.
+   *
+   * @param functions the list of scalar function variants
+   */
   public StrptimeTimeFunctionMapper(List<ScalarFunctionVariant> functions) {
     super(STRPTIME_TIME_FUNCTION_NAME, SqlLibraryOperators.PARSE_TIME, functions);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimestampFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/StrptimeTimestampFunctionMapper.java
@@ -12,6 +12,11 @@ import org.apache.calcite.sql.fun.SqlLibraryOperators;
 public final class StrptimeTimestampFunctionMapper extends AbstractStrptimeFunctionMapper {
   private static final String STRPTIME_TIMESTAMP_FUNCTION_NAME = "strptime_timestamp";
 
+  /**
+   * Constructor.
+   *
+   * @param functions the list of scalar function variants
+   */
   public StrptimeTimestampFunctionMapper(List<ScalarFunctionVariant> functions) {
     super(STRPTIME_TIMESTAMP_FUNCTION_NAME, SqlLibraryOperators.PARSE_TIMESTAMP, functions);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -82,7 +82,7 @@ public class SubstraitCreateStatementParser {
    *
    * @param createStatements List of SQL strings containing only CREATE statements, must not be null
    * @return a {@link CalciteCatalogReader} generated from the CREATE statements
-   * @throws SqlParseException
+   * @throws SqlParseException if there is an error parsing the SQL statements
    */
   public static CalciteCatalogReader processCreateStatementsToCatalog(
       @NonNull final List<String> createStatements) throws SqlParseException {


### PR DESCRIPTION
- Add missing javadoc to isthmus subproject.
- Enable build failure on javadoc warnings for isthmus subproject.
- Re-enable build failure on javadoc warnings for isthus-cli subproject, which was disabled in an earlier change.
- Javadoc warnings are reported in core subproject but do not fail the build.