### PR TITLE
docs(core): fix javadoc in ScatterExchange

### DIFF
--- a/core/src/main/java/io/substrait/relation/physical/ScatterExchange.java
+++ b/core/src/main/java/io/substrait/relation/physical/ScatterExchange.java
@@ -6,8 +6,17 @@ import io.substrait.util.VisitationContext;
 import java.util.List;
 import org.immutables.value.Value;
 
+/**
+ * Exchange relation that scatters rows across destinations by hashing on a set of partitioning
+ * fields.
+ */
 @Value.Immutable
 public abstract class ScatterExchange extends AbstractExchangeRel {
+  /**
+   * Returns the fields used to determine each row's destination.
+   *
+   * @return the partitioning fields
+   */
   public abstract List<FieldReference> getFields();
 
   @Override
@@ -16,6 +25,11 @@ public abstract class ScatterExchange extends AbstractExchangeRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link ScatterExchange}.
+   *
+   * @return a new builder
+   */
   public static ImmutableScatterExchange.Builder builder() {
     return ImmutableScatterExchange.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/physical/ScatterExchange.java`.