### PR TITLE
feat(isthmus): map RIGHTSHIFT to Substrait shift_right

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus.calcite;
 
 import io.substrait.isthmus.AggregateFunctions;
 import io.substrait.isthmus.expression.CurrentTimezoneFunction;
+import io.substrait.isthmus.expression.FunctionMappings;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -55,7 +56,7 @@ public class SubstraitOperatorTable implements SqlOperatorTable {
   // feed OVERRIDE_KINDS: they share generic kinds such as OTHER_FUNCTION with many standard
   // operators, which we must not shadow.
   private static final SqlOperatorTable SUBSTRAIT_SCALAR_OPERATOR_TABLE =
-      SqlOperatorTables.of(List.of(CurrentTimezoneFunction.INSTANCE));
+      SqlOperatorTables.of(List.of(CurrentTimezoneFunction.INSTANCE, FunctionMappings.RIGHTSHIFT));
 
   // Utilisation of extended library operators available from calcite 1.35+, i.e hyperbolic
   // functions

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -11,6 +11,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -49,6 +50,18 @@ public class FunctionMappings {
           "all_match",
           opBinding -> opBinding.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN),
           OperandTypes.family(SqlTypeFamily.ARRAY, SqlTypeFamily.ANY));
+
+  /**
+   * The {@code RIGHTSHIFT(value, shift)} function. Calcite provides {@link
+   * SqlStdOperatorTable#LEFTSHIFT} (and the {@code <<} operator {@link
+   * SqlStdOperatorTable#BIT_LEFT_SHIFT}) but has no right-shift counterpart, so Isthmus defines one
+   * to map to the Substrait {@code shift_right} function.
+   */
+  public static final SqlFunction RIGHTSHIFT =
+      SqlBasicFunction.create(
+          "RIGHTSHIFT",
+          ReturnTypes.ARG0_NULLABLE,
+          OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER));
 
   /** Scalar function mappings. */
   public static final ImmutableList<Sig> SCALAR_SIGS =
@@ -128,6 +141,7 @@ public class FunctionMappings {
               s(SqlLibraryOperators.GREATEST, "greatest"),
               s(SqlStdOperatorTable.BIT_LEFT_SHIFT, "shift_left"),
               s(SqlStdOperatorTable.LEFTSHIFT, "shift_left"),
+              s(RIGHTSHIFT, "shift_right"),
               s(SqlLibraryOperators.STARTS_WITH, "starts_with"),
               s(SqlLibraryOperators.ENDS_WITH, "ends_with"),
               s(SqlLibraryOperators.CONTAINS_SUBSTR, "contains"),

--- a/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ArithmeticFunctionTest.java
@@ -220,4 +220,11 @@ class ArithmeticFunctionTest extends PlanTestBase {
     String query = String.format("SELECT LEFTSHIFT(%s, 1) FROM numbers", column);
     assertFullRoundTrip(query, CREATES);
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"i8", "i16", "i32", "i64"})
+  void rightshift(String column) throws Exception {
+    String query = String.format("SELECT RIGHTSHIFT(%s, 1) FROM numbers", column);
+    assertFullRoundTrip(query, CREATES);
+  }
 }


### PR DESCRIPTION
## What

Adds a mapping so a right-shift can be converted to the Substrait `shift_right` function. Calcite defines the `<<` operator (`BIT_LEFT_SHIFT`) and the `LEFTSHIFT` function — both already mapped to Substrait `shift_left` — but has **no right-shift counterpart at all**. This PR defines an Isthmus `RIGHTSHIFT(value, shift)` `SqlFunction` (mirroring Calcite's `LEFTSHIFT`), registers it in `SubstraitOperatorTable`, and maps it to `shift_right`.

## Why

`shift_right` exists in `functions_arithmetic.yaml` (i32/i64, same shape as `shift_left`) but was unreachable from SQL because no Calcite operator produced it.

## Scope

- Covers the **function-call spelling** `RIGHTSHIFT(x, n)`. Round-trips to Substrait `shift_right` and back.
- The **`>>` infix operator is intentionally out of scope.** Calcite 1.42 has no `>>` token, no `SqlKind`, and no operator (only `<<`). Supporting `>>` requires isthmus to *generate* its own parser: Calcite exposes the needed extension hooks (`binaryOperatorsTokens` + `extraBinaryExpressions`, the same mechanism calcite-babel uses for the `::` infix cast), but isthmus currently consumes the prebuilt `SqlDdlParserImpl` and has no parser codegen. Tracking that as a separate follow-up; the cleanest long-term fix is likely to upstream `BIT_RIGHT_SHIFT` into Calcite core (a genuine gap, given it already has `<<`), which is being pursued in [apache/calcite#5073](https://github.com/apache/calcite/pull/5073) — once that lands, this reduces to a one-line mapping.

## Testing

- New round-trip test in `ArithmeticFunctionTest` (`i8`/`i16`/`i32`/`i64`), symmetric to the existing `leftshift` test.
- Full `:isthmus:test` suite passes locally.

🤖 Generated with AI