### PR TITLE
feat(core): support ExecutionContextVariable

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -945,6 +945,34 @@ public class SubstraitBuilder {
   }
 
   /**
+   * Creates a {@code CURRENT_TIMESTAMP} execution context variable expression.
+   *
+   * @param precision the fractional-second precision of the timestamp
+   * @return a new {@link Expression.CurrentTimestamp}
+   */
+  public Expression.CurrentTimestamp currentTimestamp(int precision) {
+    return Expression.CurrentTimestamp.builder().precision(precision).build();
+  }
+
+  /**
+   * Creates a {@code CURRENT_TIMEZONE} execution context variable expression.
+   *
+   * @return a new {@link Expression.CurrentTimezone}
+   */
+  public Expression.CurrentTimezone currentTimezone() {
+    return Expression.CurrentTimezone.builder().build();
+  }
+
+  /**
+   * Creates a {@code CURRENT_DATE} execution context variable expression.
+   *
+   * @return a new {@link Expression.CurrentDate}
+   */
+  public Expression.CurrentDate currentDate() {
+    return Expression.CurrentDate.builder().build();
+  }
+
+  /**
    * Creates a cast expression that converts an expression to a different type.
    *
    * @param input the expression to cast

--- a/core/src/main/java/io/substrait/expression/AbstractExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/AbstractExpressionVisitor.java
@@ -616,4 +616,43 @@ public abstract class AbstractExpressionVisitor<O, C extends VisitationContext, 
   public O visit(Expression.DynamicParameter expr, C context) throws E {
     return visitFallback(expr, context);
   }
+
+  /**
+   * Visits a current timestamp execution context variable expression.
+   *
+   * @param expr the current timestamp expression
+   * @param context the visitation context
+   * @return the visit result
+   * @throws E if visitation fails
+   */
+  @Override
+  public O visit(Expression.CurrentTimestamp expr, C context) throws E {
+    return visitFallback(expr, context);
+  }
+
+  /**
+   * Visits a current timezone execution context variable expression.
+   *
+   * @param expr the current timezone expression
+   * @param context the visitation context
+   * @return the visit result
+   * @throws E if visitation fails
+   */
+  @Override
+  public O visit(Expression.CurrentTimezone expr, C context) throws E {
+    return visitFallback(expr, context);
+  }
+
+  /**
+   * Visits a current date execution context variable expression.
+   *
+   * @param expr the current date expression
+   * @param context the visitation context
+   * @return the visit result
+   * @throws E if visitation fails
+   */
+  @Override
+  public O visit(Expression.CurrentDate expr, C context) throws E {
+    return visitFallback(expr, context);
+  }
 }

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -2113,6 +2113,112 @@ public interface Expression extends FunctionArg {
     }
   }
 
+  /**
+   * Marker interface for execution-context-dependent variables such as {@code CURRENT_TIMESTAMP},
+   * {@code CURRENT_TIMEZONE}, and {@code CURRENT_DATE}.
+   *
+   * <p>The Substrait spec models these as expressions rather than functions because they take no
+   * input arguments, depend on the execution context rather than input data, and require evaluation
+   * mode control (see {@link io.substrait.plan.Plan.ExecutionBehavior}). The result type of an
+   * execution context variable always has {@code NULLABILITY_REQUIRED} nullability.
+   */
+  interface ExecutionContextVariable extends Expression {}
+
+  /**
+   * Execution context variable holding the current timestamp in the current session timezone.
+   *
+   * <p>Its result type is a {@code precision_timestamp_tz} with the configured {@link #precision()}
+   * and required nullability.
+   */
+  @Value.Immutable
+  abstract class CurrentTimestamp implements ExecutionContextVariable {
+    /**
+     * Returns the fractional-second precision of the current timestamp, expressed as the number of
+     * digits after the decimal point (e.g. {@code 6} for microseconds).
+     *
+     * @return the timestamp precision
+     */
+    public abstract int precision();
+
+    @Override
+    public Type getType() {
+      return TypeCreator.REQUIRED.precisionTimestampTZ(precision());
+    }
+
+    /**
+     * Creates a new builder for constructing a CurrentTimestamp.
+     *
+     * @return a new builder instance
+     */
+    public static ImmutableExpression.CurrentTimestamp.Builder builder() {
+      return ImmutableExpression.CurrentTimestamp.builder();
+    }
+
+    @Override
+    public <R, C extends VisitationContext, E extends Throwable> R accept(
+        ExpressionVisitor<R, C, E> visitor, C context) throws E {
+      return visitor.visit(this, context);
+    }
+  }
+
+  /**
+   * Execution context variable holding the current session timezone as a string defined by the IANA
+   * timezone database (<a
+   * href="https://www.iana.org/time-zones">https://www.iana.org/time-zones</a>).
+   *
+   * <p>Its result type is a {@code string} with required nullability.
+   */
+  @Value.Immutable
+  abstract class CurrentTimezone implements ExecutionContextVariable {
+    @Override
+    public Type getType() {
+      return TypeCreator.REQUIRED.STRING;
+    }
+
+    /**
+     * Creates a new builder for constructing a CurrentTimezone.
+     *
+     * @return a new builder instance
+     */
+    public static ImmutableExpression.CurrentTimezone.Builder builder() {
+      return ImmutableExpression.CurrentTimezone.builder();
+    }
+
+    @Override
+    public <R, C extends VisitationContext, E extends Throwable> R accept(
+        ExpressionVisitor<R, C, E> visitor, C context) throws E {
+      return visitor.visit(this, context);
+    }
+  }
+
+  /**
+   * Execution context variable holding the current date.
+   *
+   * <p>Its result type is a {@code date} with required nullability.
+   */
+  @Value.Immutable
+  abstract class CurrentDate implements ExecutionContextVariable {
+    @Override
+    public Type getType() {
+      return TypeCreator.REQUIRED.DATE;
+    }
+
+    /**
+     * Creates a new builder for constructing a CurrentDate.
+     *
+     * @return a new builder instance
+     */
+    public static ImmutableExpression.CurrentDate.Builder builder() {
+      return ImmutableExpression.CurrentDate.builder();
+    }
+
+    @Override
+    public <R, C extends VisitationContext, E extends Throwable> R accept(
+        ExpressionVisitor<R, C, E> visitor, C context) throws E {
+      return visitor.visit(this, context);
+    }
+  }
+
   /** Defines the operation type for set predicates (EXISTS, UNIQUE). */
   enum PredicateOp {
     /** Unspecified predicate operation. */

--- a/core/src/main/java/io/substrait/expression/ExpressionCreator.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionCreator.java
@@ -1044,4 +1044,32 @@ public class ExpressionCreator {
         .failureBehavior(failureBehavior)
         .build();
   }
+
+  /**
+   * Creates a {@code CURRENT_TIMESTAMP} execution context variable.
+   *
+   * @param precision the fractional-second precision of the timestamp
+   * @return the current timestamp expression
+   */
+  public static Expression.CurrentTimestamp currentTimestamp(int precision) {
+    return Expression.CurrentTimestamp.builder().precision(precision).build();
+  }
+
+  /**
+   * Creates a {@code CURRENT_TIMEZONE} execution context variable.
+   *
+   * @return the current timezone expression
+   */
+  public static Expression.CurrentTimezone currentTimezone() {
+    return Expression.CurrentTimezone.builder().build();
+  }
+
+  /**
+   * Creates a {@code CURRENT_DATE} execution context variable.
+   *
+   * @return the current date expression
+   */
+  public static Expression.CurrentDate currentDate() {
+    return Expression.CurrentDate.builder().build();
+  }
 }

--- a/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
+++ b/core/src/main/java/io/substrait/expression/ExpressionVisitor.java
@@ -480,4 +480,34 @@ public interface ExpressionVisitor<R, C extends VisitationContext, E extends Thr
    * @throws E on visit failure
    */
   R visit(Expression.DynamicParameter expr, C context) throws E;
+
+  /**
+   * Visit a current timestamp execution context variable expression.
+   *
+   * @param expr the current timestamp expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
+  R visit(Expression.CurrentTimestamp expr, C context) throws E;
+
+  /**
+   * Visit a current timezone execution context variable expression.
+   *
+   * @param expr the current timezone expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
+  R visit(Expression.CurrentTimezone expr, C context) throws E;
+
+  /**
+   * Visit a current date execution context variable expression.
+   *
+   * @param expr the current date expression
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
+  R visit(Expression.CurrentDate expr, C context) throws E;
 }

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -795,6 +795,39 @@ public class ExpressionProtoConverter
         .build();
   }
 
+  @Override
+  public Expression visit(
+      io.substrait.expression.Expression.CurrentTimestamp expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return Expression.newBuilder()
+        .setExecutionContextVariable(
+            Expression.ExecutionContextVariable.newBuilder()
+                .setCurrentTimestamp(toProto(expr.getType()).getPrecisionTimestampTz()))
+        .build();
+  }
+
+  @Override
+  public Expression visit(
+      io.substrait.expression.Expression.CurrentTimezone expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return Expression.newBuilder()
+        .setExecutionContextVariable(
+            Expression.ExecutionContextVariable.newBuilder()
+                .setCurrentTimezone(toProto(expr.getType()).getString()))
+        .build();
+  }
+
+  @Override
+  public Expression visit(
+      io.substrait.expression.Expression.CurrentDate expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return Expression.newBuilder()
+        .setExecutionContextVariable(
+            Expression.ExecutionContextVariable.newBuilder()
+                .setCurrentDate(toProto(expr.getType()).getDate()))
+        .build();
+  }
+
   /** Converts a {@link WindowBound} to its protobuf {@link Expression.WindowFunction.Bound}. */
   public static class BoundConverter
       implements WindowBound.WindowBoundVisitor<Expression.WindowFunction.Bound, RuntimeException> {

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -318,6 +318,25 @@ public class ProtoExpressionConverter {
               .parameterReference(dp.getParameterReference())
               .build();
         }
+      case EXECUTION_CONTEXT_VARIABLE:
+        {
+          io.substrait.proto.Expression.ExecutionContextVariable ecv =
+              expr.getExecutionContextVariable();
+          switch (ecv.getExecutionContextVariableTypeCase()) {
+            case CURRENT_TIMESTAMP:
+              return Expression.CurrentTimestamp.builder()
+                  .precision(ecv.getCurrentTimestamp().getPrecision())
+                  .build();
+            case CURRENT_TIMEZONE:
+              return Expression.CurrentTimezone.builder().build();
+            case CURRENT_DATE:
+              return Expression.CurrentDate.builder().build();
+            default:
+              throw new IllegalArgumentException(
+                  "Unknown execution context variable type: "
+                      + ecv.getExecutionContextVariableTypeCase());
+          }
+        }
       // TODO enum.
       case ENUM:
         throw new UnsupportedOperationException("Unsupported type: " + expr.getRexTypeCase());

--- a/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/ExpressionCopyOnWriteVisitor.java
@@ -508,6 +508,24 @@ public class ExpressionCopyOnWriteVisitor<E extends Exception>
     return Optional.empty();
   }
 
+  @Override
+  public Optional<Expression> visit(
+      Expression.CurrentTimestamp expr, EmptyVisitationContext context) throws E {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Expression> visit(Expression.CurrentTimezone expr, EmptyVisitationContext context)
+      throws E {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Expression> visit(Expression.CurrentDate expr, EmptyVisitationContext context)
+      throws E {
+    return Optional.empty();
+  }
+
   // utilities
 
   /**

--- a/core/src/test/java/io/substrait/type/proto/ExecutionContextVariableRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExecutionContextVariableRoundtripTest.java
@@ -1,0 +1,43 @@
+package io.substrait.type.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.type.TypeCreator;
+import org.junit.jupiter.api.Test;
+
+class ExecutionContextVariableRoundtripTest extends TestBase {
+
+  @Test
+  void currentTimestampMicros() {
+    Expression.CurrentTimestamp expr = Expression.CurrentTimestamp.builder().precision(6).build();
+
+    assertEquals(TypeCreator.REQUIRED.precisionTimestampTZ(6), expr.getType());
+    verifyRoundTrip(expr);
+  }
+
+  @Test
+  void currentTimestampSeconds() {
+    Expression.CurrentTimestamp expr = Expression.CurrentTimestamp.builder().precision(0).build();
+
+    assertEquals(TypeCreator.REQUIRED.precisionTimestampTZ(0), expr.getType());
+    verifyRoundTrip(expr);
+  }
+
+  @Test
+  void currentTimezone() {
+    Expression.CurrentTimezone expr = Expression.CurrentTimezone.builder().build();
+
+    assertEquals(TypeCreator.REQUIRED.STRING, expr.getType());
+    verifyRoundTrip(expr);
+  }
+
+  @Test
+  void currentDate() {
+    Expression.CurrentDate expr = Expression.CurrentDate.builder().build();
+
+    assertEquals(TypeCreator.REQUIRED.DATE, expr.getType());
+    verifyRoundTrip(expr);
+  }
+}

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/ExpressionStringify.java
@@ -369,4 +369,22 @@ public class ExpressionStringify extends ParentStringify
       throws RuntimeException {
     return "<DynamicParameter " + expr.parameterReference() + " " + expr.type() + ">";
   }
+
+  @Override
+  public String visit(Expression.CurrentTimestamp expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<CurrentTimestamp precision=" + expr.precision() + ">";
+  }
+
+  @Override
+  public String visit(Expression.CurrentTimezone expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<CurrentTimezone>";
+  }
+
+  @Override
+  public String visit(Expression.CurrentDate expr, EmptyVisitationContext context)
+      throws RuntimeException {
+    return "<CurrentDate>";
+  }
 }


### PR DESCRIPTION
## Summary

Adds support for the `Expression.ExecutionContextVariable` message introduced in Substrait v0.87.0, modeling the three execution-context-dependent variables as POJO expressions:

- `CURRENT_TIMESTAMP` (`CurrentTimestamp`, carries a fractional-second `precision`)
- `CURRENT_TIMEZONE` (`CurrentTimezone`)
- `CURRENT_DATE` (`CurrentDate`)

All three implement a shared `ExecutionContextVariable` marker interface (extending `Expression`, mirroring the `Literal`/`Nested`/`Subquery` precedent). Per the spec, each is a leaf expression whose result type always has `NULLABILITY_REQUIRED` nullability.

Resolves #802 (part of the v0.87.0 epic #790; sibling to the `ExecutionBehavior` work in #791).

## Changes

- **POJO model** (`Expression.java`): marker interface + three `@Value.Immutable` classes.
- **Visitor**: new `visit` methods on `ExpressionVisitor`, fallback defaults on `AbstractExpressionVisitor`, and handlers in the direct implementors (`ExpressionProtoConverter`, `ExpressionCopyOnWriteVisitor`, examples `ExpressionStringify`).
- **Proto conversion**: POJO→proto in `ExpressionProtoConverter`; proto→POJO `EXECUTION_CONTEXT_VARIABLE` case in `ProtoExpressionConverter`.
- **Ergonomics**: `ExpressionCreator` factories and `SubstraitBuilder` DSL helpers (`currentTimestamp(precision)`, `currentTimezone()`, `currentDate()`).
- **Tests**: `ExecutionContextVariableRoundtripTest` covering `getType()` and POJO↔proto round-trip for all three variants.

## Verification

`:core:test`, `:core:spotlessCheck`, and compilation of `:isthmus`, `:spark:spark-3.5_2.12`, and `:examples:substrait-spark` all pass.

🤖 Generated with AI