### PR TITLE
docs(core): fix javadoc in NamedWrite

### DIFF
--- a/core/src/main/java/io/substrait/relation/NamedWrite.java
+++ b/core/src/main/java/io/substrait/relation/NamedWrite.java
@@ -4,8 +4,14 @@ import io.substrait.util.VisitationContext;
 import java.util.List;
 import org.immutables.value.Value;
 
+/** A write relation that writes to a table identified by a multi-part name. */
 @Value.Immutable
 public abstract class NamedWrite extends AbstractWriteRel {
+  /**
+   * Returns the multi-part (namespaced) name identifying the table to write to.
+   *
+   * @return the table name components
+   */
   public abstract List<String> getNames();
 
   @Override
@@ -14,6 +20,11 @@ public abstract class NamedWrite extends AbstractWriteRel {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link NamedWrite}.
+   *
+   * @return a new builder
+   */
   public static ImmutableNamedWrite.Builder builder() {
     return ImmutableNamedWrite.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/NamedWrite.java`.