### PR TITLE
docs(core): fix javadoc in TypeExpressionCreator

### DIFF
--- a/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
+++ b/core/src/main/java/io/substrait/function/TypeExpressionCreator.java
@@ -3,12 +3,24 @@ package io.substrait.function;
 import io.substrait.type.TypeCreator;
 import java.util.Arrays;
 
+/**
+ * Creates {@link TypeExpression}s, including derivation expressions whose parameters are themselves
+ * expressions.
+ */
 public class TypeExpressionCreator extends TypeCreator
     implements ExtendedTypeCreator<TypeExpression, TypeExpression> {
 
+  /** Creator producing non-nullable type expressions. */
   public static final TypeExpressionCreator REQUIRED = new TypeExpressionCreator(false);
+
+  /** Creator producing nullable type expressions. */
   public static final TypeExpressionCreator NULLABLE = new TypeExpressionCreator(true);
 
+  /**
+   * Creates a type-expression creator.
+   *
+   * @param nullable whether produced type expressions are nullable
+   */
   protected TypeExpressionCreator(boolean nullable) {
     super(nullable);
   }
@@ -37,10 +49,22 @@ public class TypeExpressionCreator extends TypeCreator
         .build();
   }
 
+  /**
+   * Creates an interval-day type expression with a parameterized precision.
+   *
+   * @param precision the precision expression
+   * @return the interval-day type expression
+   */
   public TypeExpression intervalDayE(TypeExpression precision) {
     return TypeExpression.IntervalDay.builder().nullable(nullable).precision(precision).build();
   }
 
+  /**
+   * Creates an interval-compound type expression with a parameterized precision.
+   *
+   * @param precision the precision expression
+   * @return the interval-compound type expression
+   */
   public TypeExpression intervalCompoundE(TypeExpression precision) {
     return TypeExpression.IntervalCompound.builder()
         .nullable(nullable)
@@ -48,10 +72,22 @@ public class TypeExpressionCreator extends TypeCreator
         .build();
   }
 
+  /**
+   * Creates a precision-time type expression with a parameterized precision.
+   *
+   * @param precision the precision expression
+   * @return the precision-time type expression
+   */
   public TypeExpression precisionTimeE(TypeExpression precision) {
     return TypeExpression.PrecisionTime.builder().nullable(nullable).precision(precision).build();
   }
 
+  /**
+   * Creates a precision-timestamp type expression with a parameterized precision.
+   *
+   * @param precision the precision expression
+   * @return the precision-timestamp type expression
+   */
   public TypeExpression precisionTimestampE(TypeExpression precision) {
     return TypeExpression.PrecisionTimestamp.builder()
         .nullable(nullable)
@@ -59,6 +95,12 @@ public class TypeExpressionCreator extends TypeCreator
         .build();
   }
 
+  /**
+   * Creates a precision-timestamp-with-timezone type expression with a parameterized precision.
+   *
+   * @param precision the precision expression
+   * @return the precision-timestamp-tz type expression
+   */
   public TypeExpression precisionTimestampTZE(TypeExpression precision) {
     return TypeExpression.PrecisionTimestampTZ.builder()
         .nullable(nullable)
@@ -96,27 +138,52 @@ public class TypeExpressionCreator extends TypeCreator
         .build();
   }
 
+  /** A named assignment within a type derivation program. */
   public static class Assign {
     String name;
     TypeExpression expr;
 
+    /** Creates an empty assignment. */
     public Assign() {}
 
+    /**
+     * Creates an assignment binding a name to an expression.
+     *
+     * @param name the assignment name
+     * @param expr the assigned expression
+     */
     public Assign(final String name, final TypeExpression expr) {
       this.name = name;
       this.expr = expr;
     }
 
+    /**
+     * Returns the assignment name.
+     *
+     * @return the name
+     */
     public String name() {
       return name;
     }
 
+    /**
+     * Returns the assigned expression.
+     *
+     * @return the expression
+     */
     public TypeExpression expr() {
       return expr;
     }
   }
   ;
 
+  /**
+   * Creates a type derivation program with the given final expression and assignments.
+   *
+   * @param finalExpr the final expression the program evaluates to
+   * @param assignments the named assignments evaluated before the final expression
+   * @return the program type expression
+   */
   public static TypeExpression program(TypeExpression finalExpr, Assign... assignments) {
     return TypeExpression.ReturnProgram.builder()
         .finalExpression(finalExpr)
@@ -132,19 +199,47 @@ public class TypeExpressionCreator extends TypeCreator
         .build();
   }
 
+  /**
+   * Creates a binary addition type expression.
+   *
+   * @param left the left operand
+   * @param right the right operand
+   * @return the addition expression
+   */
   public static TypeExpression plus(TypeExpression left, TypeExpression right) {
     return binary(TypeExpression.BinaryOperation.OpType.ADD, left, right);
   }
 
+  /**
+   * Creates a binary subtraction type expression.
+   *
+   * @param left the left operand
+   * @param right the right operand
+   * @return the subtraction expression
+   */
   public static TypeExpression minus(TypeExpression left, TypeExpression right) {
     return binary(TypeExpression.BinaryOperation.OpType.SUBTRACT, left, right);
   }
 
+  /**
+   * Creates a binary operation type expression.
+   *
+   * @param op the binary operator
+   * @param left the left operand
+   * @param right the right operand
+   * @return the binary operation expression
+   */
   public static TypeExpression binary(
       TypeExpression.BinaryOperation.OpType op, TypeExpression left, TypeExpression right) {
     return TypeExpression.BinaryOperation.builder().opType(op).left(left).right(right).build();
   }
 
+  /**
+   * Creates an integer literal type expression.
+   *
+   * @param i the integer value
+   * @return the integer literal
+   */
   public static TypeExpression.IntegerLiteral i(int i) {
     return TypeExpression.IntegerLiteral.builder().value(i).build();
   }


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/function/TypeExpressionCreator.java`.