### PR TITLE
docs(core): fix javadoc in NestedLoopJoin

### DIFF
--- a/core/src/main/java/io/substrait/relation/physical/NestedLoopJoin.java
+++ b/core/src/main/java/io/substrait/relation/physical/NestedLoopJoin.java
@@ -11,22 +11,43 @@ import io.substrait.util.VisitationContext;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
 
+/** A physical join relation that evaluates the condition for every pair of left and right rows. */
 @Value.Immutable
 public abstract class NestedLoopJoin extends BiRel implements HasExtension {
 
+  /**
+   * Returns the condition evaluated against each pair of left and right rows.
+   *
+   * @return the join condition
+   */
   public abstract Expression getCondition();
 
+  /**
+   * Returns the type of join to perform.
+   *
+   * @return the join type
+   */
   public abstract JoinType getJoinType();
 
+  /** The kinds of join supported by a {@link NestedLoopJoin} relation. */
   public enum JoinType {
+    /** Unspecified or unknown join type. */
     UNKNOWN(NestedLoopJoinRel.JoinType.JOIN_TYPE_UNSPECIFIED),
+    /** Inner join: only matching left/right row pairs. */
     INNER(NestedLoopJoinRel.JoinType.JOIN_TYPE_INNER),
+    /** Full outer join: all rows from both sides, with non-matches padded with nulls. */
     OUTER(NestedLoopJoinRel.JoinType.JOIN_TYPE_OUTER),
+    /** Left outer join: all left rows, with non-matching right columns padded with nulls. */
     LEFT(NestedLoopJoinRel.JoinType.JOIN_TYPE_LEFT),
+    /** Right outer join: all right rows, with non-matching left columns padded with nulls. */
     RIGHT(NestedLoopJoinRel.JoinType.JOIN_TYPE_RIGHT),
+    /** Left semi join: left rows that have at least one match on the right. */
     LEFT_SEMI(NestedLoopJoinRel.JoinType.JOIN_TYPE_LEFT_SEMI),
+    /** Right semi join: right rows that have at least one match on the left. */
     RIGHT_SEMI(NestedLoopJoinRel.JoinType.JOIN_TYPE_RIGHT_SEMI),
+    /** Left anti join: left rows that have no match on the right. */
     LEFT_ANTI(NestedLoopJoinRel.JoinType.JOIN_TYPE_LEFT_ANTI),
+    /** Right anti join: right rows that have no match on the left. */
     RIGHT_ANTI(NestedLoopJoinRel.JoinType.JOIN_TYPE_RIGHT_ANTI);
 
     private NestedLoopJoinRel.JoinType proto;
@@ -35,10 +56,22 @@ public abstract class NestedLoopJoin extends BiRel implements HasExtension {
       this.proto = proto;
     }
 
+    /**
+     * Returns the protobuf representation of this join type.
+     *
+     * @return the proto join type
+     */
     public NestedLoopJoinRel.JoinType toProto() {
       return proto;
     }
 
+    /**
+     * Returns the {@link JoinType} matching the given protobuf join type.
+     *
+     * @param proto the proto join type
+     * @return the matching join type
+     * @throws IllegalArgumentException if the type is not recognized
+     */
     public static JoinType fromProto(NestedLoopJoinRel.JoinType proto) {
       for (JoinType v : values()) {
         if (v.proto == proto) {
@@ -89,6 +122,11 @@ public abstract class NestedLoopJoin extends BiRel implements HasExtension {
     return visitor.visit(this, context);
   }
 
+  /**
+   * Creates a builder for {@link NestedLoopJoin}.
+   *
+   * @return a new builder
+   */
   public static ImmutableNestedLoopJoin.Builder builder() {
     return ImmutableNestedLoopJoin.builder();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/relation/physical/NestedLoopJoin.java`.