### PR TITLE
ci: update to latest Node LTS v24

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -110,6 +110,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Check current status before next release
         run: ./ci/release/dry_run.sh

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - run: npm install @commitlint/config-conventional
       - run: >
           echo 'module.exports = {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           distribution: "temurin"
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Download isthmus-ubuntu-latest binary


### PR DESCRIPTION
This PR updates our usage of Node.js in the Github Actions workflows to the latest LTS v24.