### PR TITLE
docs(core): fix javadoc in NamedUpdate

### DIFF
--- a/core/src/main/java/io/substrait/relation/NamedUpdate.java
+++ b/core/src/main/java/io/substrait/relation/NamedUpdate.java
@@ -4,9 +4,15 @@ import io.substrait.util.VisitationContext;
 import java.util.List;
 import org.immutables.value.Value;
 
+/** An update relation that targets a table identified by a multi-part name. */
 @Value.Immutable
 public abstract class NamedUpdate extends AbstractUpdate {
 
+  /**
+   * Returns the multi-part (namespaced) name identifying the table to update.
+   *
+   * @return the table name components
+   */
   public abstract List<String> getNames();
 
   @Override
@@ -15,6 +21,11 @@ public abstract class NamedUpdate extends AbstractUpdate {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link NamedUpdate}.
+   *
+   * @return a new builder
+   */
   public static ImmutableNamedUpdate.Builder builder() {
     return ImmutableNamedUpdate.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/NamedUpdate.java`.