### PR TITLE
chore(spark): remove unneccessary ‘compat’ functions

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/compat/SparkCompat.scala
+++ b/spark/src/main/scala/io/substrait/spark/compat/SparkCompat.scala
@@ -10,16 +10,6 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRela
  */
 trait SparkCompat {
 
-  /** Create a ScalarSubquery with version-appropriate constructor */
-  def createScalarSubquery(plan: LogicalPlan): ScalarSubquery
-
-  /** Create an Aggregate with version-appropriate constructor */
-  def createAggregate(
-      groupingExpressions: Seq[Expression],
-      aggregateExpressions: Seq[NamedExpression],
-      child: LogicalPlan
-  ): Aggregate
-
   /** Create a LogicalRelation with version-appropriate constructor */
   def createLogicalRelation(
       relation: HadoopFsRelation,

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -231,7 +231,7 @@ class ToSparkExpression(
         relConverter => {
           val plan = rel.accept(relConverter, context)
           require(plan.resolved)
-          val result = SparkCompat.instance.createScalarSubquery(plan)
+          val result = ScalarSubquery(plan, exprId = NamedExpression.newExprId)
           SparkTypeUtil.sameType(result.dataType, dataType)
           result
         })

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSubstraitExpression.scala
@@ -69,15 +69,16 @@ abstract class ToSubstraitExpression extends HasOutputStack[Seq[Attribute]] {
                 }
                 val filteredAggExprs = agg.aggregateExpressions.filter(ae => used == ae.exprId.id)
                 Some(
-                  SparkCompat.instance.createScalarSubquery(
-                    SparkCompat.instance
-                      .createAggregate(agg.groupingExpressions, filteredAggExprs, agg.child)
+                  ScalarSubquery(
+                    Aggregate(agg.groupingExpressions, filteredAggExprs, agg.child),
+                    exprId = NamedExpression.newExprId
                   )
                 )
               case _ =>
                 Some(
-                  SparkCompat.instance.createScalarSubquery(
-                    Project(Seq(Alias(value, name.toString())()), child)
+                  ScalarSubquery(
+                    Project(Seq(Alias(value, name.toString())()), child),
+                    exprId = NamedExpression.newExprId
                   )
                 )
             }

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -141,7 +141,7 @@ class ToLogicalPlan(val spark: AnyRef = SparkCompat.instance.getOrCreateSparkSes
       val outputs = groupBy.map(toNamedExpression)
       val aggregateExpressions =
         aggregate.getMeasures.asScala.map(fromMeasure).map(toNamedExpression).toSeq
-      SparkCompat.instance.createAggregate(groupBy, outputs ++ aggregateExpressions, child)
+      Aggregate(groupBy, outputs ++ aggregateExpressions, child)
     }
   }
 
@@ -669,7 +669,7 @@ class ToLogicalPlan(val spark: AnyRef = SparkCompat.instance.getOrCreateSparkSes
       // This is helps a bit with round-trip testing and plan readability
       case project: Project => Project(renameAndCastExprs(project.projectList), project.child)
       case aggregate: Aggregate =>
-        SparkCompat.instance.createAggregate(
+        Aggregate(
           aggregate.groupingExpressions,
           renameAndCastExprs(aggregate.aggregateExpressions),
           aggregate.child)

--- a/spark/src/main/spark-3.4/io/substrait/spark/compat/SparkCompatImpl.scala
+++ b/spark/src/main/spark-3.4/io/substrait/spark/compat/SparkCompatImpl.scala
@@ -8,20 +8,6 @@ import io.substrait.relation
 
 class SparkCompatImpl extends SparkCompat {
 
-  override def createScalarSubquery(plan: LogicalPlan): ScalarSubquery = {
-    // Spark 3.4 requires exprId parameter
-    ScalarSubquery(plan, exprId = NamedExpression.newExprId)
-  }
-
-  override def createAggregate(
-      groupingExpressions: Seq[Expression],
-      aggregateExpressions: Seq[NamedExpression],
-      child: LogicalPlan
-  ): Aggregate = {
-    // Spark 3.4 uses 3-parameter constructor
-    Aggregate(groupingExpressions, aggregateExpressions, child)
-  }
-
   override def createLogicalRelation(
       relation: HadoopFsRelation,
       output: Seq[AttributeReference],

--- a/spark/src/main/spark-3.5/io/substrait/spark/compat/SparkCompatImpl.scala
+++ b/spark/src/main/spark-3.5/io/substrait/spark/compat/SparkCompatImpl.scala
@@ -8,20 +8,6 @@ import io.substrait.relation
 
 class SparkCompatImpl extends SparkCompat {
 
-  override def createScalarSubquery(plan: LogicalPlan): ScalarSubquery = {
-    // Spark 3.5 requires exprId parameter
-    ScalarSubquery(plan, exprId = NamedExpression.newExprId)
-  }
-
-  override def createAggregate(
-      groupingExpressions: Seq[Expression],
-      aggregateExpressions: Seq[NamedExpression],
-      child: LogicalPlan
-  ): Aggregate = {
-    // Spark 3.5 uses 3-parameter constructor
-    Aggregate(groupingExpressions, aggregateExpressions, child)
-  }
-
   override def createLogicalRelation(
       relation: HadoopFsRelation,
       output: Seq[AttributeReference],

--- a/spark/src/main/spark-4.0/io/substrait/spark/compat/SparkCompatImpl.scala
+++ b/spark/src/main/spark-4.0/io/substrait/spark/compat/SparkCompatImpl.scala
@@ -6,20 +6,6 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRela
 
 class SparkCompatImpl extends SparkCompat {
 
-  override def createScalarSubquery(plan: LogicalPlan): ScalarSubquery = {
-    // Spark 4.0 simplified constructor - no exprId needed
-    ScalarSubquery(plan)
-  }
-
-  override def createAggregate(
-      groupingExpressions: Seq[Expression],
-      aggregateExpressions: Seq[NamedExpression],
-      child: LogicalPlan
-  ): Aggregate = {
-    // Spark 4.0 simplified constructor - no aggregateAttributes needed
-    Aggregate(groupingExpressions, aggregateExpressions, child)
-  }
-
   override def createLogicalRelation(
       relation: HadoopFsRelation,
       output: Seq[AttributeReference],


### PR DESCRIPTION
When the Spark converter code was refactored to support all of spark v3.0, v3.5 and v4.0, a number of functions with incompatible APIs were abstracted into the ‘SparkCompat’ trait. In the event, `ScalarSubquery` and `Aggregate` didn’t need this treatment, so this commit restores the original (simpler) code.