### PR TITLE
ci: align commitlint config across pre-commit and CI

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,128 +1,13 @@
 module.exports = {
+  "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "body-leading-blank": [1, "always"],
-    "body-max-line-length": [2, "always", 100],
-    "footer-leading-blank": [1, "always"],
-    "footer-max-line-length": [2, "always", 100],
-    "header-max-length": [2, "always", 100],
-    "subject-case": [
-      2,
-      "never",
-      ["sentence-case", "start-case", "pascal-case", "upper-case"]
-    ],
-    "subject-empty": [2, "never"],
-    "subject-full-stop": [2, "never", "."],
-    "type-case": [2, "always", "lower-case"],
-    "type-empty": [2, "never"],
-    "type-enum": [
-      2,
-      "always",
-      [
-        "build",
-        "chore",
-        "ci",
-        "docs",
-        "feat",
-        "fix",
-        "perf",
-        "refactor",
-        "revert",
-        "style",
-        "test"
-      ]
-    ]
-  },
-  "prompt": {
-    "questions": {
-      "type": {
-        "description": "Select the type of change that you're committing",
-        "enum": {
-          "feat": {
-            "description": "A new feature",
-            "title": "Features",
-            "emoji": "✨"
-          },
-          "fix": {
-            "description": "A bug fix",
-            "title": "Bug Fixes",
-            "emoji": "🐛"
-          },
-          "docs": {
-            "description": "Documentation only changes",
-            "title": "Documentation",
-            "emoji": "📚"
-          },
-          "style": {
-            "description": "Changes that do not affect the meaning of the code (whitespace, formatting, missing semi-colons, etc)",
-            "title": "Styles",
-            "emoji": "💎"
-          },
-          "refactor": {
-            "description": "A code change that neither fixes a bug nor adds a feature",
-            "title": "Code Refactoring",
-            "emoji": "📦"
-          },
-          "perf": {
-            "description": "A code change that improves performance",
-            "title": "Performance Improvements",
-            "emoji": "🚀"
-          },
-          "test": {
-            "description": "Adding missing tests or fixing existing tests",
-            "title": "Tests",
-            "emoji": "🚨"
-          },
-          "build": {
-            "description": "Changes that affect the build system or external dependencies (example scopes: poetry, nix)",
-            "title": "Builds",
-            "emoji": "🛠"
-          },
-          "ci": {
-            "description": "Changes to our CI configuration files and scripts (example scopes: actions, gh-actions, github-actions)",
-            "title": "Continuous Integrations",
-            "emoji": "⚙️"
-          },
-          "chore": {
-            "description": "Other changes that don't modify source or test files",
-            "title": "Chores",
-            "emoji": "♻️"
-          },
-          "revert": {
-            "description": "Reverts a previous commit",
-            "title": "Reverts",
-            "emoji": "🗑"
-          }
-        }
-      },
-      "scope": {
-        "description": "What is the scope of this change (e.g. component or file name)"
-      },
-      "subject": {
-        "description": "Write a short, imperative tense description of the change"
-      },
-      "body": {
-        "description": "Provide a longer description of the change"
-      },
-      "isBreaking": {
-        "description": "Are there any breaking changes?"
-      },
-      "breakingBody": {
-        "description": "A BREAKING CHANGE commit requires a body. Please enter a longer description of the commit itself"
-      },
-      "breaking": {
-        "description": "Describe the breaking changes"
-      },
-      "isIssueAffected": {
-        "description": "Does this change affect any open issues?"
-      },
-      "issuesBody": {
-        "description": "If issues are closed, the commit requires a body. Please enter a longer description of the commit itself"
-      },
-      "issues": {
-        "description": "Add issue references (e.g. \"fix #123\", \"re #123\".)"
-      }
-    }
+    "body-max-line-length": [0, "always", Infinity],
+    "footer-max-line-length": [0, "always", Infinity],
+    "body-leading-blank": [0, "always"]
   },
   // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-  "ignores": [(message) => /^build\(deps\): bump .+ from .+ to .+$/s.test(message)]
+  "ignores": [
+    (message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message),
+    (message) => /^Updates the requirements on .+ to permit the latest version\.$/m.test(message)
+  ]
 }

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -12,6 +12,10 @@ jobs:
         with:
           node-version: "24"
       - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .commitlintrc.js
+          sparse-checkout-cone-mode: false
       - run: npm install @commitlint/config-conventional
       - run: npx commitlint --verbose <<< $COMMIT_MSG
         env:

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -11,18 +11,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+      - uses: actions/checkout@v6
       - run: npm install @commitlint/config-conventional
-      - run: >
-          echo 'module.exports = {
-            // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
-            "rules": {
-              "body-max-line-length": [0, "always", Infinity],
-              "footer-max-line-length": [0, "always", Infinity],
-              "body-leading-blank": [0, "always"]
-            }
-          }' > .commitlintrc.js
-      - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
+      - run: npx commitlint --verbose <<< $COMMIT_MSG
         env:
           COMMIT_MSG: >
             ${{ github.event.pull_request.title }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
   hooks:
   - id: commitlint
     stages: [commit-msg]
+    additional_dependencies: ['@commitlint/config-conventional']


### PR DESCRIPTION
## Summary

The PR title check workflow generated its own throwaway commitlint config inline, while `.commitlintrc.js` (used by the local pre-commit hook) maintained a separate, stricter rule set. The two diverged, so local commits were validated differently than PR titles in CI.

This makes `.commitlintrc.js` the single source of truth, mirroring the [substrait](https://github.com/substrait-io/substrait) repo:

- **`.commitlintrc.js`** now `extends` `@commitlint/config-conventional` (which supplies the same type list, case, and length rules that were previously hand-maintained), loosens the body/footer length rules, and ignores dependabot messages — including the `Updates the requirements on … to permit the latest version.` pattern that substrait has but we were missing.
- **`.github/workflows/pr_title.yaml`** no longer generates a config inline. It checks out the repo and runs `commitlint` against the checked-in config. Under `pull_request_target`, `actions/checkout` defaults to the trusted base branch, so a PR cannot supply its own commitlint rules.
- **`.pre-commit-config.yaml`** gains `additional_dependencies: ['@commitlint/config-conventional']` so the local commit-msg hook can resolve the now-extended config (the hook only bundles `@commitlint/cli`).

## Notes

Local commits now use the same loosened length rules as CI rather than the old strict 100-char limits — that is the intended convergence, since CI was the effective authority anyway. The commitizen `prompt` block was dropped to match substrait's config.

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)