### PR TITLE
docs(core): fix javadoc in Deserializers

### DIFF
--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -48,6 +48,7 @@ public class Deserializers {
 
     private static final long serialVersionUID = 2105956703553161270L;
 
+    /** Converts a parsed type expression into the target type {@code T}. */
     private final BiFunction<String, SubstraitTypeParser.StartRuleContext, T> converter;
 
     /**


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/type/Deserializers.java`.