### PR TITLE
feat(core): add TopNRel physical operator

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -38,8 +38,10 @@ import io.substrait.relation.Sort;
 import io.substrait.relation.VirtualTableScan;
 import io.substrait.relation.physical.ComparisonJoinKey;
 import io.substrait.relation.physical.HashJoin;
+import io.substrait.relation.physical.ImmutableTopN;
 import io.substrait.relation.physical.MergeJoin;
 import io.substrait.relation.physical.NestedLoopJoin;
+import io.substrait.relation.physical.TopN;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -881,6 +883,66 @@ public class SubstraitBuilder {
       Rel input) {
     Iterable<? extends Expression.SortField> condition = sortFieldFn.apply(input);
     return Sort.builder().input(input).sortFields(condition).remap(remap).build();
+  }
+
+  /**
+   * Creates a top-N relation that sorts and then returns a limited number of rows, using {@link
+   * TopN.Mode#ROWS_ONLY}.
+   *
+   * @param sortFieldFn function to derive the sort fields from the input relation
+   * @param offset the number of leading rows to skip
+   * @param count the maximum number of rows to return
+   * @param input the input relation
+   * @return a new {@link TopN} relation
+   */
+  public TopN topN(
+      Function<Rel, Iterable<? extends Expression.SortField>> sortFieldFn,
+      long offset,
+      long count,
+      Rel input) {
+    return topN(sortFieldFn, offset, count, TopN.Mode.ROWS_ONLY, Optional.empty(), input);
+  }
+
+  /**
+   * Creates a top-N relation that sorts and then returns a limited number of rows with a specific
+   * tie-handling mode.
+   *
+   * @param sortFieldFn function to derive the sort fields from the input relation
+   * @param offset the number of leading rows to skip
+   * @param count the maximum number of rows to return
+   * @param mode the tie-handling mode
+   * @param input the input relation
+   * @return a new {@link TopN} relation
+   */
+  public TopN topN(
+      Function<Rel, Iterable<? extends Expression.SortField>> sortFieldFn,
+      long offset,
+      long count,
+      TopN.Mode mode,
+      Rel input) {
+    return topN(sortFieldFn, offset, count, mode, Optional.empty(), input);
+  }
+
+  private TopN topN(
+      Function<Rel, Iterable<? extends Expression.SortField>> sortFieldFn,
+      long offset,
+      long count,
+      TopN.Mode mode,
+      Optional<Rel.Remap> remap,
+      Rel input) {
+    Iterable<? extends Expression.SortField> sortFields = sortFieldFn.apply(input);
+    ImmutableTopN.Builder builder =
+        TopN.builder()
+            .input(input)
+            .sortFields(sortFields)
+            .count(i64(count))
+            .mode(mode)
+            .remap(remap);
+    // A null offset is treated as 0, so only emit an offset expression when it is non-zero.
+    if (offset != 0) {
+      builder.offset(i64(offset));
+    }
+    return builder.build();
   }
 
   // Expressions

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -8,6 +8,7 @@ import io.substrait.relation.physical.NestedLoopJoin;
 import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.relation.physical.TopN;
 import io.substrait.util.VisitationContext;
 
 /**
@@ -177,5 +178,10 @@ public abstract class AbstractRelVisitor<O, C extends VisitationContext, E exten
   @Override
   public O visit(RoundRobinExchange exchange, C context) throws E {
     return visitFallback(exchange, context);
+  }
+
+  @Override
+  public O visit(TopN topN, C context) throws E {
+    return visitFallback(topN, context);
   }
 }

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -36,6 +36,7 @@ import io.substrait.proto.ProjectRel;
 import io.substrait.proto.ReadRel;
 import io.substrait.proto.SetRel;
 import io.substrait.proto.SortRel;
+import io.substrait.proto.TopNRel;
 import io.substrait.proto.UpdateRel;
 import io.substrait.proto.WriteRel;
 import io.substrait.relation.extensions.EmptyDetail;
@@ -51,6 +52,7 @@ import io.substrait.relation.physical.ImmutableMultiBucketExchange;
 import io.substrait.relation.physical.ImmutableRoundRobinExchange;
 import io.substrait.relation.physical.ImmutableScatterExchange;
 import io.substrait.relation.physical.ImmutableSingleBucketExchange;
+import io.substrait.relation.physical.ImmutableTopN;
 import io.substrait.relation.physical.MergeJoin;
 import io.substrait.relation.physical.MultiBucketExchange;
 import io.substrait.relation.physical.NestedLoopJoin;
@@ -58,6 +60,7 @@ import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
 import io.substrait.relation.physical.TargetType;
+import io.substrait.relation.physical.TopN;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.proto.ProtoTypeConverter;
@@ -203,6 +206,8 @@ public class ProtoRelConverter {
         return newUpdate(rel.getUpdate());
       case EXCHANGE:
         return newExchange(rel.getExchange());
+      case TOP_N:
+        return newTopN(rel.getTopN());
       default:
         throw new UnsupportedOperationException("Unsupported RelTypeCase of " + relType);
     }
@@ -958,6 +963,41 @@ public class ProtoRelConverter {
                                 .expr(converter.from(field.getExpr()))
                                 .build())
                     .collect(java.util.stream.Collectors.toList()));
+
+    builder
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()));
+    if (rel.hasAdvancedExtension()) {
+      builder.extension(protoExtensionConverter.fromProto(rel.getAdvancedExtension()));
+    }
+    return builder.build();
+  }
+
+  /**
+   * Converts the corresponding protobuf message to its POJO representation.
+   *
+   * @param rel the protobuf value to convert
+   * @return the converted result
+   */
+  protected TopN newTopN(TopNRel rel) {
+    Rel input = from(rel.getInput());
+    ProtoExpressionConverter converter =
+        new ProtoExpressionConverter(lookup, extensions, input.getRecordType(), this);
+    ImmutableTopN.Builder builder =
+        TopN.builder()
+            .input(input)
+            .sortFields(
+                rel.getSortsList().stream()
+                    .map(converter::fromSortField)
+                    .collect(Collectors.toList()))
+            .mode(TopN.Mode.fromProto(rel.getMode()));
+    if (rel.hasOffset()) {
+      builder.offset(converter.from(rel.getOffset()));
+    }
+    if (rel.hasCount()) {
+      builder.count(converter.from(rel.getCount()));
+    }
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -17,6 +17,7 @@ import io.substrait.relation.physical.NestedLoopJoin;
 import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.relation.physical.TopN;
 import io.substrait.util.EmptyVisitationContext;
 import java.util.List;
 import java.util.Optional;
@@ -413,6 +414,27 @@ public class RelCopyOnWriteVisitor<E extends Exception>
             .from(sort)
             .input(input.orElse(sort.getInput()))
             .sortFields(sortFields.orElse(sort.getSortFields()))
+            .build());
+  }
+
+  @Override
+  public Optional<Rel> visit(TopN topN, EmptyVisitationContext context) throws E {
+    Optional<Rel> input = topN.getInput().accept(this, context);
+    Optional<List<Expression.SortField>> sortFields =
+        transformList(topN.getSortFields(), context, this::visitSortField);
+    Optional<Expression> offset = visitOptionalExpression(topN.getOffset(), context);
+    Optional<Expression> count = visitOptionalExpression(topN.getCount(), context);
+
+    if (allEmpty(input, sortFields, offset, count)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        TopN.builder()
+            .from(topN)
+            .input(input.orElse(topN.getInput()))
+            .sortFields(sortFields.orElse(topN.getSortFields()))
+            .offset(or(offset, topN::getOffset))
+            .count(or(count, topN::getCount))
             .build());
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -42,6 +42,7 @@ import io.substrait.proto.RelRoot;
 import io.substrait.proto.SetRel;
 import io.substrait.proto.SortField;
 import io.substrait.proto.SortRel;
+import io.substrait.proto.TopNRel;
 import io.substrait.proto.UpdateRel;
 import io.substrait.proto.WriteRel;
 import io.substrait.relation.files.FileOrFiles;
@@ -56,6 +57,7 @@ import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
 import io.substrait.relation.physical.TargetType;
+import io.substrait.relation.physical.TopN;
 import io.substrait.type.proto.TypeProtoConverter;
 import io.substrait.util.EmptyVisitationContext;
 import java.util.ArrayList;
@@ -854,6 +856,23 @@ public class RelProtoConverter
     sort.getExtension()
         .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
     return Rel.newBuilder().setSort(builder).build();
+  }
+
+  @Override
+  public Rel visit(TopN topN, EmptyVisitationContext context) throws RuntimeException {
+    TopNRel.Builder builder =
+        TopNRel.newBuilder()
+            .setCommon(common(topN))
+            .setInput(toProto(topN.getInput()))
+            .addAllSorts(toProtoS(topN.getSortFields()))
+            .setMode(topN.getMode().toProto());
+
+    topN.getOffset().ifPresent(offset -> builder.setOffset(toProto(offset)));
+    topN.getCount().ifPresent(count -> builder.setCount(toProto(count)));
+
+    topN.getExtension()
+        .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
+    return Rel.newBuilder().setTopN(builder).build();
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -8,6 +8,7 @@ import io.substrait.relation.physical.NestedLoopJoin;
 import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.relation.physical.TopN;
 import io.substrait.util.VisitationContext;
 
 /**
@@ -318,4 +319,14 @@ public interface RelVisitor<O, C extends VisitationContext, E extends Exception>
    * @throws E on visit failure
    */
   O visit(BroadcastExchange exchange, C context) throws E;
+
+  /**
+   * Visit a physical top-N relation.
+   *
+   * @param topN the top-N node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
+  O visit(TopN topN, C context) throws E;
 }

--- a/core/src/main/java/io/substrait/relation/physical/TopN.java
+++ b/core/src/main/java/io/substrait/relation/physical/TopN.java
@@ -1,0 +1,125 @@
+package io.substrait.relation.physical;
+
+import io.substrait.expression.Expression;
+import io.substrait.proto.FetchMode;
+import io.substrait.relation.HasExtension;
+import io.substrait.relation.RelVisitor;
+import io.substrait.relation.SingleInputRel;
+import io.substrait.type.Type;
+import io.substrait.util.VisitationContext;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/**
+ * A physical relation that combines a sort and a fetch, retaining only the number of records
+ * required to produce a limited, ordered output. Optionally supports {@code WITH TIES} semantics
+ * via its {@link Mode}.
+ */
+@Value.Immutable
+public abstract class TopN extends SingleInputRel implements HasExtension {
+
+  /**
+   * Returns the sort fields defining the ordering, applied in order of precedence. At least one
+   * sort field is required.
+   *
+   * @return the sort fields
+   */
+  public abstract List<Expression.SortField> getSortFields();
+
+  /**
+   * Returns the expression evaluating to the number of leading rows to skip. When empty, no rows
+   * are skipped (equivalent to an offset of 0).
+   *
+   * @return the optional offset expression
+   */
+  public abstract Optional<Expression> getOffset();
+
+  /**
+   * Returns the expression evaluating to the maximum number of rows to return. When empty, all
+   * remaining rows are returned.
+   *
+   * @return the optional row count expression
+   */
+  public abstract Optional<Expression> getCount();
+
+  /**
+   * Returns the tie-handling mode for rows tied with the last returned row. Defaults to {@link
+   * Mode#ROWS_ONLY}.
+   *
+   * @return the fetch mode
+   */
+  @Value.Default
+  public Mode getMode() {
+    return Mode.ROWS_ONLY;
+  }
+
+  /**
+   * Determines how a {@link TopN} handles rows tied with the last returned row. Only the modes a
+   * producer may set are represented; an unspecified proto mode is normalized to {@link #ROWS_ONLY}
+   * on conversion (see {@link #fromProto}).
+   */
+  public enum Mode {
+    /** Return only the requested number of rows. */
+    ROWS_ONLY(FetchMode.FETCH_MODE_ROWS_ONLY),
+    /** Include additional rows tied with the last row, per the sort fields. */
+    WITH_TIES(FetchMode.FETCH_MODE_WITH_TIES);
+
+    private final FetchMode proto;
+
+    Mode(FetchMode proto) {
+      this.proto = proto;
+    }
+
+    /**
+     * Returns the protobuf representation of this mode.
+     *
+     * @return the proto fetch mode
+     */
+    public FetchMode toProto() {
+      return proto;
+    }
+
+    /**
+     * Returns the {@link Mode} matching the given protobuf fetch mode. An unspecified proto mode
+     * ({@code FETCH_MODE_UNSPECIFIED}) carries no tie-handling semantics and is normalized to the
+     * spec default, {@link #ROWS_ONLY}.
+     *
+     * @param proto the proto fetch mode
+     * @return the matching mode
+     * @throws IllegalArgumentException if the mode is not recognized
+     */
+    public static Mode fromProto(FetchMode proto) {
+      if (proto == FetchMode.FETCH_MODE_UNSPECIFIED) {
+        return ROWS_ONLY;
+      }
+      for (Mode v : values()) {
+        if (v.proto == proto) {
+          return v;
+        }
+      }
+
+      throw new IllegalArgumentException("Unknown mode: " + proto);
+    }
+  }
+
+  @Override
+  protected Type.Struct deriveRecordType() {
+    return getInput().getRecordType();
+  }
+
+  @Override
+  public <O, C extends VisitationContext, E extends Exception> O accept(
+      RelVisitor<O, C, E> visitor, C context) throws E {
+    return visitor.visit(this, context);
+  }
+
+  /**
+   * Creates a builder for {@link TopN}.
+   *
+   * @return a new builder
+   */
+  public static ImmutableTopN.Builder builder() {
+    return ImmutableTopN.builder();
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/TopNRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/TopNRelRoundtripTest.java
@@ -1,0 +1,163 @@
+package io.substrait.type.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Rel;
+import io.substrait.relation.physical.TopN;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class TopNRelRoundtripTest extends TestBase {
+
+  final Rel baseTable =
+      sb.namedScan(
+          Collections.singletonList("topn_test_table"),
+          Arrays.asList("id", "amount", "name", "category"),
+          Arrays.asList(R.I64, R.FP64, R.STRING, R.STRING));
+
+  private Expression.SortField sortField(int field, Expression.SortDirection direction) {
+    return Expression.SortField.builder()
+        .expr(sb.fieldReference(baseTable, field))
+        .direction(direction)
+        .build();
+  }
+
+  @Test
+  void rowsOnlyWithCount() {
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(sortField(0, Expression.SortDirection.ASC_NULLS_FIRST))
+            .count(sb.i64(10))
+            .build();
+
+    verifyRoundTrip(topN);
+  }
+
+  @Test
+  void offsetAndCount() {
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(sortField(1, Expression.SortDirection.DESC_NULLS_LAST))
+            .offset(sb.i64(5))
+            .count(sb.i64(20))
+            .build();
+
+    verifyRoundTrip(topN);
+  }
+
+  @Test
+  void countAbsentReturnsAll() {
+    // No count set: signals ALL. Offset present.
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(sortField(0, Expression.SortDirection.ASC_NULLS_FIRST))
+            .offset(sb.i64(3))
+            .build();
+
+    verifyRoundTrip(topN);
+  }
+
+  @Test
+  void withTiesMode() {
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(sortField(1, Expression.SortDirection.DESC_NULLS_FIRST))
+            .count(sb.i64(15))
+            .mode(TopN.Mode.WITH_TIES)
+            .build();
+
+    verifyRoundTrip(topN);
+  }
+
+  @Test
+  void defaultModeIsRowsOnly() {
+    // No mode set: defaults to ROWS_ONLY and must round-trip.
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(sortField(2, Expression.SortDirection.ASC_NULLS_LAST))
+            .count(sb.i64(1))
+            .build();
+
+    verifyRoundTrip(topN);
+  }
+
+  @Test
+  void multipleSortFields() {
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(
+                sortField(3, Expression.SortDirection.ASC_NULLS_FIRST),
+                sortField(1, Expression.SortDirection.DESC_NULLS_LAST))
+            .offset(sb.i64(2))
+            .count(sb.i64(8))
+            .mode(TopN.Mode.WITH_TIES)
+            .build();
+
+    verifyRoundTrip(topN);
+  }
+
+  @Test
+  void viaBuilderHelper() {
+    Rel topN =
+        sb.topN(
+            input -> Arrays.asList(sortField(0, Expression.SortDirection.ASC_NULLS_FIRST)),
+            0,
+            5,
+            baseTable);
+
+    verifyRoundTrip(topN);
+  }
+
+  @Test
+  void nestedUnderTopN() {
+    Rel inner =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(sortField(0, Expression.SortDirection.ASC_NULLS_FIRST))
+            .count(sb.i64(100))
+            .build();
+
+    Rel outer =
+        TopN.builder()
+            .input(inner)
+            .addSortFields(
+                Expression.SortField.builder()
+                    .expr(sb.fieldReference(inner, 1))
+                    .direction(Expression.SortDirection.DESC_NULLS_LAST)
+                    .build())
+            .count(sb.i64(10))
+            .build();
+
+    verifyRoundTrip(outer);
+  }
+
+  @Test
+  void unspecifiedProtoModeNormalizesToRowsOnly() {
+    // A producer may leave the mode unset (FETCH_MODE_UNSPECIFIED); the spec defines its default
+    // as ROWS_ONLY, so proto -> POJO conversion surfaces ROWS_ONLY rather than UNSPECIFIED.
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .addSortFields(sortField(0, Expression.SortDirection.ASC_NULLS_FIRST))
+            .count(sb.i64(10))
+            .build();
+
+    io.substrait.proto.Rel proto = relProtoConverter.toProto(topN);
+    io.substrait.proto.Rel unsetMode =
+        proto.toBuilder().setTopN(proto.getTopN().toBuilder().clearMode()).build();
+
+    Rel converted = protoRelConverter.from(unsetMode);
+    assertInstanceOf(TopN.class, converted);
+    assertEquals(TopN.Mode.ROWS_ONLY, ((TopN) converted).getMode());
+  }
+}

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/SubstraitStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/SubstraitStringify.java
@@ -34,6 +34,7 @@ import io.substrait.relation.physical.NestedLoopJoin;
 import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.relation.physical.TopN;
 import io.substrait.type.NamedStruct;
 import io.substrait.util.EmptyVisitationContext;
 import java.util.ArrayList;
@@ -424,6 +425,23 @@ public class SubstraitStringify extends ParentStringify
   public String visit(BroadcastExchange exchange, EmptyVisitationContext context)
       throws RuntimeException {
     StringBuilder sb = getIndent().append("broadcastExchange:: ");
+    return getOutdent(sb);
+  }
+
+  @Override
+  public String visit(TopN topN, EmptyVisitationContext context) throws RuntimeException {
+    StringBuilder sb = getIndent().append("TopN:: ").append(getRemap(topN));
+    topN.getSortFields()
+        .forEach(
+            sf -> {
+              ExpressionStringify expr = new ExpressionStringify(indent);
+              sb.append(sf.expr().accept(expr, context)).append(" ").append(sf.direction());
+            });
+    topN.getInputs()
+        .forEach(
+            i -> {
+              sb.append(i.accept(this, context));
+            });
     return getOutdent(sb);
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlKindFromRel.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlKindFromRel.java
@@ -31,6 +31,7 @@ import io.substrait.relation.physical.NestedLoopJoin;
 import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.relation.physical.TopN;
 import io.substrait.util.EmptyVisitationContext;
 import org.apache.calcite.sql.SqlKind;
 
@@ -263,5 +264,10 @@ public class SqlKindFromRel
   public SqlKind visit(BroadcastExchange exchange, EmptyVisitationContext context)
       throws RuntimeException {
     return SqlKind.OTHER_DDL;
+  }
+
+  @Override
+  public SqlKind visit(TopN topN, EmptyVisitationContext context) throws RuntimeException {
+    return QUERY_KIND;
   }
 }


### PR DESCRIPTION
## What

Adds core support for the `TopNRel` physical relational operator, introduced to the
Substrait spec in [substrait#1009](https://github.com/substrait-io/substrait/pull/1009)
and released in **v0.88.0** (the spec version this repo's submodule pins). `TopNRel`
is a combined sort + fetch operator (`top_n = 23` in the `Rel` oneof) — a genuinely new
relation rather than sugar over the existing `Sort` + `Fetch`, since it uses
**`Expression`-based** offset/count and adds **`WITH TIES`** semantics.

## Changes

- **New POJO** `io.substrait.relation.physical.TopN` (a `SingleInputRel`): `>= 1` sort
  fields, `Optional<Expression>` offset (null → 0) and count (absent → ALL), and a nested
  `Mode` enum (`ROWS_ONLY` / `WITH_TIES`, default `ROWS_ONLY`) that maps to/from the proto
  `FetchMode` via `toProto()` / `fromProto()`.
- **Relation visitor wiring**: `RelVisitor.visit(TopN)`, an `AbstractRelVisitor` fallback
  default, and `RelCopyOnWriteVisitor.visit(TopN)`.
- **Both proto converters**: `RelProtoConverter` (POJO → proto) and `ProtoRelConverter`
  (proto → POJO, including the `TOP_N` dispatch case).
- **DSL helper** `SubstraitBuilder.topN(...)` for ergonomics.
- **Proto round-trip test** `TopNRelRoundtripTest` covering rows-only, offset+count,
  count-absent (ALL), `WITH_TIES`, default mode, multiple sort fields, and nesting.

### Mode normalization

The POJO `Mode` enum models only the two modes a producer may set (`ROWS_ONLY`, `WITH_TIES`). On
proto → POJO conversion, an unset/`FETCH_MODE_UNSPECIFIED` mode is normalized to `ROWS_ONLY`,
which the spec defines as its default — so downstream code never encounters an unspecified mode.
The consequence is that a proto → POJO → proto pass over a plan with an unset mode is not
byte-identical (mode `0` → `1`) but is semantically equivalent — the kind of spec-irrelevant
difference tracked by #994 (semantics-aware plan comparison).

## Scope

Engine mappings for **isthmus (Calcite)** and **Spark** are intentionally **out of scope**:
those integrations map only logical operators today, and neither engine has a native
single top-N node or `WITH TIES` semantics, so how to map this physical operator there is a
separate decision left for a follow-up. To keep the two direct `RelVisitor` implementors
outside `:core` compiling, `SqlKindFromRel` returns `SELECT` for `TopN` and the example
`SubstraitStringify` gains a stringify branch — no behavioral engine mapping is added.

## Testing

`./gradlew clean build` passes: `:core` (PMD, javadoc, spotless, tests incl. the new
round-trip test), `:isthmus`, `:examples:substrait-spark`, and all three Spark variants
(`spark-3.4_2.12`, `spark-3.5_2.12`, `spark-4.0_2.13`).

Closes #806

🤖 Generated with AI
