### PR TITLE
docs(core): fix javadoc in Extension

### DIFF
--- a/core/src/main/java/io/substrait/relation/Extension.java
+++ b/core/src/main/java/io/substrait/relation/Extension.java
@@ -7,6 +7,7 @@ import java.util.List;
 /** Contains tag interfaces for handling {@link com.google.protobuf.Any} types within Substrait. */
 public class Extension {
 
+  /** Detail object carrying the behavior of an {@link ExtensionLeaf} relation. */
   public interface LeafRelDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @return the record layout for the associated {@link ExtensionLeaf} relation
@@ -14,6 +15,7 @@ public class Extension {
     Type.Struct deriveRecordType();
   }
 
+  /** Detail object carrying the behavior of an {@link ExtensionSingle} relation. */
   public interface SingleRelDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @param input to the associated {@link ExtensionSingle} relation
@@ -22,6 +24,7 @@ public class Extension {
     Type.Struct deriveRecordType(Rel input);
   }
 
+  /** Detail object carrying the behavior of an {@link ExtensionMulti} relation. */
   public interface MultiRelDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @param inputs to the associated {@link ExtensionMulti} relation
@@ -30,6 +33,7 @@ public class Extension {
     Type.Struct deriveRecordType(List<Rel> inputs);
   }
 
+  /** Detail object carrying the behavior of an {@link ExtensionTable} relation. */
   public interface ExtensionTableDetail extends ToProto<com.google.protobuf.Any> {
     /**
      * @return the table schema for the associated {@link ExtensionTable} relation
@@ -37,7 +41,9 @@ public class Extension {
     NamedStruct deriveSchema();
   }
 
+  /** Detail object carrying the behavior of an {@link ExtensionWrite} relation. */
   public interface WriteExtensionObject extends ToProto<com.google.protobuf.Any> {}
 
+  /** Detail object carrying the behavior of an {@link ExtensionDdl} relation. */
   public interface DdlExtensionObject extends ToProto<com.google.protobuf.Any> {}
 }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/Extension.java`.