### PR TITLE
ci: run yamllint on pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -115,9 +115,8 @@ jobs:
         ./isthmus-cli/src/test/script/smoke.sh
         ./isthmus-cli/src/test/script/tpch_smoke.sh
     - name: Rename the artifact to OS-unique name
-      shell: bash
-      run: |
-        value=`mv isthmus-cli/build/native/nativeCompile/isthmus isthmus-cli/build/native/nativeCompile/isthmus-${{ matrix.os }}`
+      working-directory: isthmus-cli/build/native/nativeCompile
+      run: mv isthmus isthmus-${{ matrix.os }}
     - name: Publish artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,17 @@ jobs:
           fetch-depth: 0
       - uses: editorconfig-checker/action-editorconfig-checker@v2
       - run: editorconfig-checker
+  yamllint:
+    name: Lint YAML
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: yamllint --all-files
   security:
     name: Security validation
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_title.yaml
+++ b/.github/workflows/pr_title.yaml
@@ -45,6 +45,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      # The message below is prose inside the github-script template literal;
+      # wrapping it would change the rendered comment, so disable line-length here.
+      # yamllint disable rule:line-length
       - uses: actions/github-script@v9
         with:
           script: |
@@ -90,3 +93,4 @@ jobs:
             core.setFailed(
               "PR title and description do not follow the Conventional Commits specification."
             );
+      # yamllint enable rule:line-length

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,8 @@ jobs:
           ./isthmus-cli/src/test/script/smoke.sh
           ./isthmus-cli/src/test/script/tpch_smoke.sh
       - name: Rename the artifact to OS-unique name
-        shell: bash
-        run: |
-          value=`mv isthmus-cli/build/native/nativeCompile/isthmus isthmus-cli/build/native/nativeCompile/isthmus-${{ matrix.os }}`
+        working-directory: isthmus-cli/build/native/nativeCompile
+        run: mv isthmus isthmus-${{ matrix.os }}
       - name: Publish artifact
         uses: actions/upload-artifact@v7
         with:
@@ -86,18 +85,21 @@ jobs:
         with:
           name: isthmus-macOS-latest
           path: native/libs
-      - name: Get bot user ID
+      - name: Get bot user ID and email
         id: bot-user-id
         run: |
-          echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+          slug="${{ steps.app-token.outputs.app-slug }}"
+          user_id="$(gh api "/users/${slug}[bot]" --jq .id)"
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
+          echo "email=${user_id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Run semantic-release
         run: ./ci/release/run.sh
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          GIT_AUTHOR_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-          GIT_COMMITTER_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          GIT_AUTHOR_EMAIL: ${{ steps.bot-user-id.outputs.email }}
+          GIT_COMMITTER_EMAIL: ${{ steps.bot-user-id.outputs.email }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}


### PR DESCRIPTION
`yamllint` is configured as a pre-commit hook but is not enforced in CI, so line-length and bracket violations have accumulated on `main` and committing a touched workflow file requires `git commit --no-verify`. This adds a CI check and brings the existing workflows into compliance so the check passes.

### Enforce in CI
- Add a **Lint YAML** job to the PR build workflow that runs the `yamllint` pre-commit hook against all files. It reuses the pinned config and version from `.pre-commit-config.yaml` (`.yamllint.yaml`, yamllint v1.33.0), keeping CI and local checks in lockstep.

### Fix existing violations
- **Rename step (`release.yml`, `pr.yml`):** use a step `working-directory` instead of repeating the long `isthmus-cli/build/native/nativeCompile/` path twice in `mv` (also drops the unused `value=` capture).
- **Release-bot email (`release.yml`):** derive the email once as an output of the bot-user-id step and reference it, removing the two duplicated long `GIT_AUTHOR_EMAIL` / `GIT_COMMITTER_EMAIL` lines.
- **`pr_title.yaml`:** scope a `# yamllint disable/enable rule:line-length` pair around the github-script step — its long lines are prose inside a template literal, where wrapping would alter the rendered PR comment. The rest of the file stays checked.

No behavior change to the workflows. Verified `pre-commit run yamllint --all-files` passes.

🤖 Generated with AI