### PR TITLE
ci: build only the Linux native image per PR

### DIFF
--- a/.github/workflows/native-image-macos.yml
+++ b/.github/workflows/native-image-macos.yml
@@ -1,0 +1,51 @@
+name: macOS Native Image
+
+# macOS native-image coverage is kept off the per-PR critical path: the macOS
+# build is the long pole and macOS runners bill at 10x. Instead we build and
+# smoke-test the macOS native image on every push to main (per-merge signal)
+# plus a weekly backstop, so macOS-specific native regressions are still caught
+# promptly before the Sunday release. PRs build only the Linux native image
+# (see pr.yml).
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # Saturday 04:23 UTC — backstop ahead of the Sunday release build.
+    - cron: "23 4 * * 6"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  isthmus-native-image-macos:
+    name: Build Isthmus Native Image (macOS)
+    if: github.repository == 'substrait-io/substrait-java'
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: recursive
+    - uses: actions/setup-java@v5
+      with:
+        java-version: 25
+        distribution: graalvm
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+    - name: Report Java Version
+      run: java -version
+    - name: Build with Gradle
+      run: |
+        # fetch submodule tags since actions/checkout@v7 does not
+        git submodule foreach 'git fetch --unshallow || true'
+
+        # Full optimization (no --quick-build-native) so this mirrors the
+        # release build and catches anything that would break shipping.
+        ./gradlew nativeCompile
+    - name: Smoke Test
+      run: |
+        ./isthmus-cli/src/test/script/smoke.sh
+        ./isthmus-cli/src/test/script/tpch_smoke.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,15 +94,18 @@ jobs:
           git submodule foreach 'git fetch --unshallow || true'
 
           ./gradlew integrationTest
-  isthmus-native-image-mac-linux:
+  isthmus-native-image-linux:
+    # Only the Linux native image is built per PR: it validates the GraalVM
+    # configuration and runs the smoke tests, and its binary is throwaway (only
+    # smoke-tested, never shipped). macOS-specific native coverage runs in
+    # native-image-macos.yml (on push to main + a weekly schedule), keeping the
+    # slow, 10x-billed macOS build off the PR critical path. This job also runs
+    # in parallel with the java/integration jobs rather than after them.
     name: Build Isthmus Native Image
-    needs:
-      - java
-      - integration
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v7
       with:
@@ -120,7 +123,9 @@ jobs:
         # fetch submodule tags since actions/checkout@v7 does not
         git submodule foreach 'git fetch --unshallow || true'
 
-        ./gradlew nativeCompile
+        # --quick-build-native (-Ob) trades binary runtime performance for a
+        # much faster build; the PR binary is only smoke-tested, so this is free.
+        ./gradlew nativeCompile --quick-build-native
     - name: Smoke Test
       run: |
         ./isthmus-cli/src/test/script/smoke.sh


### PR DESCRIPTION
## What

Speeds up PR builds by taking the slow, 10x-billed **macOS** native-image build off the PR critical path, without losing macOS coverage.

The native image built on PRs is only used to run the smoke tests (`smoke.sh` / `tpch_smoke.sh`) and is uploaded as a throwaway PR artifact — the shipped release binaries are compiled separately in `release.yml`. That means the *runtime performance* of the PR binary is irrelevant, which unlocks the cheapest win below.

## Changes

1. **Quick build mode on PRs.** The Linux native image is now built with `--quick-build-native` (GraalVM `-Ob`), which skips the expensive optimizing compiles and typically cuts native-image build time ~30–40%. The tradeoff — a slower/larger binary — doesn't matter because the PR binary is only smoke-tested.
2. **Linux-only per PR.** The `macOS-latest` matrix entry is dropped from the PR native-image job. The Linux build already validates the GraalVM configuration and runs the full smoke suite; macOS-specific native regressions are rare and now covered out-of-band (see below). macOS runners are the long pole *and* bill at 10x.
3. **Runs in parallel with tests.** Removed `needs: [java, integration]` so the native-image job starts immediately instead of waiting for the Java + integration jobs to finish.

To keep macOS native coverage, a new `native-image-macos.yml` workflow builds and smoke-tests the macOS native image (full optimization, mirroring the release build) on **push to `main`** (per-merge signal) plus a **weekly** backstop and `workflow_dispatch`. Regressions are still caught promptly, and before the Sunday release build — just not on the per-PR critical path.

## Notes for reviewers

- **Required status checks:** the per-PR macOS native check (`Build Isthmus Native Image (macOS-latest)`) no longer runs. If branch protection requires it, that setting needs updating; the Linux check (`Build Isthmus Native Image (ubuntu-latest)`) is unchanged.
- `--quick-build-native` was verified to be a recognized option on the `nativeCompile` task (`gradle help --task nativeCompile` → "Enables quick build mode").
- `release.yml` is intentionally left untouched — release binaries stay fully optimized on both Linux and macOS.

Closes #768

🤖 Generated with AI