### PR TITLE
feat(core)!: remove AggregateRel.Grouping.grouping_expressions

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -719,33 +719,20 @@ public class ProtoRelConverter {
 
     List<Aggregate.Grouping> groupings = new ArrayList<>(rel.getGroupingsCount());
 
-    // Groupings are set using the AggregateRel grouping_expression mechanism
-    if (!rel.getGroupingExpressionsList().isEmpty()) {
-      List<Expression> allGroupingExpressions =
-          rel.getGroupingExpressionsList().stream()
-              .map(protoExprConverter::from)
-              .collect(java.util.stream.Collectors.toList());
+    // Convert grouping expressions from the aggregate-level grouping_expressions list
+    // Each grouping references expressions by index into this list
+    List<Expression> allGroupingExpressions =
+        rel.getGroupingExpressionsList().stream()
+            .map(protoExprConverter::from)
+            .collect(java.util.stream.Collectors.toList());
 
-      for (AggregateRel.Grouping grouping : rel.getGroupingsList()) {
-        List<Integer> references = grouping.getExpressionReferencesList();
-        List<Expression> groupExpressions = new ArrayList<>();
-        for (int ref : references) {
-          groupExpressions.add(allGroupingExpressions.get(ref));
-        }
-        groupings.add(Aggregate.Grouping.builder().addAllExpressions(groupExpressions).build());
+    for (AggregateRel.Grouping grouping : rel.getGroupingsList()) {
+      List<Integer> references = grouping.getExpressionReferencesList();
+      List<Expression> groupExpressions = new ArrayList<>();
+      for (int ref : references) {
+        groupExpressions.add(allGroupingExpressions.get(ref));
       }
-
-    } else {
-      // Groupings are set using the deprecated Grouping grouping_expressions mechanism
-      for (AggregateRel.Grouping grouping : rel.getGroupingsList()) {
-        groupings.add(
-            Aggregate.Grouping.builder()
-                .expressions(
-                    grouping.getGroupingExpressionsList().stream()
-                        .map(protoExprConverter::from)
-                        .collect(java.util.stream.Collectors.toList()))
-                .build());
-      }
+      groupings.add(Aggregate.Grouping.builder().addAllExpressions(groupExpressions).build());
     }
 
     List<Aggregate.Measure> measures = new ArrayList<>(rel.getMeasuresCount());

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -216,8 +216,6 @@ public class RelProtoConverter
   private AggregateRel.Grouping toProto(
       Aggregate.Grouping grouping, List<Expression> uniqueGroupingExpressions) {
     return AggregateRel.Grouping.newBuilder()
-        .addAllGroupingExpressions(
-            grouping.getExpressions().stream().map(this::toProto).collect(Collectors.toList()))
         .addAllExpressionReferences(
             grouping.getExpressions().stream()
                 .map(e -> uniqueGroupingExpressions.indexOf(e))

--- a/core/src/test/java/io/substrait/relation/AggregateRelTest.java
+++ b/core/src/test/java/io/substrait/relation/AggregateRelTest.java
@@ -73,27 +73,15 @@ class AggregateRelTest extends TestBase {
         .collect(Collectors.toList());
   }
 
-  /**
-   * Helper method to extract deprecated grouping expressions from an AggregateRel.
-   *
-   * @param aggregateRel the AggregateRel to extract grouping expressions from
-   * @return a list of lists, where each inner list contains the grouping expressions for a grouping
-   */
-  private static List<List<Expression>> getGroupingExpressions(AggregateRel aggregateRel) {
-    return aggregateRel.getGroupingsList().stream()
-        .map(grouping -> grouping.getGroupingExpressionsList())
-        .collect(Collectors.toList());
-  }
-
   @Test
-  void testDeprecatedGroupingExpressionConversion() {
+  void testGroupingExpressionConversion() {
     Expression col1Ref = createFieldReference(0);
     Expression col2Ref = createFieldReference(1);
 
     AggregateRel.Grouping grouping =
         AggregateRel.Grouping.newBuilder()
-            .addGroupingExpressions(col1Ref) // deprecated proto form
-            .addGroupingExpressions(col2Ref)
+            .addExpressionReferences(0)
+            .addExpressionReferences(1)
             .build();
 
     // Build an input ReadRel
@@ -103,10 +91,12 @@ class AggregateRelTest extends TestBase {
             .setBaseSchema(namedStruct)
             .build();
 
-    // Build the AggregateRel with the new grouping_expressions field
+    // Build the AggregateRel with grouping_expressions field
     AggregateRel aggrProto =
         AggregateRel.newBuilder()
             .setInput(Rel.newBuilder().setRead(readProto))
+            .addGroupingExpressions(col1Ref)
+            .addGroupingExpressions(col2Ref)
             .addGroupings(grouping)
             .build();
 
@@ -123,10 +113,8 @@ class AggregateRelTest extends TestBase {
     assertTrue(roundtripRel.hasAggregate());
 
     AggregateRel roundtripAgg = roundtripRel.getAggregate();
-    // Verify new expression_references structure
+    // Verify expression_references structure
     assertEquals(List.of(List.of(0, 1)), getExpressionReferences(roundtripAgg));
-    // Verify backward compatibility: deprecated grouping_expressions field is also populated
-    assertEquals(List.of(List.of(col1Ref, col2Ref)), getGroupingExpressions(roundtripAgg));
     // Verify aggregate-level grouping_expressions field is populated
     assertEquals(List.of(col1Ref, col2Ref), roundtripAgg.getGroupingExpressionsList());
   }
@@ -149,7 +137,7 @@ class AggregateRelTest extends TestBase {
             .setBaseSchema(namedStruct)
             .build();
 
-    // Build the AggregateRel with the new grouping_expressions field
+    // Build the AggregateRel with grouping_expressions field
     AggregateRel aggrProto =
         AggregateRel.newBuilder()
             .setInput(Rel.newBuilder().setRead(readProto))
@@ -171,10 +159,8 @@ class AggregateRelTest extends TestBase {
     assertTrue(roundtripRel.hasAggregate());
 
     AggregateRel roundtripAgg = roundtripRel.getAggregate();
-    // Verify new expression_references structure
+    // Verify expression_references structure
     assertEquals(List.of(List.of(0, 1)), getExpressionReferences(roundtripAgg));
-    // Verify backward compatibility: deprecated grouping_expressions field is also populated
-    assertEquals(List.of(List.of(col1Ref, col2Ref)), getGroupingExpressions(roundtripAgg));
     // Verify aggregate-level grouping_expressions field is populated
     assertEquals(List.of(col1Ref, col2Ref), roundtripAgg.getGroupingExpressionsList());
   }
@@ -200,7 +186,7 @@ class AggregateRelTest extends TestBase {
             .setBaseSchema(namedStruct)
             .build();
 
-    // Build the AggregateRel with the new grouping_expressions field
+    // Build the AggregateRel with grouping_expressions field
     AggregateRel aggrProto =
         AggregateRel.newBuilder()
             .setInput(Rel.newBuilder().setRead(readProto))
@@ -224,11 +210,8 @@ class AggregateRelTest extends TestBase {
     assertTrue(roundtripRel.hasAggregate());
 
     AggregateRel roundtripAgg = roundtripRel.getAggregate();
-    // Verify new expression_references structure
+    // Verify expression_references structure
     assertEquals(List.of(List.of(0, 1), List.of(1)), getExpressionReferences(roundtripAgg));
-    // Verify backward compatibility: deprecated grouping_expressions field is also populated
-    assertEquals(
-        List.of(List.of(col1Ref, col2Ref), List.of(col2Ref)), getGroupingExpressions(roundtripAgg));
     // Verify aggregate-level grouping_expressions field is populated
     assertEquals(List.of(col1Ref, col2Ref), roundtripAgg.getGroupingExpressionsList());
   }


### PR DESCRIPTION
BREAKING CHANGE: removes the deprecated Aggregate.Grouping.grouping_expressions field which was removed in Substrait v0.88.0

Closes #805 

I'm not sure how to best introduce these changes. We could update the Git submodule first which then breaks a whole lot of code which we would all need to migrate in one big PR or we gradually introduce the changes in PRs like this one and then update the git submodule.