### PR TITLE
docs(core): fix javadoc in ExtensionMulti

### DIFF
--- a/core/src/main/java/io/substrait/relation/ExtensionMulti.java
+++ b/core/src/main/java/io/substrait/relation/ExtensionMulti.java
@@ -6,9 +6,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
+/** A multi-input relation whose behavior is supplied by an extension-defined detail object. */
 @Value.Immutable
 public abstract class ExtensionMulti extends AbstractRel {
 
+  /**
+   * Returns the extension-specific detail describing this relation.
+   *
+   * @return the extension detail object
+   */
   public abstract Extension.MultiRelDetail getDetail();
 
   @Override
@@ -17,11 +23,25 @@ public abstract class ExtensionMulti extends AbstractRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder initialized from the given extension detail and input relations.
+   *
+   * @param detail the extension detail describing the relation
+   * @param inputs the input relations
+   * @return a builder populated from {@code detail} and {@code inputs}
+   */
   public static ImmutableExtensionMulti.Builder from(
       Extension.MultiRelDetail detail, Rel... inputs) {
     return from(detail, Arrays.stream(inputs).collect(Collectors.toList()));
   }
 
+  /**
+   * Creates a builder initialized from the given extension detail and input relations.
+   *
+   * @param detail the extension detail describing the relation
+   * @param inputs the input relations
+   * @return a builder populated from {@code detail} and {@code inputs}
+   */
   public static ImmutableExtensionMulti.Builder from(
       Extension.MultiRelDetail detail, List<Rel> inputs) {
     return ImmutableExtensionMulti.builder()
@@ -30,6 +50,11 @@ public abstract class ExtensionMulti extends AbstractRel {
         .deriveRecordType(detail.deriveRecordType(inputs));
   }
 
+  /**
+   * Creates a builder for {@link ExtensionMulti}.
+   *
+   * @return a new builder
+   */
   public static ImmutableExtensionMulti.Builder builder() {
     return ImmutableExtensionMulti.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/ExtensionMulti.java`.