### PR TITLE
build(core): exclude generated sources from javadoc

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -369,9 +369,16 @@ tasks.named<Javadoc>("javadoc") {
   dependsOn("javadocProto")
   description = "Generate Javadoc for main sources (excludes protobuf-generated sources)."
 
-  // Exclude the protobuf-generated directory from the main pass
-  val protoDirFile = protoJavaDir.get().asFile
-  exclude { spec -> spec.file.toPath().startsWith(protoDirFile.toPath()) }
+  // Exclude the protobuf-, ANTLR- and version-generated directories from the main pass.
+  // These sources are regenerated on every build and cannot carry hand-written Javadoc.
+  val generatedDirs =
+    listOf(
+        protoJavaDir,
+        layout.buildDirectory.dir("generated/sources/antlr/main/java"),
+        layout.buildDirectory.dir("generated/sources/version"),
+      )
+      .map { it.get().asFile.toPath() }
+  exclude { spec -> generatedDirs.any { spec.file.toPath().startsWith(it) } }
   source(fileTree(immuteableJavaDir) { include("**/*.java") })
 
   // Keep normal behavior for main javadoc (warnings allowed to show/fail if you want)


### PR DESCRIPTION
The `core:javadoc` task linted the ANTLR- and version-generated sources (`SubstraitTypeParser`, `SubstraitTypeLexer`, `SubstraitLexer`, `SubstraitVersion`), producing ~640 "no comment" warnings for code that is regenerated on every build and cannot carry hand-written Javadoc.

This excludes these generated directories from the main Javadoc pass, alongside the already-excluded protobuf-generated sources, so the task only reports warnings for sources we can actually fix.

This is the first step in a series of changes to clean up the missing Javadoc reported by `./gradlew core:javadoc`, fixing the remaining warnings file by file in follow-up PRs.

🤖 Generated with AI