### PR TITLE
docs(core): fix javadoc in ExtensionDdl

### DIFF
--- a/core/src/main/java/io/substrait/relation/ExtensionDdl.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionDdl.java
@@ -3,8 +3,14 @@ package io.substrait.relation;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/** A DDL relation whose behavior is supplied by an extension-defined detail object. */
 @Value.Immutable
 public abstract class ExtensionDdl extends AbstractDdlRel implements HasExtension {
+  /**
+   * Returns the extension-specific detail describing this DDL relation.
+   *
+   * @return the extension detail object
+   */
   public abstract Extension.DdlExtensionObject getDetail();
 
   @Override
@@ -13,6 +19,11 @@ public abstract class ExtensionDdl extends AbstractDdlRel implements HasExtensio
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link ExtensionDdl}.
+   *
+   * @return a new builder
+   */
   public static ImmutableExtensionDdl.Builder builder() {
     return ImmutableExtensionDdl.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/ExtensionDdl.java`.