### PR TITLE
ci: use client-id instead of deprecated app-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASER_ID }}
+          client-id: ${{ secrets.RELEASER_ID }}
           private-key: ${{ secrets.RELEASER_KEY }}
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
Just noticed this deprecation warning by chance:
<img width="911" height="376" alt="image" src="https://github.com/user-attachments/assets/28cba9bf-ebd5-4c23-a8c1-17a5c28956c1" />
https://github.com/substrait-io/substrait-java/actions/runs/24298746175/job/70949184096