### PR TITLE
docs(core): fix javadoc in PlanProtoConverter

### DIFF
--- a/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
+++ b/core/src/main/java/io/substrait/plan/PlanProtoConverter.java
@@ -16,6 +16,7 @@ import org.jspecify.annotations.NonNull;
 
 /** Converts from {@link io.substrait.plan.Plan} to {@link io.substrait.proto.Plan} */
 public class PlanProtoConverter {
+  /** Converts gathered function and type extensions into their proto representation. */
   @NonNull protected final ExtensionProtoConverter<?, ?> extensionProtoConverter;
 
   @NonNull private final ExtensionCollection extensionCollection;


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/plan/PlanProtoConverter.java`.