### PR TITLE
build(core): fail javadoc build on warnings

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -381,10 +381,11 @@ tasks.named<Javadoc>("javadoc") {
   exclude { spec -> generatedDirs.any { spec.file.toPath().startsWith(it) } }
   source(fileTree(immuteableJavaDir) { include("**/*.java") })
 
-  // Keep normal behavior for main javadoc (warnings allowed to show/fail if you want)
+  // Fail the build if Javadoc linting finds any issues in the hand-written sources.
   options {
     require(this is StandardJavadocDocletOptions)
     addBooleanOption("Xdoclint:all", true)
+    addBooleanOption("Xwerror", true)
     encoding = "UTF-8"
     setDestinationDir(rootProject.layout.buildDirectory.dir("docs/${version}/core").get().asFile)
     addStringOption("overview", "${rootProject.projectDir}/core/src/main/javadoc/overview.html")


### PR DESCRIPTION
Now that all hand-written sources in `:core` carry complete Javadoc (added file by file in the preceding `docs(core): fix javadoc in ...` PRs), this enables the `-Xwerror` javadoc option so that the `core:javadoc` task fails the build on any Javadoc lint warning.

This is the final step of the Javadoc cleanup and prevents missing-Javadoc regressions from being reintroduced. Verified locally: `./gradlew core:javadoc` builds successfully with `-Xwerror` against the current main.

🤖 Generated with AI