### PR TITLE
docs(core): fix javadoc in Util

### DIFF
--- a/core/src/main/java/io/substrait/util/Util.java
+++ b/core/src/main/java/io/substrait/util/Util.java
@@ -2,8 +2,17 @@ package io.substrait.util;
 
 import java.util.function.Supplier;
 
+/** Miscellaneous shared utility helpers. */
 public class Util {
 
+  /**
+   * Wraps a supplier so that its value is computed at most once, on first access, and cached for
+   * subsequent calls.
+   *
+   * @param supplier the supplier to memoize
+   * @param <T> the supplied value type
+   * @return a memoizing supplier delegating to {@code supplier}
+   */
   public static <T> Supplier<T> memoize(Supplier<T> supplier) {
     return new Memoizer<T>(supplier);
   }
@@ -28,10 +37,18 @@ public class Util {
     }
   }
 
+  /** A half-open range of {@code int} values, with an inclusive start and an exclusive end. */
   public static class IntRange {
     private final int startInclusive;
     private final int endExclusive;
 
+    /**
+     * Creates a range covering {@code [startInclusive, endExclusive)}.
+     *
+     * @param startInclusive the inclusive lower bound
+     * @param endExclusive the exclusive upper bound
+     * @return the range
+     */
     public static IntRange of(int startInclusive, int endExclusive) {
       return new IntRange(startInclusive, endExclusive);
     }
@@ -41,14 +58,30 @@ public class Util {
       this.endExclusive = endExclusive;
     }
 
+    /**
+     * Returns the inclusive lower bound of the range.
+     *
+     * @return the inclusive start
+     */
     public int getStartInclusive() {
       return startInclusive;
     }
 
+    /**
+     * Returns the exclusive upper bound of the range.
+     *
+     * @return the exclusive end
+     */
     public int getEndExclusive() {
       return endExclusive;
     }
 
+    /**
+     * Returns whether the given value falls within this range.
+     *
+     * @param val the value to test
+     * @return {@code true} if {@code startInclusive <= val < endExclusive}
+     */
     public boolean within(int val) {
       return val >= startInclusive && val < endExclusive;
     }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/util/Util.java`.