### PR TITLE
docs(core): fix javadoc in ZeroInputRel

### DIFF
--- a/core/src/main/java/io/substrait/relation/ZeroInputRel.java
+++ b/core/src/main/java/io/substrait/relation/ZeroInputRel.java
@@ -3,6 +3,10 @@ package io.substrait.relation;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Base class for relations that have no input relations, such as leaf relations that read directly
+ * from a source.
+ */
 public abstract class ZeroInputRel extends AbstractRel {
 
   @Override


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/ZeroInputRel.java`.