### PR TITLE
docs(core): fix javadoc in StringTypeVisitor

### DIFF
--- a/core/src/main/java/io/substrait/type/StringTypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/StringTypeVisitor.java
@@ -2,6 +2,11 @@ package io.substrait.type;
 
 import java.util.stream.Collectors;
 
+/**
+ * {@link TypeVisitor} that renders a {@link Type} as its human-readable string representation (for
+ * example {@code "boolean"}, {@code "i32"} or {@code "decimal<10,2>"}), appending a trailing {@code
+ * "?"} for nullable types.
+ */
 public class StringTypeVisitor implements TypeVisitor<String, RuntimeException> {
 
   private String n(Type type) {


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/type/StringTypeVisitor.java`.