### PR TITLE
docs(core): fix javadoc in Fetch

### DIFF
--- a/core/src/main/java/io/substrait/relation/Fetch.java
+++ b/core/src/main/java/io/substrait/relation/Fetch.java
@@ -5,11 +5,25 @@ import io.substrait.util.VisitationContext;
 import java.util.OptionalLong;
 import org.immutables.value.Value;
 
+/**
+ * A relation that returns a contiguous range of its input rows, skipping an offset and optionally
+ * limiting the number of rows returned.
+ */
 @Value.Immutable
 public abstract class Fetch extends SingleInputRel implements HasExtension {
 
+  /**
+   * Returns the number of leading input rows to skip.
+   *
+   * @return the offset
+   */
   public abstract long getOffset();
 
+  /**
+   * Returns the maximum number of rows to return, or empty to return all remaining rows.
+   *
+   * @return the optional row count limit
+   */
   public abstract OptionalLong getCount();
 
   @Override
@@ -23,6 +37,11 @@ public abstract class Fetch extends SingleInputRel implements HasExtension {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link Fetch}.
+   *
+   * @return a new builder
+   */
   public static ImmutableFetch.Builder builder() {
     return ImmutableFetch.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/Fetch.java`.