### PR TITLE
build: update vulnerability scan and constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ gen
 out/**
 *.iws
 .pmdCache
+gradle.lockfile
+settings-gradle.lockfile
 
 # VS Code ignores
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,10 @@
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-
-OSV_SCANNER_IMAGE := ghcr.io/google/osv-scanner:v2.0.2
+OSV_SCANNER_IMAGE := ghcr.io/google/osv-scanner:v2.3.5
 
 .PHONY: scan
 scan:
 ifdef component
 	./gradlew --quiet ':$(component):dependencies' --write-locks --configuration runtimeClasspath
-	docker run --rm --volume './$(component)/gradle.lockfile:/gradle.lockfile' $(OSV_SCANNER_IMAGE) scan --lockfile /gradle.lockfile
+	docker run --rm --volume './$(component)/gradle.lockfile:/gradle.lockfile' $(OSV_SCANNER_IMAGE) scan source --lockfile /gradle.lockfile
 else
 	$(MAKE) component=core scan
 	$(MAKE) component=isthmus scan

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,15 +2,13 @@
 antlr = "4.13.2"
 calcite = "1.41.0"
 classgraph = "4.8.184"
-commons-lang3 = "[3.18.0,)"
 graal = "25.0.2"
 graal-plugin = "1.0.0"
 gradle-extensions = "3.0.1"
 guava = "33.5.0-jre"
-httpclient5 = "5.6"
 immutables = "2.12.1"
 jackson = "2.21.2"
-json-smart = "2.6.0"
+json-smart = "[2.5.2,)"
 jspecify = "1.0.0"
 junit = "6.0.3"
 nmcp = "1.4.4"
@@ -39,10 +37,8 @@ calcite-core = { module = "org.apache.calcite:calcite-core", version.ref = "calc
 calcite-plus = { module = "org.apache.calcite:calcite-plus", version.ref = "calcite" }
 calcite-server = { module = "org.apache.calcite:calcite-server", version.ref = "calcite" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
-commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graal" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpclient5" }
 immutables-value = { module = "org.immutables:value", version.ref = "immutables" }
 immutables-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -88,14 +88,9 @@ dependencies {
       )
   }
   constraints {
-    // calcite-core:1.39.0 has dependencies that contain vulnerabilities:
-    // - CVE-2025-27820 (org.apache.httpcomponents.client5:httpclient5 < 5.4.3)
+    // calcite-core:1.41.0 has dependencies that contain vulnerabilities:
     // - CVE-2024-57699 (net.minidev:json-smart < 2.5.2)
-    implementation(libs.httpclient5)
     implementation(libs.json.smart)
-    // calcite-core:1.40.0 has dependencies that contain vulnerabilities:
-    // - CVE-2025-48924 (org.apache.commons:commons-lang3 < 3.18.0)
-    implementation(libs.commons.lang3)
   }
   implementation(libs.calcite.server) {
     exclude(group = "commons-lang", module = "commons-lang")


### PR DESCRIPTION
- Update OSV-Scanner from 2.0.2 to 2.3.5.
- Remove redundant version constraints for httpclient5 and commons-lang3.