### PR TITLE
docs: trim stale native-image CI note in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,11 +205,5 @@ compile — they have their own visitor implementors:
   proto message usually needs: POJO + visitor wiring + both proto converters + a
   round-trip test, and often `ExpressionCreator` factories and `dsl/SubstraitBuilder`
   helpers for ergonomics.
-- When monitoring PR checks: the per-PR native-image job (`Build Isthmus Native Image` in
-  `pr.yml`) builds **Linux only**, uses `--quick-build-native`, and runs **in parallel**
-  with the `java` + `integration` jobs (no `needs:`), so it's fast and not a long pole. The
-  **macOS** native image is *not* built on PRs — it runs out-of-band in
-  `.github/workflows/native-image-macos.yml` (push to `main`, a weekly backstop, and
-  `workflow_dispatch`), fully optimized to mirror `release.yml`. So a PR that stays yellow
-  isn't waiting on a macOS native build, and macOS-specific native regressions surface on
-  `main` or the weekly run rather than on the PR.
+- The macOS native image is not built on PRs (only Linux is), so macOS-specific native
+  regressions surface on `main` or the weekly `native-image-macos.yml` run, not on the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,8 +205,11 @@ compile — they have their own visitor implementors:
   proto message usually needs: POJO + visitor wiring + both proto converters + a
   round-trip test, and often `ExpressionCreator` factories and `dsl/SubstraitBuilder`
   helpers for ergonomics.
-- When monitoring PR checks, budget for a long tail: the **macOS `Build Isthmus Native
-  Image`** job is the long pole — it `needs:` the `java` + `integration` jobs (so it
-  starts late), then AOT-compiles for ~15–20 min on a slower macOS runner. A PR staying
-  yellow after the other checks pass usually just means that job is still running, not
-  that it's stuck or failing.
+- When monitoring PR checks: the per-PR native-image job (`Build Isthmus Native Image` in
+  `pr.yml`) builds **Linux only**, uses `--quick-build-native`, and runs **in parallel**
+  with the `java` + `integration` jobs (no `needs:`), so it's fast and not a long pole. The
+  **macOS** native image is *not* built on PRs — it runs out-of-band in
+  `.github/workflows/native-image-macos.yml` (push to `main`, a weekly backstop, and
+  `workflow_dispatch`), fully optimized to mirror `release.yml`. So a PR that stays yellow
+  isn't waiting on a macOS native build, and macOS-specific native regressions surface on
+  `main` or the weekly run rather than on the PR.


### PR DESCRIPTION
## Summary

Trims the AGENTS.md note about monitoring the native-image CI job down to the one durable, non-obvious fact.

The note originally existed to warn contributors/agents that a PR staying yellow was usually just waiting on the slow macOS `Build Isthmus Native Image` long-pole job. #997 removed that long pole — the per-PR native build is now **Linux only**, uses `--quick-build-native`, and runs **in parallel** with the `java`/`integration` jobs. So most of what the note (and my first pass at updating it) described was either the *absence* of a gotcha or detail already spelled out in `pr.yml`.

Per @bestbeforetoday's review feedback — this is guidance loaded into an agent's context every session, so it should earn its keep — I cut it to the single fact that isn't easily discoverable and that changes behavior:

> The macOS native image is not built on PRs (only Linux is), so macOS-specific native regressions surface on `main` or the weekly `native-image-macos.yml` run, not on the PR.

Docs-only; no code or workflow behavior is affected.

🤖 Generated with AI