### PR TITLE
feat(core): add typeVariationReference to UserDefined type

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -1510,6 +1510,23 @@ public class SubstraitBuilder {
     return Type.UserDefined.builder().urn(urn).name(typeName).nullable(false).build();
   }
 
+  /**
+   * Creates a user-defined type with the specified URN, type name, and type variation.
+   *
+   * @param urn the URN of the extension containing the type
+   * @param typeName the name of the user-defined type
+   * @param typeVariationReference the type variation reference
+   * @return a new {@link Type.UserDefined}
+   */
+  public Type.UserDefined userDefinedType(String urn, String typeName, int typeVariationReference) {
+    return Type.UserDefined.builder()
+        .urn(urn)
+        .name(typeName)
+        .nullable(false)
+        .typeVariationReference(typeVariationReference)
+        .build();
+  }
+
   // Misc
 
   /**

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -1507,7 +1507,7 @@ public class SubstraitBuilder {
    * @return a new {@link Type.UserDefined}
    */
   public Type.UserDefined userDefinedType(String urn, String typeName) {
-    return Type.UserDefined.builder().urn(urn).name(typeName).nullable(false).build();
+    return userDefinedType(urn, typeName, 0);
   }
 
   /**

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -422,11 +422,11 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   }
 
   @Value.Immutable
-  abstract class UserDefined implements Type {
+  interface UserDefined extends Type {
 
-    public abstract String urn();
+    String urn();
 
-    public abstract String name();
+    String name();
 
     /**
      * Returns the type parameters for this user-defined type.
@@ -437,7 +437,7 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
      * @return a list of type parameters, or an empty list if this type is not parameterized
      */
     @Value.Default
-    public java.util.List<Parameter> typeParameters() {
+    default java.util.List<Parameter> typeParameters() {
       return java.util.Collections.emptyList();
     }
 
@@ -449,17 +449,17 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
      *
      * @return the type variation reference, or {@code 0} if using the default variation
      */
-    // Note: Cannot use @Value.Default here due to an Immutables bug with @Value.Enclosing
-    // and multiple @Value.Default fields in the same class (generates broken InitShim code).
-    // The default value (0) is set in the builder() factory method below.
-    public abstract int typeVariationReference();
+    @Value.Default
+    default int typeVariationReference() {
+      return 0;
+    }
 
-    public static ImmutableType.UserDefined.Builder builder() {
-      return ImmutableType.UserDefined.builder().typeVariationReference(0);
+    static ImmutableType.UserDefined.Builder builder() {
+      return ImmutableType.UserDefined.builder();
     }
 
     @Override
-    public <R, E extends Throwable> R accept(TypeVisitor<R, E> typeVisitor) throws E {
+    default <R, E extends Throwable> R accept(TypeVisitor<R, E> typeVisitor) throws E {
       return typeVisitor.visit(this);
     }
   }

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -441,8 +441,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
       return java.util.Collections.emptyList();
     }
 
+    /**
+     * Returns the type variation reference for this user-defined type.
+     *
+     * <p>Type variations allow different physical representations or semantics for the same logical
+     * type. The reference value maps to an {@code ExtensionTypeVariation} declaration in the plan.
+     *
+     * @return the type variation reference, or {@code 0} if using the default variation
+     */
+    // Note: Cannot use @Value.Default here due to an Immutables bug with @Value.Enclosing
+    // and multiple @Value.Default fields in the same class (generates broken InitShim code).
+    // The default value (0) is set in the builder() factory method below.
+    public abstract int typeVariationReference();
+
     public static ImmutableType.UserDefined.Builder builder() {
-      return ImmutableType.UserDefined.builder();
+      return ImmutableType.UserDefined.builder().typeVariationReference(0);
     }
 
     @Override

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -115,6 +115,15 @@ public class TypeCreator {
     return Type.UserDefined.builder().nullable(nullable).urn(urn).name(name).build();
   }
 
+  public Type userDefined(String urn, String name, int typeVariationReference) {
+    return Type.UserDefined.builder()
+        .nullable(nullable)
+        .urn(urn)
+        .name(name)
+        .typeVariationReference(typeVariationReference)
+        .build();
+  }
+
   public static TypeCreator of(boolean nullability) {
     return nullability ? NULLABLE : REQUIRED;
   }

--- a/core/src/main/java/io/substrait/type/TypeCreator.java
+++ b/core/src/main/java/io/substrait/type/TypeCreator.java
@@ -112,7 +112,7 @@ public class TypeCreator {
   }
 
   public Type userDefined(String urn, String name) {
-    return Type.UserDefined.builder().nullable(nullable).urn(urn).name(name).build();
+    return userDefined(urn, name, 0);
   }
 
   public Type userDefined(String urn, String name, int typeVariationReference) {

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -175,6 +175,7 @@ abstract class BaseProtoConverter<T, I>
   public final T visit(final Type.UserDefined expr) {
     int ref =
         extensionCollector.getTypeReference(SimpleExtension.TypeAnchor.of(expr.urn(), expr.name()));
-    return typeContainer(expr).userDefined(ref, expr.typeParameters());
+    return typeContainer(expr)
+        .userDefined(ref, expr.typeVariationReference(), expr.typeParameters());
   }
 }

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
@@ -131,7 +131,9 @@ abstract class BaseProtoTypes<T, I> {
 
   public abstract T map(T key, T value);
 
-  public abstract T userDefined(int ref, int typeVariationReference);
+  public T userDefined(int ref, int typeVariationReference) {
+    return userDefined(ref, typeVariationReference, java.util.Collections.emptyList());
+  }
 
   public abstract T userDefined(
       int ref,

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
@@ -131,10 +131,12 @@ abstract class BaseProtoTypes<T, I> {
 
   public abstract T map(T key, T value);
 
-  public abstract T userDefined(int ref);
+  public abstract T userDefined(int ref, int typeVariationReference);
 
   public abstract T userDefined(
-      int ref, java.util.List<io.substrait.type.Type.Parameter> typeParameters);
+      int ref,
+      int typeVariationReference,
+      java.util.List<io.substrait.type.Type.Parameter> typeParameters);
 
   protected abstract T wrap(Object o);
 

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -107,6 +107,7 @@ public class ProtoTypeConverter {
                   userDefined.getTypeParametersList().stream()
                       .map(this::from)
                       .collect(java.util.stream.Collectors.toList()))
+              .typeVariationReference(userDefined.getTypeVariationReference())
               .build();
         }
       case USER_DEFINED_TYPE_REFERENCE:

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -181,16 +181,6 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     }
 
     @Override
-    public Type userDefined(int ref, int typeVariationReference) {
-      return wrap(
-          Type.UserDefined.newBuilder()
-              .setTypeReference(ref)
-              .setTypeVariationReference(typeVariationReference)
-              .setNullability(nullability)
-              .build());
-    }
-
-    @Override
     public Type userDefined(
         int ref,
         int typeVariationReference,

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -181,17 +181,24 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
     }
 
     @Override
-    public Type userDefined(int ref) {
+    public Type userDefined(int ref, int typeVariationReference) {
       return wrap(
-          Type.UserDefined.newBuilder().setTypeReference(ref).setNullability(nullability).build());
+          Type.UserDefined.newBuilder()
+              .setTypeReference(ref)
+              .setTypeVariationReference(typeVariationReference)
+              .setNullability(nullability)
+              .build());
     }
 
     @Override
     public Type userDefined(
-        int ref, java.util.List<io.substrait.type.Type.Parameter> typeParameters) {
+        int ref,
+        int typeVariationReference,
+        java.util.List<io.substrait.type.Type.Parameter> typeParameters) {
       return wrap(
           Type.UserDefined.newBuilder()
               .setTypeReference(ref)
+              .setTypeVariationReference(typeVariationReference)
               .setNullability(nullability)
               .addAllTypeParameters(
                   typeParameters.stream()

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -78,6 +78,38 @@ class TypeExtensionTest extends TestBase {
     io.substrait.proto.Plan protoPlan = planProtoConverter.toProto(plan);
     Plan planReturned = protoPlanConverter.from(protoPlan);
     assertEquals(plan, planReturned);
+
+    // verify default typeVariationReference is 0
+    assertEquals(0, ((Type.UserDefined) customType1).typeVariationReference());
+  }
+
+  @Test
+  void roundtripCustomTypeWithVariationReference() {
+    Type customTypeWithVariation = sb.userDefinedType(URN, "customType1", 42);
+
+    List<String> tableName = Stream.of("example").collect(Collectors.toList());
+    List<String> columnNames = Stream.of("custom_type_column").collect(Collectors.toList());
+    List<Type> types = Stream.of(customTypeWithVariation).collect(Collectors.toList());
+
+    Plan plan = sb.plan(sb.root(sb.namedScan(tableName, columnNames, types)));
+
+    io.substrait.proto.Plan protoPlan = planProtoConverter.toProto(plan);
+
+    // verify the type variation reference is set in the proto
+    io.substrait.proto.Type protoType =
+        protoPlan
+            .getRelations(0)
+            .getRoot()
+            .getInput()
+            .getRead()
+            .getBaseSchema()
+            .getStruct()
+            .getTypes(0);
+    assertEquals(42, protoType.getUserDefined().getTypeVariationReference());
+
+    // verify full roundtrip
+    Plan planReturned = protoPlanConverter.from(protoPlan);
+    assertEquals(plan, planReturned);
   }
 
   @Test

--- a/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/TypeExtensionTest.java
@@ -94,20 +94,6 @@ class TypeExtensionTest extends TestBase {
     Plan plan = sb.plan(sb.root(sb.namedScan(tableName, columnNames, types)));
 
     io.substrait.proto.Plan protoPlan = planProtoConverter.toProto(plan);
-
-    // verify the type variation reference is set in the proto
-    io.substrait.proto.Type protoType =
-        protoPlan
-            .getRelations(0)
-            .getRoot()
-            .getInput()
-            .getRead()
-            .getBaseSchema()
-            .getStruct()
-            .getTypes(0);
-    assertEquals(42, protoType.getUserDefined().getTypeVariationReference());
-
-    // verify full roundtrip
     Plan planReturned = protoPlanConverter.from(protoPlan);
     assertEquals(plan, planReturned);
   }


### PR DESCRIPTION
## What does this PR do?

Adds `typeVariationReference` support to the `Type.UserDefined` POJO, closing the gap where the Substrait proto defines `type_variation_reference` (field #2) on `UserDefined` but substrait-java ignores it entirely.

Downstream users who need type variations on UDTs (e.g., specialized execution engine variants) previously had to drop to raw proto manipulation. This change threads the field through the full POJO ↔ proto roundtrip.

Closes #567

## Changes

- **Type.java** — Add `typeVariationReference()` to `UserDefined` (abstract + builder default, see note below)
- **ProtoTypeConverter** — Read `getTypeVariationReference()` from proto when building POJO
- **BaseProtoTypes / TypeProtoConverter / BaseProtoConverter** — Thread `typeVariationReference` through POJO→proto conversion
- **TypeCreator / SubstraitBuilder** — Add overloads accepting `typeVariationReference`
- **TypeExtensionTest** — Roundtrip test verifying non-zero variation reference survives proto conversion, plus default-value assertion

### Note on Immutables workaround

`typeVariationReference` uses `abstract` + builder factory default instead of `@Value.Default` due to an Immutables codegen bug: when a `@Value.Enclosing` type has multiple `@Value.Default` fields in a nested class, the generated `InitShim` references `UserDefined.super` from a non-subclass context. The workaround achieves identical ergonomics — callers don't need to set the field explicitly.

## Test plan

- [x] New `roundtripCustomTypeWithVariationReference` test: creates UDT with `typeVariationReference=42`, roundtrips through proto, verifies both proto-level field value and full POJO equality
- [x] Existing `roundtripCustomType` test: added assertion that default `typeVariationReference` is 0
- [x] Full test suite passes (core, isthmus, spark)