### PR TITLE
fix(isthmus): support variadic concat conversion

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -521,6 +521,13 @@ public class ExpressionRexConverter
             .collect(Collectors.toList());
 
     RelDataType returnType = typeConverter.toCalcite(typeFactory, expr.outputType());
+    if (operator == SqlStdOperatorTable.CONCAT && args.size() > 2) {
+      return args.stream()
+          .skip(1)
+          .reduce(
+              args.get(0),
+              (left, right) -> rexBuilder.makeCall(returnType, operator, List.of(left, right)));
+    }
     return rexBuilder.makeCall(returnType, operator, args);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -210,6 +211,31 @@ class FunctionConversionTest extends PlanTestBase {
   @Test
   void concatStringLiteralAndChar() throws Exception {
     assertProtoPlanRoundrip("select 'brand_'||P_BRAND from PART");
+  }
+
+  @Test
+  void variadicConcat() {
+    ScalarFunctionInvocation concat =
+        sb.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_STRING,
+            "concat:str",
+            TypeCreator.REQUIRED.STRING,
+            Expression.StrLiteral.builder().value("a").build(),
+            Expression.StrLiteral.builder().value("b").build(),
+            Expression.StrLiteral.builder().value("c").build());
+
+    RexCall outer =
+        assertInstanceOf(
+            RexCall.class, concat.accept(expressionRexConverter, Context.newContext()));
+    assertEquals(SqlStdOperatorTable.CONCAT, outer.getOperator());
+    assertEquals(2, outer.getOperands().size());
+
+    RexCall inner = assertInstanceOf(RexCall.class, outer.getOperands().get(0));
+    assertEquals(SqlStdOperatorTable.CONCAT, inner.getOperator());
+    assertEquals(2, inner.getOperands().size());
+    assertEquals("'a':VARCHAR", inner.getOperands().get(0).toString());
+    assertEquals("'b':VARCHAR", inner.getOperands().get(1).toString());
+    assertEquals("'c':VARCHAR", outer.getOperands().get(1).toString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Convert variadic Substrait `concat` expressions into left-associated binary Calcite calls. This preserves argument order while satisfying Calcite `||` operand-count validation.

Closes #724.

## Changes

- Fold concat calls with more than two arguments into nested binary calls.
- Keep existing two-argument conversion unchanged.
- Add regression coverage for operator shape and operand order.

## Repro

Converting `concat("a", "b", "c")` previously passed three operands to Calcite `||` and failed with `wrong operand count 3 for ||`. It now produces `concat(concat("a", "b"), "c")`.

## Testing

- `./gradlew :isthmus:test --tests io.substrait.isthmus.FunctionConversionTest`
- `./gradlew spotlessApply`
- `./gradlew build --rerun-tasks`

Local `integrationTest` could not start because no Docker daemon is available; GitHub Actions runs that Testcontainers suite.

## Did this cause any problems?

No. Revert this commit to restore previous conversion behavior.