### PR TITLE
docs(core): fix javadoc in ExtensionSingle

### DIFF
--- a/core/src/main/java/io/substrait/relation/ExtensionSingle.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionSingle.java
@@ -3,9 +3,15 @@ package io.substrait.relation;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/** A single-input relation whose behavior is supplied by an extension-defined detail object. */
 @Value.Immutable
 public abstract class ExtensionSingle extends SingleInputRel {
 
+  /**
+   * Returns the extension-specific detail describing this relation.
+   *
+   * @return the extension detail object
+   */
   public abstract Extension.SingleRelDetail getDetail();
 
   @Override
@@ -14,6 +20,13 @@ public abstract class ExtensionSingle extends SingleInputRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder initialized from the given extension detail and input relation.
+   *
+   * @param detail the extension detail describing the relation
+   * @param input the input relation
+   * @return a builder populated from {@code detail} and {@code input}
+   */
   public static ImmutableExtensionSingle.Builder from(Extension.SingleRelDetail detail, Rel input) {
     return ImmutableExtensionSingle.builder()
         .input(input)
@@ -21,6 +34,11 @@ public abstract class ExtensionSingle extends SingleInputRel {
         .deriveRecordType(detail.deriveRecordType(input));
   }
 
+  /**
+   * Creates a builder for {@link ExtensionSingle}.
+   *
+   * @return a new builder
+   */
   public static ImmutableExtensionSingle.Builder builder() {
     return ImmutableExtensionSingle.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/ExtensionSingle.java`.