### PR TITLE
docs(core): fix javadoc in NamedScan

### DIFF
--- a/core/src/main/java/io/substrait/relation/NamedScan.java
+++ b/core/src/main/java/io/substrait/relation/NamedScan.java
@@ -4,9 +4,15 @@ import io.substrait.util.VisitationContext;
 import java.util.List;
 import org.immutables.value.Value;
 
+/** A read relation that reads from a table identified by a multi-part name. */
 @Value.Immutable
 public abstract class NamedScan extends AbstractReadRel {
 
+  /**
+   * Returns the multi-part (namespaced) name identifying the table to read.
+   *
+   * @return the table name components
+   */
   public abstract List<String> getNames();
 
   @Override
@@ -15,6 +21,11 @@ public abstract class NamedScan extends AbstractReadRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link NamedScan}.
+   *
+   * @return a new builder
+   */
   public static ImmutableNamedScan.Builder builder() {
     return ImmutableNamedScan.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/NamedScan.java`.