### PR TITLE
docs(core): fix javadoc in ExpressionCreator

### DIFF
--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -18,50 +18,132 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Utility class for creating Substrait expression objects.
+ *
+ * <p>This class provides factory methods for constructing various types of expressions, literals,
+ * and function invocations used in Substrait query plans.
+ */
 public class ExpressionCreator {
 
   private ExpressionCreator() {}
 
+  /**
+   * Creates a null literal expression with a specific type.
+   *
+   * @param t the type of the null literal
+   * @return a NullLiteral expression
+   */
   public static Expression.NullLiteral typedNull(Type t) {
     return Expression.NullLiteral.builder().type(t).build();
   }
 
+  /**
+   * Creates a boolean literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the boolean value
+   * @return a BoolLiteral expression
+   */
   public static Expression.BoolLiteral bool(boolean nullable, boolean value) {
     return Expression.BoolLiteral.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates an 8-bit integer literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the integer value
+   * @return an I8Literal expression
+   */
   public static Expression.I8Literal i8(boolean nullable, int value) {
     return Expression.I8Literal.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a 16-bit integer literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the integer value
+   * @return an I16Literal expression
+   */
   public static Expression.I16Literal i16(boolean nullable, int value) {
     return Expression.I16Literal.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a 32-bit integer literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the integer value
+   * @return an I32Literal expression
+   */
   public static Expression.I32Literal i32(boolean nullable, int value) {
     return Expression.I32Literal.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a 64-bit integer literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the long value
+   * @return an I64Literal expression
+   */
   public static Expression.I64Literal i64(boolean nullable, long value) {
     return Expression.I64Literal.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a 32-bit floating point literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the float value
+   * @return an FP32Literal expression
+   */
   public static Expression.FP32Literal fp32(boolean nullable, float value) {
     return Expression.FP32Literal.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a 64-bit floating point literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the double value
+   * @return an FP64Literal expression
+   */
   public static Expression.FP64Literal fp64(boolean nullable, double value) {
     return Expression.FP64Literal.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a string literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the string value
+   * @return a StrLiteral expression
+   */
   public static Expression.StrLiteral string(boolean nullable, String value) {
     return Expression.StrLiteral.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a binary literal expression from a ByteString.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the ByteString value
+   * @return a BinaryLiteral expression
+   */
   public static Expression.BinaryLiteral binary(boolean nullable, ByteString value) {
     return Expression.BinaryLiteral.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a binary literal expression from a byte array.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the byte array value
+   * @return a BinaryLiteral expression
+   */
   public static Expression.BinaryLiteral binary(boolean nullable, byte[] value) {
     return Expression.BinaryLiteral.builder()
         .nullable(nullable)
@@ -69,11 +151,23 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a date literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the date value as days since epoch
+   * @return a DateLiteral expression
+   */
   public static Expression.DateLiteral date(boolean nullable, int value) {
     return Expression.DateLiteral.builder().nullable(nullable).value(value).build();
   }
 
   /**
+   * Creates a time literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the time value in microseconds since midnight
+   * @return a TimeLiteral expression
    * @deprecated Time is deprecated in favor of PrecisionTime
    */
   @Deprecated
@@ -81,6 +175,14 @@ public class ExpressionCreator {
     return Expression.TimeLiteral.builder().nullable(nullable).value(value).build();
   }
 
+  /**
+   * Creates a precision time literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the time value
+   * @param precision the precision of the time
+   * @return a PrecisionTimeLiteral expression
+   */
   public static Expression.PrecisionTimeLiteral precisionTime(
       boolean nullable, long value, int precision) {
     return Expression.PrecisionTimeLiteral.builder()
@@ -108,6 +210,11 @@ public class ExpressionCreator {
   }
 
   /**
+   * Creates a timestamp literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the timestamp value in microseconds since epoch
+   * @return a TimestampLiteral expression
    * @deprecated Timestamp is deprecated in favor of PrecisionTimestamp
    */
   @Deprecated
@@ -116,6 +223,11 @@ public class ExpressionCreator {
   }
 
   /**
+   * Creates a timestamp literal expression from a LocalDateTime.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the LocalDateTime value (interpreted as UTC)
+   * @return a TimestampLiteral expression
    * @deprecated Timestamp is deprecated in favor of PrecisionTimestamp
    */
   @Deprecated
@@ -127,6 +239,17 @@ public class ExpressionCreator {
   }
 
   /**
+   * Creates a timestamp literal expression from date/time components.
+   *
+   * @param nullable whether the literal can be null
+   * @param year the year
+   * @param month the month (1-12)
+   * @param dayOfMonth the day of month (1-31)
+   * @param hour the hour (0-23)
+   * @param minute the minute (0-59)
+   * @param second the second (0-59)
+   * @param micros the microseconds (0-999999)
+   * @return a TimestampLiteral expression
    * @deprecated Timestamp is deprecated in favor of PrecisionTimestamp
    */
   @Deprecated
@@ -146,6 +269,11 @@ public class ExpressionCreator {
   }
 
   /**
+   * Creates a timestamp with timezone literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the timestamp value in microseconds since epoch
+   * @return a TimestampTZLiteral expression
    * @deprecated TimestampTZ is deprecated in favor of PrecisionTimestampTZ
    */
   @Deprecated
@@ -154,6 +282,11 @@ public class ExpressionCreator {
   }
 
   /**
+   * Creates a timestamp with timezone literal expression from an Instant.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the Instant value
+   * @return a TimestampTZLiteral expression
    * @deprecated TimestampTZ is deprecated in favor of PrecisionTimestampTZ
    */
   @Deprecated
@@ -164,6 +297,14 @@ public class ExpressionCreator {
     return timestampTZ(nullable, epochMicro);
   }
 
+  /**
+   * Creates a precision timestamp literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the timestamp value
+   * @param precision the precision of the timestamp
+   * @return a PrecisionTimestampLiteral expression
+   */
   public static Expression.PrecisionTimestampLiteral precisionTimestamp(
       boolean nullable, long value, int precision) {
     return Expression.PrecisionTimestampLiteral.builder()
@@ -193,6 +334,14 @@ public class ExpressionCreator {
     return precisionTimestamp(nullable, epochNano, 9);
   }
 
+  /**
+   * Creates a precision timestamp with timezone literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the timestamp value
+   * @param precision the precision of the timestamp
+   * @return a PrecisionTimestampTZLiteral expression
+   */
   public static Expression.PrecisionTimestampTZLiteral precisionTimestampTZ(
       boolean nullable, long value, int precision) {
     return Expression.PrecisionTimestampTZLiteral.builder()
@@ -202,6 +351,14 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates an interval year literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param years the number of years
+   * @param months the number of months
+   * @return an IntervalYearLiteral expression
+   */
   public static Expression.IntervalYearLiteral intervalYear(
       boolean nullable, int years, int months) {
     return Expression.IntervalYearLiteral.builder()
@@ -211,10 +368,28 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates an interval day literal expression with default subseconds and precision.
+   *
+   * @param nullable whether the literal can be null
+   * @param days the number of days
+   * @param seconds the number of seconds
+   * @return an IntervalDayLiteral expression
+   */
   public static Expression.IntervalDayLiteral intervalDay(boolean nullable, int days, int seconds) {
     return intervalDay(nullable, days, seconds, 0, 0);
   }
 
+  /**
+   * Creates an interval day literal expression with subseconds and precision.
+   *
+   * @param nullable whether the literal can be null
+   * @param days the number of days
+   * @param seconds the number of seconds
+   * @param subseconds the subsecond component
+   * @param precision the precision of subseconds
+   * @return an IntervalDayLiteral expression
+   */
   public static Expression.IntervalDayLiteral intervalDay(
       boolean nullable, int days, int seconds, long subseconds, int precision) {
     return Expression.IntervalDayLiteral.builder()
@@ -226,6 +401,18 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates an interval compound literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param years the number of years
+   * @param months the number of months
+   * @param days the number of days
+   * @param seconds the number of seconds
+   * @param subseconds the subsecond component
+   * @param precision the precision of subseconds
+   * @return an IntervalCompoundLiteral expression
+   */
   public static Expression.IntervalCompoundLiteral intervalCompound(
       boolean nullable,
       int years,
@@ -245,6 +432,13 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a UUID literal expression from a ByteString.
+   *
+   * @param nullable whether the literal can be null
+   * @param uuid the UUID value as a ByteString
+   * @return a UUIDLiteral expression
+   */
   public static Expression.UUIDLiteral uuid(boolean nullable, ByteString uuid) {
     ByteBuffer bb = uuid.asReadOnlyByteBuffer();
     return Expression.UUIDLiteral.builder()
@@ -253,22 +447,58 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a UUID literal expression from a UUID object.
+   *
+   * @param nullable whether the literal can be null
+   * @param uuid the UUID value
+   * @return a UUIDLiteral expression
+   */
   public static Expression.UUIDLiteral uuid(boolean nullable, UUID uuid) {
     return Expression.UUIDLiteral.builder().nullable(nullable).value(uuid).build();
   }
 
+  /**
+   * Creates a fixed-length character literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param str the string value
+   * @return a FixedCharLiteral expression
+   */
   public static Expression.FixedCharLiteral fixedChar(boolean nullable, String str) {
     return Expression.FixedCharLiteral.builder().nullable(nullable).value(str).build();
   }
 
+  /**
+   * Creates a variable-length character literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param str the string value
+   * @param len the maximum length
+   * @return a VarCharLiteral expression
+   */
   public static Expression.VarCharLiteral varChar(boolean nullable, String str, int len) {
     return Expression.VarCharLiteral.builder().nullable(nullable).value(str).length(len).build();
   }
 
+  /**
+   * Creates a fixed-length binary literal expression from a ByteString.
+   *
+   * @param nullable whether the literal can be null
+   * @param bytes the ByteString value
+   * @return a FixedBinaryLiteral expression
+   */
   public static Expression.FixedBinaryLiteral fixedBinary(boolean nullable, ByteString bytes) {
     return Expression.FixedBinaryLiteral.builder().nullable(nullable).value(bytes).build();
   }
 
+  /**
+   * Creates a fixed-length binary literal expression from a byte array.
+   *
+   * @param nullable whether the literal can be null
+   * @param bytes the byte array value
+   * @return a FixedBinaryLiteral expression
+   */
   public static Expression.FixedBinaryLiteral fixedBinary(boolean nullable, byte[] bytes) {
     return Expression.FixedBinaryLiteral.builder()
         .nullable(nullable)
@@ -276,6 +506,15 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a decimal literal expression from a ByteString.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the ByteString value containing the decimal in two's complement format
+   * @param precision the precision of the decimal
+   * @param scale the scale of the decimal
+   * @return a DecimalLiteral expression
+   */
   public static Expression.DecimalLiteral decimal(
       boolean nullable, ByteString value, int precision, int scale) {
     return Expression.DecimalLiteral.builder()
@@ -286,6 +525,15 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a decimal literal expression from a BigDecimal.
+   *
+   * @param nullable whether the literal can be null
+   * @param value the BigDecimal value
+   * @param precision the precision of the decimal
+   * @param scale the scale of the decimal
+   * @return a DecimalLiteral expression
+   */
   public static Expression.DecimalLiteral decimal(
       boolean nullable, BigDecimal value, int precision, int scale) {
     byte[] twosComplement = DecimalUtil.encodeDecimalIntoBytes(value, scale, 16);
@@ -298,11 +546,26 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a map literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param values the map of key-value pairs
+   * @return a MapLiteral expression
+   */
   public static Expression.MapLiteral map(
       boolean nullable, Map<Expression.Literal, Expression.Literal> values) {
     return Expression.MapLiteral.builder().nullable(nullable).putAllValues(values).build();
   }
 
+  /**
+   * Creates an empty map literal expression.
+   *
+   * @param nullable whether the literal can be null
+   * @param keyType the type of map keys
+   * @param valueType the type of map values
+   * @return an EmptyMapLiteral expression
+   */
   public static Expression.EmptyMapLiteral emptyMap(
       boolean nullable, Type keyType, Type valueType) {
     return Expression.EmptyMapLiteral.builder()
@@ -312,15 +575,36 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a list literal expression from varargs.
+   *
+   * @param nullable whether the literal can be null
+   * @param values the literal values in the list
+   * @return a ListLiteral expression
+   */
   public static Expression.ListLiteral list(boolean nullable, Expression.Literal... values) {
     return Expression.ListLiteral.builder().nullable(nullable).addValues(values).build();
   }
 
+  /**
+   * Creates a list literal expression from an iterable.
+   *
+   * @param nullable whether the literal can be null
+   * @param values the literal values in the list
+   * @return a ListLiteral expression
+   */
   public static Expression.ListLiteral list(
       boolean nullable, Iterable<? extends Expression.Literal> values) {
     return Expression.ListLiteral.builder().nullable(nullable).addAllValues(values).build();
   }
 
+  /**
+   * Creates an empty list literal expression.
+   *
+   * @param listNullable whether the list can be null
+   * @param elementType the type of list elements
+   * @return an EmptyListLiteral expression
+   */
   public static Expression.EmptyListLiteral emptyList(boolean listNullable, Type elementType) {
     return Expression.EmptyListLiteral.builder()
         .elementType(elementType)
@@ -328,6 +612,13 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a struct literal expression from varargs.
+   *
+   * @param nullable whether the literal can be null
+   * @param values the literal field values
+   * @return a StructLiteral expression
+   */
   public static Expression.StructLiteral struct(boolean nullable, Expression.Literal... values) {
     return Expression.StructLiteral.builder().nullable(nullable).addFields(values).build();
   }
@@ -335,24 +626,49 @@ public class ExpressionCreator {
   /**
    * Creates a nested list expression with one or more elements.
    *
-   * <p>Note: This class cannot be used to construct an empty list. To create an empty list, use
+   * <p>Note: This method cannot be used to construct an empty list. To create an empty list, use
    * {@link ExpressionCreator#emptyList(boolean, Type)} which returns an {@link
    * Expression.EmptyListLiteral}.
+   *
+   * @param nullable whether the literal can be null
+   * @param values the expression values in the nested list
+   * @return a NestedList expression
    */
   public static Expression.NestedList nestedList(boolean nullable, List<Expression> values) {
     return Expression.NestedList.builder().nullable(nullable).addAllValues(values).build();
   }
 
+  /**
+   * Creates a struct literal expression from an iterable.
+   *
+   * @param nullable whether the literal can be null
+   * @param values the literal field values
+   * @return a StructLiteral expression
+   */
   public static Expression.StructLiteral struct(
       boolean nullable, Iterable<? extends Expression.Literal> values) {
     return Expression.StructLiteral.builder().nullable(nullable).addAllFields(values).build();
   }
 
+  /**
+   * Creates a nested struct expression from an iterable.
+   *
+   * @param nullable whether the struct can be null
+   * @param fields the expression fields
+   * @return a NestedStruct expression
+   */
   public static Expression.NestedStruct nestedStruct(
       boolean nullable, Iterable<Expression> fields) {
     return Expression.NestedStruct.builder().nullable(nullable).addAllFields(fields).build();
   }
 
+  /**
+   * Creates a nested struct expression from varargs.
+   *
+   * @param nullable whether the struct can be null
+   * @param fields the expression fields
+   * @return a NestedStruct expression
+   */
   public static Expression.NestedStruct nestedStruct(boolean nullable, Expression... fields) {
     return Expression.NestedStruct.builder().nullable(nullable).addFields(fields).build();
   }
@@ -365,6 +681,7 @@ public class ExpressionCreator {
    * @param name the name of the user-defined type
    * @param typeParameters the type parameters for the user-defined type (can be an empty list)
    * @param value the value, encoded as google.protobuf.Any
+   * @return a UserDefinedAnyLiteral expression
    */
   public static Expression.UserDefinedAnyLiteral userDefinedLiteralAny(
       boolean nullable,
@@ -389,6 +706,7 @@ public class ExpressionCreator {
    * @param name the name of the user-defined type
    * @param typeParameters the type parameters for the user-defined type (can be an empty list)
    * @param fields the fields, as a list of Literal values
+   * @return a UserDefinedStructLiteral expression
    */
   public static Expression.UserDefinedStructLiteral userDefinedLiteralStruct(
       boolean nullable,
@@ -405,6 +723,14 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a switch statement with varargs clauses.
+   *
+   * @param match the expression to match against
+   * @param defaultExpression the default expression if no clause matches
+   * @param conditionClauses the switch clauses
+   * @return a Switch expression
+   */
   public static Expression.Switch switchStatement(
       Expression match, Expression defaultExpression, Expression.SwitchClause... conditionClauses) {
     return Expression.Switch.builder()
@@ -414,6 +740,14 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a switch statement with an iterable of clauses.
+   *
+   * @param match the expression to match against
+   * @param defaultExpression the default expression if no clause matches
+   * @param conditionClauses the switch clauses
+   * @return a Switch expression
+   */
   public static Expression.Switch switchStatement(
       Expression match,
       Expression defaultExpression,
@@ -425,6 +759,13 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a switch clause.
+   *
+   * @param expectedValue the literal value to match
+   * @param resultExpression the result expression if matched
+   * @return a SwitchClause
+   */
   public static Expression.SwitchClause switchClause(
       Expression.Literal expectedValue, Expression resultExpression) {
     return Expression.SwitchClause.builder()
@@ -433,6 +774,13 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates an if-then statement with varargs clauses.
+   *
+   * @param elseExpression the else clause expression
+   * @param conditionClauses the if clauses
+   * @return an IfThen expression
+   */
   public static Expression.IfThen ifThenStatement(
       Expression elseExpression, Expression.IfClause... conditionClauses) {
     return Expression.IfThen.builder()
@@ -441,6 +789,13 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates an if-then statement with an iterable of clauses.
+   *
+   * @param elseExpression the else clause expression
+   * @param conditionClauses the if clauses
+   * @return an IfThen expression
+   */
   public static Expression.IfThen ifThenStatement(
       Expression elseExpression, Iterable<? extends Expression.IfClause> conditionClauses) {
     return Expression.IfThen.builder()
@@ -449,6 +804,13 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates an if-then clause.
+   *
+   * @param conditionExpression the condition expression
+   * @param resultExpression the result expression if condition is true
+   * @return an IfClause
+   */
   public static Expression.IfClause ifThenClause(
       Expression conditionExpression, Expression resultExpression) {
     return Expression.IfClause.builder()
@@ -457,6 +819,14 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a scalar function invocation with varargs.
+   *
+   * @param declaration the function declaration
+   * @param outputType the output type of the function
+   * @param arguments the function arguments
+   * @return a ScalarFunctionInvocation expression
+   */
   public static Expression.ScalarFunctionInvocation scalarFunction(
       SimpleExtension.ScalarFunctionVariant declaration,
       Type outputType,
@@ -465,8 +835,15 @@ public class ExpressionCreator {
   }
 
   /**
-   * Use {@link Expression.ScalarFunctionInvocation#builder()} directly to specify other parameters,
-   * e.g. options
+   * Creates a scalar function invocation.
+   *
+   * <p>Use {@link Expression.ScalarFunctionInvocation#builder()} directly to specify other
+   * parameters, e.g. options
+   *
+   * @param declaration the function declaration
+   * @param outputType the output type of the function
+   * @param arguments the function arguments
+   * @return a ScalarFunctionInvocation expression
    */
   public static Expression.ScalarFunctionInvocation scalarFunction(
       SimpleExtension.ScalarFunctionVariant declaration,
@@ -480,8 +857,18 @@ public class ExpressionCreator {
   }
 
   /**
-   * Use {@link AggregateFunctionInvocation#builder()} directly to specify other parameters, e.g.
+   * Creates an aggregate function invocation.
+   *
+   * <p>Use {@link AggregateFunctionInvocation#builder()} directly to specify other parameters, e.g.
    * options
+   *
+   * @param declaration the function declaration
+   * @param outputType the output type of the function
+   * @param phase the aggregation phase
+   * @param sort the sort fields
+   * @param invocation the aggregation invocation type
+   * @param arguments the function arguments
+   * @return an AggregateFunctionInvocation
    */
   public static AggregateFunctionInvocation aggregateFunction(
       SimpleExtension.AggregateFunctionVariant declaration,
@@ -500,6 +887,17 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates an aggregate function invocation with varargs.
+   *
+   * @param declaration the function declaration
+   * @param outputType the output type of the function
+   * @param phase the aggregation phase
+   * @param sort the sort fields
+   * @param invocation the aggregation invocation type
+   * @param arguments the function arguments
+   * @return an AggregateFunctionInvocation
+   */
   public static AggregateFunctionInvocation aggregateFunction(
       SimpleExtension.AggregateFunctionVariant declaration,
       Type outputType,
@@ -512,8 +910,22 @@ public class ExpressionCreator {
   }
 
   /**
-   * Use {@link Expression.WindowFunctionInvocation#builder()} directly to specify other parameters,
-   * e.g. options
+   * Creates a window function invocation.
+   *
+   * <p>Use {@link Expression.WindowFunctionInvocation#builder()} directly to specify other
+   * parameters, e.g. options
+   *
+   * @param declaration the function declaration
+   * @param outputType the output type of the function
+   * @param phase the aggregation phase
+   * @param sort the sort fields
+   * @param invocation the aggregation invocation type
+   * @param partitionBy the partition by expressions
+   * @param boundsType the window bounds type
+   * @param lowerBound the lower bound of the window
+   * @param upperBound the upper bound of the window
+   * @param arguments the function arguments
+   * @return a WindowFunctionInvocation expression
    */
   public static Expression.WindowFunctionInvocation windowFunction(
       SimpleExtension.WindowFunctionVariant declaration,
@@ -541,8 +953,20 @@ public class ExpressionCreator {
   }
 
   /**
-   * Use {@link ConsistentPartitionWindow.WindowRelFunctionInvocation#builder()} directly to specify
-   * other parameters, e.g. options
+   * Creates a window relation function invocation.
+   *
+   * <p>Use {@link ConsistentPartitionWindow.WindowRelFunctionInvocation#builder()} directly to
+   * specify other parameters, e.g. options
+   *
+   * @param declaration the function declaration
+   * @param outputType the output type of the function
+   * @param phase the aggregation phase
+   * @param invocation the aggregation invocation type
+   * @param boundsType the window bounds type
+   * @param lowerBound the lower bound of the window
+   * @param upperBound the upper bound of the window
+   * @param arguments the function arguments
+   * @return a WindowRelFunctionInvocation
    */
   public static ConsistentPartitionWindow.WindowRelFunctionInvocation windowRelFunction(
       SimpleExtension.WindowFunctionVariant declaration,
@@ -565,6 +989,21 @@ public class ExpressionCreator {
         .build();
   }
 
+  /**
+   * Creates a window function invocation with varargs.
+   *
+   * @param declaration the function declaration
+   * @param outputType the output type of the function
+   * @param phase the aggregation phase
+   * @param sort the sort fields
+   * @param invocation the aggregation invocation type
+   * @param partitionBy the partition by expressions
+   * @param boundsType the window bounds type
+   * @param lowerBound the lower bound of the window
+   * @param upperBound the upper bound of the window
+   * @param arguments the function arguments
+   * @return a WindowFunctionInvocation expression
+   */
   public static Expression.WindowFunctionInvocation windowFunction(
       SimpleExtension.WindowFunctionVariant declaration,
       Type outputType,
@@ -589,6 +1028,14 @@ public class ExpressionCreator {
         Arrays.asList(arguments));
   }
 
+  /**
+   * Creates a cast expression.
+   *
+   * @param type the target type to cast to
+   * @param expression the expression to cast
+   * @param failureBehavior the failure behavior for the cast
+   * @return a Cast expression
+   */
   public static Expression cast(
       Type type, Expression expression, Expression.FailureBehavior failureBehavior) {
     return Expression.Cast.builder()


### PR DESCRIPTION
I used AI to generate missing javadoc comments for `core/src/main/java/io/substrait/expression/ExpressionCreator.java`.