### PR TITLE
ci: remove PR title check comment when check passes

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -3,6 +3,10 @@ name: PR Title Check
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
 jobs:
   commitlint:
     name: PR title / description conforms to semantic-release
@@ -17,42 +21,60 @@ jobs:
             .commitlintrc.js
           sparse-checkout-cone-mode: false
       - run: npm install @commitlint/config-conventional
-      - run: npx commitlint --verbose <<< $COMMIT_MSG
+      - id: commitlint
+        continue-on-error: true
+        run: npx commitlint --verbose <<< $COMMIT_MSG
         env:
           COMMIT_MSG: >
             ${{ github.event.pull_request.title }}
 
             ${{ github.event.pull_request.body }}
-      - if: failure()
-        uses: actions/github-script@v9
+      - uses: actions/github-script@v9
         with:
           script: |
-            const message = `**ACTION NEEDED**
+            // Hidden marker used to find this job's comment regardless of wording.
+            const marker = "<!-- pr-title-check -->";
+            const message = `${marker}
+            **ACTION NEEDED**
 
-              Substrait follows the [Conventional Commits
-              specification](https://www.conventionalcommits.org/en/v1.0.0/) for
-              release automation.
+            Substrait follows the [Conventional Commits
+            specification](https://www.conventionalcommits.org/en/v1.0.0/) for
+            release automation.
 
-              The PR title and description are used as the merge commit message.\
-              Please update your PR title and description to match the specification.
-              `
-            // Get list of current comments
+            The PR title and description are used as the merge commit message.
+            Please update your PR title and description to match the specification.
+            `;
+            const passed = "${{ steps.commitlint.outcome }}" === "success";
+
+            // Find an existing comment from this job, if any.
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-            // Check if this job already commented
-            for (const comment of comments) {
-              if (comment.body === message) {
-                return // Already commented
-              }
-            }
-            // Post the comment about Conventional Commits
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: message
-            })
-            core.setFailed(message)
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (passed) {
+              // Clean up the comment now that the check passes.
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            // Check failed: post the comment if it isn't already there, then fail the job.
+            if (!existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: message,
+              });
+            }
+            core.setFailed(
+              "PR title and description do not follow the Conventional Commits specification."
+            );


### PR DESCRIPTION
## Summary

The PR Title Check workflow posts an **ACTION NEEDED** comment when the PR title/description doesn't follow Conventional Commits, but it never removed that comment once the title was fixed and the check passed. This updates the workflow so the comment is deleted when the check passes.

## Changes

- Collapse the previous `failure()`-only logic into a single `github-script` step that branches on the commitlint outcome (`continue-on-error: true` + `core.setFailed(...)` keeps the check red on failure).
- When the check **passes**, delete any previously posted comment; when it **fails**, post the comment (if not already present).
- Identify the bot comment via a hidden `<!-- pr-title-check -->` marker rather than exact body matching, so detection/cleanup survives wording or whitespace changes.
- Declare `permissions: pull-requests: write` so the workflow can delete comments.

## Notes

Cleanup is marker-based, so it applies to comments posted by the new version going forward; pre-existing comments from the old workflow won't be auto-removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)