### PR TITLE
fix(core): add compiled output to javadocImmutable classpath

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -337,8 +337,10 @@ tasks.register<Javadoc>("javadocImmutable") {
   // Only the generated proto sources
   setSource(fileTree(immuteableJavaDir) { include("**/*.java") })
 
-  // Use the main source set classpath to resolve types referenced by the generated code
-  classpath = sourceSets["main"].compileClasspath
+  // Use the main source set classpath + compiled output to resolve types referenced by the
+  // generated code (the Immutables-generated sources import the hand-written enclosing types,
+  // which live in the project's own output, not in external dependency JARs).
+  classpath = sourceSets["main"].compileClasspath + sourceSets["main"].output.classesDirs
 
   // Destination separate from main Javadoc
   setDestinationDir(rootProject.layout.buildDirectory.dir("docs/${version}/immutable").get().asFile)


### PR DESCRIPTION
The `javadocImmutable` task only had `compileClasspath` (external dependency JARs) but not the project's own compiled output. Immutables-generated sources import their hand-written enclosing types (`Hint`, `Rel`, etc.) which live in the project's compiled classes, not in external JARs, causing 100+ `cannot find symbol` / `package does not exist` errors from javadoc.

Add `sourceSets["main"].output.classesDirs` to the classpath so javadoc can resolve cross-references between generated and hand-written sources.

---

🤖 Generated with AI