### PR TITLE
docs(core): fix javadoc in ExtensionLeaf

### DIFF
--- a/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionLeaf.java
@@ -3,9 +3,15 @@ package io.substrait.relation;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/** A leaf relation whose behavior is supplied by an extension-defined detail object. */
 @Value.Immutable
 public abstract class ExtensionLeaf extends ZeroInputRel {
 
+  /**
+   * Returns the extension-specific detail describing this leaf relation.
+   *
+   * @return the extension detail object
+   */
   public abstract Extension.LeafRelDetail getDetail();
 
   @Override
@@ -14,6 +20,12 @@ public abstract class ExtensionLeaf extends ZeroInputRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder initialized from the given extension detail.
+   *
+   * @param detail the extension detail describing the leaf relation
+   * @return a builder populated from {@code detail}
+   */
   public static ImmutableExtensionLeaf.Builder from(Extension.LeafRelDetail detail) {
     return ImmutableExtensionLeaf.builder()
         .detail(detail)


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/ExtensionLeaf.java`.