### PR TITLE
docs(core): fix javadoc in Type

### DIFF
--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -8,6 +8,7 @@ import io.substrait.function.TypeExpression;
 import io.substrait.util.VisitationContext;
 import org.immutables.value.Value;
 
+/** The Substrait type model: a concrete, fully-resolved data type. */
 @Value.Enclosing
 public interface Type extends TypeExpression, ParameterizedType, NullableType, FunctionArg {
 
@@ -16,9 +17,18 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
    *
    * <p>This method is implemented by all concrete {@link Type} classes via Immutables code
    * generation.
+   *
+   * @param nullable the desired nullability
+   * @return a copy of this type with the given nullability
    */
   Type withNullable(boolean nullable);
 
+  /**
+   * Returns the type creator for the given nullability.
+   *
+   * @param nullable whether nullable types are desired
+   * @return the matching type creator
+   */
   static TypeCreator withNullability(boolean nullable) {
     return nullable ? TypeCreator.NULLABLE : TypeCreator.REQUIRED;
   }
@@ -43,8 +53,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     return TypeCreator.asNullable(this).equals(TypeCreator.asNullable(other));
   }
 
+  /** The boolean type. */
   @Value.Immutable
   abstract class Bool implements Type {
+    /**
+     * Creates a builder for {@link Bool}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Bool.Builder builder() {
       return ImmutableType.Bool.builder();
     }
@@ -55,8 +71,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The 8-bit integer type. */
   @Value.Immutable
   abstract class I8 implements Type {
+    /**
+     * Creates a builder for {@link I8}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.I8.Builder builder() {
       return ImmutableType.I8.builder();
     }
@@ -67,8 +89,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The 16-bit integer type. */
   @Value.Immutable
   abstract class I16 implements Type {
+    /**
+     * Creates a builder for {@link I16}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.I16.Builder builder() {
       return ImmutableType.I16.builder();
     }
@@ -79,8 +107,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The 32-bit integer type. */
   @Value.Immutable
   abstract class I32 implements Type {
+    /**
+     * Creates a builder for {@link I32}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.I32.Builder builder() {
       return ImmutableType.I32.builder();
     }
@@ -91,8 +125,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The 64-bit integer type. */
   @Value.Immutable
   abstract class I64 implements Type {
+    /**
+     * Creates a builder for {@link I64}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.I64.Builder builder() {
       return ImmutableType.I64.builder();
     }
@@ -103,8 +143,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The 32-bit floating point type. */
   @Value.Immutable
   abstract class FP32 implements Type {
+    /**
+     * Creates a builder for {@link FP32}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.FP32.Builder builder() {
       return ImmutableType.FP32.builder();
     }
@@ -115,8 +161,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The 64-bit floating point type. */
   @Value.Immutable
   abstract class FP64 implements Type {
+    /**
+     * Creates a builder for {@link FP64}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.FP64.Builder builder() {
       return ImmutableType.FP64.builder();
     }
@@ -127,8 +179,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The string type. */
   @Value.Immutable
   abstract class Str implements Type {
+    /**
+     * Creates a builder for {@link Str}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Str.Builder builder() {
       return ImmutableType.Str.builder();
     }
@@ -139,8 +197,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The binary type. */
   @Value.Immutable
   abstract class Binary implements Type {
+    /**
+     * Creates a builder for {@link Binary}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Binary.Builder builder() {
       return ImmutableType.Binary.builder();
     }
@@ -151,8 +215,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The date type. */
   @Value.Immutable
   abstract class Date implements Type {
+    /**
+     * Creates a builder for {@link Date}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Date.Builder builder() {
       return ImmutableType.Date.builder();
     }
@@ -163,9 +233,19 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /**
+   * The time type.
+   *
+   * @deprecated use {@link PrecisionTime} instead
+   */
   @Value.Immutable
   @Deprecated
   abstract class Time implements Type {
+    /**
+     * Creates a builder for {@link Time}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Time.Builder builder() {
       return ImmutableType.Time.builder();
     }
@@ -181,7 +261,13 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   @Deprecated
   abstract class TimestampTZ implements Type {
 
-    /** Deprecated, use {@link PrecisionTimestampTZ#builder()} instead */
+    /**
+     * Creates a builder for {@link TimestampTZ}.
+     *
+     * @return a new builder
+     * @deprecated use {@link PrecisionTimestampTZ#builder()} instead
+     */
+    @Deprecated
     public static ImmutableType.TimestampTZ.Builder builder() {
       return ImmutableType.TimestampTZ.builder();
     }
@@ -197,7 +283,12 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   @Deprecated
   abstract class Timestamp implements Type {
 
-    /** Deprecated, use {@link PrecisionTimestamp#builder()} instead */
+    /**
+     * Creates a builder for {@link Timestamp}.
+     *
+     * @return a new builder
+     * @deprecated use {@link PrecisionTimestamp#builder()} instead
+     */
     @Deprecated
     public static ImmutableType.Timestamp.Builder builder() {
       return ImmutableType.Timestamp.builder();
@@ -209,8 +300,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The year-month interval type. */
   @Value.Immutable
   abstract class IntervalYear implements Type {
+    /**
+     * Creates a builder for {@link IntervalYear}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.IntervalYear.Builder builder() {
       return ImmutableType.IntervalYear.builder();
     }
@@ -221,10 +318,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The day-time interval type. */
   @Value.Immutable
   abstract class IntervalDay implements Type {
+    /**
+     * Returns the fractional-second precision.
+     *
+     * @return the precision
+     */
     public abstract int precision();
 
+    /**
+     * Creates a builder for {@link IntervalDay}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.IntervalDay.Builder builder() {
       return ImmutableType.IntervalDay.builder();
     }
@@ -235,10 +343,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The compound interval type. */
   @Value.Immutable
   abstract class IntervalCompound implements Type {
+    /**
+     * Returns the fractional-second precision.
+     *
+     * @return the precision
+     */
     public abstract int precision();
 
+    /**
+     * Creates a builder for {@link IntervalCompound}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.IntervalCompound.Builder builder() {
       return ImmutableType.IntervalCompound.builder();
     }
@@ -249,8 +368,14 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The UUID type. */
   @Value.Immutable
   abstract class UUID implements Type {
+    /**
+     * Creates a builder for {@link UUID}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.UUID.Builder builder() {
       return ImmutableType.UUID.builder();
     }
@@ -261,10 +386,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The fixed-length character type. */
   @Value.Immutable
   abstract class FixedChar implements Type {
+    /**
+     * Returns the fixed length.
+     *
+     * @return the length
+     */
     public abstract int length();
 
+    /**
+     * Creates a builder for {@link FixedChar}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.FixedChar.Builder builder() {
       return ImmutableType.FixedChar.builder();
     }
@@ -275,10 +411,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The variable-length character type. */
   @Value.Immutable
   abstract class VarChar implements Type {
+    /**
+     * Returns the maximum length.
+     *
+     * @return the maximum length
+     */
     public abstract int length();
 
+    /**
+     * Creates a builder for {@link VarChar}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.VarChar.Builder builder() {
       return ImmutableType.VarChar.builder();
     }
@@ -289,10 +436,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The fixed-length binary type. */
   @Value.Immutable
   abstract class FixedBinary implements Type {
+    /**
+     * Returns the fixed length.
+     *
+     * @return the length
+     */
     public abstract int length();
 
+    /**
+     * Creates a builder for {@link FixedBinary}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.FixedBinary.Builder builder() {
       return ImmutableType.FixedBinary.builder();
     }
@@ -303,12 +461,28 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The decimal type. */
   @Value.Immutable
   abstract class Decimal implements Type {
+    /**
+     * Returns the number of digits to the right of the decimal point.
+     *
+     * @return the scale
+     */
     public abstract int scale();
 
+    /**
+     * Returns the total number of digits.
+     *
+     * @return the precision
+     */
     public abstract int precision();
 
+    /**
+     * Creates a builder for {@link Decimal}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Decimal.Builder builder() {
       return ImmutableType.Decimal.builder();
     }
@@ -319,10 +493,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The precision-time type. */
   @Value.Immutable
   abstract class PrecisionTime implements Type {
+    /**
+     * Returns the fractional-second precision.
+     *
+     * @return the precision
+     */
     public abstract int precision();
 
+    /**
+     * Creates a builder for {@link PrecisionTime}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.PrecisionTime.Builder builder() {
       return ImmutableType.PrecisionTime.builder();
     }
@@ -333,10 +518,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The precision-timestamp (without timezone) type. */
   @Value.Immutable
   abstract class PrecisionTimestamp implements Type {
+    /**
+     * Returns the fractional-second precision.
+     *
+     * @return the precision
+     */
     public abstract int precision();
 
+    /**
+     * Creates a builder for {@link PrecisionTimestamp}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.PrecisionTimestamp.Builder builder() {
       return ImmutableType.PrecisionTimestamp.builder();
     }
@@ -347,10 +543,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The precision-timestamp with timezone type. */
   @Value.Immutable
   abstract class PrecisionTimestampTZ implements Type {
+    /**
+     * Returns the fractional-second precision.
+     *
+     * @return the precision
+     */
     public abstract int precision();
 
+    /**
+     * Creates a builder for {@link PrecisionTimestampTZ}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.PrecisionTimestampTZ.Builder builder() {
       return ImmutableType.PrecisionTimestampTZ.builder();
     }
@@ -361,12 +568,28 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The function type. */
   @Value.Immutable
   abstract class Func implements Type {
+    /**
+     * Returns the parameter types.
+     *
+     * @return the parameter types
+     */
     public abstract java.util.List<Type> parameterTypes();
 
+    /**
+     * Returns the return type.
+     *
+     * @return the return type
+     */
     public abstract Type returnType();
 
+    /**
+     * Creates a builder for {@link Func}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Func.Builder builder() {
       return ImmutableType.Func.builder();
     }
@@ -377,10 +600,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The struct type. */
   @Value.Immutable
   abstract class Struct implements Type {
+    /**
+     * Returns the field types.
+     *
+     * @return the field types
+     */
     public abstract java.util.List<Type> fields();
 
+    /**
+     * Creates a builder for {@link Struct}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Struct.Builder builder() {
       return ImmutableType.Struct.builder();
     }
@@ -391,10 +625,21 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The list type. */
   @Value.Immutable
   abstract class ListType implements Type {
+    /**
+     * Returns the element type.
+     *
+     * @return the element type
+     */
     public abstract Type elementType();
 
+    /**
+     * Creates a builder for {@link ListType}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.ListType.Builder builder() {
       return ImmutableType.ListType.builder();
     }
@@ -405,12 +650,28 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** The map type. */
   @Value.Immutable
   abstract class Map implements Type {
+    /**
+     * Returns the key type.
+     *
+     * @return the key type
+     */
     public abstract Type key();
 
+    /**
+     * Returns the value type.
+     *
+     * @return the value type
+     */
     public abstract Type value();
 
+    /**
+     * Creates a builder for {@link Map}.
+     *
+     * @return a new builder
+     */
     public static ImmutableType.Map.Builder builder() {
       return ImmutableType.Map.builder();
     }
@@ -421,11 +682,22 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /** A user-defined (extension) type, identified by an extension URN and name. */
   @Value.Immutable
   interface UserDefined extends Type {
 
+    /**
+     * Returns the extension URN declaring this type.
+     *
+     * @return the extension URN
+     */
     String urn();
 
+    /**
+     * Returns the name of this type within its extension.
+     *
+     * @return the type name
+     */
     String name();
 
     /**
@@ -454,6 +726,11 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
       return 0;
     }
 
+    /**
+     * Creates a builder for {@link UserDefined}.
+     *
+     * @return a new builder
+     */
     static ImmutableType.UserDefined.Builder builder() {
       return ImmutableType.UserDefined.builder();
     }
@@ -476,35 +753,61 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   /** A data type parameter, such as the {@code i32} in {@code List<i32>}. */
   @Value.Immutable
   abstract class ParameterDataType implements Parameter {
+    /**
+     * Returns the data type used as the parameter.
+     *
+     * @return the parameter type
+     */
     public abstract Type type();
   }
 
   /** A boolean value parameter. */
   @Value.Immutable
   abstract class ParameterBooleanValue implements Parameter {
+    /**
+     * Returns the boolean parameter value.
+     *
+     * @return the value
+     */
     public abstract boolean value();
   }
 
   /** An integer value parameter, such as the {@code 10} in {@code VARCHAR<10>}. */
   @Value.Immutable
   abstract class ParameterIntegerValue implements Parameter {
+    /**
+     * Returns the integer parameter value.
+     *
+     * @return the value
+     */
     public abstract long value();
   }
 
   /** An enum value parameter (represented as a string). */
   @Value.Immutable
   abstract class ParameterEnumValue implements Parameter {
+    /**
+     * Returns the enum parameter value.
+     *
+     * @return the value
+     */
     public abstract String value();
   }
 
   /** A string value parameter. */
   @Value.Immutable
   abstract class ParameterStringValue implements Parameter {
+    /**
+     * Returns the string parameter value.
+     *
+     * @return the value
+     */
     public abstract String value();
   }
 
   /** An explicitly null/unspecified parameter, used to select the default value (if any). */
   class ParameterNull implements Parameter {
+    /** The shared singleton instance of the null parameter. */
     public static final ParameterNull INSTANCE = new ParameterNull();
 
     private ParameterNull() {}


### PR DESCRIPTION
I used AI to generate missing javadoc comments for
`core/src/main/java/io/substrait/type/Type.java`.