### PR TITLE
docs(core): fix javadoc in ExtensionWrite

### DIFF
--- a/core/src/main/java/io/substrait/relation/ExtensionWrite.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionWrite.java
@@ -3,8 +3,14 @@ package io.substrait.relation;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/** A write relation whose behavior is supplied by an extension-defined detail object. */
 @Value.Immutable
 public abstract class ExtensionWrite extends AbstractWriteRel {
+  /**
+   * Returns the extension-specific detail describing this write relation.
+   *
+   * @return the extension detail object
+   */
   public abstract Extension.WriteExtensionObject getDetail();
 
   @Override
@@ -13,6 +19,11 @@ public abstract class ExtensionWrite extends AbstractWriteRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link ExtensionWrite}.
+   *
+   * @return a new builder
+   */
   public static ImmutableExtensionWrite.Builder builder() {
     return ImmutableExtensionWrite.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/ExtensionWrite.java`.