### PR TITLE
build: workflow concurrency for PR title check

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -4,6 +4,11 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+# Most recent PR change superseeds previous changes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Default to the minimum read-only token for all jobs.
 permissions:
   contents: read


### PR DESCRIPTION
This change adds concurrency configuration to the PR title check workflow so that more recent modifications to a PR superseed previous ones. Any active workflow runs triggered by earlier PR modifications are cancelled. This avoids a race condition when multiple workflows are running in parallel and minimises the the impact on build resources.