### PR TITLE
fix(core): correct mark join output schema

### DIFF
--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -65,7 +65,8 @@ public abstract class Join extends BiRel implements HasExtension {
   protected Type.Struct deriveRecordType() {
     Stream<Type> leftTypes = getLeftTypes();
     Stream<Type> rightTypes = getRightTypes();
-    return TypeCreator.REQUIRED.struct(Stream.concat(leftTypes, rightTypes));
+    Stream<Type> markType = getMarkType();
+    return TypeCreator.REQUIRED.struct(Stream.of(leftTypes, rightTypes, markType).flatMap(s -> s));
   }
 
   private Stream<Type> getLeftTypes() {
@@ -76,11 +77,9 @@ public abstract class Join extends BiRel implements HasExtension {
         return getLeft().getRecordType().fields().stream().map(TypeCreator::asNullable);
       case RIGHT_SEMI:
       case RIGHT_ANTI:
-        // these are right joins which ignore left side columns
-        return Stream.of();
       case RIGHT_MARK:
-        // right mark join keeps all fields from right and adds a boolean mark field
-        return Stream.of(TypeCreator.REQUIRED.BOOLEAN);
+        // these joins ignore left side columns
+        return Stream.of();
       default:
         return getLeft().getRecordType().fields().stream();
     }
@@ -96,13 +95,26 @@ public abstract class Join extends BiRel implements HasExtension {
       case ANTI:
       case LEFT_SEMI:
       case LEFT_ANTI:
-        // these are left joins which ignore right side columns
-        return Stream.of();
       case LEFT_MARK:
-        // left mark join keeps all fields from left and adds a boolean mark field
-        return Stream.of(TypeCreator.REQUIRED.BOOLEAN);
+        // these joins ignore right side columns
+        return Stream.of();
       default:
         return getRight().getRecordType().fields().stream();
+    }
+  }
+
+  private Stream<Type> getMarkType() {
+    // Mark joins append a nullable boolean "mark" column at the end of the
+    // emitted side. The column is nullable because the match state is 3-valued:
+    //  - true  : at least one partner matched
+    //  - false : no partner, and no NULL-producing comparisons
+    //  - NULL  : no partner, but some comparison produced NULL
+    switch (getJoinType()) {
+      case LEFT_MARK:
+      case RIGHT_MARK:
+        return Stream.of(TypeCreator.NULLABLE.BOOLEAN);
+      default:
+        return Stream.of();
     }
   }
 

--- a/core/src/test/java/io/substrait/relation/JoinTest.java
+++ b/core/src/test/java/io/substrait/relation/JoinTest.java
@@ -1,0 +1,89 @@
+package io.substrait.relation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.TestBase;
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class JoinTest extends TestBase {
+
+  final Rel leftTable =
+      sb.namedScan(
+          Arrays.asList("T1"),
+          Arrays.asList("a", "b", "c"),
+          Arrays.asList(R.I64, R.FP64, R.STRING));
+
+  final Rel rightTable =
+      sb.namedScan(
+          Arrays.asList("T2"),
+          Arrays.asList("d", "e", "f"),
+          Arrays.asList(R.FP64, R.STRING, R.I64));
+
+  /**
+   * Per the Substrait spec, a LEFT MARK join emits every left row with a nullable boolean "mark"
+   * column appended at the end. The mark is nullable because the match state is 3-valued: true (a
+   * partner matched), false (no partner, no NULL comparisons) or NULL (no partner but some
+   * comparison was NULL).
+   */
+  @Test
+  void leftMarkJoinRecordType() {
+    Join join =
+        Join.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .condition(ExpressionCreator.bool(false, true))
+            .joinType(Join.JoinType.LEFT_MARK)
+            .build();
+
+    Type.Struct expected =
+        TypeCreator.REQUIRED.struct(R.I64, R.FP64, R.STRING, TypeCreator.NULLABLE.BOOLEAN);
+    assertEquals(expected, join.getRecordType());
+  }
+
+  /**
+   * Per the Substrait spec, a RIGHT MARK join emits every right row with a nullable boolean "mark"
+   * column appended at the end.
+   */
+  @Test
+  void rightMarkJoinRecordType() {
+    Join join =
+        Join.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .condition(ExpressionCreator.bool(false, true))
+            .joinType(Join.JoinType.RIGHT_MARK)
+            .build();
+
+    Type.Struct expected =
+        TypeCreator.REQUIRED.struct(R.FP64, R.STRING, R.I64, TypeCreator.NULLABLE.BOOLEAN);
+    assertEquals(expected, join.getRecordType());
+  }
+
+  @Test
+  void leftMarkJoinRoundtrip() {
+    Join join =
+        Join.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .condition(ExpressionCreator.bool(false, true))
+            .joinType(Join.JoinType.LEFT_MARK)
+            .build();
+    verifyRoundTrip(join);
+  }
+
+  @Test
+  void rightMarkJoinRoundtrip() {
+    Join join =
+        Join.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .condition(ExpressionCreator.bool(false, true))
+            .joinType(Join.JoinType.RIGHT_MARK)
+            .build();
+    verifyRoundTrip(join);
+  }
+}


### PR DESCRIPTION
## Summary

`Join.deriveRecordType()` produced the wrong output schema for `LEFT_MARK` and `RIGHT_MARK` joins:

1. **Mark column nullability is wrong.** The mark was typed `boolean NOT NULL`, but the [spec](https://substrait.io/relations/logical_relations/#join-types) defines it as `boolean NULL`. The mark is 3-valued -- `true` / `false` / `NULL` -- and a non-nullable type can't represent the "unknown match" state. This silently breaks `NOT IN` / `EXISTS` subquery lowering whenever the right side contains NULLs: the engine is forced to coerce NULL → false and returns wrong rows.

2. **`RIGHT_MARK` prepends the mark instead of appending.** The current code put the boolean in the left-side slot, so the emitted schema was `[mark, right_fields...]` instead of `[right_fields..., mark]`. Every downstream field index into the right side is off by one.

`LEFT_MARK` happened to place the column at the tail (only because the left side was emitted first), so the ordering bug was hidden there -- only the nullability was wrong.

### Fix

Refactor `deriveRecordType()` to compute `left`, `right`, and `mark` streams independently and concatenate them:

```
LEFT_MARK  -> left_fields  ++ [boolean NULL]
RIGHT_MARK -> right_fields ++ [boolean NULL]
```

### Proof

Added `JoinTest` which fails on `main` with the exact symptom:

```
RIGHT_MARK expected: [FP64, Str, I64, Bool{nullable=true}]
           but was:  [Bool{nullable=false}, FP64, Str, I64]

LEFT_MARK  expected: [I64, FP64, Str, Bool{nullable=true}]
           but was:  [I64, FP64, Str, Bool{nullable=false}]
```

and passes after the fix. Also covers proto roundtrip for both mark join types. Prior to this PR, `grep LEFT_MARK\|RIGHT_MARK` across the whole repo returned only the enum declaration and the two buggy switch cases -- zero test coverage.

Draft for visibility; happy to take review before un-drafting.

## Test plan

- [x] `./gradlew :core:test --tests 'io.substrait.relation.JoinTest'` -- 4 new tests, all pass after fix, all fail before
- [x] `./gradlew :core:test :isthmus:test` -- full core + isthmus suites green
- [x] `./gradlew build` -- full build including spark 3.4 / 3.5 / 4.0 variants green
- [x] `./gradlew spotlessApply` -- formatting clean