### PR TITLE
docs(core): fix javadoc in NullableType

### DIFF
--- a/core/src/main/java/io/substrait/function/NullableType.java
+++ b/core/src/main/java/io/substrait/function/NullableType.java
@@ -1,5 +1,11 @@
 package io.substrait.function;
 
+/** A type that may carry nullability information. */
 public interface NullableType {
+  /**
+   * Returns whether this type is nullable.
+   *
+   * @return {@code true} if the type accepts null values, {@code false} otherwise
+   */
   boolean nullable();
 }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/function/NullableType.java`.