### PR TITLE
docs(core): fix javadoc in SingleBucketExchange

### DIFF
--- a/core/src/main/java/io/substrait/relation/physical/SingleBucketExchange.java
+++ b/core/src/main/java/io/substrait/relation/physical/SingleBucketExchange.java
@@ -5,8 +5,17 @@ import io.substrait.relation.RelVisitor;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/**
+ * Exchange relation that assigns each row to a single bucket computed from an expression, routing
+ * the row to the destination identified by that bucket.
+ */
 @Value.Immutable
 public abstract class SingleBucketExchange extends AbstractExchangeRel {
+  /**
+   * Returns the expression used to compute the destination bucket for each row.
+   *
+   * @return the bucket expression
+   */
   public abstract Expression getExpression();
 
   @Override
@@ -15,6 +24,11 @@ public abstract class SingleBucketExchange extends AbstractExchangeRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link SingleBucketExchange}.
+   *
+   * @return a new builder
+   */
   public static ImmutableSingleBucketExchange.Builder builder() {
     return ImmutableSingleBucketExchange.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/physical/SingleBucketExchange.java`.