### PR TITLE
build: replace deprecated Gradle delegated-property APIs

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -78,7 +78,7 @@ signing {
 }
 
 // This allows specifying deps to be shadowed so that they don't get included in the POM file
-val shadowImplementation by configurations.creating
+val shadowImplementation = configurations.create("shadowImplementation")
 
 configurations[JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME].extendsFrom(shadowImplementation)
 
@@ -267,8 +267,8 @@ project.configure<IdeaModel> {
   }
 }
 
-val submodulesUpdate by
-  tasks.registering(Exec::class) {
+val submodulesUpdate =
+  tasks.register<Exec>("submodulesUpdate") {
     group = "Build Setup"
     description = "Updates (and inits) substrait git submodule"
     commandLine = listOf("git", "submodule", "update", "--init", "--recursive")

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -153,7 +153,7 @@ tasks {
 }
 
 // Register a separate task to run integration tests
-val test by testing.suites.existing(JvmTestSuite::class)
+val test = testing.suites.named<JvmTestSuite>("test")
 
 tasks.register<Test>("integrationTest") {
   description = "Run integration tests"


### PR DESCRIPTION
Building locally with Gradle 9.6 surfaces Kotlin deprecation warnings for the delegated-property forms used in the build scripts:

- `val shadowImplementation by configurations.creating`
- `val submodulesUpdate by tasks.registering(Exec::class) { … }`
- `val test by testing.suites.existing(JvmTestSuite::class)`

Gradle 9.6 deprecated these in favor of the direct `create` / `register<T>` / `named<T>` calls (see the Gradle 9.6 upgrading guide). This switches to the recommended forms, which return the same types (`Configuration`, `TaskProvider<Exec>`, `NamedDomainObjectProvider<JvmTestSuite>`), so downstream uses (`extendsFrom`, `dependsOn`, `test.map { … }`) are unchanged.

No functional change — build configuration is verified clean with the warnings gone.

🤖 Generated with AI