### PR TITLE
docs(core): fix javadoc in RoundRobinExchange

### DIFF
--- a/core/src/main/java/io/substrait/relation/physical/RoundRobinExchange.java
+++ b/core/src/main/java/io/substrait/relation/physical/RoundRobinExchange.java
@@ -4,8 +4,15 @@ import io.substrait.relation.RelVisitor;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/** Exchange relation that distributes rows across destinations in a round-robin fashion. */
 @Value.Immutable
 public abstract class RoundRobinExchange extends AbstractExchangeRel {
+  /**
+   * Returns whether the distribution must be exact (rows spread as evenly as possible) rather than
+   * approximate.
+   *
+   * @return {@code true} if an exact round-robin distribution is required
+   */
   public abstract boolean getExact();
 
   @Override
@@ -14,6 +21,11 @@ public abstract class RoundRobinExchange extends AbstractExchangeRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link RoundRobinExchange}.
+   *
+   * @return a new builder
+   */
   public static ImmutableRoundRobinExchange.Builder builder() {
     return ImmutableRoundRobinExchange.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/physical/RoundRobinExchange.java`.