### PR TITLE
build: use PR number for title check concurrency

### DIFF
--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -4,9 +4,9 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-# Most recent PR change superseeds previous changes.
+# Most recent PR change supersedes previous changes.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Default to the minimum read-only token for all jobs.


### PR DESCRIPTION
The github.ref may just be the target branch name, which results in all PR title checks sharing the same concurrency group. This change uses the PR number (if available) as the discriminator.