### PR TITLE
docs(core): fix javadoc in MultiBucketExchange

### DIFF
--- a/core/src/main/java/io/substrait/relation/physical/MultiBucketExchange.java
+++ b/core/src/main/java/io/substrait/relation/physical/MultiBucketExchange.java
@@ -5,10 +5,24 @@ import io.substrait.relation.RelVisitor;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/**
+ * Exchange relation that assigns each row to one of several buckets computed from an expression,
+ * distributing rows across destinations accordingly.
+ */
 @Value.Immutable
 public abstract class MultiBucketExchange extends AbstractExchangeRel {
+  /**
+   * Returns the expression used to compute the destination bucket for each row.
+   *
+   * @return the bucket expression
+   */
   public abstract Expression getExpression();
 
+  /**
+   * Returns whether the number of buckets is constrained to the number of partitions/destinations.
+   *
+   * @return {@code true} if the bucket count is constrained to the partition count
+   */
   public abstract boolean getConstrainedToCount();
 
   @Override
@@ -17,6 +31,11 @@ public abstract class MultiBucketExchange extends AbstractExchangeRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link MultiBucketExchange}.
+   *
+   * @return a new builder
+   */
   public static ImmutableMultiBucketExchange.Builder builder() {
     return ImmutableMultiBucketExchange.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/physical/MultiBucketExchange.java`.