### PR TITLE
feat(isthmus)!: remove invalid SetOp to Calcite relation mappings

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -285,10 +285,6 @@ public class SubstraitRelNodeConverter
             input -> {
               relBuilder.push(input.accept(this, context));
             });
-    // TODO: MINUS_MULTISET and INTERSECTION_PRIMARY mappings are set to be removed as they do not
-    //   correspond to the Calcite relations they are associated with. They are retained for now
-    //   to enable users to migrate off of them.
-    //   See:  https://github.com/substrait-io/substrait-java/issues/303
     RelBuilder builder = getRelBuilder(set);
     RelNode node = builder.build();
     return applyRemap(node, set.getRemap());
@@ -301,9 +297,7 @@ public class SubstraitRelNodeConverter
       case MINUS_PRIMARY:
         return relBuilder.minus(false, numInputs);
       case MINUS_PRIMARY_ALL:
-      case MINUS_MULTISET:
         return relBuilder.minus(true, numInputs);
-      case INTERSECTION_PRIMARY:
       case INTERSECTION_MULTISET:
         return relBuilder.intersect(false, numInputs);
       case INTERSECTION_MULTISET_ALL:

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -1,5 +1,7 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import io.substrait.plan.Plan;
 import io.substrait.relation.Join.JoinType;
 import io.substrait.relation.Rel;
@@ -241,6 +243,24 @@ class SubstraitRelNodeConverterTest extends PlanTestBase {
 
       RelNode relNode = substraitToCalcite.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING);
+    }
+
+    // MINUS_MULTISET and INTERSECTION_PRIMARY have no equivalent Calcite relation, so converting
+    // them to Calcite is unsupported.
+    @Test
+    void minusMultisetUnsupported() {
+      Plan.Root root = sb.root(sb.set(SetOp.MINUS_MULTISET, commonTable, commonTable));
+
+      assertThrows(
+          UnsupportedOperationException.class, () -> substraitToCalcite.convert(root.getInput()));
+    }
+
+    @Test
+    void intersectionPrimaryUnsupported() {
+      Plan.Root root = sb.root(sb.set(SetOp.INTERSECTION_PRIMARY, commonTable, commonTable));
+
+      assertThrows(
+          UnsupportedOperationException.class, () -> substraitToCalcite.convert(root.getInput()));
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/utils/SetUtils.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/utils/SetUtils.java
@@ -59,7 +59,8 @@ public class SetUtils {
   }
 
   // Generate all SetOp types excluding:
-  // * MINUS_MULTISET, INTERSECTION_PRIMARY: do not map to Calcite relations
+  // * MINUS_MULTISET, INTERSECTION_PRIMARY: no equivalent Calcite relation, so they are
+  //   unsupported in Substrait -> Calcite conversion
   // * UNKNOWN: invalid
   public static Stream<Arguments> setTestConfig() {
     return Arrays.stream(Set.SetOp.values())


### PR DESCRIPTION
## Summary

Removes the two incorrect `SetOp` → Calcite relation mappings in the Substrait → Calcite converter (`SubstraitRelNodeConverter`):

- `MINUS_MULTISET` → Calcite `Minus(all=true)`
- `INTERSECTION_PRIMARY` → Calcite `Intersect(all=false)`

These mappings were incorrect — the Substrait spec behaviour of these set operations does not match the Calcite relations they were mapped to. They were retained temporarily (with a `TODO` referencing this issue) to let users migrate off of them after the correct mappings were introduced.

Neither `MINUS_MULTISET` nor `INTERSECTION_PRIMARY` has an equivalent Calcite relation, so converting a plan containing either to Calcite now throws `UnsupportedOperationException` (the `default` branch of the switch), consistent with how the test utilities already excluded them.

Note: `MINUS_MULTISET` and `INTERSECTION_PRIMARY` remain valid Substrait spec operations — this only touches the Isthmus (Calcite) conversion. The core POJO model, dialect enum, type-derivation, `SqlKindFromRel`, and the Calcite → Substrait direction (`SubstraitRelVisitor`, which already produces the correct ops) are unchanged.

## Changes

- Remove the `MINUS_MULTISET` and `INTERSECTION_PRIMARY` cases from `SubstraitRelNodeConverter.getRelBuilder`.
- Remove the stale `TODO` comment referencing the issue.
- Add tests asserting both ops now throw `UnsupportedOperationException` on conversion.
- Clarify the exclusion comment in `SetUtils`.

## Breaking change

Converting a Substrait plan that uses `MINUS_MULTISET` or `INTERSECTION_PRIMARY` to Calcite now throws `UnsupportedOperationException` instead of producing an incorrect Calcite relation. The supported set-difference operations are `MINUS_PRIMARY` (`Minus all=false`) and `MINUS_PRIMARY_ALL` (`Minus all=true`); the supported intersection operations are `INTERSECTION_MULTISET` (`Intersect all=false`) and `INTERSECTION_MULTISET_ALL` (`Intersect all=true`).

## Testing

- `./gradlew :isthmus:test --tests "io.substrait.isthmus.SubstraitRelNodeConverterTest" --tests "io.substrait.isthmus.Substrait2SqlTest" --tests "io.substrait.isthmus.ProtoPlanConverterTest"`
- `./gradlew spotlessApply :core:check :isthmus:check`

Closes #303

🤖 Generated with AI