### PR TITLE
docs(core): fix javadoc in AbstractReadRel

### DIFF
--- a/core/src/main/java/io/substrait/relation/AbstractReadRel.java
+++ b/core/src/main/java/io/substrait/relation/AbstractReadRel.java
@@ -35,6 +35,12 @@ public abstract class AbstractReadRel extends ZeroInputRel implements HasExtensi
    */
   public abstract Optional<Expression> getBestEffortFilter();
 
+  /**
+   * Returns the projection mask expression for this read relation.
+   *
+   * @return an Optional containing the MaskExpression if present, or empty if no projection is
+   *     specified
+   */
   public abstract Optional<MaskExpression> getProjection();
 
   @Override


### PR DESCRIPTION
I used AI to add the missing javadoc comments to `core/src/main/java/io/substrait/relation/AbstractReadRel.java`