### PR TITLE
feat(extensions): support deprecation info in extensions

### DIFF
--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -124,7 +124,6 @@ public class SimpleExtension {
 
   /**
    * Deprecation information for an extension entry (type, function, or function implementation).
-   * See <a href="https://github.com/substrait-io/substrait/pull/1014">substrait#1014</a>.
    *
    * <p>Consumers of extension files are not required to understand or validate deprecation fields;
    * the information is provided so tooling can surface deprecation warnings.

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -122,6 +122,32 @@ public class SimpleExtension {
     List<String> getValues();
   }
 
+  /**
+   * Deprecation information for an extension entry (type, function, or function implementation).
+   * See <a href="https://github.com/substrait-io/substrait/pull/1014">substrait#1014</a>.
+   *
+   * <p>Consumers of extension files are not required to understand or validate deprecation fields;
+   * the information is provided so tooling can surface deprecation warnings.
+   */
+  @JsonDeserialize(as = ImmutableSimpleExtension.DeprecationStatus.class)
+  @JsonSerialize(as = ImmutableSimpleExtension.DeprecationStatus.class)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @Value.Immutable
+  public interface DeprecationStatus {
+    /**
+     * The version at which the entry was deprecated, as a core semantic version string (e.g. {@code
+     * "1.2.0"}).
+     */
+    @JsonProperty(required = true)
+    String since();
+
+    /** Optional human-readable description of why the entry was deprecated. */
+    Optional<String> reason();
+
+    /** Optional arbitrary data provided by the extension author. */
+    Optional<Map<String, Object>> metadata();
+  }
+
   @JsonSerialize(as = ImmutableSimpleExtension.ValueArgument.class)
   @JsonDeserialize(as = ImmutableSimpleExtension.ValueArgument.class)
   @Value.Immutable
@@ -280,6 +306,8 @@ public class SimpleExtension {
 
     public abstract Optional<Map<String, Object>> metadata();
 
+    public abstract Optional<DeprecationStatus> deprecated();
+
     public List<Argument> requiredArguments() {
       return requiredArgsSupplier.get();
     }
@@ -387,10 +415,13 @@ public class SimpleExtension {
 
     public abstract Optional<Map<String, Object>> metadata();
 
+    public abstract Optional<DeprecationStatus> deprecated();
+
     public abstract List<ScalarFunctionVariant> impls();
 
     public Stream<ScalarFunctionVariant> resolve(String urn) {
-      return impls().stream().map(f -> f.resolve(urn, name(), description(), metadata()));
+      return impls().stream()
+          .map(f -> f.resolve(urn, name(), description(), metadata(), deprecated()));
     }
   }
 
@@ -399,7 +430,11 @@ public class SimpleExtension {
   @Value.Immutable
   public abstract static class ScalarFunctionVariant extends Function {
     public ScalarFunctionVariant resolve(
-        String urn, String name, String description, Optional<Map<String, Object>> metadata) {
+        String urn,
+        String name,
+        String description,
+        Optional<Map<String, Object>> metadata,
+        Optional<DeprecationStatus> deprecated) {
       return ImmutableSimpleExtension.ScalarFunctionVariant.builder()
           .urn(urn)
           .name(name)
@@ -408,6 +443,7 @@ public class SimpleExtension {
           .args(args())
           .options(options())
           .metadata(metadata)
+          .deprecated(deprecated().isPresent() ? deprecated() : deprecated)
           .ordered(ordered())
           .variadic(variadic())
           .returnType(returnType())
@@ -427,10 +463,13 @@ public class SimpleExtension {
 
     public abstract Optional<Map<String, Object>> metadata();
 
+    public abstract Optional<DeprecationStatus> deprecated();
+
     public abstract List<AggregateFunctionVariant> impls();
 
     public Stream<AggregateFunctionVariant> resolve(String urn) {
-      return impls().stream().map(f -> f.resolve(urn, name(), description(), metadata()));
+      return impls().stream()
+          .map(f -> f.resolve(urn, name(), description(), metadata(), deprecated()));
     }
   }
 
@@ -446,10 +485,13 @@ public class SimpleExtension {
 
     public abstract Optional<Map<String, Object>> metadata();
 
+    public abstract Optional<DeprecationStatus> deprecated();
+
     public abstract List<WindowFunctionVariant> impls();
 
     public Stream<WindowFunctionVariant> resolve(String urn) {
-      return impls().stream().map(f -> f.resolve(urn, name(), description(), metadata()));
+      return impls().stream()
+          .map(f -> f.resolve(urn, name(), description(), metadata(), deprecated()));
     }
 
     public static ImmutableSimpleExtension.WindowFunction.Builder builder() {
@@ -476,7 +518,11 @@ public class SimpleExtension {
     public abstract TypeExpression intermediate();
 
     AggregateFunctionVariant resolve(
-        String urn, String name, String description, Optional<Map<String, Object>> metadata) {
+        String urn,
+        String name,
+        String description,
+        Optional<Map<String, Object>> metadata,
+        Optional<DeprecationStatus> deprecated) {
       return ImmutableSimpleExtension.AggregateFunctionVariant.builder()
           .urn(urn)
           .name(name)
@@ -485,6 +531,7 @@ public class SimpleExtension {
           .args(args())
           .options(options())
           .metadata(metadata)
+          .deprecated(deprecated().isPresent() ? deprecated() : deprecated)
           .ordered(ordered())
           .variadic(variadic())
           .decomposability(decomposability())
@@ -520,7 +567,11 @@ public class SimpleExtension {
     }
 
     WindowFunctionVariant resolve(
-        String urn, String name, String description, Optional<Map<String, Object>> metadata) {
+        String urn,
+        String name,
+        String description,
+        Optional<Map<String, Object>> metadata,
+        Optional<DeprecationStatus> deprecated) {
       return ImmutableSimpleExtension.WindowFunctionVariant.builder()
           .urn(urn)
           .name(name)
@@ -529,6 +580,7 @@ public class SimpleExtension {
           .args(args())
           .options(options())
           .metadata(metadata)
+          .deprecated(deprecated().isPresent() ? deprecated() : deprecated)
           .ordered(ordered())
           .variadic(variadic())
           .decomposability(decomposability())
@@ -566,6 +618,8 @@ public class SimpleExtension {
     protected abstract Optional<Boolean> variadic();
 
     public abstract Optional<Map<String, Object>> metadata();
+
+    public abstract Optional<DeprecationStatus> deprecated();
 
     public TypeAnchor getAnchor() {
       return anchorSupplier.get();

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -428,7 +428,7 @@ public class SimpleExtension {
   @JsonSerialize(as = ImmutableSimpleExtension.ScalarFunctionVariant.class)
   @Value.Immutable
   public abstract static class ScalarFunctionVariant extends Function {
-    public ScalarFunctionVariant resolve(
+    ScalarFunctionVariant resolve(
         String urn,
         String name,
         String description,

--- a/core/src/test/java/io/substrait/extension/DeprecationExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/DeprecationExtensionTest.java
@@ -1,0 +1,117 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.TestBase;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that deprecation information can be read from extension YAML files at multiple levels:
+ *
+ * <ul>
+ *   <li>Type-level deprecation
+ *   <li>Function-level deprecation (scalar, aggregate, window)
+ *   <li>Function-implementation-level deprecation (individual overloads)
+ * </ul>
+ *
+ * See <a href="https://github.com/substrait-io/substrait/pull/1014">substrait#1014</a>.
+ */
+class DeprecationExtensionTest extends TestBase {
+
+  static final String URN = "extension:test:deprecation_extensions";
+  static final SimpleExtension.ExtensionCollection DEPRECATION_EXTENSION;
+
+  static {
+    try {
+      String extensionStr = asString("extensions/deprecation_extensions.yaml");
+      DEPRECATION_EXTENSION = SimpleExtension.load(extensionStr);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  DeprecationExtensionTest() {
+    super(DEPRECATION_EXTENSION);
+  }
+
+  @Test
+  void testTypeDeprecation() {
+    SimpleExtension.TypeAnchor anchor = SimpleExtension.TypeAnchor.of(URN, "deprecatedType");
+    SimpleExtension.DeprecationStatus deprecation =
+        extensions.getType(anchor).deprecated().orElseThrow();
+    assertEquals("0.50.0", deprecation.since());
+    assertEquals("Replaced by newType", deprecation.reason().orElseThrow());
+  }
+
+  @Test
+  void testScalarFunctionDeprecation() {
+    SimpleExtension.FunctionAnchor anchor =
+        SimpleExtension.FunctionAnchor.of(URN, "deprecatedScalar:i64");
+    SimpleExtension.DeprecationStatus deprecation =
+        extensions.getScalarFunction(anchor).deprecated().orElseThrow();
+    assertEquals("0.1.1", deprecation.since());
+    assertEquals("Use newScalar instead", deprecation.reason().orElseThrow());
+  }
+
+  @Test
+  void testScalarFunctionDeprecationWithMetadata() {
+    SimpleExtension.FunctionAnchor anchor =
+        SimpleExtension.FunctionAnchor.of(URN, "deprecatedScalarWithMetadata:i64");
+    SimpleExtension.DeprecationStatus deprecation =
+        extensions.getScalarFunction(anchor).deprecated().orElseThrow();
+    assertEquals("2.0.0", deprecation.since());
+    Map<String, Object> metadata = deprecation.metadata().orElseThrow();
+    assertEquals("newScalar", metadata.get("alternative"));
+  }
+
+  @Test
+  void testAggregateFunctionDeprecation() {
+    SimpleExtension.FunctionAnchor anchor =
+        SimpleExtension.FunctionAnchor.of(URN, "deprecatedAggregate:i64");
+    SimpleExtension.DeprecationStatus deprecation =
+        extensions.getAggregateFunction(anchor).deprecated().orElseThrow();
+    assertEquals("1.2.0", deprecation.since());
+    assertTrue(deprecation.reason().isEmpty());
+  }
+
+  @Test
+  void testWindowFunctionDeprecation() {
+    SimpleExtension.FunctionAnchor anchor =
+        SimpleExtension.FunctionAnchor.of(URN, "deprecatedWindow:i64");
+    SimpleExtension.DeprecationStatus deprecation =
+        extensions.getWindowFunction(anchor).deprecated().orElseThrow();
+    assertEquals("1.3.0", deprecation.since());
+  }
+
+  @Test
+  void testImplLevelDeprecation() {
+    // Only the i64 overload of evolvingScalar is deprecated; the fp32 overload is not.
+    SimpleExtension.DeprecationStatus deprecation =
+        extensions
+            .getScalarFunction(SimpleExtension.FunctionAnchor.of(URN, "evolvingScalar:i64"))
+            .deprecated()
+            .orElseThrow();
+    assertEquals("3.1.0", deprecation.since());
+    assertEquals("Use the fp32 overload instead", deprecation.reason().orElseThrow());
+
+    assertTrue(
+        extensions
+            .getScalarFunction(SimpleExtension.FunctionAnchor.of(URN, "evolvingScalar:fp32"))
+            .deprecated()
+            .isEmpty());
+  }
+
+  @Test
+  void testNonDeprecatedAggregateAsWindowFunction() {
+    // Aggregate functions are also registered as window functions; deprecation must carry over.
+    SimpleExtension.FunctionAnchor anchor =
+        SimpleExtension.FunctionAnchor.of(URN, "deprecatedAggregate:i64");
+    assertFalse(extensions.getWindowFunction(anchor).deprecated().isEmpty());
+    assertEquals("1.2.0", extensions.getWindowFunction(anchor).deprecated().orElseThrow().since());
+  }
+}

--- a/core/src/test/java/io/substrait/extension/DeprecationExtensionTest.java
+++ b/core/src/test/java/io/substrait/extension/DeprecationExtensionTest.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.Test;
  *   <li>Function-level deprecation (scalar, aggregate, window)
  *   <li>Function-implementation-level deprecation (individual overloads)
  * </ul>
- *
- * See <a href="https://github.com/substrait-io/substrait/pull/1014">substrait#1014</a>.
  */
 class DeprecationExtensionTest extends TestBase {
 

--- a/core/src/test/resources/extensions/deprecation_extensions.yaml
+++ b/core/src/test/resources/extensions/deprecation_extensions.yaml
@@ -1,0 +1,57 @@
+%YAML 1.2
+---
+urn: extension:test:deprecation_extensions
+types:
+  - name: "deprecatedType"
+    deprecated:
+      since: "0.50.0"
+      reason: "Replaced by newType"
+scalar_functions:
+  # Function-level deprecation
+  - name: "deprecatedScalar"
+    deprecated:
+      since: "0.1.1"
+      reason: "Use newScalar instead"
+    impls:
+      - args:
+          - value: i64
+        return: i64
+  # Function-level deprecation with reason and metadata
+  - name: "deprecatedScalarWithMetadata"
+    deprecated:
+      since: "2.0.0"
+      reason: "This function is deprecated for removal in a future version"
+      metadata:
+        alternative: "newScalar"
+    impls:
+      - args:
+          - value: i64
+        return: i64
+  # Only one overload (impl) is deprecated
+  - name: "evolvingScalar"
+    impls:
+      - args:
+          - value: fp32
+        return: fp32
+      - args:
+          - value: i64
+        deprecated:
+          since: "3.1.0"
+          reason: "Use the fp32 overload instead"
+        return: i64
+aggregate_functions:
+  - name: "deprecatedAggregate"
+    deprecated:
+      since: "1.2.0"
+    impls:
+      - args:
+          - value: i64
+        return: i64
+window_functions:
+  - name: "deprecatedWindow"
+    deprecated:
+      since: "1.3.0"
+    impls:
+      - args:
+          - value: i64
+        return: i64


### PR DESCRIPTION
BREAKING CHANGE: changes the visibility of the `ScalarFunctionVariant.resolve()` function from public to package-private

## Summary

Implements support for deprecation information in simple extensions, introduced in Substrait v0.86.0 ([substrait-io/substrait#1014](https://github.com/substrait-io/substrait/pull/1014)).

An optional `deprecated` object can now be parsed and exposed on:
- types
- scalar / aggregate / window functions (function-level)
- individual function implementations / overloads (impl-level)

The `deprecated` object carries a required `since` (core semantic version string), an optional `reason`, and optional `metadata`. As with the existing `metadata` support, consumers are not required to validate these fields — the information is surfaced so tooling can produce deprecation warnings.

Type variations are not modeled in substrait-java's extension schema (`ExtensionSignatures` only covers `types`, `scalar_functions`, `aggregate_functions`, `window_functions`), so type-variation deprecation is out of scope. I opened #847 to track adding type-variation support to the extension model (which would then also cover their deprecation info).

## Details

- New `SimpleExtension.DeprecationStatus` immutable value type (`since`, `reason`, `metadata`), following the existing `Option` / `VariadicBehavior` pattern.
- Added `Optional<DeprecationStatus> deprecated()` to `Type`, the `ScalarFunction`/`AggregateFunction`/`WindowFunction` parent classes, and the `Function` base class (per impl).
- Function-level deprecation is propagated into each resolved variant. When both a function-level and an impl-level deprecation are present, the impl-level value takes precedence. Aggregate functions registered as window functions retain their deprecation automatically.

## Testing

- New `DeprecationExtensionTest` (7 tests) covering type, function-level, and impl-level deprecation, deprecation `metadata`, an overload-specific deprecation where a sibling overload is not deprecated, and carry-over to aggregate-as-window functions.
- New `deprecation_extensions.yaml` test resource.

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)