### PR TITLE
refactor(core): make Type.UserDefined an interface to fix Immutables bug

### DIFF
--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -422,11 +422,11 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   }
 
   @Value.Immutable
-  abstract class UserDefined implements Type {
+  interface UserDefined extends Type {
 
-    public abstract String urn();
+    String urn();
 
-    public abstract String name();
+    String name();
 
     /**
      * Returns the type parameters for this user-defined type.
@@ -437,16 +437,16 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
      * @return a list of type parameters, or an empty list if this type is not parameterized
      */
     @Value.Default
-    public java.util.List<Parameter> typeParameters() {
+    default java.util.List<Parameter> typeParameters() {
       return java.util.Collections.emptyList();
     }
 
-    public static ImmutableType.UserDefined.Builder builder() {
+    static ImmutableType.UserDefined.Builder builder() {
       return ImmutableType.UserDefined.builder();
     }
 
     @Override
-    public <R, E extends Throwable> R accept(TypeVisitor<R, E> typeVisitor) throws E {
+    default <R, E extends Throwable> R accept(TypeVisitor<R, E> typeVisitor) throws E {
       return typeVisitor.visit(this);
     }
   }


### PR DESCRIPTION
Changes `Type.UserDefined` from an abstract class to an interface.

Immutables has a [bug](https://github.com/immutables/immutables/issues/1139) where `@Value.Default` fields inside an abstract class nested under `@Value.Enclosing` generate broken code. This doesn't happen with interfaces. Making `UserDefined` an interface means we can freely add `@Value.Default` fields to it, which is needed by #794 to add `typeVariationReference` with a default of 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)