### PR TITLE
feat(core): support max length, scale, precision in Substrait dialect

### DIFF
--- a/core/src/main/java/io/substrait/dialect/SupportedType.java
+++ b/core/src/main/java/io/substrait/dialect/SupportedType.java
@@ -36,11 +36,29 @@ public abstract class SupportedType {
   public abstract Optional<SystemTypeMetadata> systemMetadata();
 
   /**
-   * The maximum precision supported for the type, if constrained.
+   * The maximum precision supported for the type, if constrained. Applies to the
+   * subsecond-precision temporal types ({@code PRECISION_TIME}, {@code PRECISION_TIMESTAMP}, {@code
+   * PRECISION_TIMESTAMP_TZ}, {@code INTERVAL_COMPOUND}, {@code INTERVAL_DAY}) and, together with
+   * {@link #maxScale()}, to {@code DECIMAL}.
    *
    * @return the optional maximum precision
    */
   public abstract Optional<Integer> maxPrecision();
+
+  /**
+   * The maximum scale supported for a {@code DECIMAL} type, if constrained.
+   *
+   * @return the optional maximum scale
+   */
+  public abstract Optional<Integer> maxScale();
+
+  /**
+   * The maximum length supported for a variable- or fixed-length type ({@code FIXED_BINARY}, {@code
+   * VARCHAR}, {@code FIXED_CHAR}), if constrained.
+   *
+   * @return the optional maximum length
+   */
+  public abstract Optional<Integer> maxLength();
 
   /**
    * Dependency (alias) where a {@code USER_DEFINED} type is declared.
@@ -66,6 +84,8 @@ public abstract class SupportedType {
         && !metadata().isPresent()
         && !systemMetadata().isPresent()
         && !maxPrecision().isPresent()
+        && !maxScale().isPresent()
+        && !maxLength().isPresent()
         && !source().isPresent()
         && !name().isPresent();
   }

--- a/core/src/main/java/io/substrait/dialect/SupportedTypeDeserializer.java
+++ b/core/src/main/java/io/substrait/dialect/SupportedTypeDeserializer.java
@@ -35,6 +35,12 @@ class SupportedTypeDeserializer extends JsonDeserializer<SupportedType> {
     if (node.hasNonNull("max_precision")) {
       builder.maxPrecision(node.get("max_precision").asInt());
     }
+    if (node.hasNonNull("max_scale")) {
+      builder.maxScale(node.get("max_scale").asInt());
+    }
+    if (node.hasNonNull("max_length")) {
+      builder.maxLength(node.get("max_length").asInt());
+    }
     if (node.hasNonNull("source")) {
       builder.source(node.get("source").asText());
     }

--- a/core/src/main/java/io/substrait/dialect/SupportedTypeSerializer.java
+++ b/core/src/main/java/io/substrait/dialect/SupportedTypeSerializer.java
@@ -30,6 +30,12 @@ class SupportedTypeSerializer extends JsonSerializer<SupportedType> {
     if (value.maxPrecision().isPresent()) {
       gen.writeNumberField("max_precision", value.maxPrecision().get());
     }
+    if (value.maxScale().isPresent()) {
+      gen.writeNumberField("max_scale", value.maxScale().get());
+    }
+    if (value.maxLength().isPresent()) {
+      gen.writeNumberField("max_length", value.maxLength().get());
+    }
     if (value.systemMetadata().isPresent()) {
       provider.defaultSerializeField("system_metadata", value.systemMetadata().get(), gen);
     }

--- a/core/src/test/java/io/substrait/dialect/SupportedTypeParameterizedRoundTripTest.java
+++ b/core/src/test/java/io/substrait/dialect/SupportedTypeParameterizedRoundTripTest.java
@@ -1,0 +1,69 @@
+package io.substrait.dialect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.networknt.schema.Error;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the parameterized-type constraints {@code max_length} (for {@code FIXED_BINARY},
+ * {@code VARCHAR}, {@code FIXED_CHAR}) and {@code max_precision}/{@code max_scale} (for {@code
+ * DECIMAL}) serialize as configuration objects, validate against the published {@code
+ * dialect_schema.yaml}, and survive a POJO &rarr; YAML &rarr; POJO round trip.
+ */
+class SupportedTypeParameterizedRoundTripTest {
+
+  private static Dialect dialectWith(SupportedType type) {
+    return Dialect.builder().addSupportedTypes(type).build();
+  }
+
+  private static void assertRoundTrips(SupportedType type) {
+    assertFalse(type.isBare(), "configured type must not be bare");
+    Dialect original = dialectWith(type);
+    String yaml = Dialect.toYaml(original);
+
+    List<Error> errors = SchemaValidator.validate(yaml);
+    assertTrue(errors.isEmpty(), () -> "Generated dialect failed schema validation: " + errors);
+
+    assertEquals(original, Dialect.load(yaml));
+  }
+
+  @Test
+  void fixedBinaryMaxLength() {
+    SupportedType type =
+        SupportedType.builder().type(TypeKind.FIXED_BINARY).maxLength(1024).build();
+
+    assertTrue(Dialect.toYaml(dialectWith(type)).contains("max_length: 1024"));
+    assertRoundTrips(type);
+  }
+
+  @Test
+  void varcharMaxLength() {
+    SupportedType type = SupportedType.builder().type(TypeKind.VARCHAR).maxLength(255).build();
+
+    assertTrue(Dialect.toYaml(dialectWith(type)).contains("max_length: 255"));
+    assertRoundTrips(type);
+  }
+
+  @Test
+  void fixedCharMaxLength() {
+    SupportedType type = SupportedType.builder().type(TypeKind.FIXED_CHAR).maxLength(64).build();
+
+    assertTrue(Dialect.toYaml(dialectWith(type)).contains("max_length: 64"));
+    assertRoundTrips(type);
+  }
+
+  @Test
+  void decimalMaxPrecisionAndScale() {
+    SupportedType type =
+        SupportedType.builder().type(TypeKind.DECIMAL).maxPrecision(38).maxScale(10).build();
+
+    String yaml = Dialect.toYaml(dialectWith(type));
+    assertTrue(yaml.contains("max_precision: 38"), yaml);
+    assertTrue(yaml.contains("max_scale: 10"), yaml);
+    assertRoundTrips(type);
+  }
+}


### PR DESCRIPTION
## What

Adds support for the parameterized-type constraints `max_length` and `max_scale` to the `core` Substrait *dialect* model, mirroring the schema additions from [substrait-io/substrait#1030](https://github.com/substrait-io/substrait/pull/1030) (spec v0.88.0):

- `max_length` for `FIXED_BINARY`, `VARCHAR`, `FIXED_CHAR`
- `max_scale` for `DECIMAL` (alongside the existing `max_precision`, whose Javadoc is clarified to note it also applies to `DECIMAL`)

## How

- `SupportedType` gains `maxScale()` and `maxLength()` optionals; `isBare()` accounts for both so a configured entry never collapses to a bare enum string.
- `SupportedTypeSerializer` / `SupportedTypeDeserializer` write and read `max_scale` and `max_length`.
- New `SupportedTypeParameterizedRoundTripTest` builds each configured type, validates the generated YAML against the bundled `dialect_schema.yaml`, and asserts a lossless POJO → YAML → POJO round trip.

## Notes

- Depends on the v0.88.0 submodule bump that landed in #950 — this branch is based on top of it, so the v0.88.0 `dialect_schema.yaml` (which defines these fields) is available for schema validation.

Closes #808

🤖 Generated with AI
