### PR TITLE
build(core): ignore jackson-databind CVE-2026-54515 in OSV scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ OSV_SCANNER_IMAGE := ghcr.io/google/osv-scanner:v2.3.5
 scan:
 ifdef component
 	./gradlew --quiet ':$(component):dependencies' --write-locks --configuration runtimeClasspath
-	docker run --rm --volume './$(component)/gradle.lockfile:/gradle.lockfile' $(OSV_SCANNER_IMAGE) scan source --lockfile /gradle.lockfile
+	docker run --rm \
+		--volume './$(component)/gradle.lockfile:/gradle.lockfile' \
+		--volume './osv-scanner.toml:/osv-scanner.toml' \
+		$(OSV_SCANNER_IMAGE) scan source --lockfile /gradle.lockfile --config /osv-scanner.toml
 else
 	$(MAKE) component=core scan
 	$(MAKE) component=isthmus scan

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,7 @@
+[[IgnoredVulns]]
+id = "GHSA-5jmj-h7xm-6q6v"
+# CVE-2026-54515: case-insensitive deserialization bypasses per-property
+# @JsonIgnoreProperties. The fix is backported upstream but not yet in a
+# released jackson-databind version.
+ignoreUntil = 2026-08-15
+reason = "Awaiting jackson-databind release with the backported fix."


### PR DESCRIPTION
## Problem

PR builds fail because the `osv-scanner` job flags `jackson-databind 2.22.0` for [GHSA-5jmj-h7xm-6q6v](https://github.com/advisories/GHSA-5jmj-h7xm-6q6v) (CVE-2026-54515) — a case-insensitive deserialization bug that bypasses per-property `@JsonIgnoreProperties`. The maintainer has [backported the fix](https://github.com/FasterXML/jackson-databind/issues/5962) but has not released a version yet, so we cannot bump the dependency to resolve it.

## Change

- Add `osv-scanner.toml` that ignores this single advisory via `[[IgnoredVulns]]`, with an `ignoreUntil` of `2026-08-15` and a reason.
- Wire the config into the `scan` target with `--config` (mounting it into the scanner container alongside the lockfile).

This suppresses only the one known, tracked advisory — the scan still fails on any other vulnerability — and the ignore auto-expires so it is revisited once a fixed `jackson-databind` is released.

🤖 Generated with AI