### PR TITLE
docs(core): fix javadoc in Project

### DIFF
--- a/core/src/main/java/io/substrait/relation/Project.java
+++ b/core/src/main/java/io/substrait/relation/Project.java
@@ -8,9 +8,18 @@ import java.util.List;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
 
+/**
+ * A relation that appends additional computed columns to its input by evaluating a list of
+ * expressions for each row.
+ */
 @Value.Immutable
 public abstract class Project extends SingleInputRel implements HasExtension {
 
+  /**
+   * Returns the expressions whose results are appended to the input columns.
+   *
+   * @return the projection expressions
+   */
   public abstract List<Expression> getExpressions();
 
   @Override
@@ -28,6 +37,11 @@ public abstract class Project extends SingleInputRel implements HasExtension {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link Project}.
+   *
+   * @return a new builder
+   */
   public static ImmutableProject.Builder builder() {
     return ImmutableProject.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/Project.java`.