### PR TITLE
fix: declare constants as final

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -21,19 +21,19 @@ import org.apache.calcite.sql.type.ReturnTypes;
 public class AggregateFunctions {
 
   /** Substrait-specific MIN aggregate function (nullable return type). */
-  public static SqlAggFunction MIN = new SubstraitSqlMinMaxAggFunction(SqlKind.MIN);
+  public static final SqlAggFunction MIN = new SubstraitSqlMinMaxAggFunction(SqlKind.MIN);
 
   /** Substrait-specific MAX aggregate function (nullable return type). */
-  public static SqlAggFunction MAX = new SubstraitSqlMinMaxAggFunction(SqlKind.MAX);
+  public static final SqlAggFunction MAX = new SubstraitSqlMinMaxAggFunction(SqlKind.MAX);
 
   /** Substrait-specific AVG aggregate function (nullable return type). */
-  public static SqlAggFunction AVG = new SubstraitAvgAggFunction(SqlKind.AVG);
+  public static final SqlAggFunction AVG = new SubstraitAvgAggFunction(SqlKind.AVG);
 
   /** Substrait-specific SUM aggregate function (nullable return type). */
-  public static SqlAggFunction SUM = new SubstraitSumAggFunction();
+  public static final SqlAggFunction SUM = new SubstraitSumAggFunction();
 
   /** Substrait-specific SUM0 aggregate function (non-null BIGINT return type). */
-  public static SqlAggFunction SUM0 = new SubstraitSumEmptyIsZeroAggFunction();
+  public static final SqlAggFunction SUM0 = new SubstraitSumEmptyIsZeroAggFunction();
 
   /**
    * Converts default Calcite aggregate functions to Substrait-specific variants when needed.

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -40,7 +40,7 @@ public class TypeConverter {
    * <p>Both {@link UserTypeMapper#toSubstrait(RelDataType)} and {@link
    * UserTypeMapper#toCalcite(Type.UserDefined)} return {@code null} in this default configuration.
    */
-  public static TypeConverter DEFAULT =
+  public static final TypeConverter DEFAULT =
       new TypeConverter(
           new UserTypeMapper() {
             @Nullable

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
@@ -32,7 +32,7 @@ import org.jspecify.annotations.Nullable;
 public class SubstraitOperatorTable implements SqlOperatorTable {
 
   /** Singleton instance of the Substrait operator table. */
-  public static SubstraitOperatorTable INSTANCE = new SubstraitOperatorTable();
+  public static final SubstraitOperatorTable INSTANCE = new SubstraitOperatorTable();
 
   private static final SqlOperatorTable SUBSTRAIT_OPERATOR_TABLE =
       SqlOperatorTables.of(

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -40,7 +40,7 @@ public class CallConverters {
    *
    * @see ExpressionCreator#cast(Type, Expression, Expression.FailureBehavior)
    */
-  public static Function<TypeConverter, SimpleCallConverter> CAST =
+  public static final Function<TypeConverter, SimpleCallConverter> CAST =
       typeConverter ->
           (call, visitor) -> {
             Expression.FailureBehavior failureBehavior;
@@ -78,7 +78,7 @@ public class CallConverters {
    * <p>When converting from Calcite to Substrait, this call converter extracts the stored {@link
    * Expression.UserDefinedLiteral}.
    */
-  public static Function<TypeConverter, SimpleCallConverter> REINTERPRET =
+  public static final Function<TypeConverter, SimpleCallConverter> REINTERPRET =
       typeConverter ->
           (call, visitor) -> {
             if (call.getKind() != SqlKind.REINTERPRET) {
@@ -136,7 +136,7 @@ public class CallConverters {
    *
    * <p>Each literal's nullability is set to match its field type's nullability.
    */
-  public static SimpleCallConverter ROW =
+  public static final SimpleCallConverter ROW =
       (call, visitor) -> {
         if (call.getKind() != SqlKind.ROW) {
           return null;
@@ -189,7 +189,7 @@ public class CallConverters {
    * <p>This converter assumes that operand expressions have already been converted by the provided
    * top-level visitor.
    */
-  public static SimpleCallConverter CASE =
+  public static final SimpleCallConverter CASE =
       (call, visitor) -> {
         if (call.getKind() != SqlKind.CASE) {
           return null;
@@ -225,7 +225,7 @@ public class CallConverters {
    * <p>Returns a {@link SimpleCallConverter} that expands SEARCH calls using the provided {@link
    * RexBuilder}
    */
-  public static Function<RexBuilder, SimpleCallConverter> CREATE_SEARCH_CONV =
+  public static final Function<RexBuilder, SimpleCallConverter> CREATE_SEARCH_CONV =
       (RexBuilder rexBuilder) ->
           (RexCall call, Function<RexNode, Expression> visitor) -> {
             if (call.getKind() != SqlKind.SEARCH) {
@@ -247,7 +247,7 @@ public class CallConverters {
    * <p>Matching is done on operator identity (these are niladic {@link SqlKind#OTHER_FUNCTION}
    * functions with no dedicated {@link SqlKind}).
    */
-  public static SimpleCallConverter EXECUTION_CONTEXT_VARIABLE =
+  public static final SimpleCallConverter EXECUTION_CONTEXT_VARIABLE =
       (call, visitor) -> {
         if (call.getOperator() == SqlStdOperatorTable.CURRENT_TIMESTAMP) {
           return ExpressionCreator.currentTimestamp(call.getType().getPrecision());

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlDialect.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlDialect.java
@@ -15,10 +15,10 @@ import org.apache.calcite.sql.util.SqlString;
 public class SubstraitSqlDialect extends SqlDialect {
 
   /** Default context for the Substrait SQL dialect. */
-  public static SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT;
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT;
 
   /** Default instance of Substrait SQL dialect. */
-  public static SqlDialect DEFAULT = new SubstraitSqlDialect(DEFAULT_CONTEXT);
+  public static final SqlDialect DEFAULT = new SubstraitSqlDialect(DEFAULT_CONTEXT);
 
   /**
    * Converts a Calcite {@link RelNode} to its SQL representation using the default dialect.

--- a/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/RelCopyOnWriteVisitorTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.Test;
 
 class RelCopyOnWriteVisitorTest extends PlanTestBase {
 
-  public static SimpleExtension.FunctionAnchor APPROX_COUNT_DISTINCT =
+  public static final SimpleExtension.FunctionAnchor APPROX_COUNT_DISTINCT =
       SimpleExtension.FunctionAnchor.of(
           "extension:io.substrait:functions_aggregate_approx", "approx_count_distinct:any");
-  public static SimpleExtension.FunctionAnchor COUNT =
+  public static final SimpleExtension.FunctionAnchor COUNT =
       SimpleExtension.FunctionAnchor.of(
           "extension:io.substrait:functions_aggregate_generic", "count:any");
 


### PR DESCRIPTION
Some public static constants were not declared final, allowing them to be incorrectly modified at runtime. This change adds the final modifier to these constants.