### PR TITLE
docs(core): fix javadoc in Rel

### DIFF
--- a/core/src/main/java/io/substrait/relation/Rel.java
+++ b/core/src/main/java/io/substrait/relation/Rel.java
@@ -10,7 +10,13 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 import org.immutables.value.Value;
 
+/** Base type for all Substrait relational operators. */
 public interface Rel {
+  /**
+   * Returns the output field remapping applied to this relation, if any.
+   *
+   * @return the optional output mapping
+   */
   Optional<Remap> getRemap();
 
   /**
@@ -33,21 +39,53 @@ public interface Rel {
    */
   List<Rel> getInputs();
 
+  /**
+   * Returns the hint associated with this relation, if any.
+   *
+   * @return the optional hint
+   */
   Optional<Hint> getHint();
 
+  /**
+   * Reorders and/or selects a relation's output fields by index, producing the emitted record type.
+   */
   @Value.Immutable
   abstract class Remap {
+    /**
+     * Returns the output field indices, in emission order.
+     *
+     * @return the field indices
+     */
     public abstract List<Integer> indices();
 
+    /**
+     * Applies this remap to the given record type, selecting and reordering fields by index.
+     *
+     * @param initial the record type to remap
+     * @return the remapped record type
+     */
     public Type.Struct remap(Type.Struct initial) {
       List<Type> types = initial.fields();
       return TypeCreator.of(initial.nullable()).struct(indices().stream().map(i -> types.get(i)));
     }
 
+    /**
+     * Creates a remap that emits the given field indices in order.
+     *
+     * @param fields the field indices to emit
+     * @return the remap
+     */
     public static Remap of(Iterable<Integer> fields) {
       return ImmutableRemap.builder().addAllIndices(fields).build();
     }
 
+    /**
+     * Creates a remap that emits a contiguous range of field indices.
+     *
+     * @param start the first field index to emit
+     * @param length the number of consecutive fields to emit
+     * @return the remap
+     */
     public static Remap offset(int start, int length) {
       return of(
           IntStream.range(start, start + length)


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/Rel.java`.