### PR TITLE
docs(core): fix javadoc in SingleInputRel

### DIFF
--- a/core/src/main/java/io/substrait/relation/SingleInputRel.java
+++ b/core/src/main/java/io/substrait/relation/SingleInputRel.java
@@ -3,8 +3,14 @@ package io.substrait.relation;
 import java.util.Collections;
 import java.util.List;
 
+/** Base class for relations that operate on exactly one input relation. */
 public abstract class SingleInputRel extends AbstractRel {
 
+  /**
+   * Returns the single input relation.
+   *
+   * @return the input relation
+   */
   public abstract Rel getInput();
 
   @Override


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/SingleInputRel.java`.