### PR TITLE
feat(isthmus)!: preserve aggregate output types and semantics through Calcite

### DIFF
--- a/core/src/main/java/io/substrait/extension/FunctionBindingResolver.java
+++ b/core/src/main/java/io/substrait/extension/FunctionBindingResolver.java
@@ -1,0 +1,586 @@
+package io.substrait.extension;
+
+import io.substrait.expression.FunctionOption;
+import io.substrait.function.NullableType;
+import io.substrait.function.ParameterizedType;
+import io.substrait.function.TypeExpression;
+import io.substrait.type.Type;
+import io.substrait.type.TypeExpressionEvaluator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves an extension function invocation to a {@link ResolvedFunctionBinding} and, on demand,
+ * validates and derives its output type.
+ *
+ * <p>{@link #resolve} only captures identity (anchor, arguments, options); it performs no
+ * validation, so a plan that merely differs from the declaration still resolves. {@link #validate}
+ * (and {@link #resolveAndValidate}) opt into checking the signature (arity, argument kinds and
+ * types), the options and the plan-declared output type against the declaration. {@link
+ * #deriveOutputType} derives the return type; unsupported derivations fail closed (see {@link
+ * TypeExpressionEvaluator}), never falling back to a plan-supplied type.
+ *
+ * <p>Signature type matching is fail-closed. It checks value- and type-argument patterns alike:
+ * wildcards, concrete types and the scalar-parameterized classes (decimal, char, binary, precision
+ * time/timestamp, intervals); a declared shape carrying nested types (lists, maps, structs,
+ * function types) is rejected rather than accepted unchecked. Occurrences of one numbered wildcard
+ * ({@code any1}) must agree on a single type, while each plain {@code any} matches independently; a
+ * variadic declaration repeats its trailing argument, requiring the repetitions to agree only when
+ * its parameters are {@code CONSISTENT} — a literal integer parameter (the {@code 0} of {@code
+ * DECIMAL<P,0>}) constrains every repetition regardless. Enum options and option preferences are
+ * matched case-insensitively; an unspecified enum option is always rejected, since the extension
+ * schema cannot declare an optional one.
+ */
+public final class FunctionBindingResolver {
+
+  private FunctionBindingResolver() {}
+
+  /**
+   * Resolves a function declaration and arguments into a binding, capturing its identity. This
+   * performs no validation against the declaration; see {@link #validate}.
+   *
+   * @param declaration the function declaration
+   * @param arguments the ordered resolved arguments
+   * @param options the function options
+   * @return the resolved binding
+   */
+  public static ResolvedFunctionBinding resolve(
+      SimpleExtension.Function declaration,
+      List<ResolvedArgument> arguments,
+      List<FunctionOption> options) {
+    // Resolving only captures identity; it does not validate. Signature/options/output validation
+    // is a separate, opt-in concern (see #validate), so a plan that merely differs from the
+    // declaration still converts under the default policy.
+    // Options are kept exactly as the plan spelled them, so a binding always reproduces the
+    // invocation it was resolved from.
+    return ResolvedFunctionBinding.builder()
+        .anchor(declaration.getAnchor())
+        .declaration(declaration)
+        .arguments(arguments)
+        .options(options)
+        .build();
+  }
+
+  /**
+   * Resolves a function declaration and validates that the plan-declared output type matches the
+   * derived one.
+   *
+   * @param declaration the function declaration
+   * @param arguments the ordered resolved arguments
+   * @param options the function options
+   * @param declaredOutputType the output type declared by the plan
+   * @return the resolved binding
+   * @throws InvalidFunctionBindingException if the signature, options or output type are invalid
+   */
+  public static ResolvedFunctionBinding resolveAndValidate(
+      SimpleExtension.Function declaration,
+      List<ResolvedArgument> arguments,
+      List<FunctionOption> options,
+      Type declaredOutputType) {
+    ResolvedFunctionBinding binding = resolve(declaration, arguments, options);
+    validate(binding, declaredOutputType);
+    return binding;
+  }
+
+  /**
+   * Validates a resolved binding against its extension declaration: the signature (arity, argument
+   * kinds and types), the options, and — against the given plan-declared type — the output type.
+   * This is the opt-in extension-declaration check, separate from resolving the binding.
+   *
+   * @param binding the resolved binding
+   * @param declaredOutputType the output type declared by the plan
+   * @throws InvalidFunctionBindingException if the binding is inconsistent with the declaration
+   */
+  public static void validate(ResolvedFunctionBinding binding, Type declaredOutputType) {
+    validateSignature(binding.declaration(), binding.arguments());
+    validateOptions(binding.declaration(), binding.options());
+    validateOutputType(binding, declaredOutputType);
+  }
+
+  /**
+   * Validates a resolved aggregate binding against its extension declaration. Identical to {@link
+   * #validate(ResolvedFunctionBinding, Type)} except that the type a partial aggregate produces is
+   * its declaration's intermediate type rather than its return type, which {@link
+   * ResolvedAggregateBinding#outputType()} selects by phase.
+   *
+   * @param binding the resolved aggregate binding
+   * @param declaredOutputType the output type declared by the plan
+   * @throws InvalidFunctionBindingException if the binding is inconsistent with the declaration
+   */
+  public static void validate(ResolvedAggregateBinding binding, Type declaredOutputType) {
+    validateAggregate(binding);
+    if (!binding.outputType().equals(declaredOutputType)) {
+      throw InvalidFunctionBindingException.outputTypeMismatch(
+          binding.function().anchor(), declaredOutputType, binding.outputType());
+    }
+  }
+
+  /**
+   * Reports whether a resolved aggregate binding is consistent with its declaration — its signature
+   * (as its phase defines it) and its options — without comparing any plan-declared output type and
+   * without throwing. Note that consistency is not the same question as "does this binding still
+   * describe that invocation": a phase whose state is parameterized by the initial arguments cannot
+   * be re-validated from the state alone, so comparing the recorded arguments answers that better.
+   *
+   * @param binding the resolved aggregate binding
+   * @return {@code true} if the binding satisfies its declaration
+   */
+  public static boolean matchesDeclaration(ResolvedAggregateBinding binding) {
+    try {
+      validateAggregate(binding);
+      return true;
+    } catch (InvalidFunctionBindingException e) {
+      return false;
+    }
+  }
+
+  private static void validateAggregate(ResolvedAggregateBinding binding) {
+    ResolvedFunctionBinding function = binding.function();
+    if (binding.consumesIntermediateState()) {
+      validateIntermediateSignature(binding);
+    } else {
+      validateSignature(function.declaration(), function.arguments());
+    }
+    validateOptions(function.declaration(), function.options());
+  }
+
+  /**
+   * Validates the signature of a phase that consumes an intermediate state: by contract its single
+   * argument is the declaration's intermediate value, not one of its declared arguments, and only a
+   * decomposable declaration has such a state at all.
+   */
+  private static void validateIntermediateSignature(ResolvedAggregateBinding binding) {
+    ResolvedFunctionBinding function = binding.function();
+    SimpleExtension.Function declaration = function.declaration();
+    if (!(declaration instanceof SimpleExtension.AggregateFunctionVariant)) {
+      throw new InvalidFunctionBindingException(
+          String.format("%s is not an aggregate declaration", function.anchor()));
+    }
+    List<ResolvedArgument> arguments = function.arguments();
+    if (arguments.size() != 1) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s in phase %s takes a single intermediate-state argument but got %d",
+              function.anchor(), binding.phase(), arguments.size()));
+    }
+    ResolvedArgument state = arguments.get(0);
+    if (state.kind() != ResolvedArgument.Kind.VALUE) {
+      // The state is a value the previous phase produced. A type or enum argument in its place
+      // would carry no operand at all, and conversion drops it silently.
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s in phase %s takes its intermediate state as a value argument but got %s",
+              function.anchor(), binding.phase(), state.kind()));
+    }
+    Type intermediate =
+        deriveIntermediateType(
+            (SimpleExtension.AggregateFunctionVariant) declaration, function.arguments());
+    Type stateType = state.type().orElseThrow(IllegalStateException::new);
+    if (!stateType.equals(intermediate)) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s in phase %s takes its intermediate state %s but got %s",
+              function.anchor(), binding.phase(), intermediate, stateType));
+    }
+  }
+
+  /**
+   * Validates that a plan-declared output type exactly matches the type derived from the binding's
+   * declaration.
+   *
+   * @param binding the resolved binding
+   * @param declaredOutputType the output type declared by the plan
+   * @throws InvalidFunctionBindingException if the declared type differs from the derived type
+   */
+  public static void validateOutputType(ResolvedFunctionBinding binding, Type declaredOutputType) {
+    if (!binding.outputType().equals(declaredOutputType)) {
+      throw InvalidFunctionBindingException.outputTypeMismatch(
+          binding.anchor(), declaredOutputType, binding.outputType());
+    }
+  }
+
+  /**
+   * Derives the output type of a function from its declaration and arguments, applying the
+   * declaration's nullability policy.
+   *
+   * @param declaration the function declaration
+   * @param arguments the ordered resolved arguments
+   * @return the derived output type
+   */
+  public static Type deriveOutputType(
+      SimpleExtension.Function declaration, List<ResolvedArgument> arguments) {
+    // SimpleExtension.Function.resolveType is the production derivation: it evaluates the return
+    // expression and applies the declaration's nullability policy. This only adds the uniform
+    // binding-error wrapping.
+    try {
+      return declaration.resolveType(valueAndTypeArgumentTypes(arguments));
+    } catch (UnsupportedOperationException e) {
+      throw new InvalidFunctionBindingException(
+          String.format("Cannot derive type for %s: %s", declaration.getAnchor(), e.getMessage()),
+          e);
+    }
+  }
+
+  /**
+   * Derives the intermediate type of a decomposable aggregate — the type its partial phases produce
+   * — from its declaration and arguments, applying the declaration's nullability policy.
+   *
+   * <p>The type parameters are bound from the given arguments, so an intermediate expression that
+   * refers to a parameter of the <em>initial</em> arguments cannot be derived from a phase that
+   * only sees the intermediate value; that fails closed rather than guessing.
+   *
+   * @param declaration the aggregate function declaration
+   * @param arguments the ordered resolved arguments
+   * @return the derived intermediate type
+   * @throws InvalidFunctionBindingException if the declaration is not decomposable or its
+   *     intermediate expression cannot be derived
+   */
+  public static Type deriveIntermediateType(
+      SimpleExtension.AggregateFunctionVariant declaration, List<ResolvedArgument> arguments) {
+    TypeExpression intermediate = declaration.intermediate();
+    if (declaration.decomposability() == SimpleExtension.Decomposability.NONE
+        || intermediate == null) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s is not decomposable and has no intermediate state", declaration.getAnchor()));
+    }
+    return derive(intermediate, declaration, arguments);
+  }
+
+  private static Type derive(
+      TypeExpression expression,
+      SimpleExtension.Function declaration,
+      List<ResolvedArgument> arguments) {
+    List<Type> valueTypes = valueAndTypeArgumentTypes(arguments);
+    Type base;
+    try {
+      base =
+          TypeExpressionEvaluator.evaluateExpression(
+              expression, declaration.args(), declaration.variadic(), valueTypes);
+    } catch (UnsupportedOperationException e) {
+      // Surface unresolved/inconsistent type expressions as a binding error rather than an
+      // unchecked "not implemented" exception, so callers can handle them uniformly.
+      throw new InvalidFunctionBindingException(
+          String.format("Cannot derive type for %s: %s", declaration.getAnchor(), e.getMessage()),
+          e);
+    }
+    if (declaration.nullability() == SimpleExtension.Nullability.MIRROR) {
+      // MIRROR: the output is nullable iff any value argument is nullable.
+      return base.withNullable(anyValueArgumentNullable(arguments));
+    }
+    // DECLARED_OUTPUT / DISCRETE: the declared type's nullability is authoritative.
+    return base;
+  }
+
+  private static List<Type> valueAndTypeArgumentTypes(List<ResolvedArgument> arguments) {
+    List<Type> types = new ArrayList<>();
+    for (ResolvedArgument argument : arguments) {
+      if (argument.kind() != ResolvedArgument.Kind.ENUM) {
+        argument.type().ifPresent(types::add);
+      }
+    }
+    return types;
+  }
+
+  private static boolean anyValueArgumentNullable(List<ResolvedArgument> arguments) {
+    for (ResolvedArgument argument : arguments) {
+      if (argument.kind() == ResolvedArgument.Kind.VALUE
+          && argument.type().map(Type::nullable).orElse(false)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void validateSignature(
+      SimpleExtension.Function declaration, List<ResolvedArgument> arguments) {
+    List<SimpleExtension.Argument> declared = declaration.args();
+    // getRange() already accounts for variadic min/max and required arguments.
+    if (!declaration.getRange().within(arguments.size())) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s does not accept %d argument(s)", declaration.getAnchor(), arguments.size()));
+    }
+    if (declared.isEmpty()) {
+      return;
+    }
+    boolean discrete = declaration.nullability() == SimpleExtension.Nullability.DISCRETE;
+    // A variadic declaration whose parameters are INCONSISTENT repeats its trailing argument
+    // without requiring the repetitions to agree with each other.
+    boolean bindRepeats =
+        declaration
+            .variadic()
+            .map(
+                behavior ->
+                    behavior.parameterConsistency()
+                        == SimpleExtension.VariadicBehavior.ParameterConsistency.CONSISTENT)
+            .orElse(false);
+    Map<String, Type> wildcardBindings = new HashMap<>();
+    for (int i = 0; i < arguments.size(); i++) {
+      // For variadic functions the trailing declared argument repeats.
+      SimpleExtension.Argument declaredArgument = declared.get(Math.min(i, declared.size() - 1));
+      boolean repeated = i >= declared.size();
+      checkArgument(
+          declaration,
+          i,
+          declaredArgument,
+          arguments.get(i),
+          discrete,
+          !repeated || bindRepeats,
+          wildcardBindings);
+    }
+  }
+
+  private static void checkArgument(
+      SimpleExtension.Function declaration,
+      int index,
+      SimpleExtension.Argument declared,
+      ResolvedArgument actual,
+      boolean discrete,
+      boolean bindWildcards,
+      Map<String, Type> wildcardBindings) {
+    if (declared instanceof SimpleExtension.ValueArgument) {
+      requireKind(declaration, index, ResolvedArgument.Kind.VALUE, actual);
+      checkArgumentType(
+          declaration,
+          index,
+          ((SimpleExtension.ValueArgument) declared).value(),
+          actual,
+          discrete,
+          bindWildcards,
+          wildcardBindings);
+    } else if (declared instanceof SimpleExtension.TypeArgument) {
+      requireKind(declaration, index, ResolvedArgument.Kind.TYPE, actual);
+      // The declared pattern constrains the supplied type just as a value argument's does, and a
+      // numbered wildcard inside it participates in the same cross-argument consistency.
+      checkArgumentType(
+          declaration,
+          index,
+          ((SimpleExtension.TypeArgument) declared).type(),
+          actual,
+          discrete,
+          bindWildcards,
+          wildcardBindings);
+    } else if (declared instanceof SimpleExtension.EnumArgument) {
+      requireKind(declaration, index, ResolvedArgument.Kind.ENUM, actual);
+      checkEnumOption(declaration, index, (SimpleExtension.EnumArgument) declared, actual);
+    }
+  }
+
+  private static void checkArgumentType(
+      SimpleExtension.Function declaration,
+      int index,
+      ParameterizedType declaredType,
+      ResolvedArgument actual,
+      boolean discrete,
+      boolean bindWildcards,
+      Map<String, Type> wildcardBindings) {
+    Type actualType = actual.type().orElseThrow(IllegalStateException::new);
+    if (declaredType instanceof ParameterizedType.StringLiteral
+        && ((ParameterizedType.StringLiteral) declaredType).isWildcard()) {
+      checkWildcardArgument(
+          declaration,
+          index,
+          (ParameterizedType.StringLiteral) declaredType,
+          actualType,
+          discrete,
+          bindWildcards,
+          wildcardBindings);
+    } else if (!typeMatches(declaredType, actualType, discrete)) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: type %s is not compatible with declared %s",
+              declaration.getAnchor(), index, actualType, declaredType));
+    }
+  }
+
+  private static void checkWildcardArgument(
+      SimpleExtension.Function declaration,
+      int index,
+      ParameterizedType.StringLiteral declared,
+      Type actualType,
+      boolean discrete,
+      boolean bindWildcards,
+      Map<String, Type> wildcardBindings) {
+    if (discrete && declared.nullable() != actualType.nullable()) {
+      // Under DISCRETE the declared nullability is part of the signature, wildcards included.
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: type %s is not compatible with declared %s",
+              declaration.getAnchor(), index, actualType, declared.value()));
+    }
+    if (!declared.isNumberedWildcard() || !bindWildcards) {
+      // A plain "any" matches each argument independently; only a numbered wildcard (any1) has to
+      // bind to a single type across the invocation.
+      return;
+    }
+    String name = declared.value();
+    Type existing = wildcardBindings.putIfAbsent(name, actualType);
+    if (existing != null && !existing.equalsIgnoringNullability(actualType)) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: wildcard '%s' is bound to both %s and %s",
+              declaration.getAnchor(), index, name, existing, actualType));
+    }
+  }
+
+  private static void checkEnumOption(
+      SimpleExtension.Function declaration,
+      int index,
+      SimpleExtension.EnumArgument declared,
+      ResolvedArgument actual) {
+    Optional<String> option = actual.enumValue();
+    if (!option.isPresent()) {
+      // The proto can spell an unspecified enum argument, but the extension schema cannot declare
+      // an optional one — every declared enum argument requires an option — so an unspecified
+      // option never satisfies a declaration.
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: enum option is required but was left unspecified (expected one of"
+                  + " %s)",
+              declaration.getAnchor(), index, declared.options()));
+    }
+    // Substrait matches enum option symbols case-insensitively.
+    for (String allowed : declared.options()) {
+      if (allowed.equalsIgnoreCase(option.get())) {
+        return;
+      }
+    }
+    throw new InvalidFunctionBindingException(
+        String.format(
+            "%s argument %d: enum option '%s' is not one of %s",
+            declaration.getAnchor(), index, option.get(), declared.options()));
+  }
+
+  private static void requireKind(
+      SimpleExtension.Function declaration,
+      int index,
+      ResolvedArgument.Kind expected,
+      ResolvedArgument actual) {
+    if (actual.kind() != expected) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: expected %s argument but got %s",
+              declaration.getAnchor(), index, expected, actual.kind()));
+    }
+  }
+
+  private static boolean typeMatches(
+      ParameterizedType declared, Type actual, boolean exactNullability) {
+    if (declared instanceof ParameterizedType.StringLiteral) {
+      // Non-wildcard extension parameter names at the top level are accepted; numbered wildcards
+      // are handled by the caller for cross-argument consistency.
+      return true;
+    }
+    if (declared instanceof Type) {
+      // A concrete declared argument type (e.g. i32) matches ignoring nullability, except under a
+      // DISCRETE declaration where argument nullability is part of the signature.
+      return exactNullability
+          ? actual.equals(declared)
+          : actual.equalsIgnoringNullability((Type) declared);
+    }
+    if (declared instanceof ParameterizedType.Decimal) {
+      return actual instanceof Type.Decimal
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.FixedChar) {
+      return actual instanceof Type.FixedChar
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.VarChar) {
+      return actual instanceof Type.VarChar
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.FixedBinary) {
+      return actual instanceof Type.FixedBinary
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.PrecisionTimestamp) {
+      return actual instanceof Type.PrecisionTimestamp
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.PrecisionTimestampTZ) {
+      return actual instanceof Type.PrecisionTimestampTZ
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.PrecisionTime) {
+      return actual instanceof Type.PrecisionTime
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.IntervalDay) {
+      return actual instanceof Type.IntervalDay
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.IntervalCompound) {
+      return actual instanceof Type.IntervalCompound
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    // The remaining declared shapes — lists, maps, structs and function types — carry nested types
+    // this validator cannot yet check structurally, and the spec requires nested structure and
+    // nullability to match exactly: h(list<any1>, list<any1>) invoked as h(list<i32>, list<i32?>)
+    // must not bind (spec v0.99.0, scalar binding rules). A validator that advertises strictness
+    // must fail closed on a shape it cannot judge rather than silently accept it.
+    throw new InvalidFunctionBindingException(
+        String.format("Validation of the declared argument shape %s is not supported", declared));
+  }
+
+  /**
+   * Under a DISCRETE declaration the declared nullability is part of the signature, for a
+   * parameterized argument as much as for a concrete one. A declared shape that carries no
+   * nullability of its own has nothing to compare, so it is accepted.
+   */
+  private static boolean nullabilityMatches(
+      ParameterizedType declared, Type actual, boolean exactNullability) {
+    if (!exactNullability || !(declared instanceof NullableType)) {
+      return true;
+    }
+    return ((NullableType) declared).nullable() == actual.nullable();
+  }
+
+  private static void validateOptions(
+      SimpleExtension.Function declaration, List<FunctionOption> options) {
+    // A binding keeps option names and values exactly as the plan spelled them, so lower-case both
+    // sides here: the Substrait spec matches options case-insensitively.
+    Map<String, List<String>> declaredOptions = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleExtension.Option> entry : declaration.options().entrySet()) {
+      List<String> values = new ArrayList<>();
+      for (String value : entry.getValue().getValues()) {
+        values.add(value.toLowerCase(Locale.ROOT));
+      }
+      if (declaredOptions.putIfAbsent(entry.getKey().toLowerCase(Locale.ROOT), values) != null) {
+        // Option names match case-insensitively, so a declaration whose option names differ only
+        // in case is ambiguous; reject it instead of silently letting one shadow the other.
+        throw new InvalidFunctionBindingException(
+            String.format(
+                "%s declares options whose names differ only in case ('%s')",
+                declaration.getAnchor(), entry.getKey()));
+      }
+    }
+    for (FunctionOption option : options) {
+      String name = option.getName().toLowerCase(Locale.ROOT);
+      List<String> allowed = declaredOptions.get(name);
+      if (allowed == null) {
+        throw new InvalidFunctionBindingException(
+            String.format("%s has no option named '%s'", declaration.getAnchor(), name));
+      }
+      if (option.values().isEmpty()) {
+        throw new InvalidFunctionBindingException(
+            String.format(
+                "%s option '%s' has an empty preference list", declaration.getAnchor(), name));
+      }
+      for (String value : option.values()) {
+        if (!allowed.contains(value.toLowerCase(Locale.ROOT))) {
+          throw new InvalidFunctionBindingException(
+              String.format(
+                  "%s option '%s' value '%s' is not one of %s",
+                  declaration.getAnchor(), name, value, allowed));
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/substrait/extension/FunctionBindingResolver.java
+++ b/core/src/main/java/io/substrait/extension/FunctionBindingResolver.java
@@ -1,0 +1,524 @@
+package io.substrait.extension;
+
+import io.substrait.expression.FunctionOption;
+import io.substrait.function.NullableType;
+import io.substrait.function.ParameterizedType;
+import io.substrait.function.TypeExpression;
+import io.substrait.type.Type;
+import io.substrait.type.TypeExpressionEvaluator;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves an extension function invocation to a {@link ResolvedFunctionBinding} and, on demand,
+ * validates and derives its output type.
+ *
+ * <p>{@link #resolve} only captures identity (anchor, arguments, options); it performs no
+ * validation, so a plan that merely differs from the declaration still resolves. {@link #validate}
+ * (and {@link #resolveAndValidate}) opt into checking the signature (arity, argument kinds and
+ * types), the options and the plan-declared output type against the declaration. {@link
+ * #deriveOutputType} derives the return type; unsupported derivations fail closed (see {@link
+ * TypeExpressionEvaluator}), never falling back to a plan-supplied type.
+ *
+ * <p>Signature type matching covers value-argument kinds, wildcards and the common
+ * concrete/decimal/char/binary type classes; other parameterized argument shapes are accepted
+ * without deep structural checking. Occurrences of one numbered wildcard ({@code any1}) must agree
+ * on a single type, while each plain {@code any} matches independently; a variadic declaration
+ * repeats its trailing argument, and only requires the repetitions to agree when its parameters are
+ * {@code CONSISTENT}. Enum options and option preferences are matched case-insensitively; an
+ * unspecified enum option is rejected only where the declaration requires one.
+ */
+public final class FunctionBindingResolver {
+
+  private FunctionBindingResolver() {}
+
+  /**
+   * Resolves a function declaration and arguments into a binding, capturing its identity. This
+   * performs no validation against the declaration; see {@link #validate}.
+   *
+   * @param declaration the function declaration
+   * @param arguments the ordered resolved arguments
+   * @param options the function options
+   * @return the resolved binding
+   */
+  public static ResolvedFunctionBinding resolve(
+      SimpleExtension.Function declaration,
+      List<ResolvedArgument> arguments,
+      List<FunctionOption> options) {
+    // Resolving only captures identity; it does not validate. Signature/options/output validation
+    // is a separate, opt-in concern (see #validate), so a plan that merely differs from the
+    // declaration still converts under the default policy.
+    // Options are kept exactly as the plan spelled them, so a binding always reproduces the
+    // invocation it was resolved from.
+    return ResolvedFunctionBinding.builder()
+        .anchor(declaration.getAnchor())
+        .declaration(declaration)
+        .arguments(arguments)
+        .options(options)
+        .build();
+  }
+
+  /**
+   * Resolves a function declaration and validates that the plan-declared output type matches the
+   * derived one.
+   *
+   * @param declaration the function declaration
+   * @param arguments the ordered resolved arguments
+   * @param options the function options
+   * @param declaredOutputType the output type declared by the plan
+   * @return the resolved binding
+   * @throws InvalidFunctionBindingException if the signature, options or output type are invalid
+   */
+  public static ResolvedFunctionBinding resolveAndValidate(
+      SimpleExtension.Function declaration,
+      List<ResolvedArgument> arguments,
+      List<FunctionOption> options,
+      Type declaredOutputType) {
+    ResolvedFunctionBinding binding = resolve(declaration, arguments, options);
+    validate(binding, declaredOutputType);
+    return binding;
+  }
+
+  /**
+   * Validates a resolved binding against its extension declaration: the signature (arity, argument
+   * kinds and types), the options, and — against the given plan-declared type — the output type.
+   * This is the opt-in extension-declaration check, separate from resolving the binding.
+   *
+   * @param binding the resolved binding
+   * @param declaredOutputType the output type declared by the plan
+   * @throws InvalidFunctionBindingException if the binding is inconsistent with the declaration
+   */
+  public static void validate(ResolvedFunctionBinding binding, Type declaredOutputType) {
+    validateSignature(binding.declaration(), binding.arguments());
+    validateOptions(binding.declaration(), binding.options());
+    validateOutputType(binding, declaredOutputType);
+  }
+
+  /**
+   * Validates a resolved aggregate binding against its extension declaration. Identical to {@link
+   * #validate(ResolvedFunctionBinding, Type)} except that the type a partial aggregate produces is
+   * its declaration's intermediate type rather than its return type, which {@link
+   * ResolvedAggregateBinding#outputType()} selects by phase.
+   *
+   * @param binding the resolved aggregate binding
+   * @param declaredOutputType the output type declared by the plan
+   * @throws InvalidFunctionBindingException if the binding is inconsistent with the declaration
+   */
+  public static void validate(ResolvedAggregateBinding binding, Type declaredOutputType) {
+    validateAggregate(binding);
+    if (!binding.outputType().equals(declaredOutputType)) {
+      throw InvalidFunctionBindingException.outputTypeMismatch(
+          binding.function().anchor(), declaredOutputType, binding.outputType());
+    }
+  }
+
+  /**
+   * Reports whether a resolved aggregate binding is consistent with its declaration — its signature
+   * (as its phase defines it) and its options — without comparing any plan-declared output type and
+   * without throwing. Note that consistency is not the same question as "does this binding still
+   * describe that invocation": a phase whose state is parameterized by the initial arguments cannot
+   * be re-validated from the state alone, so comparing the recorded arguments answers that better.
+   *
+   * @param binding the resolved aggregate binding
+   * @return {@code true} if the binding satisfies its declaration
+   */
+  public static boolean matchesDeclaration(ResolvedAggregateBinding binding) {
+    try {
+      validateAggregate(binding);
+      return true;
+    } catch (InvalidFunctionBindingException e) {
+      return false;
+    }
+  }
+
+  private static void validateAggregate(ResolvedAggregateBinding binding) {
+    ResolvedFunctionBinding function = binding.function();
+    if (binding.consumesIntermediateState()) {
+      validateIntermediateSignature(binding);
+    } else {
+      validateSignature(function.declaration(), function.arguments());
+    }
+    validateOptions(function.declaration(), function.options());
+  }
+
+  /**
+   * Validates the signature of a phase that consumes an intermediate state: by contract its single
+   * argument is the declaration's intermediate value, not one of its declared arguments, and only a
+   * decomposable declaration has such a state at all.
+   */
+  private static void validateIntermediateSignature(ResolvedAggregateBinding binding) {
+    ResolvedFunctionBinding function = binding.function();
+    SimpleExtension.Function declaration = function.declaration();
+    if (!(declaration instanceof SimpleExtension.AggregateFunctionVariant)) {
+      throw new InvalidFunctionBindingException(
+          String.format("%s is not an aggregate declaration", function.anchor()));
+    }
+    List<ResolvedArgument> arguments = function.arguments();
+    if (arguments.size() != 1) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s in phase %s takes a single intermediate-state argument but got %d",
+              function.anchor(), binding.phase(), arguments.size()));
+    }
+    ResolvedArgument state = arguments.get(0);
+    if (state.kind() != ResolvedArgument.Kind.VALUE) {
+      // The state is a value the previous phase produced. A type or enum argument in its place
+      // would carry no operand at all, and conversion drops it silently.
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s in phase %s takes its intermediate state as a value argument but got %s",
+              function.anchor(), binding.phase(), state.kind()));
+    }
+    Type intermediate =
+        deriveIntermediateType(
+            (SimpleExtension.AggregateFunctionVariant) declaration, function.arguments());
+    Type stateType = state.type().orElseThrow(IllegalStateException::new);
+    if (!stateType.equals(intermediate)) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s in phase %s takes its intermediate state %s but got %s",
+              function.anchor(), binding.phase(), intermediate, stateType));
+    }
+  }
+
+  /**
+   * Validates that a plan-declared output type exactly matches the type derived from the binding's
+   * declaration.
+   *
+   * @param binding the resolved binding
+   * @param declaredOutputType the output type declared by the plan
+   * @throws InvalidFunctionBindingException if the declared type differs from the derived type
+   */
+  public static void validateOutputType(ResolvedFunctionBinding binding, Type declaredOutputType) {
+    if (!binding.outputType().equals(declaredOutputType)) {
+      throw InvalidFunctionBindingException.outputTypeMismatch(
+          binding.anchor(), declaredOutputType, binding.outputType());
+    }
+  }
+
+  /**
+   * Derives the output type of a function from its declaration and arguments, applying the
+   * declaration's nullability policy.
+   *
+   * @param declaration the function declaration
+   * @param arguments the ordered resolved arguments
+   * @return the derived output type
+   */
+  public static Type deriveOutputType(
+      SimpleExtension.Function declaration, List<ResolvedArgument> arguments) {
+    return derive(declaration.returnType(), declaration, arguments);
+  }
+
+  /**
+   * Derives the intermediate type of a decomposable aggregate — the type its partial phases produce
+   * — from its declaration and arguments, applying the declaration's nullability policy.
+   *
+   * <p>The type parameters are bound from the given arguments, so an intermediate expression that
+   * refers to a parameter of the <em>initial</em> arguments cannot be derived from a phase that
+   * only sees the intermediate value; that fails closed rather than guessing.
+   *
+   * @param declaration the aggregate function declaration
+   * @param arguments the ordered resolved arguments
+   * @return the derived intermediate type
+   * @throws InvalidFunctionBindingException if the declaration is not decomposable or its
+   *     intermediate expression cannot be derived
+   */
+  public static Type deriveIntermediateType(
+      SimpleExtension.AggregateFunctionVariant declaration, List<ResolvedArgument> arguments) {
+    TypeExpression intermediate = declaration.intermediate();
+    if (declaration.decomposability() == SimpleExtension.Decomposability.NONE
+        || intermediate == null) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s is not decomposable and has no intermediate state", declaration.getAnchor()));
+    }
+    return derive(intermediate, declaration, arguments);
+  }
+
+  private static Type derive(
+      TypeExpression expression,
+      SimpleExtension.Function declaration,
+      List<ResolvedArgument> arguments) {
+    List<Type> valueTypes = valueAndTypeArgumentTypes(arguments);
+    Type base;
+    try {
+      base =
+          TypeExpressionEvaluator.evaluateExpression(
+              expression, declaration.args(), declaration.variadic(), valueTypes);
+    } catch (UnsupportedOperationException e) {
+      // Surface unresolved/inconsistent type expressions as a binding error rather than an
+      // unchecked "not implemented" exception, so callers can handle them uniformly.
+      throw new InvalidFunctionBindingException(
+          String.format("Cannot derive type for %s: %s", declaration.getAnchor(), e.getMessage()));
+    }
+    if (declaration.nullability() == SimpleExtension.Nullability.MIRROR) {
+      // MIRROR: the output is nullable iff any value argument is nullable.
+      return base.withNullable(anyValueArgumentNullable(arguments));
+    }
+    // DECLARED_OUTPUT / DISCRETE: the declared type's nullability is authoritative.
+    return base;
+  }
+
+  private static List<Type> valueAndTypeArgumentTypes(List<ResolvedArgument> arguments) {
+    List<Type> types = new ArrayList<>();
+    for (ResolvedArgument argument : arguments) {
+      if (argument.kind() != ResolvedArgument.Kind.ENUM) {
+        argument.type().ifPresent(types::add);
+      }
+    }
+    return types;
+  }
+
+  private static boolean anyValueArgumentNullable(List<ResolvedArgument> arguments) {
+    for (ResolvedArgument argument : arguments) {
+      if (argument.kind() == ResolvedArgument.Kind.VALUE
+          && argument.type().map(Type::nullable).orElse(false)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void validateSignature(
+      SimpleExtension.Function declaration, List<ResolvedArgument> arguments) {
+    List<SimpleExtension.Argument> declared = declaration.args();
+    // getRange() already accounts for variadic min/max and required arguments.
+    if (!declaration.getRange().within(arguments.size())) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s does not accept %d argument(s)", declaration.getAnchor(), arguments.size()));
+    }
+    if (declared.isEmpty()) {
+      return;
+    }
+    boolean discrete = declaration.nullability() == SimpleExtension.Nullability.DISCRETE;
+    // A variadic declaration whose parameters are INCONSISTENT repeats its trailing argument
+    // without requiring the repetitions to agree with each other.
+    boolean bindRepeats =
+        declaration
+            .variadic()
+            .map(
+                behavior ->
+                    behavior.parameterConsistency()
+                        == SimpleExtension.VariadicBehavior.ParameterConsistency.CONSISTENT)
+            .orElse(false);
+    Map<String, Type> wildcardBindings = new HashMap<>();
+    for (int i = 0; i < arguments.size(); i++) {
+      // For variadic functions the trailing declared argument repeats.
+      SimpleExtension.Argument declaredArgument = declared.get(Math.min(i, declared.size() - 1));
+      boolean repeated = i >= declared.size();
+      checkArgument(
+          declaration,
+          i,
+          declaredArgument,
+          arguments.get(i),
+          discrete,
+          !repeated || bindRepeats,
+          wildcardBindings);
+    }
+  }
+
+  private static void checkArgument(
+      SimpleExtension.Function declaration,
+      int index,
+      SimpleExtension.Argument declared,
+      ResolvedArgument actual,
+      boolean discrete,
+      boolean bindWildcards,
+      Map<String, Type> wildcardBindings) {
+    if (declared instanceof SimpleExtension.ValueArgument) {
+      requireKind(declaration, index, ResolvedArgument.Kind.VALUE, actual);
+      Type actualType = actual.type().orElseThrow(IllegalStateException::new);
+      ParameterizedType declaredType = ((SimpleExtension.ValueArgument) declared).value();
+      if (declaredType instanceof ParameterizedType.StringLiteral
+          && ((ParameterizedType.StringLiteral) declaredType).isWildcard()) {
+        checkWildcardArgument(
+            declaration,
+            index,
+            (ParameterizedType.StringLiteral) declaredType,
+            actualType,
+            discrete,
+            bindWildcards,
+            wildcardBindings);
+      } else if (!typeMatches(declaredType, actualType, discrete)) {
+        throw new InvalidFunctionBindingException(
+            String.format(
+                "%s argument %d: type %s is not compatible with declared %s",
+                declaration.getAnchor(), index, actualType, declared.toTypeString()));
+      }
+    } else if (declared instanceof SimpleExtension.TypeArgument) {
+      requireKind(declaration, index, ResolvedArgument.Kind.TYPE, actual);
+    } else if (declared instanceof SimpleExtension.EnumArgument) {
+      requireKind(declaration, index, ResolvedArgument.Kind.ENUM, actual);
+      checkEnumOption(declaration, index, (SimpleExtension.EnumArgument) declared, actual);
+    }
+  }
+
+  private static void checkWildcardArgument(
+      SimpleExtension.Function declaration,
+      int index,
+      ParameterizedType.StringLiteral declared,
+      Type actualType,
+      boolean discrete,
+      boolean bindWildcards,
+      Map<String, Type> wildcardBindings) {
+    if (discrete && declared.nullable() != actualType.nullable()) {
+      // Under DISCRETE the declared nullability is part of the signature, wildcards included.
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: type %s is not compatible with declared %s",
+              declaration.getAnchor(), index, actualType, declared.value()));
+    }
+    if (!declared.isNumberedWildcard() || !bindWildcards) {
+      // A plain "any" matches each argument independently; only a numbered wildcard (any1) has to
+      // bind to a single type across the invocation.
+      return;
+    }
+    String name = declared.value();
+    Type existing = wildcardBindings.putIfAbsent(name, actualType);
+    if (existing != null && !existing.equalsIgnoringNullability(actualType)) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: wildcard '%s' is bound to both %s and %s",
+              declaration.getAnchor(), index, name, existing, actualType));
+    }
+  }
+
+  private static void checkEnumOption(
+      SimpleExtension.Function declaration,
+      int index,
+      SimpleExtension.EnumArgument declared,
+      ResolvedArgument actual) {
+    Optional<String> option = actual.enumValue();
+    if (!option.isPresent()) {
+      // A plan may leave an enum argument unspecified; that is only valid where the declaration
+      // does not require an option.
+      if (declared.required()) {
+        throw new InvalidFunctionBindingException(
+            String.format(
+                "%s argument %d: enum option is required but was left unspecified (expected one of"
+                    + " %s)",
+                declaration.getAnchor(), index, declared.options()));
+      }
+      return;
+    }
+    // Substrait matches enum option symbols case-insensitively.
+    for (String allowed : declared.options()) {
+      if (allowed.equalsIgnoreCase(option.get())) {
+        return;
+      }
+    }
+    throw new InvalidFunctionBindingException(
+        String.format(
+            "%s argument %d: enum option '%s' is not one of %s",
+            declaration.getAnchor(), index, option.get(), declared.options()));
+  }
+
+  private static void requireKind(
+      SimpleExtension.Function declaration,
+      int index,
+      ResolvedArgument.Kind expected,
+      ResolvedArgument actual) {
+    if (actual.kind() != expected) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s argument %d: expected %s argument but got %s",
+              declaration.getAnchor(), index, expected, actual.kind()));
+    }
+  }
+
+  private static boolean typeMatches(
+      ParameterizedType declared, Type actual, boolean exactNullability) {
+    if (declared instanceof ParameterizedType.StringLiteral) {
+      // Non-wildcard extension parameter names at the top level are accepted; numbered wildcards
+      // are handled by the caller for cross-argument consistency.
+      return true;
+    }
+    if (declared instanceof Type) {
+      // A concrete declared argument type (e.g. i32) matches ignoring nullability, except under a
+      // DISCRETE declaration where argument nullability is part of the signature.
+      return exactNullability
+          ? actual.equals(declared)
+          : actual.equalsIgnoringNullability((Type) declared);
+    }
+    if (declared instanceof ParameterizedType.Decimal) {
+      return actual instanceof Type.Decimal
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.FixedChar) {
+      return actual instanceof Type.FixedChar
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.VarChar) {
+      return actual instanceof Type.VarChar
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.FixedBinary) {
+      return actual instanceof Type.FixedBinary
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.PrecisionTimestamp) {
+      return actual instanceof Type.PrecisionTimestamp
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    if (declared instanceof ParameterizedType.PrecisionTimestampTZ) {
+      return actual instanceof Type.PrecisionTimestampTZ
+          && nullabilityMatches(declared, actual, exactNullability);
+    }
+    // Other parameterized shapes (structs, lists, maps, ...) are accepted without deep checking.
+    return true;
+  }
+
+  /**
+   * Under a DISCRETE declaration the declared nullability is part of the signature, for a
+   * parameterized argument as much as for a concrete one. A declared shape that carries no
+   * nullability of its own has nothing to compare, so it is accepted.
+   */
+  private static boolean nullabilityMatches(
+      ParameterizedType declared, Type actual, boolean exactNullability) {
+    if (!exactNullability || !(declared instanceof NullableType)) {
+      return true;
+    }
+    return ((NullableType) declared).nullable() == actual.nullable();
+  }
+
+  private static void validateOptions(
+      SimpleExtension.Function declaration, List<FunctionOption> options) {
+    // A binding keeps option names and values exactly as the plan spelled them, so lower-case both
+    // sides here: the Substrait spec matches options case-insensitively.
+    Map<String, List<String>> declaredOptions = new LinkedHashMap<>();
+    for (Map.Entry<String, SimpleExtension.Option> entry : declaration.options().entrySet()) {
+      List<String> values = new ArrayList<>();
+      for (String value : entry.getValue().getValues()) {
+        values.add(value.toLowerCase(Locale.ROOT));
+      }
+      declaredOptions.put(entry.getKey().toLowerCase(Locale.ROOT), values);
+    }
+    for (FunctionOption option : options) {
+      String name = option.getName().toLowerCase(Locale.ROOT);
+      List<String> allowed = declaredOptions.get(name);
+      if (allowed == null) {
+        throw new InvalidFunctionBindingException(
+            String.format("%s has no option named '%s'", declaration.getAnchor(), name));
+      }
+      if (option.values().isEmpty()) {
+        throw new InvalidFunctionBindingException(
+            String.format(
+                "%s option '%s' has an empty preference list", declaration.getAnchor(), name));
+      }
+      for (String value : option.values()) {
+        if (!allowed.contains(value.toLowerCase(Locale.ROOT))) {
+          throw new InvalidFunctionBindingException(
+              String.format(
+                  "%s option '%s' value '%s' is not one of %s",
+                  declaration.getAnchor(), name, value, allowed));
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/io/substrait/extension/InvalidFunctionBindingException.java
+++ b/core/src/main/java/io/substrait/extension/InvalidFunctionBindingException.java
@@ -1,0 +1,50 @@
+package io.substrait.extension;
+
+import io.substrait.type.Type;
+
+/**
+ * Thrown when an extension function invocation cannot be resolved, or when the output type declared
+ * by a plan is inconsistent with the type derived from the function's extension declaration.
+ *
+ * <p>Resolution is fail-closed: rather than trusting a plan-supplied output type, the resolver
+ * derives the type from the declaration and raises this exception when they disagree.
+ */
+public class InvalidFunctionBindingException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Creates an exception with the given message.
+   *
+   * @param message the detail message
+   */
+  public InvalidFunctionBindingException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception with the given message and cause.
+   *
+   * @param message the detail message
+   * @param cause the underlying failure
+   */
+  public InvalidFunctionBindingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Creates an exception describing a mismatch between the declared and the derived output type.
+   *
+   * @param anchor the function anchor being resolved
+   * @param declared the output type declared by the plan
+   * @param derived the output type derived from the declaration
+   * @return the exception
+   */
+  public static InvalidFunctionBindingException outputTypeMismatch(
+      SimpleExtension.FunctionAnchor anchor, Type declared, Type derived) {
+    return new InvalidFunctionBindingException(
+        String.format(
+            "Declared output type %s for %s does not match the type %s derived from its declaration",
+            declared, anchor, derived));
+  }
+}

--- a/core/src/main/java/io/substrait/extension/InvalidFunctionBindingException.java
+++ b/core/src/main/java/io/substrait/extension/InvalidFunctionBindingException.java
@@ -1,0 +1,40 @@
+package io.substrait.extension;
+
+import io.substrait.type.Type;
+
+/**
+ * Thrown when an extension function invocation cannot be resolved, or when the output type declared
+ * by a plan is inconsistent with the type derived from the function's extension declaration.
+ *
+ * <p>Resolution is fail-closed: rather than trusting a plan-supplied output type, the resolver
+ * derives the type from the declaration and raises this exception when they disagree.
+ */
+public class InvalidFunctionBindingException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Creates an exception with the given message.
+   *
+   * @param message the detail message
+   */
+  public InvalidFunctionBindingException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates an exception describing a mismatch between the declared and the derived output type.
+   *
+   * @param anchor the function anchor being resolved
+   * @param declared the output type declared by the plan
+   * @param derived the output type derived from the declaration
+   * @return the exception
+   */
+  public static InvalidFunctionBindingException outputTypeMismatch(
+      SimpleExtension.FunctionAnchor anchor, Type declared, Type derived) {
+    return new InvalidFunctionBindingException(
+        String.format(
+            "Declared output type %s for %s does not match the type %s derived from its declaration",
+            declared, anchor, derived));
+  }
+}

--- a/core/src/main/java/io/substrait/extension/ResolvedAggregateBinding.java
+++ b/core/src/main/java/io/substrait/extension/ResolvedAggregateBinding.java
@@ -1,0 +1,163 @@
+package io.substrait.extension;
+
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.EnumArg;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionArg;
+import io.substrait.type.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/**
+ * A fully-resolved binding of an aggregate function invocation.
+ *
+ * <p>Wraps a {@link ResolvedFunctionBinding} with the aggregate-specific phase and invocation
+ * semantics. The output type is derived from the function declaration (never from a plan-supplied
+ * value) and depends on the phase, so it does not participate in the binding's identity.
+ */
+@Value.Immutable
+public abstract class ResolvedAggregateBinding {
+
+  /**
+   * Returns the resolved function binding.
+   *
+   * @return the function binding
+   */
+  public abstract ResolvedFunctionBinding function();
+
+  /**
+   * Returns the aggregation phase.
+   *
+   * @return the aggregation phase
+   */
+  public abstract Expression.AggregationPhase phase();
+
+  /**
+   * Returns the aggregation invocation semantics (all vs. distinct).
+   *
+   * @return the aggregation invocation
+   */
+  public abstract Expression.AggregationInvocation invocation();
+
+  /**
+   * Returns the intermediate type, when it has been resolved explicitly. When empty, {@link
+   * #outputType()} derives it from the declaration on demand. Not part of the binding identity.
+   *
+   * @return the intermediate type, if known
+   */
+  @Value.Auxiliary
+  public abstract Optional<Type> intermediateType();
+
+  /**
+   * Returns the type this aggregate produces <em>in its phase</em>: a phase that stops at the
+   * intermediate state produces the declaration's intermediate type, while a phase that runs to the
+   * result produces its return type. Derived from the declaration, never from a plan-supplied
+   * value.
+   *
+   * @return the output type of this phase
+   * @throws InvalidFunctionBindingException if an intermediate type is required but the declaration
+   *     is not an aggregate variant, or its type expression cannot be derived
+   */
+  public Type outputType() {
+    return producesIntermediateState()
+        ? intermediateType().orElseGet(this::deriveIntermediateType)
+        : function().outputType();
+  }
+
+  /**
+   * Returns whether this phase stops at the declaration's intermediate state instead of producing
+   * its result.
+   *
+   * @return {@code true} for the initial-to-intermediate and intermediate-to-intermediate phases
+   */
+  public boolean producesIntermediateState() {
+    return phase() == Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE
+        || phase() == Expression.AggregationPhase.INTERMEDIATE_TO_INTERMEDIATE;
+  }
+
+  /**
+   * Returns whether this phase consumes the declaration's intermediate state instead of its
+   * declared arguments. The arguments of such an invocation are intermediate values, so they are
+   * not expected to match the declaration's argument list.
+   *
+   * <p>An unspecified phase implies the intermediate-to-result phase, per the {@code
+   * AggregationPhase} proto enum, so it consumes an intermediate state too.
+   *
+   * @return {@code true} for the intermediate-to-intermediate and intermediate-to-result phases,
+   *     and for an unspecified phase
+   */
+  public boolean consumesIntermediateState() {
+    return phase() == Expression.AggregationPhase.INTERMEDIATE_TO_INTERMEDIATE
+        || phase() == Expression.AggregationPhase.INTERMEDIATE_TO_RESULT
+        || phase() == Expression.AggregationPhase.UNSPECIFIED;
+  }
+
+  private Type deriveIntermediateType() {
+    SimpleExtension.Function declaration = function().declaration();
+    if (!(declaration instanceof SimpleExtension.AggregateFunctionVariant)) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s is not an aggregate declaration and has no intermediate type",
+              function().anchor()));
+    }
+    return FunctionBindingResolver.deriveIntermediateType(
+        (SimpleExtension.AggregateFunctionVariant) declaration, function().arguments());
+  }
+
+  /**
+   * Creates a builder for {@link ResolvedAggregateBinding}.
+   *
+   * @return a new builder
+   */
+  public static ImmutableResolvedAggregateBinding.Builder builder() {
+    return ImmutableResolvedAggregateBinding.builder();
+  }
+
+  /**
+   * Resolves an aggregate function invocation into a binding, capturing its semantic identity
+   * (anchor, arguments and options). This does <em>not</em> validate the invocation against the
+   * declaration; signature, options and output-type validation is a separate, opt-in step (see
+   * {@link FunctionBindingResolver#validate}). The output type is derived on demand via {@link
+   * #outputType()}.
+   *
+   * @param invocation the aggregate invocation to resolve
+   * @return the resolved aggregate binding
+   */
+  public static ResolvedAggregateBinding resolve(AggregateFunctionInvocation invocation) {
+    List<ResolvedArgument> arguments = resolvedArguments(invocation.arguments());
+    ResolvedFunctionBinding function =
+        FunctionBindingResolver.resolve(invocation.declaration(), arguments, invocation.options());
+    return builder()
+        .function(function)
+        .phase(invocation.aggregationPhase())
+        .invocation(invocation.invocation())
+        .intermediateType(Optional.empty())
+        .build();
+  }
+
+  private static List<ResolvedArgument> resolvedArguments(List<FunctionArg> arguments) {
+    List<ResolvedArgument> resolved = new ArrayList<>();
+    for (FunctionArg arg : arguments) {
+      if (arg instanceof Expression) {
+        resolved.add(ResolvedArgument.value(((Expression) arg).getType()));
+      } else if (arg instanceof Type) {
+        resolved.add(ResolvedArgument.type((Type) arg));
+      } else if (arg instanceof EnumArg) {
+        // An enum argument may carry no option; keep that distinct from an empty one so the
+        // identity is faithful and validation can report it against the declaration.
+        resolved.add(
+            ((EnumArg) arg)
+                .value()
+                .map(ResolvedArgument::enumOption)
+                .orElseGet(ResolvedArgument::unspecifiedEnumOption));
+      } else {
+        // The resolved list is consumed positionally; silently skipping an unrecognized argument
+        // kind would misalign every consumer downstream.
+        throw new IllegalArgumentException("Unsupported function argument kind: " + arg);
+      }
+    }
+    return resolved;
+  }
+}

--- a/core/src/main/java/io/substrait/extension/ResolvedAggregateBinding.java
+++ b/core/src/main/java/io/substrait/extension/ResolvedAggregateBinding.java
@@ -1,0 +1,154 @@
+package io.substrait.extension;
+
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.EnumArg;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionArg;
+import io.substrait.type.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/**
+ * A fully-resolved binding of an aggregate function invocation.
+ *
+ * <p>Wraps a {@link ResolvedFunctionBinding} with the aggregate-specific phase and invocation
+ * semantics. The output type is derived from the function declaration (never from a plan-supplied
+ * value) and depends on the phase, so it does not participate in the binding's identity.
+ */
+@Value.Immutable
+public abstract class ResolvedAggregateBinding {
+
+  /**
+   * Returns the resolved function binding.
+   *
+   * @return the function binding
+   */
+  public abstract ResolvedFunctionBinding function();
+
+  /**
+   * Returns the aggregation phase.
+   *
+   * @return the aggregation phase
+   */
+  public abstract Expression.AggregationPhase phase();
+
+  /**
+   * Returns the aggregation invocation semantics (all vs. distinct).
+   *
+   * @return the aggregation invocation
+   */
+  public abstract Expression.AggregationInvocation invocation();
+
+  /**
+   * Returns the intermediate type, when it has been resolved explicitly. When empty, {@link
+   * #outputType()} derives it from the declaration on demand. Not part of the binding identity.
+   *
+   * @return the intermediate type, if known
+   */
+  @Value.Auxiliary
+  public abstract Optional<Type> intermediateType();
+
+  /**
+   * Returns the type this aggregate produces <em>in its phase</em>: a phase that stops at the
+   * intermediate state produces the declaration's intermediate type, while a phase that runs to the
+   * result produces its return type. Derived from the declaration, never from a plan-supplied
+   * value.
+   *
+   * @return the output type of this phase
+   * @throws InvalidFunctionBindingException if an intermediate type is required but the declaration
+   *     is not an aggregate variant, or its type expression cannot be derived
+   */
+  public Type outputType() {
+    return producesIntermediateState()
+        ? intermediateType().orElseGet(this::deriveIntermediateType)
+        : function().outputType();
+  }
+
+  /**
+   * Returns whether this phase stops at the declaration's intermediate state instead of producing
+   * its result.
+   *
+   * @return {@code true} for the initial-to-intermediate and intermediate-to-intermediate phases
+   */
+  public boolean producesIntermediateState() {
+    return phase() == Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE
+        || phase() == Expression.AggregationPhase.INTERMEDIATE_TO_INTERMEDIATE;
+  }
+
+  /**
+   * Returns whether this phase consumes the declaration's intermediate state instead of its
+   * declared arguments. The arguments of such an invocation are intermediate values, so they are
+   * not expected to match the declaration's argument list.
+   *
+   * @return {@code true} for the intermediate-to-intermediate and intermediate-to-result phases
+   */
+  public boolean consumesIntermediateState() {
+    return phase() == Expression.AggregationPhase.INTERMEDIATE_TO_INTERMEDIATE
+        || phase() == Expression.AggregationPhase.INTERMEDIATE_TO_RESULT;
+  }
+
+  private Type deriveIntermediateType() {
+    SimpleExtension.Function declaration = function().declaration();
+    if (!(declaration instanceof SimpleExtension.AggregateFunctionVariant)) {
+      throw new InvalidFunctionBindingException(
+          String.format(
+              "%s is not an aggregate declaration and has no intermediate type",
+              function().anchor()));
+    }
+    return FunctionBindingResolver.deriveIntermediateType(
+        (SimpleExtension.AggregateFunctionVariant) declaration, function().arguments());
+  }
+
+  /**
+   * Creates a builder for {@link ResolvedAggregateBinding}.
+   *
+   * @return a new builder
+   */
+  public static ImmutableResolvedAggregateBinding.Builder builder() {
+    return ImmutableResolvedAggregateBinding.builder();
+  }
+
+  /**
+   * Resolves an aggregate function invocation into a binding, capturing its semantic identity
+   * (anchor, arguments and options). This does <em>not</em> validate the invocation against the
+   * declaration; signature, options and output-type validation is a separate, opt-in step (see
+   * {@link FunctionBindingResolver#validate}). The output type is derived on demand via {@link
+   * #outputType()}.
+   *
+   * @param invocation the aggregate invocation to resolve
+   * @return the resolved aggregate binding
+   */
+  public static ResolvedAggregateBinding resolve(AggregateFunctionInvocation invocation) {
+    List<ResolvedArgument> arguments = resolvedArguments(invocation.arguments());
+    ResolvedFunctionBinding function =
+        FunctionBindingResolver.resolve(invocation.declaration(), arguments, invocation.options());
+    return builder()
+        .function(function)
+        .phase(invocation.aggregationPhase())
+        .invocation(invocation.invocation())
+        .intermediateType(Optional.empty())
+        .build();
+  }
+
+  private static List<ResolvedArgument> resolvedArguments(List<FunctionArg> arguments) {
+    List<ResolvedArgument> resolved = new ArrayList<>();
+    for (FunctionArg arg : arguments) {
+      if (arg instanceof Expression) {
+        resolved.add(ResolvedArgument.value(((Expression) arg).getType()));
+      } else if (arg instanceof Type) {
+        resolved.add(ResolvedArgument.type((Type) arg));
+      } else if (arg instanceof EnumArg) {
+        // An enum argument may carry no option; keep that distinct from an empty one so the
+        // identity is faithful and validation can report it against the declaration.
+        resolved.add(
+            ((EnumArg) arg)
+                .value()
+                .map(ResolvedArgument::enumOption)
+                .orElseGet(ResolvedArgument::unspecifiedEnumOption));
+      }
+    }
+    return resolved;
+  }
+}

--- a/core/src/main/java/io/substrait/extension/ResolvedArgument.java
+++ b/core/src/main/java/io/substrait/extension/ResolvedArgument.java
@@ -1,0 +1,143 @@
+package io.substrait.extension;
+
+import io.substrait.type.Type;
+import java.util.Objects;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An ordered, kind-aware argument of a resolved function binding.
+ *
+ * <p>Unlike a bare {@link Type} list, this preserves the argument <em>kind</em> (value, type or
+ * enum) and the selected enum option, so that two invocations that differ only by an enum argument
+ * — e.g. {@code std_dev(POPULATION, fp32)} vs {@code std_dev(SAMPLE, fp32)} — are not conflated.
+ *
+ * <p>An enum argument may also carry <em>no</em> option, for a plan that leaves it unspecified;
+ * that is distinct from any specified option. An option is kept exactly as the plan spelled it, so
+ * identity is case-sensitive and merely conservative: two invocations differing only in the case of
+ * an enum symbol stay distinct, which costs a missed deduplication and never rewrites the plan's
+ * data. Matching an option against its declaration is case-insensitive, as the spec requires.
+ */
+public final class ResolvedArgument {
+
+  /** The kind of a function argument. */
+  public enum Kind {
+    /** A value argument, carrying a data {@link Type}. */
+    VALUE,
+    /** A type argument, carrying a {@link Type}. */
+    TYPE,
+    /** An enum argument, carrying a selected option. */
+    ENUM
+  }
+
+  private final Kind kind;
+  private final @Nullable Type type;
+  private final @Nullable String enumValue;
+
+  private ResolvedArgument(Kind kind, @Nullable Type type, @Nullable String enumValue) {
+    this.kind = kind;
+    this.type = type;
+    this.enumValue = enumValue;
+  }
+
+  /**
+   * Creates a value argument.
+   *
+   * @param type the value type
+   * @return the resolved argument
+   */
+  public static ResolvedArgument value(Type type) {
+    return new ResolvedArgument(Kind.VALUE, Objects.requireNonNull(type), null);
+  }
+
+  /**
+   * Creates a type argument.
+   *
+   * @param type the argument type
+   * @return the resolved argument
+   */
+  public static ResolvedArgument type(Type type) {
+    return new ResolvedArgument(Kind.TYPE, Objects.requireNonNull(type), null);
+  }
+
+  /**
+   * Creates an enum argument.
+   *
+   * @param option the selected enum option
+   * @return the resolved argument
+   */
+  public static ResolvedArgument enumOption(String option) {
+    return new ResolvedArgument(Kind.ENUM, null, Objects.requireNonNull(option));
+  }
+
+  /**
+   * Creates an enum argument whose option the plan left unspecified. This is distinct from an
+   * argument carrying an empty option: the proto can spell it, so the binding keeps the plan's
+   * identity faithful — but the extension schema cannot declare an optional enum argument, so
+   * validation always rejects it.
+   *
+   * @return the resolved argument
+   */
+  public static ResolvedArgument unspecifiedEnumOption() {
+    return new ResolvedArgument(Kind.ENUM, null, null);
+  }
+
+  /**
+   * Returns the argument kind.
+   *
+   * @return the kind
+   */
+  public Kind kind() {
+    return kind;
+  }
+
+  /**
+   * Returns the data type of a value or type argument.
+   *
+   * @return the type, if this is a value or type argument
+   */
+  public Optional<Type> type() {
+    return Optional.ofNullable(type);
+  }
+
+  /**
+   * Returns the selected option of an enum argument.
+   *
+   * @return the enum option, or empty if this is not an enum argument or its option was left
+   *     unspecified
+   */
+  public Optional<String> enumValue() {
+    return Optional.ofNullable(enumValue);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ResolvedArgument)) {
+      return false;
+    }
+    ResolvedArgument other = (ResolvedArgument) o;
+    return kind == other.kind
+        && Objects.equals(type, other.type)
+        && Objects.equals(enumValue, other.enumValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(kind, type, enumValue);
+  }
+
+  @Override
+  public String toString() {
+    switch (kind) {
+      case VALUE:
+        return "value(" + type + ")";
+      case TYPE:
+        return "type(" + type + ")";
+      default:
+        return "enum(" + (enumValue == null ? "unspecified" : enumValue) + ")";
+    }
+  }
+}

--- a/core/src/main/java/io/substrait/extension/ResolvedArgument.java
+++ b/core/src/main/java/io/substrait/extension/ResolvedArgument.java
@@ -1,0 +1,142 @@
+package io.substrait.extension;
+
+import io.substrait.type.Type;
+import java.util.Objects;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An ordered, kind-aware argument of a resolved function binding.
+ *
+ * <p>Unlike a bare {@link Type} list, this preserves the argument <em>kind</em> (value, type or
+ * enum) and the selected enum option, so that two invocations that differ only by an enum argument
+ * — e.g. {@code std_dev(POPULATION, fp32)} vs {@code std_dev(SAMPLE, fp32)} — are not conflated.
+ *
+ * <p>An enum argument may also carry <em>no</em> option, for a plan that leaves it unspecified;
+ * that is distinct from any specified option. An option is kept exactly as the plan spelled it, so
+ * identity is case-sensitive and merely conservative: two invocations differing only in the case of
+ * an enum symbol stay distinct, which costs a missed deduplication and never rewrites the plan's
+ * data. Matching an option against its declaration is case-insensitive, as the spec requires.
+ */
+public final class ResolvedArgument {
+
+  /** The kind of a function argument. */
+  public enum Kind {
+    /** A value argument, carrying a data {@link Type}. */
+    VALUE,
+    /** A type argument, carrying a {@link Type}. */
+    TYPE,
+    /** An enum argument, carrying a selected option. */
+    ENUM
+  }
+
+  private final Kind kind;
+  private final @Nullable Type type;
+  private final @Nullable String enumValue;
+
+  private ResolvedArgument(Kind kind, @Nullable Type type, @Nullable String enumValue) {
+    this.kind = kind;
+    this.type = type;
+    this.enumValue = enumValue;
+  }
+
+  /**
+   * Creates a value argument.
+   *
+   * @param type the value type
+   * @return the resolved argument
+   */
+  public static ResolvedArgument value(Type type) {
+    return new ResolvedArgument(Kind.VALUE, Objects.requireNonNull(type), null);
+  }
+
+  /**
+   * Creates a type argument.
+   *
+   * @param type the argument type
+   * @return the resolved argument
+   */
+  public static ResolvedArgument type(Type type) {
+    return new ResolvedArgument(Kind.TYPE, Objects.requireNonNull(type), null);
+  }
+
+  /**
+   * Creates an enum argument.
+   *
+   * @param option the selected enum option
+   * @return the resolved argument
+   */
+  public static ResolvedArgument enumOption(String option) {
+    return new ResolvedArgument(Kind.ENUM, null, Objects.requireNonNull(option));
+  }
+
+  /**
+   * Creates an enum argument whose option the plan left unspecified. This is distinct from an
+   * argument carrying an empty option, and is only valid where the declaration does not require an
+   * option.
+   *
+   * @return the resolved argument
+   */
+  public static ResolvedArgument unspecifiedEnumOption() {
+    return new ResolvedArgument(Kind.ENUM, null, null);
+  }
+
+  /**
+   * Returns the argument kind.
+   *
+   * @return the kind
+   */
+  public Kind kind() {
+    return kind;
+  }
+
+  /**
+   * Returns the data type of a value or type argument.
+   *
+   * @return the type, if this is a value or type argument
+   */
+  public Optional<Type> type() {
+    return Optional.ofNullable(type);
+  }
+
+  /**
+   * Returns the selected option of an enum argument.
+   *
+   * @return the enum option, or empty if this is not an enum argument or its option was left
+   *     unspecified
+   */
+  public Optional<String> enumValue() {
+    return Optional.ofNullable(enumValue);
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ResolvedArgument)) {
+      return false;
+    }
+    ResolvedArgument other = (ResolvedArgument) o;
+    return kind == other.kind
+        && Objects.equals(type, other.type)
+        && Objects.equals(enumValue, other.enumValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(kind, type, enumValue);
+  }
+
+  @Override
+  public String toString() {
+    switch (kind) {
+      case VALUE:
+        return "value(" + type + ")";
+      case TYPE:
+        return "type(" + type + ")";
+      default:
+        return "enum(" + (enumValue == null ? "unspecified" : enumValue) + ")";
+    }
+  }
+}

--- a/core/src/main/java/io/substrait/extension/ResolvedFunctionBinding.java
+++ b/core/src/main/java/io/substrait/extension/ResolvedFunctionBinding.java
@@ -1,0 +1,114 @@
+package io.substrait.extension;
+
+import io.substrait.expression.FunctionOption;
+import io.substrait.type.Type;
+import java.util.List;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/**
+ * A fully-resolved binding of an extension function declaration to concrete arguments.
+ *
+ * <p>The binding captures the <em>semantic identity</em> of a function invocation: the function
+ * anchor, the ordered arguments and the options. The {@linkplain #outputType() output type} is
+ * <em>derived</em> from the declaration on demand (see {@link FunctionBindingResolver}) and is
+ * deliberately not part of this identity — it belongs to the type-carrying Calcite wrapper, not to
+ * the semantic identity of the function. Two bindings are equal when they agree on anchor,
+ * arguments and options, which is what lets a consumer distinguish two functions that happen to
+ * lower to the same engine operator.
+ */
+@Value.Immutable
+public abstract class ResolvedFunctionBinding {
+
+  /**
+   * Returns the canonical function anchor (extension urn + compound signature).
+   *
+   * @return the function anchor
+   */
+  public abstract SimpleExtension.FunctionAnchor anchor();
+
+  /**
+   * Returns the ordered, kind-aware arguments the function was resolved against.
+   *
+   * @return the resolved arguments
+   */
+  public abstract List<ResolvedArgument> arguments();
+
+  /**
+   * Returns the options exactly as the invocation carries them: named preference lists, in order,
+   * spelled the way the plan spelled them. Selecting a single value from a preference list is a
+   * consumer-specific concern and is intentionally not done here.
+   *
+   * <p>This is a list rather than a map by name because that is what a plan carries — an option
+   * name may legitimately appear more than once, and a map would silently drop all but one.
+   *
+   * @return the function options
+   */
+  public abstract List<FunctionOption> options();
+
+  /**
+   * Returns the preference list of the named option, matched case-insensitively as the Substrait
+   * spec requires.
+   *
+   * @param name the option name
+   * @return the preferred values of the first option with that name, if any
+   */
+  public Optional<List<String>> option(String name) {
+    for (FunctionOption option : options()) {
+      if (option.getName().equalsIgnoreCase(name)) {
+        return Optional.of(option.values());
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the function declaration this binding resolves. Not part of the binding identity.
+   *
+   * @return the function declaration
+   */
+  @Value.Auxiliary
+  public abstract SimpleExtension.Function declaration();
+
+  /**
+   * Derives the output type from the declaration and arguments, applying the declaration's
+   * nullability policy. Computed on demand (may throw for as-yet-unsupported derivations); it is
+   * neither stored nor part of the binding's identity.
+   *
+   * @return the derived output type
+   */
+  public Type outputType() {
+    return FunctionBindingResolver.deriveOutputType(declaration(), arguments());
+  }
+
+  /**
+   * Enforces that the anchor is consistent with the declaration.
+   *
+   * <p>Options need no normalization: {@link FunctionOption} is itself immutable, so the binding is
+   * immutable all the way down and its identity cannot change after it was built. Names and values
+   * are kept exactly as the plan spelled them — a binding is also the record of what to convert
+   * back, so it must not rewrite the plan's data. Identity is therefore case-sensitive and merely
+   * conservative: two invocations that differ only in the case of an option stay distinct, which
+   * costs a missed deduplication and never loses information. Validation against the declaration is
+   * case-insensitive, as the spec requires.
+   */
+  @Value.Check
+  protected void checkAnchor() {
+    if (!anchor().equals(declaration().getAnchor())) {
+      throw new IllegalArgumentException(
+          String.format(
+              "anchor %s does not match declaration anchor %s",
+              anchor(), declaration().getAnchor()));
+    }
+  }
+
+  /**
+   * Creates a builder for {@link ResolvedFunctionBinding}. Prefer {@link FunctionBindingResolver},
+   * which validates the signature and options before constructing a binding.
+   *
+   * @return a new builder
+   */
+  public static ImmutableResolvedFunctionBinding.Builder builder() {
+    return ImmutableResolvedFunctionBinding.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -22,6 +22,7 @@ import io.substrait.util.Util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -649,13 +650,49 @@ public class SimpleExtension {
     }
 
     /**
-     * Returns the resolve Type for the given arguments.
+     * Resolves the concrete output type for the given argument types, applying the declaration's
+     * nullability policy.
      *
-     * @param argumentTypes the argument Types
-     * @return the resolve Type
+     * <p>Pass one type per declared non-enum argument, in declaration order (a variadic
+     * declaration's trailing argument may repeat). Under the default {@code MIRROR} policy the
+     * result is nullable iff any type supplied for a declared <em>value</em> argument is nullable;
+     * under {@code DECLARED_OUTPUT} and {@code DISCRETE} the return expression's own nullability is
+     * authoritative.
+     *
+     * @param argumentTypes the actual types of the non-enum arguments
+     * @return the resolved type
+     * @throws UnsupportedOperationException if the return expression cannot be evaluated
      */
     public io.substrait.type.Type resolveType(List<io.substrait.type.Type> argumentTypes) {
-      return TypeExpressionEvaluator.evaluateExpression(returnType(), args(), argumentTypes);
+      io.substrait.type.Type base =
+          TypeExpressionEvaluator.evaluateExpression(
+              returnType(), args(), variadic(), argumentTypes);
+      if (nullability() != Nullability.MIRROR) {
+        return base;
+      }
+      return base.withNullable(anyValueArgumentNullable(argumentTypes));
+    }
+
+    private boolean anyValueArgumentNullable(List<io.substrait.type.Type> argumentTypes) {
+      // The supplied types align positionally with the declared non-enum arguments, a variadic
+      // declaration's trailing argument repeating. Only a value argument's nullability mirrors
+      // into the result: a type argument carries a type as data, not an operand that can be null.
+      List<Argument> nonEnumArguments = new ArrayList<>();
+      for (Argument argument : args()) {
+        if (!(argument instanceof EnumArgument)) {
+          nonEnumArguments.add(argument);
+        }
+      }
+      if (nonEnumArguments.isEmpty()) {
+        return false;
+      }
+      for (int i = 0; i < argumentTypes.size(); i++) {
+        Argument declared = nonEnumArguments.get(Math.min(i, nonEnumArguments.size() - 1));
+        if (declared instanceof ValueArgument && argumentTypes.get(i).nullable()) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 

--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -655,7 +655,8 @@ public class SimpleExtension {
      * @return the resolve Type
      */
     public io.substrait.type.Type resolveType(List<io.substrait.type.Type> argumentTypes) {
-      return TypeExpressionEvaluator.evaluateExpression(returnType(), args(), argumentTypes);
+      return TypeExpressionEvaluator.evaluateExpression(
+          returnType(), args(), variadic(), argumentTypes);
     }
   }
 

--- a/core/src/main/java/io/substrait/function/ParameterizedType.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedType.java
@@ -56,6 +56,17 @@ public interface ParameterizedType extends TypeExpression {
     return false;
   }
 
+  /**
+   * Returns whether this type is a <em>numbered</em> wildcard ({@code any1}, {@code any2}, ...), as
+   * opposed to a plain {@code any}. Occurrences of the same numbered wildcard within one signature
+   * must bind to the same type, while each plain {@code any} binds independently.
+   *
+   * @return {@code true} if this type is a numbered wildcard
+   */
+  default boolean isNumberedWildcard() {
+    return false;
+  }
+
   /** Base class for parameterized types that dispatch to a {@link ParameterizedTypeVisitor}. */
   abstract class BaseParameterizedType implements ParameterizedType {
     @Override
@@ -451,6 +462,20 @@ public interface ParameterizedType extends TypeExpression {
     @Override
     public boolean isWildcard() {
       return value().toLowerCase(Locale.ROOT).startsWith("any");
+    }
+
+    @Override
+    public boolean isNumberedWildcard() {
+      String literal = value().toLowerCase(Locale.ROOT);
+      if (!literal.startsWith("any") || literal.length() == "any".length()) {
+        return false;
+      }
+      for (int i = "any".length(); i < literal.length(); i++) {
+        if (!Character.isDigit(literal.charAt(i))) {
+          return false;
+        }
+      }
+      return true;
     }
 
     @Override

--- a/core/src/main/java/io/substrait/function/ParameterizedType.java
+++ b/core/src/main/java/io/substrait/function/ParameterizedType.java
@@ -1,7 +1,8 @@
 package io.substrait.function;
 
 import io.substrait.type.TypeVisitor;
-import java.util.Locale;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import org.immutables.value.Value;
 
 /**
@@ -53,6 +54,17 @@ public interface ParameterizedType extends TypeExpression {
    * @return {@code true} if this type is a wildcard
    */
   default boolean isWildcard() {
+    return false;
+  }
+
+  /**
+   * Returns whether this type is a <em>numbered</em> wildcard ({@code any1}, {@code any2}, ...), as
+   * opposed to a plain {@code any}. Occurrences of the same numbered wildcard within one signature
+   * must bind to the same type, while each plain {@code any} binds independently.
+   *
+   * @return {@code true} if this type is a numbered wildcard
+   */
+  default boolean isNumberedWildcard() {
     return false;
   }
 
@@ -432,6 +444,18 @@ public interface ParameterizedType extends TypeExpression {
   /** A string-literal type parameter, used as a placeholder for an integer or type parameter. */
   @Value.Immutable
   abstract class StringLiteral extends BaseParameterizedType implements NullableType {
+    // Transcribed from the Substrait type grammar's lexer, which is caseInsensitive:
+    //     Any:    'ANY';
+    //     AnyVar: Any [0-9];
+    // Exactly one ASCII digit: "any10" lexes as an Identifier, i.e. an ordinary named type
+    // parameter rather than a wildcard (spec v0.99.0). \A..\z rather than ^..$ because
+    // asPredicate() is find()-based, and asMatchPredicate() needs Java 11 while this module
+    // compiles for Java 8.
+    private static final Predicate<String> WILDCARD =
+        Pattern.compile("\\Aany[0-9]?\\z", Pattern.CASE_INSENSITIVE).asPredicate();
+    private static final Predicate<String> NUMBERED_WILDCARD =
+        Pattern.compile("\\Aany[0-9]\\z", Pattern.CASE_INSENSITIVE).asPredicate();
+
     /**
      * Returns the literal parameter value.
      *
@@ -450,7 +474,12 @@ public interface ParameterizedType extends TypeExpression {
 
     @Override
     public boolean isWildcard() {
-      return value().toLowerCase(Locale.ROOT).startsWith("any");
+      return WILDCARD.test(value());
+    }
+
+    @Override
+    public boolean isNumberedWildcard() {
+      return NUMBERED_WILDCARD.test(value());
     }
 
     @Override

--- a/core/src/main/java/io/substrait/function/ToTypeString.java
+++ b/core/src/main/java/io/substrait/function/ToTypeString.java
@@ -223,7 +223,11 @@ public class ToTypeString
 
   @Override
   public String visit(ParameterizedType.StringLiteral expr) throws RuntimeException {
-    if (expr.value().toLowerCase().startsWith("any")) {
+    // Only the wildcard family any / any0-any9 collapses to "any" in a signature key; an ordinary
+    // named type parameter that merely starts with "any" (e.g. "anything") is not a wildcard and
+    // falls through to the throwing base visitor, so a declaration using one fails when its key is
+    // computed rather than being keyed as if it were any.
+    if (expr.isWildcard()) {
       return "any";
     } else {
       return super.visit(expr);

--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -1,11 +1,37 @@
 package io.substrait.type;
 
 import io.substrait.extension.SimpleExtension;
+import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
+import io.substrait.function.TypeExpressionVisitor;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * Evaluates a {@link TypeExpression} to a concrete {@link Type} given a set of actual arguments.
+ *
+ * <p>A declaration's {@code return} expression is either already concrete (e.g. {@code i64?}) or
+ * parameterized in terms of its argument types (e.g. {@code DECIMAL?<38,S>}, where {@code S} is the
+ * scale of the argument). This evaluator resolves the latter by binding the integer type parameters
+ * ({@code P}, {@code S}, ...) from the actual argument types and substituting them.
+ *
+ * <p>Expression shapes that are not yet supported fail closed with an {@link
+ * UnsupportedOperationException}. The evaluator never falls back to a caller-supplied type: an
+ * unresolved expression is an error, not a default.
+ *
+ * <p>Supported shapes are concrete types, numbered wildcards ({@code any1}) and parameterized
+ * decimals ({@code DECIMAL<P,S>}). What actually fails on the standard extension catalog is the
+ * other parameterized type classes — {@code varchar<L1>}, {@code fixedchar<L1>}, {@code
+ * precision_time<P>}, {@code precision_timestamp<P>}, {@code precision_timestamp_tz<P>}, {@code
+ * interval_day<P>}, {@code list<anyN>}, parameterized structs — and multi-line return programs;
+ * {@code concat}, {@code concat_ws}, {@code assume_timezone} and the {@code strptime_*} family are
+ * all rejected today. Among the standard aggregates, {@code quantile} is the one whose output type
+ * cannot be derived at all: its declared return {@code LIST?<any>} uses a plain {@code any}, which
+ * carries no identity to bind (spec v0.99.0).
  */
 public class TypeExpressionEvaluator {
 
@@ -13,19 +39,236 @@ public class TypeExpressionEvaluator {
    * Evaluates a return-type expression to a concrete {@link Type}.
    *
    * @param returnExpression the type expression to evaluate
-   * @param parameterizedTypeList the declared parameter types of the function
+   * @param declaredArguments the declared arguments of the function (used to bind type parameters)
    * @param actualTypes the actual argument types supplied at the call site
    * @return the resolved concrete type
-   * @throws UnsupportedOperationException if the expression cannot yet be evaluated
+   * @throws UnsupportedOperationException if the expression cannot be evaluated
    */
   public static Type evaluateExpression(
       TypeExpression returnExpression,
-      List<SimpleExtension.Argument> parameterizedTypeList,
+      List<SimpleExtension.Argument> declaredArguments,
       List<Type> actualTypes) {
+    return evaluateExpression(returnExpression, declaredArguments, Optional.empty(), actualTypes);
+  }
 
+  /**
+   * Evaluates a return-type expression to a concrete {@link Type}, taking the declaration's
+   * variadic behavior into account.
+   *
+   * @param returnExpression the type expression to evaluate
+   * @param declaredArguments the declared arguments of the function (used to bind type parameters)
+   * @param variadic the declaration's variadic behavior, if it is variadic
+   * @param actualTypes the actual argument types supplied at the call site
+   * @return the resolved concrete type
+   * @throws UnsupportedOperationException if the expression cannot be evaluated
+   */
+  public static Type evaluateExpression(
+      TypeExpression returnExpression,
+      List<SimpleExtension.Argument> declaredArguments,
+      Optional<SimpleExtension.VariadicBehavior> variadic,
+      List<Type> actualTypes) {
+    // Bind the parameters even when the return type is concrete: binding is what catches a
+    // signature that uses one parameter name inconsistently — f(DECIMAL<P,S>, DECIMAL<P,S>) called
+    // with two different scales — and that is an error whatever the function returns.
+    ParameterBindings bindings = bindParameters(declaredArguments, variadic, actualTypes);
     if (returnExpression instanceof Type) {
+      // The declared return type is already concrete; nothing to derive.
       return (Type) returnExpression;
     }
-    throw new UnsupportedOperationException("NYI");
+    return returnExpression.accept(new ReturnTypeEvaluator(returnExpression, bindings));
+  }
+
+  /**
+   * Binds the declaration's type parameters — both numbered wildcards (e.g. the {@code any1} of
+   * {@code min(any1) -> any1}) and integer parameters (e.g. the {@code P} and {@code S} of {@code
+   * DECIMAL<P,S>}) — by matching each declared value argument against the corresponding actual
+   * argument type in a single pass.
+   *
+   * <p>Binding the same parameter name to two different values is a signature error and is rejected
+   * rather than silently overwritten, for wildcards and integer parameters alike. A variadic
+   * declaration states its trailing argument once but accepts it repeatedly, so every actual
+   * argument is bound against that trailing declaration — unless the declaration marks its
+   * parameters {@code INCONSISTENT}, in which case each repetition is independent and only the
+   * first one binds.
+   */
+  private static ParameterBindings bindParameters(
+      List<SimpleExtension.Argument> declaredArguments,
+      Optional<SimpleExtension.VariadicBehavior> variadic,
+      List<Type> actualTypes) {
+    // Enum arguments select an overload and carry no value type, so they do not consume an actual
+    // type; dropping them aligns the declared and actual arguments positionally. A type argument
+    // consumes an actual type and binds its declared pattern too, so that a declaration like
+    // (<type> DECIMAL<P,S>) -> DECIMAL<P,S> can derive its return from the supplied type.
+    List<ParameterizedType> declaredTypes = new ArrayList<>();
+    for (SimpleExtension.Argument declared : declaredArguments) {
+      if (declared instanceof SimpleExtension.EnumArgument) {
+        continue;
+      }
+      declaredTypes.add(
+          declared instanceof SimpleExtension.ValueArgument
+              ? ((SimpleExtension.ValueArgument) declared).value()
+              : declared instanceof SimpleExtension.TypeArgument
+                  ? ((SimpleExtension.TypeArgument) declared).type()
+                  : null);
+    }
+
+    ParameterBindings bindings = new ParameterBindings();
+    if (declaredTypes.isEmpty()) {
+      return bindings;
+    }
+    boolean bindRepeats =
+        variadic
+            .map(
+                behavior ->
+                    behavior.parameterConsistency()
+                        == SimpleExtension.VariadicBehavior.ParameterConsistency.CONSISTENT)
+            .orElse(false);
+    for (int index = 0; index < actualTypes.size(); index++) {
+      boolean repeated = index >= declaredTypes.size();
+      if (repeated && !variadic.isPresent()) {
+        // The arity is wrong; that is validated by the resolver, not here.
+        break;
+      }
+      ParameterizedType declared =
+          repeated ? declaredTypes.get(declaredTypes.size() - 1) : declaredTypes.get(index);
+      if (declared == null) {
+        continue;
+      }
+      // An INCONSISTENT variadic repetition binds no named parameters — each repetition is
+      // independent — but a literal constraint (the 0 of DECIMAL<P,0>) still applies to it.
+      bindings.bind(declared, actualTypes.get(index), !repeated || bindRepeats);
+    }
+    return bindings;
+  }
+
+  /** The wildcard and integer type parameters bound from a call site's actual argument types. */
+  private static final class ParameterBindings {
+
+    private final Map<String, Type> types = new HashMap<>();
+    private final Map<String, Integer> integers = new HashMap<>();
+
+    private Type boundType(String name) {
+      return types.get(name);
+    }
+
+    private Integer boundInteger(String token) {
+      return integers.get(token);
+    }
+
+    /**
+     * Binds the declared pattern's parameters from the actual type. With {@code bindNames} false —
+     * an INCONSISTENT variadic repetition — named parameters are left unbound (each repetition is
+     * independent) while literal constraints are still enforced.
+     */
+    private void bind(ParameterizedType declared, Type actual, boolean bindNames) {
+      if (declared instanceof ParameterizedType.StringLiteral) {
+        ParameterizedType.StringLiteral literal = (ParameterizedType.StringLiteral) declared;
+        // Only a numbered wildcard names a parameter that a return expression can refer to and that
+        // has to stay consistent across the call; a plain "any" binds independently each time.
+        if (bindNames && literal.isNumberedWildcard()) {
+          bindType(literal.value(), actual);
+        }
+      } else if (declared instanceof ParameterizedType.Decimal && actual instanceof Type.Decimal) {
+        ParameterizedType.Decimal declaredDecimal = (ParameterizedType.Decimal) declared;
+        Type.Decimal actualDecimal = (Type.Decimal) actual;
+        bindInteger(declaredDecimal.precision().value(), actualDecimal.precision(), bindNames);
+        bindInteger(declaredDecimal.scale().value(), actualDecimal.scale(), bindNames);
+      }
+    }
+
+    private void bindType(String name, Type actual) {
+      // Nullability is not part of a wildcard's identity: any1 binds to i32 and i32? alike, and the
+      // return expression's own nullability (or the MIRROR policy) decides the result's.
+      Type existing = types.putIfAbsent(name, actual);
+      if (existing != null && !existing.equalsIgnoringNullability(actual)) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Inconsistent binding for type parameter '%s': %s vs %s", name, existing, actual));
+      }
+    }
+
+    private void bindInteger(String token, int value, boolean bindNames) {
+      OptionalInt literal = parseIntegerLiteral(token);
+      if (literal.isPresent()) {
+        // A numeric token is a literal constraint, not a parameter name: the actual value has to
+        // equal it — a declared DECIMAL<P,0> only accepts a scale of exactly 0.
+        if (literal.getAsInt() != value) {
+          throw new UnsupportedOperationException(
+              String.format(
+                  "Declared literal %s does not match the actual value %d", token, value));
+        }
+        return;
+      }
+      if (!bindNames) {
+        return;
+      }
+      Integer existing = integers.putIfAbsent(token, value);
+      if (existing != null && existing != value) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Inconsistent binding for type parameter '%s': %d vs %d", token, existing, value));
+      }
+    }
+  }
+
+  /**
+   * Parses a type-parameter token as an integer literal, or returns empty when the token is a
+   * parameter name. The type grammar sends whitespace to a hidden channel, so the token is exact
+   * and needs no trimming.
+   */
+  private static OptionalInt parseIntegerLiteral(String token) {
+    try {
+      return OptionalInt.of(Integer.parseInt(token));
+    } catch (NumberFormatException e) {
+      return OptionalInt.empty();
+    }
+  }
+
+  /**
+   * Evaluates the supported return-type expression shapes. Everything else falls through to the
+   * throwing base, keeping unsupported derivations fail-closed.
+   */
+  private static final class ReturnTypeEvaluator
+      extends TypeExpressionVisitor.TypeExpressionThrowsVisitor<Type, RuntimeException> {
+
+    private final ParameterBindings bindings;
+
+    private ReturnTypeEvaluator(TypeExpression returnExpression, ParameterBindings bindings) {
+      super("Cannot evaluate return-type expression: " + returnExpression);
+      this.bindings = bindings;
+    }
+
+    @Override
+    public Type visit(ParameterizedType.Decimal decimal) {
+      int precision = resolveInteger(decimal.precision().value());
+      int scale = resolveInteger(decimal.scale().value());
+      return TypeCreator.of(decimal.nullable()).decimal(precision, scale);
+    }
+
+    @Override
+    public Type visit(ParameterizedType.StringLiteral stringLiteral) {
+      // A wildcard return (e.g. min(any1) -> any1) resolves to the bound argument type, taking the
+      // nullability declared on the return expression in both directions (a required return forces
+      // the type non-null, a nullable one forces it nullable). MIRROR policy, if any, is applied
+      // afterwards by the caller.
+      Type bound = bindings.boundType(stringLiteral.value());
+      if (bound == null) {
+        throw new UnsupportedOperationException(
+            "Unbound type parameter '" + stringLiteral.value() + "' in return-type expression");
+      }
+      return bound.withNullable(stringLiteral.nullable());
+    }
+
+    private int resolveInteger(String token) {
+      Integer bound = bindings.boundInteger(token);
+      if (bound != null) {
+        return bound;
+      }
+      return parseIntegerLiteral(token)
+          .orElseThrow(
+              () ->
+                  new UnsupportedOperationException(
+                      "Unbound type parameter '" + token + "' in return-type expression"));
+    }
   }
 }

--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -1,11 +1,26 @@
 package io.substrait.type;
 
 import io.substrait.extension.SimpleExtension;
+import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
+import io.substrait.function.TypeExpressionVisitor;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Evaluates a {@link TypeExpression} to a concrete {@link Type} given a set of actual arguments.
+ *
+ * <p>A declaration's {@code return} expression is either already concrete (e.g. {@code i64?}) or
+ * parameterized in terms of its argument types (e.g. {@code DECIMAL?<38,S>}, where {@code S} is the
+ * scale of the argument). This evaluator resolves the latter by binding the integer type parameters
+ * ({@code P}, {@code S}, ...) from the actual argument types and substituting them.
+ *
+ * <p>Expression shapes that are not yet supported (arithmetic derivations, {@code if/then}, return
+ * programs, ...) fail closed with an {@link UnsupportedOperationException}. The evaluator never
+ * falls back to a caller-supplied type: an unresolved expression is an error, not a default.
  */
 public class TypeExpressionEvaluator {
 
@@ -13,19 +28,213 @@ public class TypeExpressionEvaluator {
    * Evaluates a return-type expression to a concrete {@link Type}.
    *
    * @param returnExpression the type expression to evaluate
-   * @param parameterizedTypeList the declared parameter types of the function
+   * @param declaredArguments the declared arguments of the function (used to bind type parameters)
    * @param actualTypes the actual argument types supplied at the call site
    * @return the resolved concrete type
-   * @throws UnsupportedOperationException if the expression cannot yet be evaluated
+   * @throws UnsupportedOperationException if the expression cannot be evaluated
    */
   public static Type evaluateExpression(
       TypeExpression returnExpression,
-      List<SimpleExtension.Argument> parameterizedTypeList,
+      List<SimpleExtension.Argument> declaredArguments,
       List<Type> actualTypes) {
+    return evaluateExpression(returnExpression, declaredArguments, Optional.empty(), actualTypes);
+  }
 
+  /**
+   * Evaluates a return-type expression to a concrete {@link Type}, taking the declaration's
+   * variadic behavior into account.
+   *
+   * @param returnExpression the type expression to evaluate
+   * @param declaredArguments the declared arguments of the function (used to bind type parameters)
+   * @param variadic the declaration's variadic behavior, if it is variadic
+   * @param actualTypes the actual argument types supplied at the call site
+   * @return the resolved concrete type
+   * @throws UnsupportedOperationException if the expression cannot be evaluated
+   */
+  public static Type evaluateExpression(
+      TypeExpression returnExpression,
+      List<SimpleExtension.Argument> declaredArguments,
+      Optional<SimpleExtension.VariadicBehavior> variadic,
+      List<Type> actualTypes) {
+    // Bind the parameters even when the return type is concrete: binding is what catches a
+    // signature that uses one parameter name inconsistently — f(DECIMAL<P,S>, DECIMAL<P,S>) called
+    // with two different scales — and that is an error whatever the function returns.
+    ParameterBindings bindings = bindParameters(declaredArguments, variadic, actualTypes);
     if (returnExpression instanceof Type) {
+      // The declared return type is already concrete; nothing to derive.
       return (Type) returnExpression;
     }
-    throw new UnsupportedOperationException("NYI");
+    return returnExpression.accept(new ReturnTypeEvaluator(returnExpression, bindings));
+  }
+
+  /**
+   * Binds the declaration's type parameters — both numbered wildcards (e.g. the {@code any1} of
+   * {@code min(any1) -> any1}) and integer parameters (e.g. the {@code P} and {@code S} of {@code
+   * DECIMAL<P,S>}) — by matching each declared value argument against the corresponding actual
+   * argument type in a single pass.
+   *
+   * <p>Binding the same parameter name to two different values is a signature error and is rejected
+   * rather than silently overwritten, for wildcards and integer parameters alike. A variadic
+   * declaration states its trailing argument once but accepts it repeatedly, so every actual
+   * argument is bound against that trailing declaration — unless the declaration marks its
+   * parameters {@code INCONSISTENT}, in which case each repetition is independent and only the
+   * first one binds.
+   */
+  private static ParameterBindings bindParameters(
+      List<SimpleExtension.Argument> declaredArguments,
+      Optional<SimpleExtension.VariadicBehavior> variadic,
+      List<Type> actualTypes) {
+    // Enum arguments select an overload and carry no value type, so they do not consume an actual
+    // type; dropping them aligns the declared and actual arguments positionally. A null entry is a
+    // type argument: it consumes an actual type but binds no parameter.
+    List<ParameterizedType> declaredTypes = new ArrayList<>();
+    for (SimpleExtension.Argument declared : declaredArguments) {
+      if (declared instanceof SimpleExtension.EnumArgument) {
+        continue;
+      }
+      declaredTypes.add(
+          declared instanceof SimpleExtension.ValueArgument
+              ? ((SimpleExtension.ValueArgument) declared).value()
+              : null);
+    }
+
+    ParameterBindings bindings = new ParameterBindings();
+    if (declaredTypes.isEmpty()) {
+      return bindings;
+    }
+    boolean bindRepeats =
+        variadic
+            .map(
+                behavior ->
+                    behavior.parameterConsistency()
+                        == SimpleExtension.VariadicBehavior.ParameterConsistency.CONSISTENT)
+            .orElse(false);
+    for (int index = 0; index < actualTypes.size(); index++) {
+      boolean repeated = index >= declaredTypes.size();
+      if (repeated && !bindRepeats) {
+        // Either the arity is wrong (validated by the resolver, not here) or the repetitions are
+        // declared independent; in both cases there is nothing further to bind.
+        break;
+      }
+      ParameterizedType declared =
+          repeated ? declaredTypes.get(declaredTypes.size() - 1) : declaredTypes.get(index);
+      if (declared != null) {
+        bindings.bind(declared, actualTypes.get(index));
+      }
+    }
+    return bindings;
+  }
+
+  /** The wildcard and integer type parameters bound from a call site's actual argument types. */
+  private static final class ParameterBindings {
+
+    private final Map<String, Type> types = new HashMap<>();
+    private final Map<String, Integer> integers = new HashMap<>();
+
+    private Type boundType(String name) {
+      return types.get(name);
+    }
+
+    private Integer boundInteger(String token) {
+      return integers.get(token);
+    }
+
+    private void bind(ParameterizedType declared, Type actual) {
+      if (declared instanceof ParameterizedType.StringLiteral) {
+        ParameterizedType.StringLiteral literal = (ParameterizedType.StringLiteral) declared;
+        // Only a numbered wildcard names a parameter that a return expression can refer to and that
+        // has to stay consistent across the call; a plain "any" binds independently each time.
+        if (literal.isNumberedWildcard()) {
+          bindType(literal.value(), actual);
+        }
+      } else if (declared instanceof ParameterizedType.Decimal && actual instanceof Type.Decimal) {
+        ParameterizedType.Decimal declaredDecimal = (ParameterizedType.Decimal) declared;
+        Type.Decimal actualDecimal = (Type.Decimal) actual;
+        bindInteger(declaredDecimal.precision().value(), actualDecimal.precision());
+        bindInteger(declaredDecimal.scale().value(), actualDecimal.scale());
+      }
+    }
+
+    private void bindType(String name, Type actual) {
+      // Nullability is not part of a wildcard's identity: any1 binds to i32 and i32? alike, and the
+      // return expression's own nullability (or the MIRROR policy) decides the result's.
+      Type existing = types.putIfAbsent(name, actual);
+      if (existing != null && !existing.equalsIgnoringNullability(actual)) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Inconsistent binding for type parameter '%s': %s vs %s", name, existing, actual));
+      }
+    }
+
+    private void bindInteger(String token, int value) {
+      if (isInteger(token)) {
+        // A numeric token is a literal, not a parameter name; nothing to bind.
+        return;
+      }
+      Integer existing = integers.putIfAbsent(token, value);
+      if (existing != null && existing != value) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Inconsistent binding for type parameter '%s': %d vs %d", token, existing, value));
+      }
+    }
+
+    private static boolean isInteger(String token) {
+      try {
+        Integer.parseInt(token.trim());
+        return true;
+      } catch (NumberFormatException e) {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Evaluates the supported return-type expression shapes. Everything else falls through to the
+   * throwing base, keeping unsupported derivations fail-closed.
+   */
+  private static final class ReturnTypeEvaluator
+      extends TypeExpressionVisitor.TypeExpressionThrowsVisitor<Type, RuntimeException> {
+
+    private final ParameterBindings bindings;
+
+    private ReturnTypeEvaluator(TypeExpression returnExpression, ParameterBindings bindings) {
+      super("Cannot evaluate return-type expression: " + returnExpression);
+      this.bindings = bindings;
+    }
+
+    @Override
+    public Type visit(ParameterizedType.Decimal decimal) {
+      int precision = resolveInteger(decimal.precision().value());
+      int scale = resolveInteger(decimal.scale().value());
+      return TypeCreator.of(decimal.nullable()).decimal(precision, scale);
+    }
+
+    @Override
+    public Type visit(ParameterizedType.StringLiteral stringLiteral) {
+      // A wildcard return (e.g. min(any1) -> any1) resolves to the bound argument type, taking the
+      // nullability declared on the return expression in both directions (a required return forces
+      // the type non-null, a nullable one forces it nullable). MIRROR policy, if any, is applied
+      // afterwards by the caller.
+      Type bound = bindings.boundType(stringLiteral.value());
+      if (bound == null) {
+        throw new UnsupportedOperationException(
+            "Unbound type parameter '" + stringLiteral.value() + "' in return-type expression");
+      }
+      return bound.withNullable(stringLiteral.nullable());
+    }
+
+    private int resolveInteger(String token) {
+      Integer bound = bindings.boundInteger(token);
+      if (bound != null) {
+        return bound;
+      }
+      try {
+        return Integer.parseInt(token.trim());
+      } catch (NumberFormatException e) {
+        throw new UnsupportedOperationException(
+            "Unbound type parameter '" + token + "' in return-type expression");
+      }
+    }
   }
 }

--- a/core/src/test/java/io/substrait/extension/FunctionBindingResolverTest.java
+++ b/core/src/test/java/io/substrait/extension/FunctionBindingResolverTest.java
@@ -1,0 +1,539 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.io.Resources;
+import io.substrait.expression.FunctionOption;
+import io.substrait.type.TypeCreator;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class FunctionBindingResolverTest {
+
+  static final TypeCreator R = TypeCreator.REQUIRED;
+  static final TypeCreator N = TypeCreator.NULLABLE;
+
+  /** Declarations that the standard extensions do not provide (plain wildcards, DISCRETE). */
+  static final SimpleExtension.ExtensionCollection TEST_EXTENSIONS = loadTestExtensions();
+
+  final SimpleExtension.ExtensionCollection extensions = DefaultExtensionCatalog.DEFAULT_COLLECTION;
+
+  private static SimpleExtension.ExtensionCollection loadTestExtensions() {
+    try {
+      return SimpleExtension.load(
+          Resources.toString(
+              Resources.getResource("extensions/binding_extensions.yaml"), StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private SimpleExtension.AggregateFunctionVariant aggregate(String urn, String key) {
+    return extensions.getAggregateFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  private SimpleExtension.ScalarFunctionVariant scalar(String urn, String key) {
+    return extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  private ResolvedFunctionBinding binding(
+      SimpleExtension.Function declaration, List<ResolvedArgument> arguments) {
+    return ResolvedFunctionBinding.builder()
+        .anchor(declaration.getAnchor())
+        .declaration(declaration)
+        .arguments(arguments)
+        .options(List.of())
+        .build();
+  }
+
+  @Test
+  void resolvesConcreteIntegerSum() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            sum, List.of(ResolvedArgument.value(R.I32)), List.of(), N.I64);
+    assertEquals(N.I64, binding.outputType());
+    assertEquals(sum.getAnchor(), binding.anchor());
+  }
+
+  @Test
+  void resolvesDecimalSumWidth() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL, "sum:dec");
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            sum, List.of(ResolvedArgument.value(R.decimal(10, 2))), List.of(), N.decimal(38, 2));
+    assertEquals(N.decimal(38, 2), binding.outputType());
+  }
+
+  @Test
+  void appliesMirrorNullabilityForScalars() {
+    // add:i32_i32 has MIRROR nullability: a nullable operand makes the result nullable.
+    SimpleExtension.ScalarFunctionVariant add =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "add:i32_i32");
+    ResolvedFunctionBinding required =
+        FunctionBindingResolver.resolve(
+            add, List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.I32)), List.of());
+    assertFalse(required.outputType().nullable());
+    ResolvedFunctionBinding nullable =
+        FunctionBindingResolver.resolve(
+            add, List.of(ResolvedArgument.value(N.I32), ResolvedArgument.value(R.I32)), List.of());
+    assertTrue(nullable.outputType().nullable());
+  }
+
+  @Test
+  void derivesWildcardReturnFromArgument() {
+    // any_value(any1) -> any1?: the wildcard return resolves to the argument type, made nullable.
+    SimpleExtension.AggregateFunctionVariant anyValue =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "any_value:any");
+    assertEquals(
+        N.I32,
+        FunctionBindingResolver.deriveOutputType(anyValue, List.of(ResolvedArgument.value(R.I32))));
+  }
+
+  @Test
+  void rejectsDeclaredOutputTypeThatDivergesFromDeclaration() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // The standard declaration derives i64? for sum(i32); a plan declaring required i64 is invalid.
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                sum, List.of(ResolvedArgument.value(R.I32)), List.of(), R.I64));
+  }
+
+  @Test
+  void rejectsIncompatibleArgumentType() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // Validation is opt-in: resolve() alone captures identity and does not check the signature.
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                sum, List.of(ResolvedArgument.value(R.FP64)), List.of(), N.I64));
+  }
+
+  @Test
+  void rejectsInconsistentNumberedWildcard() {
+    // nullif(any1, any1): the numbered wildcard must bind to one type; i32 + string is invalid.
+    SimpleExtension.ScalarFunctionVariant nullif =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "nullif:any_any");
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                nullif,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.STRING)),
+                List.of(),
+                R.I32));
+  }
+
+  @Test
+  void rejectsWrongArity() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                sum,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.I32)),
+                List.of(),
+                N.I64));
+  }
+
+  @Test
+  void outputTypeIsDerivedNotSettable() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // There is no builder setter for outputType; it is always derived from the declaration.
+    assertEquals(N.I64, binding(sum, List.of(ResolvedArgument.value(R.I32))).outputType());
+  }
+
+  @Test
+  void identityIncludesArgumentsAndEnumValues() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    assertEquals(
+        binding(sum, List.of(ResolvedArgument.value(R.I32))),
+        binding(sum, List.of(ResolvedArgument.value(R.I32))));
+    // Different value-argument types are distinct identities.
+    assertNotEquals(
+        binding(sum, List.of(ResolvedArgument.value(R.I32))),
+        binding(sum, List.of(ResolvedArgument.value(R.FP64))));
+    // Different enum options are distinct identities: std_dev declares a leading "distribution"
+    // enum argument, so POPULATION and SAMPLE are two different functions on the same anchor.
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    assertNotEquals(
+        binding(stdDev, stdDevArguments("POPULATION")), binding(stdDev, stdDevArguments("SAMPLE")));
+  }
+
+  @Test
+  void identityKeepsEnumOptionsAsSpelled() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    // Identity is conservative rather than spec-exact: the plan's spelling is preserved verbatim
+    // (see acceptsEnumOptionRegardlessOfCase for the case-insensitive matching the spec requires),
+    // so two spellings of one option stay distinct instead of one of them being rewritten.
+    assertNotEquals(
+        binding(stdDev, stdDevArguments("SAMPLE")), binding(stdDev, stdDevArguments("sample")));
+    // An unspecified option is not the same as any specified one either.
+    assertNotEquals(
+        binding(
+            stdDev,
+            List.of(ResolvedArgument.unspecifiedEnumOption(), ResolvedArgument.value(R.FP32))),
+        binding(stdDev, stdDevArguments("SAMPLE")));
+  }
+
+  @Test
+  void optionsAreKeptAsSpelledButMatchedCaseInsensitively() {
+    SimpleExtension.AggregateFunctionVariant count =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any");
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            count,
+            List.of(ResolvedArgument.value(R.I32)),
+            List.of(FunctionOption.builder().name("Overflow").addValues("ERROR").build()),
+            R.I64);
+    // The declaration spells the option "overflow" with values [SILENT, SATURATE, ERROR]; matching
+    // ignores case, but the binding still reports what the plan asked for.
+    assertEquals(
+        List.of(FunctionOption.builder().name("Overflow").addValues("ERROR").build()),
+        binding.options());
+  }
+
+  @Test
+  void acceptsEnumOptionRegardlessOfCase() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            stdDev, stdDevArguments("sample"), List.of(), N.FP32);
+    assertEquals(N.FP32, binding.outputType());
+  }
+
+  @Test
+  void rejectsUnknownEnumOption() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                stdDev, stdDevArguments("MEDIAN"), List.of(), N.FP32));
+  }
+
+  @Test
+  void rejectsUnspecifiedRequiredEnumOption() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    // std_dev's distribution argument is required, so leaving it unspecified does not satisfy the
+    // declaration — but it is reported as a missing option, not as an unknown one.
+    InvalidFunctionBindingException e =
+        assertThrows(
+            InvalidFunctionBindingException.class,
+            () ->
+                FunctionBindingResolver.resolveAndValidate(
+                    stdDev,
+                    List.of(
+                        ResolvedArgument.unspecifiedEnumOption(), ResolvedArgument.value(R.FP32)),
+                    List.of(),
+                    N.FP32));
+    assertTrue(e.getMessage().contains("left unspecified"), e.getMessage());
+  }
+
+  @Test
+  void plainWildcardArgumentsBindIndependently() {
+    // pair(any, any): plain wildcards are matched per argument, so two different types are valid.
+    SimpleExtension.ScalarFunctionVariant pair = testScalar("pair:any_any");
+    assertDoesNotThrow(
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                pair,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.STRING)),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void numberedWildcardArgumentsMustAgree() {
+    // same_pair(any1, any1): the numbered wildcard has to bind to one type across the invocation.
+    SimpleExtension.ScalarFunctionVariant samePair = testScalar("same_pair:any_any");
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                samePair,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.STRING)),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void discreteDeclarationFixesWildcardNullability() {
+    // discrete_wildcard(any1) -> any1 with DISCRETE nullability: the declared required argument
+    // does not accept a nullable one, and the derived type keeps the declared nullability.
+    SimpleExtension.ScalarFunctionVariant discrete = testScalar("discrete_wildcard:any");
+    assertEquals(
+        R.I32,
+        FunctionBindingResolver.resolveAndValidate(
+                discrete, List.of(ResolvedArgument.value(R.I32)), List.of(), R.I32)
+            .outputType());
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                discrete, List.of(ResolvedArgument.value(N.I32)), List.of(), N.I32));
+  }
+
+  @Test
+  void discreteDeclarationFixesNullabilityOfParameterizedTypes() {
+    // discrete_decimal(DECIMAL?<P,S>) with DISCRETE nullability: the declared nullable argument is
+    // part of the signature, so a required decimal does not satisfy it either.
+    SimpleExtension.ScalarFunctionVariant discrete = testScalar("discrete_decimal:dec");
+    assertDoesNotThrow(
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                discrete, List.of(ResolvedArgument.value(N.decimal(10, 2))), List.of(), R.BOOLEAN));
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                discrete, List.of(ResolvedArgument.value(R.decimal(10, 2))), List.of(), R.BOOLEAN));
+  }
+
+  @Test
+  void numericLiteralParameterConstrainsTheActualType() {
+    // zero_scale(DECIMAL<P,0>): the literal 0 is a constraint, not a parameter name — an actual
+    // decimal whose scale is not 0 must be rejected, not silently accepted.
+    SimpleExtension.ScalarFunctionVariant zeroScale = testScalar("zero_scale:dec");
+    assertDoesNotThrow(
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                zeroScale,
+                List.of(ResolvedArgument.value(R.decimal(10, 0))),
+                List.of(),
+                R.BOOLEAN));
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                zeroScale,
+                List.of(ResolvedArgument.value(R.decimal(10, 2))),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void caseCollidingDeclaredOptionNamesAreRejected() {
+    // cased_options declares both "rounding" and "ROUNDING"; option names match
+    // case-insensitively, so the declaration is ambiguous and validation refuses to guess.
+    SimpleExtension.ScalarFunctionVariant cased = testScalar("cased_options:i32");
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                cased, List.of(ResolvedArgument.value(R.I32)), List.of(), R.BOOLEAN));
+  }
+
+  @Test
+  void typeArgumentDeclaredTypeIsValidated() {
+    // typed(<type: i32>, x: i64): the declared pattern constrains the supplied type argument, not
+    // just its kind — a string type argument must be rejected.
+    SimpleExtension.ScalarFunctionVariant typed = testScalar("typed:type_i64");
+    assertDoesNotThrow(
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                typed,
+                List.of(ResolvedArgument.type(R.I32), ResolvedArgument.value(R.I64)),
+                List.of(),
+                R.I64));
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                typed,
+                List.of(ResolvedArgument.type(R.STRING), ResolvedArgument.value(R.I64)),
+                List.of(),
+                R.I64));
+  }
+
+  @Test
+  void typeArgumentBindsReturnTypeParameters() {
+    // typed_decimal(<type: DECIMAL<P,S>>) -> DECIMAL<P,S>: the supplied type argument binds P and
+    // S, so the return derives from it rather than failing as unbound.
+    SimpleExtension.ScalarFunctionVariant typedDecimal = testScalar("typed_decimal:type");
+    assertEquals(
+        R.decimal(10, 2),
+        FunctionBindingResolver.deriveOutputType(
+            typedDecimal, List.of(ResolvedArgument.type(R.decimal(10, 2)))));
+  }
+
+  @Test
+  void inconsistentVariadicKeepsLiteralConstraints() {
+    // zero_scale_variadic(DECIMAL<P,0>...) is INCONSISTENT: P may differ between repetitions, but
+    // the literal scale 0 constrains every repetition, not only the first.
+    SimpleExtension.ScalarFunctionVariant zeroScale = testScalar("zero_scale_variadic:dec");
+    assertDoesNotThrow(
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                zeroScale,
+                List.of(
+                    ResolvedArgument.value(R.decimal(10, 0)),
+                    ResolvedArgument.value(R.decimal(12, 0))),
+                List.of(),
+                R.BOOLEAN));
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                zeroScale,
+                List.of(
+                    ResolvedArgument.value(R.decimal(10, 0)),
+                    ResolvedArgument.value(R.decimal(10, 2))),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void failsClosedOnANestedShapeItCannotCheck() {
+    SimpleExtension.ScalarFunctionVariant listPair = testScalar("list_pair:list_list");
+    // A declared list<any1> against a non-list actual used to be accepted silently; a strict
+    // validator must reject a shape it cannot check rather than pass it.
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                listPair,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.I32)),
+                List.of(),
+                R.BOOLEAN));
+    // list<i32> vs list<i32?> must not bind either: nested nullability is part of the structural
+    // match, which is exactly the check this validator cannot do yet — so it fails closed here too.
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                listPair,
+                List.of(
+                    ResolvedArgument.value(R.list(R.I32)), ResolvedArgument.value(R.list(N.I32))),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void variadicArgumentsBindBeyondTheDeclaredTail() {
+    // coalesce(any1...) declares its argument once but accepts it repeatedly; every actual
+    // argument has to agree on the wildcard, including the ones past the declared tail.
+    SimpleExtension.ScalarFunctionVariant coalesce =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "coalesce:any");
+    assertEquals(
+        R.I32,
+        FunctionBindingResolver.deriveOutputType(
+            coalesce,
+            List.of(
+                ResolvedArgument.value(R.I32),
+                ResolvedArgument.value(R.I32),
+                ResolvedArgument.value(R.I32))));
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.deriveOutputType(
+                coalesce,
+                List.of(
+                    ResolvedArgument.value(R.I32),
+                    ResolvedArgument.value(R.I32),
+                    ResolvedArgument.value(R.STRING))));
+  }
+
+  @Test
+  void sharedTypeParametersMustAgreeEvenWithAConcreteReturn() {
+    // decimal_pair(DECIMAL<P,S>, DECIMAL<P,S>) -> boolean: nothing about the return depends on P
+    // and S, but one signature cannot bind them to two different values.
+    SimpleExtension.ScalarFunctionVariant pair = testScalar("decimal_pair:dec_dec");
+    assertDoesNotThrow(
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                pair,
+                List.of(
+                    ResolvedArgument.value(R.decimal(10, 2)),
+                    ResolvedArgument.value(R.decimal(10, 2))),
+                List.of(),
+                R.BOOLEAN));
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                pair,
+                List.of(
+                    ResolvedArgument.value(R.decimal(10, 2)),
+                    ResolvedArgument.value(R.decimal(20, 5))),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void optionsCannotChangeAfterTheBindingIsBuilt() {
+    SimpleExtension.AggregateFunctionVariant count =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any");
+    List<FunctionOption> options =
+        new ArrayList<>(
+            List.of(FunctionOption.builder().name("overflow").addValues("error").build()));
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolve(count, List.of(ResolvedArgument.value(R.I32)), options);
+    // Mutating the list the caller handed over must not change the binding's identity: the option
+    // list is copied and every FunctionOption in it is immutable in its own right.
+    options.add(FunctionOption.builder().name("overflow").addValues("silent").build());
+    assertEquals(1, binding.options().size());
+    // Lookup by name matches case-insensitively, as the spec requires, while the stored option
+    // keeps the plan's spelling.
+    assertEquals(Optional.of(List.of("error")), binding.option("OVERFLOW"));
+  }
+
+  @Test
+  void repeatedOptionNamesAreKept() {
+    // A plan may repeat an option name; a map keyed by name would silently drop all but one.
+    SimpleExtension.AggregateFunctionVariant count =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any");
+    List<FunctionOption> options =
+        List.of(
+            FunctionOption.builder().name("overflow").addValues("error").build(),
+            FunctionOption.builder().name("overflow").addValues("silent").build());
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolve(count, List.of(ResolvedArgument.value(R.I32)), options);
+    assertEquals(options, binding.options());
+  }
+
+  @Test
+  void identityDistinguishesExtensionsByAnchor() {
+    SimpleExtension.AggregateFunctionVariant sumI32 =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    SimpleExtension.AggregateFunctionVariant sumI64 =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i64");
+    assertNotEquals(
+        binding(sumI32, List.of(ResolvedArgument.value(R.I32))),
+        binding(sumI64, List.of(ResolvedArgument.value(R.I64))));
+  }
+
+  private SimpleExtension.AggregateFunctionVariant stdDev() {
+    return aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "std_dev:req_fp32");
+  }
+
+  private SimpleExtension.ScalarFunctionVariant testScalar(String key) {
+    return TEST_EXTENSIONS.getScalarFunction(
+        SimpleExtension.FunctionAnchor.of("extension:test:binding_extensions", key));
+  }
+
+  private List<ResolvedArgument> stdDevArguments(String distribution) {
+    return List.of(ResolvedArgument.enumOption(distribution), ResolvedArgument.value(R.FP32));
+  }
+}

--- a/core/src/test/java/io/substrait/extension/FunctionBindingResolverTest.java
+++ b/core/src/test/java/io/substrait/extension/FunctionBindingResolverTest.java
@@ -1,0 +1,410 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.io.Resources;
+import io.substrait.expression.FunctionOption;
+import io.substrait.type.TypeCreator;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class FunctionBindingResolverTest {
+
+  static final TypeCreator R = TypeCreator.REQUIRED;
+  static final TypeCreator N = TypeCreator.NULLABLE;
+
+  /** Declarations that the standard extensions do not provide (plain wildcards, DISCRETE). */
+  static final SimpleExtension.ExtensionCollection TEST_EXTENSIONS = loadTestExtensions();
+
+  final SimpleExtension.ExtensionCollection extensions = DefaultExtensionCatalog.DEFAULT_COLLECTION;
+
+  private static SimpleExtension.ExtensionCollection loadTestExtensions() {
+    try {
+      return SimpleExtension.load(
+          Resources.toString(
+              Resources.getResource("extensions/binding_extensions.yaml"), StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private SimpleExtension.AggregateFunctionVariant aggregate(String urn, String key) {
+    return extensions.getAggregateFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  private SimpleExtension.ScalarFunctionVariant scalar(String urn, String key) {
+    return extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  private ResolvedFunctionBinding binding(
+      SimpleExtension.Function declaration, List<ResolvedArgument> arguments) {
+    return ResolvedFunctionBinding.builder()
+        .anchor(declaration.getAnchor())
+        .declaration(declaration)
+        .arguments(arguments)
+        .options(List.of())
+        .build();
+  }
+
+  @Test
+  void resolvesConcreteIntegerSum() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            sum, List.of(ResolvedArgument.value(R.I32)), List.of(), N.I64);
+    assertEquals(N.I64, binding.outputType());
+    assertEquals(sum.getAnchor(), binding.anchor());
+  }
+
+  @Test
+  void resolvesDecimalSumWidth() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL, "sum:dec");
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            sum, List.of(ResolvedArgument.value(R.decimal(10, 2))), List.of(), N.decimal(38, 2));
+    assertEquals(N.decimal(38, 2), binding.outputType());
+  }
+
+  @Test
+  void appliesMirrorNullabilityForScalars() {
+    // add:i32_i32 has MIRROR nullability: a nullable operand makes the result nullable.
+    SimpleExtension.ScalarFunctionVariant add =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "add:i32_i32");
+    ResolvedFunctionBinding required =
+        FunctionBindingResolver.resolve(
+            add, List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.I32)), List.of());
+    assertEquals(false, required.outputType().nullable());
+    ResolvedFunctionBinding nullable =
+        FunctionBindingResolver.resolve(
+            add, List.of(ResolvedArgument.value(N.I32), ResolvedArgument.value(R.I32)), List.of());
+    assertEquals(true, nullable.outputType().nullable());
+  }
+
+  @Test
+  void derivesWildcardReturnFromArgument() {
+    // any_value(any1) -> any1?: the wildcard return resolves to the argument type, made nullable.
+    SimpleExtension.AggregateFunctionVariant anyValue =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "any_value:any");
+    assertEquals(
+        N.I32,
+        FunctionBindingResolver.deriveOutputType(anyValue, List.of(ResolvedArgument.value(R.I32))));
+  }
+
+  @Test
+  void rejectsDeclaredOutputTypeThatDivergesFromDeclaration() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // The standard declaration derives i64? for sum(i32); a plan declaring required i64 is invalid.
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                sum, List.of(ResolvedArgument.value(R.I32)), List.of(), R.I64));
+  }
+
+  @Test
+  void rejectsIncompatibleArgumentType() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // Validation is opt-in: resolve() alone captures identity and does not check the signature.
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                sum, List.of(ResolvedArgument.value(R.FP64)), List.of(), N.I64));
+  }
+
+  @Test
+  void rejectsInconsistentNumberedWildcard() {
+    // nullif(any1, any1): the numbered wildcard must bind to one type; i32 + string is invalid.
+    SimpleExtension.ScalarFunctionVariant nullif =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "nullif:any_any");
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                nullif,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.STRING)),
+                List.of(),
+                R.I32));
+  }
+
+  @Test
+  void rejectsWrongArity() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                sum,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.I32)),
+                List.of(),
+                N.I64));
+  }
+
+  @Test
+  void outputTypeIsDerivedNotSettable() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // There is no builder setter for outputType; it is always derived from the declaration.
+    assertEquals(N.I64, binding(sum, List.of(ResolvedArgument.value(R.I32))).outputType());
+  }
+
+  @Test
+  void identityIncludesArgumentsAndEnumValues() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    assertEquals(
+        binding(sum, List.of(ResolvedArgument.value(R.I32))),
+        binding(sum, List.of(ResolvedArgument.value(R.I32))));
+    // Different value-argument types are distinct identities.
+    assertNotEquals(
+        binding(sum, List.of(ResolvedArgument.value(R.I32))),
+        binding(sum, List.of(ResolvedArgument.value(R.FP64))));
+    // Different enum options are distinct identities: std_dev declares a leading "distribution"
+    // enum argument, so POPULATION and SAMPLE are two different functions on the same anchor.
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    assertNotEquals(
+        binding(stdDev, stdDevArguments("POPULATION")), binding(stdDev, stdDevArguments("SAMPLE")));
+  }
+
+  @Test
+  void identityKeepsEnumOptionsAsSpelled() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    // Identity is conservative rather than spec-exact: the plan's spelling is preserved verbatim
+    // (see acceptsEnumOptionRegardlessOfCase for the case-insensitive matching the spec requires),
+    // so two spellings of one option stay distinct instead of one of them being rewritten.
+    assertNotEquals(
+        binding(stdDev, stdDevArguments("SAMPLE")), binding(stdDev, stdDevArguments("sample")));
+    // An unspecified option is not the same as any specified one either.
+    assertNotEquals(
+        binding(
+            stdDev,
+            List.of(ResolvedArgument.unspecifiedEnumOption(), ResolvedArgument.value(R.FP32))),
+        binding(stdDev, stdDevArguments("SAMPLE")));
+  }
+
+  @Test
+  void optionsAreKeptAsSpelledButMatchedCaseInsensitively() {
+    SimpleExtension.AggregateFunctionVariant count =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any");
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            count,
+            List.of(ResolvedArgument.value(R.I32)),
+            List.of(FunctionOption.builder().name("Overflow").addValues("ERROR").build()),
+            R.I64);
+    // The declaration spells the option "overflow" with values [SILENT, SATURATE, ERROR]; matching
+    // ignores case, but the binding still reports what the plan asked for.
+    assertEquals(
+        List.of(FunctionOption.builder().name("Overflow").addValues("ERROR").build()),
+        binding.options());
+  }
+
+  @Test
+  void acceptsEnumOptionRegardlessOfCase() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolveAndValidate(
+            stdDev, stdDevArguments("sample"), List.of(), N.FP32);
+    assertEquals(N.FP32, binding.outputType());
+  }
+
+  @Test
+  void rejectsUnknownEnumOption() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                stdDev, stdDevArguments("MEDIAN"), List.of(), N.FP32));
+  }
+
+  @Test
+  void rejectsUnspecifiedRequiredEnumOption() {
+    SimpleExtension.AggregateFunctionVariant stdDev = stdDev();
+    // std_dev's distribution argument is required, so leaving it unspecified does not satisfy the
+    // declaration — but it is reported as a missing option, not as an unknown one.
+    InvalidFunctionBindingException e =
+        assertThrows(
+            InvalidFunctionBindingException.class,
+            () ->
+                FunctionBindingResolver.resolveAndValidate(
+                    stdDev,
+                    List.of(
+                        ResolvedArgument.unspecifiedEnumOption(), ResolvedArgument.value(R.FP32)),
+                    List.of(),
+                    N.FP32));
+    assertTrue(e.getMessage().contains("left unspecified"), e.getMessage());
+  }
+
+  @Test
+  void plainWildcardArgumentsBindIndependently() {
+    // pair(any, any): plain wildcards are matched per argument, so two different types are valid.
+    SimpleExtension.ScalarFunctionVariant pair = testScalar("pair:any_any");
+    FunctionBindingResolver.resolveAndValidate(
+        pair,
+        List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.STRING)),
+        List.of(),
+        R.BOOLEAN);
+  }
+
+  @Test
+  void numberedWildcardArgumentsMustAgree() {
+    // same_pair(any1, any1): the numbered wildcard has to bind to one type across the invocation.
+    SimpleExtension.ScalarFunctionVariant samePair = testScalar("same_pair:any_any");
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                samePair,
+                List.of(ResolvedArgument.value(R.I32), ResolvedArgument.value(R.STRING)),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void discreteDeclarationFixesWildcardNullability() {
+    // discrete_wildcard(any1) -> any1 with DISCRETE nullability: the declared required argument
+    // does not accept a nullable one, and the derived type keeps the declared nullability.
+    SimpleExtension.ScalarFunctionVariant discrete = testScalar("discrete_wildcard:any");
+    assertEquals(
+        R.I32,
+        FunctionBindingResolver.resolveAndValidate(
+                discrete, List.of(ResolvedArgument.value(R.I32)), List.of(), R.I32)
+            .outputType());
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                discrete, List.of(ResolvedArgument.value(N.I32)), List.of(), N.I32));
+  }
+
+  @Test
+  void discreteDeclarationFixesNullabilityOfParameterizedTypes() {
+    // discrete_decimal(DECIMAL?<P,S>) with DISCRETE nullability: the declared nullable argument is
+    // part of the signature, so a required decimal does not satisfy it either.
+    SimpleExtension.ScalarFunctionVariant discrete = testScalar("discrete_decimal:dec");
+    FunctionBindingResolver.resolveAndValidate(
+        discrete, List.of(ResolvedArgument.value(N.decimal(10, 2))), List.of(), R.BOOLEAN);
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                discrete, List.of(ResolvedArgument.value(R.decimal(10, 2))), List.of(), R.BOOLEAN));
+  }
+
+  @Test
+  void variadicArgumentsBindBeyondTheDeclaredTail() {
+    // coalesce(any1...) declares its argument once but accepts it repeatedly; every actual
+    // argument has to agree on the wildcard, including the ones past the declared tail.
+    SimpleExtension.ScalarFunctionVariant coalesce =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "coalesce:any");
+    assertEquals(
+        R.I32,
+        FunctionBindingResolver.deriveOutputType(
+            coalesce,
+            List.of(
+                ResolvedArgument.value(R.I32),
+                ResolvedArgument.value(R.I32),
+                ResolvedArgument.value(R.I32))));
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.deriveOutputType(
+                coalesce,
+                List.of(
+                    ResolvedArgument.value(R.I32),
+                    ResolvedArgument.value(R.I32),
+                    ResolvedArgument.value(R.STRING))));
+  }
+
+  @Test
+  void sharedTypeParametersMustAgreeEvenWithAConcreteReturn() {
+    // decimal_pair(DECIMAL<P,S>, DECIMAL<P,S>) -> boolean: nothing about the return depends on P
+    // and S, but one signature cannot bind them to two different values.
+    SimpleExtension.ScalarFunctionVariant pair = testScalar("decimal_pair:dec_dec");
+    FunctionBindingResolver.resolveAndValidate(
+        pair,
+        List.of(ResolvedArgument.value(R.decimal(10, 2)), ResolvedArgument.value(R.decimal(10, 2))),
+        List.of(),
+        R.BOOLEAN);
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.resolveAndValidate(
+                pair,
+                List.of(
+                    ResolvedArgument.value(R.decimal(10, 2)),
+                    ResolvedArgument.value(R.decimal(20, 5))),
+                List.of(),
+                R.BOOLEAN));
+  }
+
+  @Test
+  void optionsCannotChangeAfterTheBindingIsBuilt() {
+    SimpleExtension.AggregateFunctionVariant count =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any");
+    List<FunctionOption> options =
+        new ArrayList<>(
+            List.of(FunctionOption.builder().name("overflow").addValues("error").build()));
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolve(count, List.of(ResolvedArgument.value(R.I32)), options);
+    // Mutating the list the caller handed over must not change the binding's identity: the option
+    // list is copied and every FunctionOption in it is immutable in its own right.
+    options.add(FunctionOption.builder().name("overflow").addValues("silent").build());
+    assertEquals(1, binding.options().size());
+    // Lookup by name matches case-insensitively, as the spec requires, while the stored option
+    // keeps the plan's spelling.
+    assertEquals(Optional.of(List.of("error")), binding.option("OVERFLOW"));
+  }
+
+  @Test
+  void repeatedOptionNamesAreKept() {
+    // A plan may repeat an option name; a map keyed by name would silently drop all but one.
+    SimpleExtension.AggregateFunctionVariant count =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any");
+    List<FunctionOption> options =
+        List.of(
+            FunctionOption.builder().name("overflow").addValues("error").build(),
+            FunctionOption.builder().name("overflow").addValues("silent").build());
+    ResolvedFunctionBinding binding =
+        FunctionBindingResolver.resolve(count, List.of(ResolvedArgument.value(R.I32)), options);
+    assertEquals(options, binding.options());
+  }
+
+  private SimpleExtension.AggregateFunctionVariant stdDev() {
+    return aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "std_dev:req_fp32");
+  }
+
+  private SimpleExtension.ScalarFunctionVariant testScalar(String key) {
+    return TEST_EXTENSIONS.getScalarFunction(
+        SimpleExtension.FunctionAnchor.of("extension:test:binding_extensions", key));
+  }
+
+  private List<ResolvedArgument> stdDevArguments(String distribution) {
+    return List.of(ResolvedArgument.enumOption(distribution), ResolvedArgument.value(R.FP32));
+  }
+
+  @Test
+  void identityDistinguishesExtensionsByAnchor() {
+    SimpleExtension.AggregateFunctionVariant sumI32 =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    SimpleExtension.AggregateFunctionVariant sumI64 =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i64");
+    assertNotEquals(
+        binding(sumI32, List.of(ResolvedArgument.value(R.I32))),
+        binding(sumI64, List.of(ResolvedArgument.value(R.I64))));
+  }
+}

--- a/core/src/test/java/io/substrait/extension/ResolvedAggregateBindingTest.java
+++ b/core/src/test/java/io/substrait/extension/ResolvedAggregateBindingTest.java
@@ -1,0 +1,178 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.TestBase;
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class ResolvedAggregateBindingTest extends TestBase {
+
+  /** The intermediate state {@code avg} accumulates: a sum and a count. */
+  static final Type AVG_INTERMEDIATE = R.struct(R.I64, R.I64);
+
+  @Test
+  void finalPhaseProducesTheDeclaredReturnType() {
+    ResolvedAggregateBinding binding =
+        ResolvedAggregateBinding.resolve(avg(Expression.AggregationPhase.INITIAL_TO_RESULT));
+    assertEquals(N.I32, binding.outputType());
+  }
+
+  @Test
+  void partialPhaseProducesTheDeclaredIntermediateType() {
+    // A phase that stops at the intermediate state produces avg's accumulator, not its average.
+    for (Expression.AggregationPhase phase :
+        new Expression.AggregationPhase[] {
+          Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE,
+          Expression.AggregationPhase.INTERMEDIATE_TO_INTERMEDIATE
+        }) {
+      assertEquals(AVG_INTERMEDIATE, ResolvedAggregateBinding.resolve(avg(phase)).outputType());
+    }
+  }
+
+  @Test
+  void validationComparesAgainstThePhaseOutputType() {
+    ResolvedAggregateBinding partial =
+        ResolvedAggregateBinding.resolve(avg(Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE));
+    // A partial aggregate that declares the intermediate type is valid ...
+    FunctionBindingResolver.validate(partial, AVG_INTERMEDIATE);
+    // ... while one declaring the final return type is not.
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () -> FunctionBindingResolver.validate(partial, N.I32));
+  }
+
+  @Test
+  void explicitIntermediateTypeWins() {
+    ResolvedAggregateBinding resolved =
+        ResolvedAggregateBinding.resolve(avg(Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE));
+    ResolvedAggregateBinding overridden =
+        ResolvedAggregateBinding.builder().from(resolved).intermediateType(R.struct(R.I64)).build();
+    assertEquals(R.struct(R.I64), overridden.outputType());
+  }
+
+  @Test
+  void phaseIsPartOfTheIdentity() {
+    // Identity has to tell a partial aggregate apart from a full one: they produce different types
+    // and cannot be substituted for one another.
+    ResolvedAggregateBinding partial =
+        ResolvedAggregateBinding.resolve(avg(Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE));
+    ResolvedAggregateBinding full =
+        ResolvedAggregateBinding.resolve(avg(Expression.AggregationPhase.INITIAL_TO_RESULT));
+    assertNotEquals(partial, full);
+  }
+
+  @Test
+  void intermediateConsumingPhaseTakesTheIntermediateState() {
+    // sum:i32 accumulates into i64?, so its final phase consumes an i64? — validating that against
+    // the declaration's i32 argument would reject a perfectly valid partial-aggregation plan.
+    ResolvedAggregateBinding finalPhase =
+        sum(Expression.AggregationPhase.INTERMEDIATE_TO_RESULT, N.I64);
+    FunctionBindingResolver.validate(finalPhase, N.I64);
+    assertTrue(FunctionBindingResolver.matchesDeclaration(finalPhase));
+
+    // The same argument in an initial phase is not valid: there it is the declared i32 that is
+    // expected.
+    assertFalse(
+        FunctionBindingResolver.matchesDeclaration(
+            sum(Expression.AggregationPhase.INITIAL_TO_RESULT, N.I64)));
+  }
+
+  @Test
+  void intermediateConsumingPhaseRejectsAnotherState() {
+    assertThrows(
+        InvalidFunctionBindingException.class,
+        () ->
+            FunctionBindingResolver.validate(
+                sum(Expression.AggregationPhase.INTERMEDIATE_TO_RESULT, R.I32), N.I64));
+  }
+
+  @Test
+  void bindingStopsMatchingWhenTheArgumentsChange() {
+    // What the reverse conversion relies on: a binding that no longer describes the call it is
+    // attached to (a rule replaced the i32 operand with an i64 one) must not be restored.
+    assertFalse(
+        FunctionBindingResolver.matchesDeclaration(
+            sum(Expression.AggregationPhase.INITIAL_TO_RESULT, R.I64)));
+    assertTrue(
+        FunctionBindingResolver.matchesDeclaration(
+            sum(Expression.AggregationPhase.INITIAL_TO_RESULT, R.I32)));
+  }
+
+  @Test
+  void intermediateStateMustArriveAsAValueArgument() {
+    // A type argument carries no operand: conversion drops it and leaves the aggregate with no
+    // arguments at all, so accepting one here would validate a plan that cannot be converted.
+    ResolvedAggregateBinding binding =
+        ResolvedAggregateBinding.builder()
+            .function(
+                FunctionBindingResolver.resolve(
+                    sumDeclaration(), List.of(ResolvedArgument.type(N.I64)), List.of()))
+            .phase(Expression.AggregationPhase.INTERMEDIATE_TO_RESULT)
+            .invocation(Expression.AggregationInvocation.ALL)
+            .intermediateType(Optional.empty())
+            .build();
+    assertFalse(FunctionBindingResolver.matchesDeclaration(binding));
+  }
+
+  @Test
+  void nonDecomposableDeclarationHasNoIntermediateState() {
+    // mode declares no decomposability, so there is no intermediate state for a partial phase to
+    // produce — deriving one fails closed rather than inventing it.
+    SimpleExtension.AggregateFunctionVariant mode =
+        extensions.getAggregateFunction(
+            SimpleExtension.FunctionAnchor.of(
+                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "mode:i32"));
+    ResolvedAggregateBinding binding =
+        ResolvedAggregateBinding.resolve(
+            AggregateFunctionInvocation.builder()
+                .declaration(mode)
+                .outputType(N.I32)
+                .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_INTERMEDIATE)
+                .invocation(Expression.AggregationInvocation.ALL)
+                .addArguments(sb.i32(1))
+                .build());
+    assertThrows(InvalidFunctionBindingException.class, binding::outputType);
+  }
+
+  private SimpleExtension.AggregateFunctionVariant sumDeclaration() {
+    return extensions.getAggregateFunction(
+        SimpleExtension.FunctionAnchor.of(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32"));
+  }
+
+  private ResolvedAggregateBinding sum(Expression.AggregationPhase phase, Type argumentType) {
+    SimpleExtension.AggregateFunctionVariant declaration = sumDeclaration();
+    Rel input = sb.namedScan(List.of("t"), List.of("x"), List.of(argumentType));
+    return ResolvedAggregateBinding.resolve(
+        AggregateFunctionInvocation.builder()
+            .declaration(declaration)
+            .outputType(N.I64)
+            .aggregationPhase(phase)
+            .invocation(Expression.AggregationInvocation.ALL)
+            .addArguments(sb.fieldReference(input, 0))
+            .build());
+  }
+
+  private AggregateFunctionInvocation avg(Expression.AggregationPhase phase) {
+    SimpleExtension.AggregateFunctionVariant declaration =
+        extensions.getAggregateFunction(
+            SimpleExtension.FunctionAnchor.of(
+                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "avg:i32"));
+    return AggregateFunctionInvocation.builder()
+        .declaration(declaration)
+        .outputType(N.I32)
+        .aggregationPhase(phase)
+        .invocation(Expression.AggregationInvocation.ALL)
+        .addArguments(sb.i32(1))
+        .build();
+  }
+}

--- a/core/src/test/java/io/substrait/function/ToTypeStringTest.java
+++ b/core/src/test/java/io/substrait/function/ToTypeStringTest.java
@@ -1,6 +1,7 @@
 package io.substrait.function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
@@ -66,5 +67,44 @@ class ToTypeStringTest {
     ParameterizedType.StringLiteral any1 =
         ParameterizedType.StringLiteral.builder().nullable(false).value("any1").build();
     assertEquals("any1", any1.accept(ToTypeString.ToTypeLiteralStringLossless.INSTANCE));
+  }
+
+  static Stream<Arguments> wildcardBoundaries() {
+    // The type grammar's lexer defines the wildcard family as 'ANY' [0-9]? (case-insensitive) with
+    // exactly one digit at most; a longer token lexes as an ordinary named type parameter.
+    return Stream.of(
+        Arguments.of("any", true, false),
+        Arguments.of("ANY", true, false),
+        Arguments.of("any0", true, true),
+        Arguments.of("any1", true, true),
+        Arguments.of("ANY2", true, true),
+        Arguments.of("any9", true, true),
+        Arguments.of("any10", false, false),
+        Arguments.of("any123", false, false),
+        Arguments.of("any1x", false, false),
+        Arguments.of("anything", false, false),
+        Arguments.of("anywhere", false, false),
+        // Character.isDigit is Unicode-aware, but the grammar admits ASCII digits only.
+        Arguments.of("any٢", false, false),
+        Arguments.of("T", false, false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("wildcardBoundaries")
+  void wildcardPredicatesFollowTheTypeGrammar(
+      String value, boolean wildcard, boolean numberedWildcard) {
+    ParameterizedType.StringLiteral literal =
+        ParameterizedType.StringLiteral.builder().nullable(false).value(value).build();
+    assertEquals(wildcard, literal.isWildcard());
+    assertEquals(numberedWildcard, literal.isNumberedWildcard());
+    // The signature key collapses exactly the wildcard family to "any". An ordinary named
+    // parameter that merely starts with "any" (e.g. "anything") no longer collides with f(any):
+    // like every other named literal ("T"), it has no short name and fails loudly instead.
+    if (wildcard) {
+      assertEquals("any", literal.accept(ToTypeString.INSTANCE));
+    } else {
+      assertThrows(
+          UnsupportedOperationException.class, () -> literal.accept(ToTypeString.INSTANCE));
+    }
   }
 }

--- a/core/src/test/java/io/substrait/type/TypeExpressionEvaluatorTest.java
+++ b/core/src/test/java/io/substrait/type/TypeExpressionEvaluatorTest.java
@@ -1,0 +1,80 @@
+package io.substrait.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.SimpleExtension;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TypeExpressionEvaluatorTest {
+
+  final SimpleExtension.ExtensionCollection extensions = DefaultExtensionCatalog.DEFAULT_COLLECTION;
+
+  private SimpleExtension.AggregateFunctionVariant aggregate(String urn, String key) {
+    return extensions.getAggregateFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  private SimpleExtension.ScalarFunctionVariant scalar(String urn, String key) {
+    return extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  @Test
+  void concreteIntegerSumPassesThrough() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // sum:i32 declares a concrete "i64?" return, independent of the argument.
+    assertEquals(TypeCreator.NULLABLE.I64, sum.resolveType(List.of(TypeCreator.REQUIRED.I32)));
+  }
+
+  @Test
+  void decimalSumDerivesWidthAndScale() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL, "sum:dec");
+    // sum:dec declares DECIMAL<P,S> -> DECIMAL?<38,S>: precision widens to 38, scale mirrors S.
+    assertEquals(
+        TypeCreator.NULLABLE.decimal(38, 2),
+        sum.resolveType(List.of(TypeCreator.REQUIRED.decimal(10, 2))));
+    assertEquals(
+        TypeCreator.NULLABLE.decimal(38, 7),
+        sum.resolveType(List.of(TypeCreator.REQUIRED.decimal(20, 7))));
+  }
+
+  @Test
+  void rejectsInconsistentWildcardBinding() {
+    SimpleExtension.ScalarFunctionVariant nullif =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "nullif:any_any");
+    // nullif(any1, any1) -> any1?: binding the same numbered wildcard to two different types is a
+    // signature error, and must be rejected rather than silently resolved to the first binding.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> nullif.resolveType(List.of(TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.STRING)));
+  }
+
+  @Test
+  void variadicWildcardBindsEveryArgument() {
+    SimpleExtension.ScalarFunctionVariant coalesce =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "coalesce:any");
+    // coalesce(any1...) states its argument once and accepts it repeatedly, so an argument past
+    // the declared tail still has to agree with the wildcard.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> coalesce.resolveType(List.of(TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.STRING)));
+    assertEquals(
+        TypeCreator.REQUIRED.I32,
+        coalesce.resolveType(
+            List.of(TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.I32)));
+  }
+
+  @Test
+  void wildcardBindingIgnoresNullability() {
+    SimpleExtension.ScalarFunctionVariant nullif =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "nullif:any_any");
+    // Nullability is not part of a wildcard's identity: i32 and i32? bind the same any1. The
+    // declared "any1?" return then decides the result's nullability.
+    assertEquals(
+        TypeCreator.NULLABLE.I32,
+        nullif.resolveType(List.of(TypeCreator.REQUIRED.I32, TypeCreator.NULLABLE.I32)));
+  }
+}

--- a/core/src/test/java/io/substrait/type/TypeExpressionEvaluatorTest.java
+++ b/core/src/test/java/io/substrait/type/TypeExpressionEvaluatorTest.java
@@ -1,0 +1,94 @@
+package io.substrait.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.SimpleExtension;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TypeExpressionEvaluatorTest {
+
+  final SimpleExtension.ExtensionCollection extensions = DefaultExtensionCatalog.DEFAULT_COLLECTION;
+
+  private SimpleExtension.AggregateFunctionVariant aggregate(String urn, String key) {
+    return extensions.getAggregateFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  private SimpleExtension.ScalarFunctionVariant scalar(String urn, String key) {
+    return extensions.getScalarFunction(SimpleExtension.FunctionAnchor.of(urn, key));
+  }
+
+  @Test
+  void concreteIntegerSumPassesThrough() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "sum:i32");
+    // sum:i32 declares a concrete "i64?" return, independent of the argument.
+    assertEquals(TypeCreator.NULLABLE.I64, sum.resolveType(List.of(TypeCreator.REQUIRED.I32)));
+  }
+
+  @Test
+  void decimalSumDerivesWidthAndScale() {
+    SimpleExtension.AggregateFunctionVariant sum =
+        aggregate(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL, "sum:dec");
+    // sum:dec declares DECIMAL<P,S> -> DECIMAL?<38,S>: precision widens to 38, scale mirrors S.
+    assertEquals(
+        TypeCreator.NULLABLE.decimal(38, 2),
+        sum.resolveType(List.of(TypeCreator.REQUIRED.decimal(10, 2))));
+    assertEquals(
+        TypeCreator.NULLABLE.decimal(38, 7),
+        sum.resolveType(List.of(TypeCreator.REQUIRED.decimal(20, 7))));
+  }
+
+  @Test
+  void rejectsInconsistentWildcardBinding() {
+    SimpleExtension.ScalarFunctionVariant nullif =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "nullif:any_any");
+    // nullif(any1, any1) -> any1?: binding the same numbered wildcard to two different types is a
+    // signature error, and must be rejected rather than silently resolved to the first binding.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> nullif.resolveType(List.of(TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.STRING)));
+  }
+
+  @Test
+  void variadicWildcardBindsEveryArgument() {
+    SimpleExtension.ScalarFunctionVariant coalesce =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "coalesce:any");
+    // coalesce(any1...) states its argument once and accepts it repeatedly, so an argument past
+    // the declared tail still has to agree with the wildcard.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> coalesce.resolveType(List.of(TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.STRING)));
+    assertEquals(
+        TypeCreator.REQUIRED.I32,
+        coalesce.resolveType(
+            List.of(TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.I32)));
+  }
+
+  @Test
+  void appliesMirrorNullabilityPolicy() {
+    // add:i32_i32 carries the (default) MIRROR policy: its concrete "i32" return mirrors the value
+    // arguments' nullability, so add(i32?, i32) is i32? — per the spec's own worked example.
+    SimpleExtension.ScalarFunctionVariant add =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "add:i32_i32");
+    assertEquals(
+        TypeCreator.REQUIRED.I32,
+        add.resolveType(List.of(TypeCreator.REQUIRED.I32, TypeCreator.REQUIRED.I32)));
+    assertEquals(
+        TypeCreator.NULLABLE.I32,
+        add.resolveType(List.of(TypeCreator.NULLABLE.I32, TypeCreator.REQUIRED.I32)));
+  }
+
+  @Test
+  void wildcardBindingIgnoresNullability() {
+    SimpleExtension.ScalarFunctionVariant nullif =
+        scalar(DefaultExtensionCatalog.FUNCTIONS_COMPARISON, "nullif:any_any");
+    // Nullability is not part of a wildcard's identity: i32 and i32? bind the same any1. The
+    // declared "any1?" return then decides the result's nullability.
+    assertEquals(
+        TypeCreator.NULLABLE.I32,
+        nullif.resolveType(List.of(TypeCreator.REQUIRED.I32, TypeCreator.NULLABLE.I32)));
+  }
+}

--- a/core/src/test/resources/extensions/binding_extensions.yaml
+++ b/core/src/test/resources/extensions/binding_extensions.yaml
@@ -1,0 +1,56 @@
+%YAML 1.2
+---
+urn: extension:test:binding_extensions
+scalar_functions:
+  - name: "pair"
+    description: >-
+      Two plain (unnumbered) wildcards. Each argument binds independently, so the two may
+      be of different types.
+    impls:
+      - args:
+          - name: x
+            value: any
+          - name: y
+            value: any
+        return: boolean
+  - name: "same_pair"
+    description: >-
+      Two occurrences of one numbered wildcard, which must agree on a single type.
+    impls:
+      - args:
+          - name: x
+            value: any1
+          - name: y
+            value: any1
+        return: boolean
+  - name: "decimal_pair"
+    description: >-
+      Two decimals sharing one set of type parameters, with a concrete return type. The shared
+      parameters must agree even though nothing about the return depends on them.
+    impls:
+      - args:
+          - name: x
+            value: DECIMAL<P,S>
+          - name: y
+            value: DECIMAL<P,S>
+        return: boolean
+  - name: "discrete_decimal"
+    description: >-
+      A DISCRETE signature over a parameterized decimal, so the declared argument nullability is
+      part of the signature just as it is for a concrete type.
+    impls:
+      - args:
+          - name: x
+            value: "DECIMAL?<P,S>"
+        nullability: DISCRETE
+        return: boolean
+  - name: "discrete_wildcard"
+    description: >-
+      A DISCRETE signature over a numbered wildcard, so the declared argument nullability is
+      part of the signature.
+    impls:
+      - args:
+          - name: x
+            value: any1
+        nullability: DISCRETE
+        return: any1

--- a/core/src/test/resources/extensions/binding_extensions.yaml
+++ b/core/src/test/resources/extensions/binding_extensions.yaml
@@ -1,0 +1,120 @@
+%YAML 1.2
+---
+urn: extension:test:binding_extensions
+scalar_functions:
+  - name: "pair"
+    description: >-
+      Two plain (unnumbered) wildcards. Each argument binds independently, so the two may
+      be of different types.
+    impls:
+      - args:
+          - name: x
+            value: any
+          - name: y
+            value: any
+        return: boolean
+  - name: "same_pair"
+    description: >-
+      Two occurrences of one numbered wildcard, which must agree on a single type.
+    impls:
+      - args:
+          - name: x
+            value: any1
+          - name: y
+            value: any1
+        return: boolean
+  - name: "decimal_pair"
+    description: >-
+      Two decimals sharing one set of type parameters, with a concrete return type. The shared
+      parameters must agree even though nothing about the return depends on them.
+    impls:
+      - args:
+          - name: x
+            value: DECIMAL<P,S>
+          - name: y
+            value: DECIMAL<P,S>
+        return: boolean
+  - name: "discrete_decimal"
+    description: >-
+      A DISCRETE signature over a parameterized decimal, so the declared argument nullability is
+      part of the signature just as it is for a concrete type.
+    impls:
+      - args:
+          - name: x
+            value: "DECIMAL?<P,S>"
+        nullability: DISCRETE
+        return: boolean
+  - name: "discrete_wildcard"
+    description: >-
+      A DISCRETE signature over a numbered wildcard, so the declared argument nullability is
+      part of the signature.
+    impls:
+      - args:
+          - name: x
+            value: any1
+        nullability: DISCRETE
+        return: any1
+  - name: "zero_scale"
+    description: >-
+      A decimal argument with a literal scale. The literal is a constraint on the actual type,
+      not a parameter name, so only an actual scale of exactly 0 binds.
+    impls:
+      - args:
+          - name: x
+            value: DECIMAL<P,0>
+        return: boolean
+  - name: "cased_options"
+    description: >-
+      Two declared option names differing only in case. Substrait matches option names
+      case-insensitively, so this declaration is ambiguous.
+    impls:
+      - args:
+          - name: x
+            value: i32
+        options:
+          rounding:
+            values: [ TIE_TO_EVEN ]
+          ROUNDING:
+            values: [ TRUNCATE ]
+        return: boolean
+  - name: "typed"
+    description: >-
+      A declaration with a type argument: the declared pattern constrains the supplied type.
+    impls:
+      - args:
+          - name: t
+            type: i32
+          - name: x
+            value: i64
+        return: i64
+  - name: "typed_decimal"
+    description: >-
+      The return type derives from the type argument's parameters.
+    impls:
+      - args:
+          - name: t
+            type: DECIMAL<P,S>
+        return: DECIMAL<P,S>
+  - name: "zero_scale_variadic"
+    description: >-
+      An INCONSISTENT variadic over DECIMAL<P,0>: P may differ per repetition, but the literal 0
+      constrains every repetition.
+    impls:
+      - args:
+          - name: x
+            value: DECIMAL<P,0>
+        variadic:
+          min: 1
+          parameterConsistency: INCONSISTENT
+        return: boolean
+  - name: "list_pair"
+    description: >-
+      A numbered wildcard nested inside a list. Nested shapes cannot be checked structurally
+      yet, so strict validation fails closed on them.
+    impls:
+      - args:
+          - name: x
+            value: list<any1>
+          - name: y
+            value: list<any1>
+        return: boolean

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
@@ -1,0 +1,109 @@
+package io.substrait.isthmus;
+
+import java.util.Objects;
+
+/**
+ * Configures how the output type of a converted Substrait aggregate is chosen and validated.
+ *
+ * <p>The two settings are independent: {@link OutputTypeSource} decides which type the resulting
+ * Calcite {@code AggregateCall} carries, and {@link FunctionBindingValidation} decides whether the
+ * plan-declared type is checked against the extension declaration.
+ *
+ * <p>The {@link #DEFAULT} is {@link OutputTypeSource#PLAN_OUTPUT} with {@link
+ * FunctionBindingValidation#NONE}: the plan's declared output type is preserved (so conversion
+ * never silently changes a type) without asserting that the plan is spec-compliant.
+ */
+public final class AggregateConversion {
+
+  /** Where the Calcite output type of a converted aggregate comes from. */
+  public enum OutputTypeSource {
+    /** Use the type Calcite infers for the operator (ignores the plan's declared type). */
+    CALCITE_INFERENCE,
+    /** Preserve the {@code AggregateFunction.output_type} declared by the plan. */
+    PLAN_OUTPUT
+  }
+
+  /** Whether the plan-declared output type is validated against the extension declaration. */
+  public enum FunctionBindingValidation {
+    /** Do not validate the declared output type. */
+    NONE,
+    /**
+     * Require the declared output type to match the type derived from the extension declaration.
+     *
+     * <p>Type derivation is fail-closed: a function whose return expression the derivation does not
+     * yet support (arithmetic derivations, {@code if/then}, return programs) is rejected rather
+     * than assumed valid, so this mode is not adoptable for plans that use such functions.
+     */
+    EXTENSION_DECLARATION
+  }
+
+  /** Preserve the plan's output type without validating it against the declaration. */
+  public static final AggregateConversion DEFAULT =
+      new AggregateConversion(OutputTypeSource.PLAN_OUTPUT, FunctionBindingValidation.NONE);
+
+  private final OutputTypeSource outputTypeSource;
+  private final FunctionBindingValidation bindingValidation;
+
+  /**
+   * Creates a configuration.
+   *
+   * @param outputTypeSource where the Calcite output type comes from
+   * @param bindingValidation whether the declared type is validated against the declaration
+   */
+  public AggregateConversion(
+      OutputTypeSource outputTypeSource, FunctionBindingValidation bindingValidation) {
+    this.outputTypeSource = Objects.requireNonNull(outputTypeSource);
+    this.bindingValidation = Objects.requireNonNull(bindingValidation);
+  }
+
+  /**
+   * Returns the output-type source.
+   *
+   * @return the output-type source
+   */
+  public OutputTypeSource outputTypeSource() {
+    return outputTypeSource;
+  }
+
+  /**
+   * Returns the binding-validation policy.
+   *
+   * @return the binding-validation policy
+   */
+  public FunctionBindingValidation bindingValidation() {
+    return bindingValidation;
+  }
+
+  /**
+   * Returns whether this configuration is equivalent to {@link #DEFAULT}.
+   *
+   * @return {@code true} if this preserves the plan output type without validation
+   */
+  public boolean isDefault() {
+    return outputTypeSource == OutputTypeSource.PLAN_OUTPUT
+        && bindingValidation == FunctionBindingValidation.NONE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AggregateConversion)) {
+      return false;
+    }
+    AggregateConversion other = (AggregateConversion) o;
+    return outputTypeSource == other.outputTypeSource
+        && bindingValidation == other.bindingValidation;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(outputTypeSource, bindingValidation);
+  }
+
+  @Override
+  public String toString() {
+    return "AggregateConversion[" + outputTypeSource + ", " + bindingValidation + "]";
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
@@ -1,0 +1,106 @@
+package io.substrait.isthmus;
+
+import java.util.Objects;
+
+/**
+ * Configures how the output type of a converted Substrait aggregate is chosen and validated.
+ *
+ * <p>The two settings are independent: {@link OutputTypeSource} decides which type the resulting
+ * Calcite {@code AggregateCall} carries, and {@link FunctionBindingValidation} decides whether the
+ * plan-declared type is checked against the extension declaration.
+ *
+ * <p>The {@link #DEFAULT} is {@link OutputTypeSource#PLAN_OUTPUT} with {@link
+ * FunctionBindingValidation#NONE}: the plan's declared output type is preserved (so conversion
+ * never silently changes a type) without asserting that the plan is spec-compliant.
+ */
+public final class AggregateConversion {
+
+  /** Where the Calcite output type of a converted aggregate comes from. */
+  public enum OutputTypeSource {
+    /** Use the type Calcite infers for the operator (ignores the plan's declared type). */
+    CALCITE_INFERENCE,
+    /** Preserve the {@code AggregateFunction.output_type} declared by the plan. */
+    PLAN_OUTPUT
+  }
+
+  /** Whether the plan-declared output type is validated against the extension declaration. */
+  public enum FunctionBindingValidation {
+    /** Do not validate the declared output type. */
+    NONE,
+    /**
+     * Require the declared output type to match the type derived from the extension declaration.
+     *
+     * <p>Type derivation is fail-closed: a function whose return expression the derivation does not
+     * yet support is rejected rather than assumed valid, so this mode is not adoptable for plans
+     * that use such functions. On the standard extension catalog the unsupported shapes are the
+     * parameterized type classes other than decimal — {@code varchar<L1>}, {@code fixedchar<L1>},
+     * {@code precision_time<P>}, {@code precision_timestamp<P>}, {@code precision_timestamp_tz<P>},
+     * {@code interval_day<P>}, {@code list<anyN>}, parameterized structs — and multi-line return
+     * programs; for example {@code concat}, {@code concat_ws}, {@code assume_timezone} and the
+     * {@code strptime_*} family are rejected today. {@code quantile}'s output type cannot be
+     * derived at all: its declared return {@code LIST?<any>} uses a plain {@code any}, which
+     * carries no identity to bind (spec v0.99.0).
+     */
+    EXTENSION_DECLARATION
+  }
+
+  /** Preserve the plan's output type without validating it against the declaration. */
+  public static final AggregateConversion DEFAULT =
+      new AggregateConversion(OutputTypeSource.PLAN_OUTPUT, FunctionBindingValidation.NONE);
+
+  private final OutputTypeSource outputTypeSource;
+  private final FunctionBindingValidation bindingValidation;
+
+  /**
+   * Creates a configuration.
+   *
+   * @param outputTypeSource where the Calcite output type comes from
+   * @param bindingValidation whether the declared type is validated against the declaration
+   */
+  public AggregateConversion(
+      OutputTypeSource outputTypeSource, FunctionBindingValidation bindingValidation) {
+    this.outputTypeSource = Objects.requireNonNull(outputTypeSource);
+    this.bindingValidation = Objects.requireNonNull(bindingValidation);
+  }
+
+  /**
+   * Returns the output-type source.
+   *
+   * @return the output-type source
+   */
+  public OutputTypeSource outputTypeSource() {
+    return outputTypeSource;
+  }
+
+  /**
+   * Returns the binding-validation policy.
+   *
+   * @return the binding-validation policy
+   */
+  public FunctionBindingValidation bindingValidation() {
+    return bindingValidation;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AggregateConversion)) {
+      return false;
+    }
+    AggregateConversion other = (AggregateConversion) o;
+    return outputTypeSource == other.outputTypeSource
+        && bindingValidation == other.bindingValidation;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(outputTypeSource, bindingValidation);
+  }
+
+  @Override
+  public String toString() {
+    return "AggregateConversion[" + outputTypeSource + ", " + bindingValidation + "]";
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -1,15 +1,25 @@
 package io.substrait.isthmus;
 
+import io.substrait.extension.ResolvedAggregateBinding;
+import java.util.Objects;
 import java.util.Optional;
+import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlSplittableAggFunction;
+import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlAvgAggFunction;
 import org.apache.calcite.sql.fun.SqlMinMaxAggFunction;
 import org.apache.calcite.sql.fun.SqlSumAggFunction;
 import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.util.Optionality;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Provides Substrait-specific variants of Calcite aggregate functions to ensure type inference
@@ -58,6 +68,100 @@ public class AggregateFunctions {
 
   /** Substrait-specific SUM0 aggregate function (non-null BIGINT return type). */
   public static final SqlAggFunction SUM0 = new SubstraitSumEmptyIsZeroAggFunction();
+
+  /**
+   * Wraps a configured aggregate function so it carries a resolved Substrait binding and infers the
+   * given output type.
+   *
+   * <p>This is a transport adapter: Calcite validates an {@code AggregateCall}'s stored type
+   * against the function's inference rule and {@code RelBuilder} re-infers it when copying a call,
+   * so the chosen output type has to travel with the function. The operator's identity is the
+   * binding alone (see {@link #boundBinding}); the carried type is readable via {@link
+   * #declaredOutputType}.
+   *
+   * @param aggFunction configured aggregate function to adapt
+   * @param binding resolved Substrait aggregate binding
+   * @param outputType Calcite output type the wrapper should infer (e.g. the plan-declared type)
+   * @return an aggregate function that carries the binding and infers the given output type
+   */
+  public static SqlAggFunction bind(
+      SqlAggFunction aggFunction, ResolvedAggregateBinding binding, RelDataType outputType) {
+    return new BoundSqlAggFunction(unwrapBound(aggFunction), binding, outputType);
+  }
+
+  /**
+   * Returns the configured aggregate function underlying a {@link #bind bound} function, or the
+   * input unchanged.
+   *
+   * @param aggFunction aggregate function to inspect
+   * @return the underlying configured aggregate function
+   */
+  public static SqlAggFunction unwrapBound(SqlAggFunction aggFunction) {
+    return aggFunction instanceof BoundSqlAggFunction
+        ? ((BoundSqlAggFunction) aggFunction).delegate
+        : aggFunction;
+  }
+
+  /**
+   * Returns the given call with a {@link #bind bound} function replaced by the configured function
+   * it wraps, keeping the type the call already carries.
+   *
+   * <p>Use this before <em>executing</em> a converted plan. Calcite dispatches aggregate
+   * implementations by operator identity ({@code RexImpTable} keyed on the {@link SqlAggFunction},
+   * which compares class, name and kind), so a bound function has no implementor and Enumerable or
+   * Bindable execution rejects the aggregate. The same already holds for the Substrait variants in
+   * this class — {@link #SUM}, {@link #MIN}, {@link #AVG} and the rest are distinct classes from
+   * the stock operators — so executability was never a property of a converted aggregate plan;
+   * unwrapping restores it for the calls that can have it, at the cost of the carried binding.
+   *
+   * @param call aggregate call to unwrap
+   * @return the call on the underlying configured function, or the call unchanged if it carries no
+   *     binding
+   */
+  public static AggregateCall unwrapBound(AggregateCall call) {
+    SqlAggFunction unwrapped = unwrapBound(call.getAggregation());
+    if (unwrapped == call.getAggregation()) {
+      return call;
+    }
+    return AggregateCall.create(
+        unwrapped,
+        call.isDistinct(),
+        call.isApproximate(),
+        call.ignoreNulls(),
+        call.rexList,
+        call.getArgList(),
+        call.filterArg,
+        call.distinctKeys,
+        call.getCollation(),
+        call.getType(),
+        call.getName());
+  }
+
+  /**
+   * Returns the resolved Substrait aggregate binding carried by the given function, if any.
+   *
+   * @param aggFunction aggregate function to inspect
+   * @return the resolved binding, or empty if the function does not carry one
+   */
+  public static Optional<ResolvedAggregateBinding> boundBinding(SqlAggFunction aggFunction) {
+    return aggFunction instanceof BoundSqlAggFunction
+        ? Optional.of(((BoundSqlAggFunction) aggFunction).binding)
+        : Optional.empty();
+  }
+
+  /**
+   * Returns the output type a {@link #bind bound} function carries, if any. This is the type the
+   * wrapper infers — under {@code PLAN_OUTPUT} the type declared by the plan, which may differ from
+   * the one derived from the extension declaration when the plan is not validated against it.
+   *
+   * @param aggFunction aggregate function to inspect
+   * @return the carried output type, or empty if the function does not carry one
+   */
+  public static Optional<RelDataType> declaredOutputType(SqlAggFunction aggFunction) {
+    return aggFunction instanceof BoundSqlAggFunction
+        ? Optional.of(((BoundSqlAggFunction) aggFunction).outputType)
+        : Optional.empty();
+  }
 
   /**
    * Converts default Calcite aggregate functions to Substrait-specific variants when needed.
@@ -152,6 +256,145 @@ public class AggregateFunctions {
     @Override
     public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
       return ReturnTypes.BIGINT.inferReturnType(opBinding);
+    }
+  }
+
+  /**
+   * Aggregate function that carries a resolved Substrait binding and infers a fixed output type.
+   * All non-type behavior is delegated to the configured function.
+   *
+   * <p>Identity is the {@link ResolvedAggregateBinding} alone, so that operator equality stays a
+   * question of <em>which function</em> is being called and never of which type it produces: two
+   * calls of the same Substrait function remain the same operator even when their plan-declared
+   * types differ, while calls resolving to different functions (different extension, options or
+   * enum arguments) stay distinct. Keeping two such calls apart in a single aggregate — {@code
+   * AggregateCall} equality ignores the stored type, so {@code RelBuilder} would otherwise
+   * deduplicate them — is the converter's job, not this operator's.
+   *
+   * <p>A bound function is a plan-interchange device, not an executable operator: Calcite looks up
+   * aggregate implementations by operator identity, so a plan containing one cannot be run by the
+   * Enumerable or Bindable convention. {@link #unwrapBound(AggregateCall)} trades the binding back
+   * for executability. (The Substrait variants above are already distinct classes from the stock
+   * operators, so the same restriction applies to them.)
+   *
+   * <p>Type-rederiving transformations that expose a {@link SqlAggFunction} hook are disabled until
+   * they become binding-aware: rollup ({@link #getRollup()}) and splitting ({@link
+   * SqlSplittableAggFunction}) both recompute the transformed call's type from the underlying
+   * function, which would discard the carried type. Rules that instead match directly on {@link
+   * org.apache.calcite.sql.SqlKind} (e.g. {@code AGGREGATE_REDUCE_FUNCTIONS}) have no such hook and
+   * are retained on the delegate's kind; a caller optimizing a converted plan with a bound
+   * aggregate should either avoid such rules or make them binding-aware, otherwise they may rewrite
+   * the call and drop the carried type.
+   */
+  private static final class BoundSqlAggFunction extends SqlAggFunction {
+    private final SqlAggFunction delegate;
+    private final ResolvedAggregateBinding binding;
+    private final RelDataType outputType;
+
+    private BoundSqlAggFunction(
+        SqlAggFunction delegate, ResolvedAggregateBinding binding, RelDataType outputType) {
+      super(
+          delegate.getName(),
+          delegate.getSqlIdentifier(),
+          delegate.getKind(),
+          ReturnTypes.explicit(outputType),
+          delegate.getOperandTypeInference(),
+          delegate.getOperandTypeChecker(),
+          delegate.getFunctionType(),
+          delegate.requiresOrder(),
+          delegate.requiresOver(),
+          delegate.requiresGroupOrder());
+      this.delegate = delegate;
+      this.binding = binding;
+      this.outputType = outputType;
+    }
+
+    @Override
+    public SqlOperandCountRange getOperandCountRange() {
+      return delegate.getOperandCountRange();
+    }
+
+    @Override
+    public SqlSyntax getSyntax() {
+      return delegate.getSyntax();
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+      delegate.unparse(writer, call, leftPrec, rightPrec);
+    }
+
+    @Override
+    public Optionality getDistinctOptionality() {
+      return delegate.getDistinctOptionality();
+    }
+
+    @Override
+    public boolean allowsFilter() {
+      return delegate.allowsFilter();
+    }
+
+    @Override
+    public boolean allowsNullTreatment() {
+      return delegate.allowsNullTreatment();
+    }
+
+    @Override
+    public boolean skipsNullInputs() {
+      return delegate.skipsNullInputs();
+    }
+
+    @Override
+    public @Nullable SqlAggFunction getRollup() {
+      // A rollup re-infers the top aggregate's return type from the underlying function, which
+      // would discard the canonical Substrait output type. Opt out until rollup is binding-aware.
+      return null;
+    }
+
+    @Override
+    public boolean isPercentile() {
+      return delegate.isPercentile();
+    }
+
+    @Override
+    public boolean allowsFraming() {
+      return delegate.allowsFraming();
+    }
+
+    @Override
+    public <T> @Nullable T unwrap(Class<T> clazz) {
+      if (clazz == SqlSplittableAggFunction.class) {
+        // Splitting (e.g. pushing an aggregate through a join) re-infers the split calls' types
+        // from the underlying function, discarding the canonical type. Opt out until it is
+        // binding-aware.
+        return null;
+      }
+      if (clazz.isInstance(binding)) {
+        // Expose the resolved binding so consumers (and the reverse converter) can recover the
+        // original Substrait function without re-matching on the Calcite operator.
+        return clazz.cast(binding);
+      }
+      T unwrapped = super.unwrap(clazz);
+      return unwrapped != null ? unwrapped : delegate.unwrap(clazz);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof BoundSqlAggFunction)) {
+        return false;
+      }
+      BoundSqlAggFunction other = (BoundSqlAggFunction) obj;
+      // Identity is the semantic binding only: the carried output type is deliberately excluded so
+      // that matching on the operator stays type-agnostic.
+      return binding.equals(other.binding);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getClass(), binding);
     }
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateFunctions.java
@@ -1,15 +1,29 @@
 package io.substrait.isthmus;
 
+import io.substrait.extension.ResolvedAggregateBinding;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlSingletonAggFunction;
+import org.apache.calcite.sql.SqlSplittableAggFunction;
+import org.apache.calcite.sql.SqlStaticAggFunction;
+import org.apache.calcite.sql.SqlSyntax;
+import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlAvgAggFunction;
 import org.apache.calcite.sql.fun.SqlMinMaxAggFunction;
 import org.apache.calcite.sql.fun.SqlSumAggFunction;
 import org.apache.calcite.sql.fun.SqlSumEmptyIsZeroAggFunction;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.util.Optionality;
 
 /**
  * Provides Substrait-specific variants of Calcite aggregate functions to ensure type inference
@@ -58,6 +72,122 @@ public class AggregateFunctions {
 
   /** Substrait-specific SUM0 aggregate function (non-null BIGINT return type). */
   public static final SqlAggFunction SUM0 = new SubstraitSumEmptyIsZeroAggFunction();
+
+  /**
+   * Wraps a configured aggregate function so it carries a resolved Substrait binding and infers the
+   * given output type.
+   *
+   * <p>This is a transport adapter: Calcite validates an {@code AggregateCall}'s stored type
+   * against the function's inference rule and {@code RelBuilder} re-infers it when copying a call,
+   * so the chosen output type has to travel with the function. The operator's identity is the
+   * binding alone (see {@link #boundBinding}); the carried type is readable via {@link
+   * #declaredOutputType}.
+   *
+   * @param aggFunction configured aggregate function to adapt
+   * @param binding resolved Substrait aggregate binding
+   * @param outputType Calcite output type the wrapper should infer (e.g. the plan-declared type)
+   * @return an aggregate function that carries the binding and infers the given output type
+   */
+  public static SqlAggFunction bind(
+      SqlAggFunction aggFunction, ResolvedAggregateBinding binding, RelDataType outputType) {
+    return new BoundSqlAggFunction(unwrapBound(aggFunction), binding, outputType);
+  }
+
+  /**
+   * Returns the configured aggregate function underlying a {@link #bind bound} function, or the
+   * input unchanged.
+   *
+   * @param aggFunction aggregate function to inspect
+   * @return the underlying configured aggregate function
+   */
+  public static SqlAggFunction unwrapBound(SqlAggFunction aggFunction) {
+    return aggFunction instanceof BoundSqlAggFunction
+        ? ((BoundSqlAggFunction) aggFunction).delegate
+        : aggFunction;
+  }
+
+  /**
+   * Returns the given aggregate with every {@link #bind bound} call replaced by a call on the
+   * configured function it wraps, its type re-inferred by that function.
+   *
+   * <p>Use this before <em>executing</em> a converted plan. Calcite dispatches aggregate
+   * implementations by operator identity ({@code RexImpTable} keyed on the {@link SqlAggFunction},
+   * which compares class, name and kind), so a bound function has no implementor and Enumerable or
+   * Bindable execution rejects the aggregate. The same already holds for the Substrait variants in
+   * this class — {@link #SUM}, {@link #MIN}, {@link #AVG} and the rest are distinct classes from
+   * the stock operators — so executability was never a property of a converted aggregate plan;
+   * unwrapping restores it for the calls that can have it.
+   *
+   * <p>Unwrapping is an honest loss: the binding is dropped, and each call's type becomes the
+   * underlying function's inference again — the type {@code
+   * AggregateConversion.OutputTypeSource#CALCITE_INFERENCE} would have chosen up front. The carried
+   * type cannot be kept on the unwrapped call, because {@code Aggregate}'s constructor asserts that
+   * a call's stored type matches what its operator infers.
+   *
+   * @param aggregate aggregate whose calls to unwrap
+   * @return an aggregate with no bound calls, or the same instance if it had none
+   */
+  public static Aggregate unwrapBound(Aggregate aggregate) {
+    List<AggregateCall> unwrappedCalls = new ArrayList<>();
+    boolean changed = false;
+    for (AggregateCall call : aggregate.getAggCallList()) {
+      SqlAggFunction unwrapped = unwrapBound(call.getAggregation());
+      if (unwrapped == call.getAggregation()) {
+        unwrappedCalls.add(call);
+        continue;
+      }
+      changed = true;
+      unwrappedCalls.add(
+          AggregateCall.create(
+              unwrapped,
+              call.isDistinct(),
+              call.isApproximate(),
+              call.ignoreNulls(),
+              call.rexList,
+              call.getArgList(),
+              call.filterArg,
+              call.distinctKeys,
+              call.getCollation(),
+              aggregate.hasEmptyGroup(),
+              aggregate.getInput(),
+              null,
+              call.getName()));
+    }
+    return changed
+        ? aggregate.copy(
+            aggregate.getTraitSet(),
+            aggregate.getInput(),
+            aggregate.getGroupSet(),
+            aggregate.getGroupSets(),
+            unwrappedCalls)
+        : aggregate;
+  }
+
+  /**
+   * Returns the resolved Substrait aggregate binding carried by the given function, if any.
+   *
+   * @param aggFunction aggregate function to inspect
+   * @return the resolved binding, or empty if the function does not carry one
+   */
+  public static Optional<ResolvedAggregateBinding> boundBinding(SqlAggFunction aggFunction) {
+    return aggFunction instanceof BoundSqlAggFunction
+        ? Optional.of(((BoundSqlAggFunction) aggFunction).binding)
+        : Optional.empty();
+  }
+
+  /**
+   * Returns the output type a {@link #bind bound} function carries, if any. This is the type the
+   * wrapper infers — under {@code PLAN_OUTPUT} the type declared by the plan, which may differ from
+   * the one derived from the extension declaration when the plan is not validated against it.
+   *
+   * @param aggFunction aggregate function to inspect
+   * @return the carried output type, or empty if the function does not carry one
+   */
+  public static Optional<RelDataType> declaredOutputType(SqlAggFunction aggFunction) {
+    return aggFunction instanceof BoundSqlAggFunction
+        ? Optional.of(((BoundSqlAggFunction) aggFunction).outputType)
+        : Optional.empty();
+  }
 
   /**
    * Converts default Calcite aggregate functions to Substrait-specific variants when needed.
@@ -152,6 +282,173 @@ public class AggregateFunctions {
     @Override
     public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
       return ReturnTypes.BIGINT.inferReturnType(opBinding);
+    }
+  }
+
+  /**
+   * Aggregate function that carries a resolved Substrait binding and infers a fixed output type.
+   * All non-type behavior is delegated to the configured function.
+   *
+   * <p>The carried type has to travel on the operator's return-type inference; storing it on the
+   * {@link org.apache.calcite.rel.core.AggregateCall} alone cannot work. {@code RelBuilder}
+   * re-creates every pre-built call with no stored type, so the operator's inference decides the
+   * type again — and more fundamentally, {@code Aggregate}'s constructor asserts that a call's
+   * stored type matches what its operator infers ({@code typeMatchesInferred}), so a stock operator
+   * carrying a divergent stored type is rejected outright, whether the aggregate is built through
+   * {@code RelBuilder} or directly.
+   *
+   * <p>Identity is the {@link ResolvedAggregateBinding} alone, so that operator equality stays a
+   * question of <em>which function</em> is being called and never of which type it produces: two
+   * calls of the same Substrait function remain the same operator even when their plan-declared
+   * types differ, while calls resolving to different functions (different extension, options or
+   * enum arguments) stay distinct. Keeping two such calls apart in a single aggregate — {@code
+   * AggregateCall} equality ignores the stored type, so {@code RelBuilder} would otherwise
+   * deduplicate them — is the converter's job, not this operator's.
+   *
+   * <p>A bound function is a plan-interchange device, not an executable operator: Calcite looks up
+   * aggregate implementations by operator identity, so a plan containing one cannot be run by the
+   * Enumerable or Bindable convention. {@link #unwrapBound(Aggregate)} trades the binding back for
+   * executability. (The Substrait variants above are already distinct classes from the stock
+   * operators, so the same restriction applies to them.)
+   *
+   * <p>Type-rederiving transformations that expose a {@link SqlAggFunction} hook are disabled until
+   * they become binding-aware: rollup ({@link #getRollup()}), splitting ({@link
+   * SqlSplittableAggFunction}), singleton flattening ({@link SqlSingletonAggFunction}, which {@code
+   * AggregateRemoveRule} unwraps) and static flattening ({@link SqlStaticAggFunction}, through
+   * which that rule and {@code RelBuilder}'s already-unique optimization rewrite the call into a
+   * constant) all recompute the transformed call's type from the underlying function or discard the
+   * call altogether, which would lose the carried type or binding. Rules that instead match
+   * directly on {@link org.apache.calcite.sql.SqlKind} (e.g. {@code AGGREGATE_REDUCE_FUNCTIONS})
+   * have no such hook and are retained on the delegate's kind; a caller optimizing a converted plan
+   * with a bound aggregate should either avoid such rules or make them binding-aware, otherwise
+   * they may rewrite the call and drop the carried type.
+   */
+  private static final class BoundSqlAggFunction extends SqlAggFunction {
+    private final SqlAggFunction delegate;
+    private final ResolvedAggregateBinding binding;
+    private final RelDataType outputType;
+
+    private BoundSqlAggFunction(
+        SqlAggFunction delegate, ResolvedAggregateBinding binding, RelDataType outputType) {
+      super(
+          delegate.getName(),
+          delegate.getSqlIdentifier(),
+          delegate.getKind(),
+          ReturnTypes.explicit(outputType),
+          delegate.getOperandTypeInference(),
+          delegate.getOperandTypeChecker(),
+          delegate.getFunctionType(),
+          delegate.requiresOrder(),
+          delegate.requiresOver(),
+          delegate.requiresGroupOrder());
+      this.delegate = delegate;
+      this.binding = binding;
+      this.outputType = outputType;
+    }
+
+    @Override
+    public SqlOperandCountRange getOperandCountRange() {
+      return delegate.getOperandCountRange();
+    }
+
+    @Override
+    public SqlSyntax getSyntax() {
+      return delegate.getSyntax();
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+      delegate.unparse(writer, call, leftPrec, rightPrec);
+    }
+
+    @Override
+    public Optionality getDistinctOptionality() {
+      return delegate.getDistinctOptionality();
+    }
+
+    @Override
+    public boolean allowsFilter() {
+      return delegate.allowsFilter();
+    }
+
+    @Override
+    public boolean allowsNullTreatment() {
+      return delegate.allowsNullTreatment();
+    }
+
+    @Override
+    public boolean skipsNullInputs() {
+      return delegate.skipsNullInputs();
+    }
+
+    @Override
+    public SqlAggFunction getRollup() {
+      // A rollup re-infers the top aggregate's return type from the underlying function, which
+      // would discard the canonical Substrait output type. Opt out until rollup is binding-aware.
+      return null;
+    }
+
+    @Override
+    public boolean isPercentile() {
+      return delegate.isPercentile();
+    }
+
+    @Override
+    public boolean allowsFraming() {
+      return delegate.allowsFraming();
+    }
+
+    @Override
+    public boolean isDeterministic() {
+      // Volatility is the delegate's trait: inheriting SqlOperator's defaults would let Calcite
+      // treat a volatile aggregate as stable and cache or collapse its results.
+      return delegate.isDeterministic();
+    }
+
+    @Override
+    public boolean isDynamicFunction() {
+      return delegate.isDynamicFunction();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> clazz) {
+      if (SqlSingletonAggFunction.class.isAssignableFrom(clazz)
+          || SqlStaticAggFunction.class.isAssignableFrom(clazz)) {
+        // Splitting (e.g. pushing an aggregate through a join) re-infers the split calls' types
+        // from the underlying function, discarding the canonical type. Opt out until it is
+        // binding-aware. This covers the SqlSingletonAggFunction supertype as well, because
+        // AggregateRemoveRule unwraps that rather than SqlSplittableAggFunction, and
+        // SqlStaticAggFunction, through which that rule and RelBuilder's alreadyUnique
+        // optimization flatten the aggregate into a Project — keeping the call's type but
+        // dropping the binding, and with it the phase, options and exact declaration.
+        return null;
+      }
+      if (clazz == ResolvedAggregateBinding.class) {
+        // Expose the resolved binding so consumers (and the reverse converter) can recover the
+        // original Substrait function without re-matching on the Calcite operator.
+        return clazz.cast(binding);
+      }
+      T unwrapped = super.unwrap(clazz);
+      return unwrapped != null ? unwrapped : delegate.unwrap(clazz);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof BoundSqlAggFunction)) {
+        return false;
+      }
+      BoundSqlAggFunction other = (BoundSqlAggFunction) obj;
+      // Identity is the semantic binding only: the carried output type is deliberately excluded so
+      // that matching on the operator stays type-agnostic.
+      return binding.equals(other.binding);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getClass(), binding);
     }
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -309,11 +309,34 @@ public class ConverterProvider {
    * A {@link SubstraitRelNodeConverter} is used when converting from Substrait {@link Rel}s to
    * Calcite {@link org.apache.calcite.rel.RelNode}s.
    *
+   * <p>This overload is used for the default {@link AggregateConversion} only; a subclass that
+   * overrides it to customize conversion should override {@link
+   * #getSubstraitRelNodeConverter(RelBuilder, AggregateConversion)} as well, otherwise the
+   * customization is skipped whenever a caller asks for a non-default configuration.
+   *
    * @param relBuilder the RelBuilder to use for creating Calcite RelNodes
    * @return a new SubstraitRelNodeConverter instance
    */
   public SubstraitRelNodeConverter getSubstraitRelNodeConverter(RelBuilder relBuilder) {
-    return new SubstraitRelNodeConverter(relBuilder, this);
+    return getSubstraitRelNodeConverter(relBuilder, AggregateConversion.DEFAULT);
+  }
+
+  /**
+   * A {@link SubstraitRelNodeConverter} is used when converting from Substrait {@link Rel}s to
+   * Calcite {@link org.apache.calcite.rel.RelNode}s.
+   *
+   * <p>{@link SubstraitToCalcite} calls this overload only for a non-default {@link
+   * AggregateConversion}, and {@link #getSubstraitRelNodeConverter(RelBuilder)} otherwise — that
+   * dispatch keeps subclasses which only override the long-standing single-argument factory
+   * working. A subclass that customizes conversion should therefore override both.
+   *
+   * @param relBuilder the RelBuilder to use for creating Calcite RelNodes
+   * @param aggregateConversion controls how aggregate output types are chosen and validated
+   * @return a new SubstraitRelNodeConverter instance
+   */
+  public SubstraitRelNodeConverter getSubstraitRelNodeConverter(
+      RelBuilder relBuilder, AggregateConversion aggregateConversion) {
+    return new SubstraitRelNodeConverter(relBuilder, this, aggregateConversion);
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -15,6 +15,7 @@ import io.substrait.plan.Plan;
 import io.substrait.relation.Rel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import org.apache.calcite.avatica.util.Casing;
@@ -87,6 +88,9 @@ public class ConverterProvider {
 
   /** Observer for supplied and independently inferred expression types. */
   protected final TypeObserver typeObserver;
+
+  /** Controls how aggregate output types are chosen and validated during conversion. */
+  protected final AggregateConversion aggregateConversion;
 
   /** Converter for Substrait scalar functions. */
   protected ScalarFunctionConverter scalarFunctionConverter;
@@ -222,6 +226,7 @@ public class ConverterProvider {
             .map(builder.sqlParserConfig::withUnquotedCasing)
             .orElse(builder.sqlParserConfig);
     this.typeObserver = builder.typeObserver;
+    this.aggregateConversion = builder.aggregateConversion;
 
     this.scalarFunctionConverter =
         builder.scalarFunctionConverter.orElseGet(
@@ -393,6 +398,8 @@ public class ConverterProvider {
    * A {@link SubstraitRelNodeConverter} is used when converting from Substrait {@link Rel}s to
    * Calcite {@link org.apache.calcite.rel.RelNode}s.
    *
+   * <p>Aggregate conversion follows {@link #getAggregateConversion()}.
+   *
    * @param relBuilder the RelBuilder to use for creating Calcite RelNodes
    * @return a new SubstraitRelNodeConverter instance
    */
@@ -430,6 +437,18 @@ public class ConverterProvider {
    */
   public TypeObserver getTypeObserver() {
     return typeObserver;
+  }
+
+  /**
+   * Returns the aggregate-conversion configuration: how the output type of a converted Substrait
+   * aggregate is chosen and whether it is validated against the extension declaration.
+   *
+   * <p>Configure via {@link Builder#aggregateConversion(AggregateConversion)}.
+   *
+   * @return {@link AggregateConversion#DEFAULT} unless configured otherwise
+   */
+  public AggregateConversion getAggregateConversion() {
+    return aggregateConversion;
   }
 
   /**
@@ -561,6 +580,7 @@ public class ConverterProvider {
     private Plan.ExecutionBehavior executionBehavior = createDefaultExecutionBehavior();
     private SqlParser.Config sqlParserConfig = DEFAULT_SQL_PARSER_CONFIG;
     private TypeObserver typeObserver = TypeObserver.NOOP;
+    private AggregateConversion aggregateConversion = AggregateConversion.DEFAULT;
     private Optional<Casing> unquotedCasing = Optional.empty();
 
     // Derived from the extensions and type factory at build time when left unset.
@@ -650,6 +670,18 @@ public class ConverterProvider {
      */
     public Builder typeObserver(TypeObserver typeObserver) {
       this.typeObserver = typeObserver;
+      return this;
+    }
+
+    /**
+     * Sets how the output type of a converted Substrait aggregate is chosen and whether it is
+     * validated against the extension declaration.
+     *
+     * @param aggregateConversion the aggregate-conversion configuration
+     * @return this builder
+     */
+    public Builder aggregateConversion(AggregateConversion aggregateConversion) {
+      this.aggregateConversion = Objects.requireNonNull(aggregateConversion, "aggregateConversion");
       return this;
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.SortDirection;
 import io.substrait.expression.FunctionArg;
+import io.substrait.extension.FunctionBindingResolver;
+import io.substrait.extension.ResolvedAggregateBinding;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.calcite.rel.CreateTable;
 import io.substrait.isthmus.calcite.rel.CreateView;
@@ -111,6 +113,9 @@ public class SubstraitRelNodeConverter
   /** Type converter to translate between Calcite and Substrait type systems. */
   private final TypeConverter typeConverter;
 
+  /** Controls how aggregate output types are chosen and validated. */
+  private final AggregateConversion aggregateConversion;
+
   /**
    * Creates a new SubstraitRelNodeConverter with the specified extensions, type factory, and
    * relation builder.
@@ -136,6 +141,20 @@ public class SubstraitRelNodeConverter
    * @param converterProvider the converter provider containing configuration and converters
    */
   public SubstraitRelNodeConverter(RelBuilder relBuilder, ConverterProvider converterProvider) {
+    this(relBuilder, converterProvider, AggregateConversion.DEFAULT);
+  }
+
+  /**
+   * Creates a new SubstraitRelNodeConverter with an explicit aggregate-conversion configuration.
+   *
+   * @param relBuilder the Calcite relation builder
+   * @param converterProvider the converter provider containing configuration and converters
+   * @param aggregateConversion controls how aggregate output types are chosen and validated
+   */
+  public SubstraitRelNodeConverter(
+      RelBuilder relBuilder,
+      ConverterProvider converterProvider,
+      AggregateConversion aggregateConversion) {
     this.typeFactory = converterProvider.getTypeFactory();
     this.typeConverter = converterProvider.getTypeConverter();
     this.relBuilder = relBuilder;
@@ -143,6 +162,7 @@ public class SubstraitRelNodeConverter
     this.scalarFunctionConverter = converterProvider.getScalarFunctionConverter();
     this.aggregateFunctionConverter = converterProvider.getAggregateFunctionConverter();
     this.expressionRexConverter = converterProvider.getExpressionRexConverter(this);
+    this.aggregateConversion = aggregateConversion;
   }
 
   /**
@@ -320,11 +340,23 @@ public class SubstraitRelNodeConverter
             .collect(java.util.stream.Collectors.toList());
     List<RexNode> groupExprs =
         groupExprLists.stream().flatMap(Collection::stream).collect(Collectors.toList());
-    RelBuilder.GroupKey groupKey = relBuilder.groupKey(groupExprs, groupExprLists);
+    // An aggregate with no groupings at all is a global aggregation, i.e. a single empty grouping
+    // set. Handing RelBuilder an empty list of grouping sets instead would leave the Calcite
+    // aggregate with no grouping set at all, and RelBuilder would then re-infer every measure as if
+    // there were no empty group — which is the opposite of what a global aggregation means.
+    boolean globalAggregation = groupExprLists.isEmpty();
+    RelBuilder.GroupKey groupKey =
+        globalAggregation
+            ? relBuilder.groupKey(groupExprs)
+            : relBuilder.groupKey(groupExprs, groupExprLists);
+    // Mirrors how RelBuilder derives an aggregate call's hasEmptyGroup from the grouping sets it
+    // builds out of this group key; the two must agree or the inferred type below is not the one
+    // the call ends up with.
+    boolean hasEmptyGroup = globalAggregation || groupExprLists.stream().anyMatch(List::isEmpty);
 
     List<AggregateCall> aggregateCalls =
         aggregate.getMeasures().stream()
-            .map(measure -> fromMeasure(measure, context))
+            .map(measure -> fromMeasure(measure, context, child, hasEmptyGroup))
             .collect(java.util.stream.Collectors.toList());
 
     Optional<Remap> remap = aggregate.getRemap();
@@ -361,11 +393,49 @@ public class SubstraitRelNodeConverter
       }
     }
 
-    RelNode node = relBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
+    // RelBuilder deduplicates equal aggregate calls, and AggregateCall equality ignores the stored
+    // type: two measures of the same function that differ only by their declared output type would
+    // collapse into one column. Opt out of deduplication for exactly those aggregates — narrowly,
+    // because transform() yields a plain RelBuilder carrying the same cluster and schema but not a
+    // custom builder subclass.
+    RelBuilder aggregateBuilder =
+        hasTypeDistinctDuplicates(aggregateCalls)
+            ? relBuilder.transform(config -> config.withDedupAggregateCalls(false))
+            : relBuilder;
+
+    RelNode node = aggregateBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
     return applyRemap(node, remap);
   }
 
-  private AggregateCall fromMeasure(Aggregate.Measure measure, Context context) {
+  /**
+   * Returns whether the binding carries semantics no stock Calcite aggregate operator can express,
+   * so that two invocations differing only in those would be indistinguishable once converted: the
+   * function's options and any phase other than a full initial-to-result aggregation. Enum
+   * arguments are excluded — they select the Calcite operator itself (e.g. {@code STDDEV_POP} vs
+   * {@code STDDEV_SAMP}) and are recovered from it on the way back.
+   */
+  private static boolean carriesOpaqueSemantics(ResolvedAggregateBinding binding) {
+    return !binding.function().options().isEmpty()
+        || binding.phase() != Expression.AggregationPhase.INITIAL_TO_RESULT;
+  }
+
+  /**
+   * Returns whether two aggregate calls are equal to Calcite yet carry different types, i.e.
+   * whether deduplicating them would silently give one of them the other's type.
+   */
+  private static boolean hasTypeDistinctDuplicates(List<AggregateCall> aggregateCalls) {
+    Map<AggregateCall, RelDataType> typesByCall = new HashMap<>();
+    for (AggregateCall call : aggregateCalls) {
+      RelDataType existing = typesByCall.putIfAbsent(call, call.getType());
+      if (existing != null && !existing.equals(call.getType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private AggregateCall fromMeasure(
+      Aggregate.Measure measure, Context context, RelNode input, boolean hasEmptyGroup) {
     List<FunctionArg> eArgs = measure.getFunction().arguments();
     // Only value (Expression) arguments map to Calcite aggregate operands. Enum arguments such as
     // the std_dev/variance "distribution" are used to disambiguate the operator, not as operands.
@@ -403,7 +473,14 @@ public class SubstraitRelNodeConverter
         measure.getFunction().invocation().equals(Expression.AggregationInvocation.DISTINCT);
 
     SqlAggFunction aggFunction;
-    RelDataType returnType = typeConverter.toCalcite(typeFactory, measure.getFunction().getType());
+    // Resolve the Substrait binding (semantic identity). Validating the signature, options and
+    // declared output type against the extension declaration is a separate, opt-in concern
+    // (EXTENSION_DECLARATION).
+    ResolvedAggregateBinding binding = ResolvedAggregateBinding.resolve(measure.getFunction());
+    if (aggregateConversion.bindingValidation()
+        == AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION) {
+      FunctionBindingResolver.validate(binding, measure.getFunction().getType());
+    }
 
     if (operator.get() instanceof SqlAggFunction) {
       aggFunction = (SqlAggFunction) operator.get();
@@ -428,6 +505,37 @@ public class SubstraitRelNodeConverter
               measure.getFunction().sort().stream()
                   .map(sortField -> toRelFieldCollation(sortField, context))
                   .collect(Collectors.toList()));
+    }
+
+    AggregateCall inferredCall =
+        AggregateCall.create(
+            aggFunction,
+            distinct,
+            false,
+            false,
+            Collections.emptyList(),
+            argIndex,
+            filterArg,
+            null,
+            relCollation,
+            hasEmptyGroup,
+            input,
+            null,
+            null);
+    RelDataType inferredType = inferredCall.getType();
+    boolean preservePlanType =
+        aggregateConversion.outputTypeSource() == AggregateConversion.OutputTypeSource.PLAN_OUTPUT;
+    // Convert the declared type only where it is used: CALCITE_INFERENCE promises to ignore it, and
+    // a type this converter cannot represent must not fail a conversion that never needed it.
+    RelDataType returnType =
+        preservePlanType
+            ? typeConverter.toCalcite(typeFactory, measure.getFunction().getType())
+            : inferredType;
+    if ((preservePlanType && !returnType.equals(inferredType)) || carriesOpaqueSemantics(binding)) {
+      // Calcite would either re-infer a different type or lose semantics its operator cannot
+      // express; carry the binding and the chosen type on a transport wrapper so both survive
+      // Calcite's re-inference (RelBuilder / planner rules) and its call deduplication.
+      aggFunction = AggregateFunctions.bind(aggFunction, binding, returnType);
     }
 
     return AggregateCall.create(

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -4,6 +4,9 @@ import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.SortDirection;
 import io.substrait.expression.FunctionArg;
+import io.substrait.extension.FunctionBindingResolver;
+import io.substrait.extension.ResolvedAggregateBinding;
+import io.substrait.extension.ResolvedArgument;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.calcite.rel.CreateTable;
 import io.substrait.isthmus.calcite.rel.CreateView;
@@ -111,6 +114,9 @@ public class SubstraitRelNodeConverter
   /** Type converter to translate between Calcite and Substrait type systems. */
   private final TypeConverter typeConverter;
 
+  /** Controls how aggregate output types are chosen and validated. */
+  private final AggregateConversion aggregateConversion;
+
   /**
    * Creates a new SubstraitRelNodeConverter with the specified extensions, type factory, and
    * relation builder.
@@ -130,7 +136,9 @@ public class SubstraitRelNodeConverter
 
   /**
    * Creates a new SubstraitRelNodeConverter with the specified relation builder and converter
-   * provider.
+   * provider. Aggregate conversion follows the provider's {@link
+   * ConverterProvider#getAggregateConversion()} — the provider is the single configuration channel,
+   * so a subclass overriding that method always takes effect.
    *
    * @param relBuilder the Calcite relation builder
    * @param converterProvider the converter provider containing configuration and converters
@@ -143,6 +151,7 @@ public class SubstraitRelNodeConverter
     this.scalarFunctionConverter = converterProvider.getScalarFunctionConverter();
     this.aggregateFunctionConverter = converterProvider.getAggregateFunctionConverter();
     this.expressionRexConverter = converterProvider.getExpressionRexConverter(this);
+    this.aggregateConversion = converterProvider.getAggregateConversion();
   }
 
   /**
@@ -321,11 +330,23 @@ public class SubstraitRelNodeConverter
             .collect(java.util.stream.Collectors.toList());
     List<RexNode> groupExprs =
         groupExprLists.stream().flatMap(Collection::stream).collect(Collectors.toList());
-    RelBuilder.GroupKey groupKey = relBuilder.groupKey(groupExprs, groupExprLists);
+    // An aggregate with no groupings at all is a global aggregation, i.e. a single empty grouping
+    // set. Handing RelBuilder an empty list of grouping sets instead would leave the Calcite
+    // aggregate with no grouping set at all, and RelBuilder would then re-infer every measure as if
+    // there were no empty group — which is the opposite of what a global aggregation means.
+    boolean globalAggregation = groupExprLists.isEmpty();
+    RelBuilder.GroupKey groupKey =
+        globalAggregation
+            ? relBuilder.groupKey(groupExprs)
+            : relBuilder.groupKey(groupExprs, groupExprLists);
+    // Mirrors how RelBuilder derives an aggregate call's hasEmptyGroup from the grouping sets it
+    // builds out of this group key; the two must agree or the inferred type below is not the one
+    // the call ends up with.
+    boolean hasEmptyGroup = globalAggregation || groupExprLists.stream().anyMatch(List::isEmpty);
 
     List<AggregateCall> aggregateCalls =
         aggregate.getMeasures().stream()
-            .map(measure -> fromMeasure(measure, context))
+            .map(measure -> fromMeasure(measure, context, child, hasEmptyGroup))
             .collect(java.util.stream.Collectors.toList());
 
     Optional<Remap> remap = aggregate.getRemap();
@@ -362,11 +383,70 @@ public class SubstraitRelNodeConverter
       }
     }
 
-    RelNode node = relBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
+    // RelBuilder deduplicates equal aggregate calls, and AggregateCall equality ignores the stored
+    // type: two measures of the same function that differ only by their declared output type would
+    // collapse into one column. Opt out of deduplication for exactly those aggregates — narrowly,
+    // because transform() yields a plain RelBuilder carrying the same cluster and schema but not a
+    // custom builder subclass.
+    RelBuilder aggregateBuilder =
+        hasTypeDistinctDuplicates(aggregateCalls)
+            ? relBuilder.transform(config -> config.withDedupAggregateCalls(false))
+            : relBuilder;
+
+    RelNode node = aggregateBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
     return applyRemap(node, remap);
   }
 
-  private AggregateCall fromMeasure(Aggregate.Measure measure, Context context) {
+  /**
+   * Returns whether the binding carries semantics no stock Calcite aggregate operator can express,
+   * so that two invocations differing only in those would be indistinguishable once converted: the
+   * function's options, any phase other than a full initial-to-result aggregation, and type
+   * arguments — only value arguments become Calcite operands, so a type argument cannot be rebuilt
+   * by re-matching. Enum arguments are an operator-dependent case decided by the caller: they are
+   * recoverable only when the operator's kind encodes them (e.g. {@code STDDEV_POP} vs {@code
+   * STDDEV_SAMP}), which {@link AggregateFunctionConverter#encodesEnumArguments} answers.
+   */
+  private static boolean carriesOpaqueSemantics(ResolvedAggregateBinding binding) {
+    return !binding.function().options().isEmpty()
+        || binding.phase() != Expression.AggregationPhase.INITIAL_TO_RESULT
+        || hasTypeArgument(binding);
+  }
+
+  private static boolean hasTypeArgument(ResolvedAggregateBinding binding) {
+    return hasArgumentOfKind(binding, ResolvedArgument.Kind.TYPE);
+  }
+
+  private static boolean hasEnumArgument(ResolvedAggregateBinding binding) {
+    return hasArgumentOfKind(binding, ResolvedArgument.Kind.ENUM);
+  }
+
+  private static boolean hasArgumentOfKind(
+      ResolvedAggregateBinding binding, ResolvedArgument.Kind kind) {
+    for (ResolvedArgument argument : binding.function().arguments()) {
+      if (argument.kind() == kind) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns whether two aggregate calls are equal to Calcite yet carry different types, i.e.
+   * whether deduplicating them would silently give one of them the other's type.
+   */
+  private static boolean hasTypeDistinctDuplicates(List<AggregateCall> aggregateCalls) {
+    Map<AggregateCall, RelDataType> typesByCall = new HashMap<>();
+    for (AggregateCall call : aggregateCalls) {
+      RelDataType existing = typesByCall.putIfAbsent(call, call.getType());
+      if (existing != null && !existing.equals(call.getType())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private AggregateCall fromMeasure(
+      Aggregate.Measure measure, Context context, RelNode input, boolean hasEmptyGroup) {
     List<FunctionArg> eArgs = measure.getFunction().arguments();
     // Only value (Expression) arguments map to Calcite aggregate operands. Enum arguments such as
     // the std_dev/variance "distribution" are used to disambiguate the operator, not as operands.
@@ -404,7 +484,14 @@ public class SubstraitRelNodeConverter
         measure.getFunction().invocation().equals(Expression.AggregationInvocation.DISTINCT);
 
     SqlAggFunction aggFunction;
-    RelDataType returnType = typeConverter.toCalcite(typeFactory, measure.getFunction().getType());
+    // Resolve the Substrait binding (semantic identity). Validating the signature, options and
+    // declared output type against the extension declaration is a separate, opt-in concern
+    // (EXTENSION_DECLARATION).
+    ResolvedAggregateBinding binding = ResolvedAggregateBinding.resolve(measure.getFunction());
+    if (aggregateConversion.bindingValidation()
+        == AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION) {
+      FunctionBindingResolver.validate(binding, measure.getFunction().getType());
+    }
 
     if (operator.get() instanceof SqlAggFunction) {
       aggFunction = (SqlAggFunction) operator.get();
@@ -429,6 +516,76 @@ public class SubstraitRelNodeConverter
               measure.getFunction().sort().stream()
                   .map(sortField -> toRelFieldCollation(sortField, context))
                   .collect(Collectors.toList()));
+    }
+
+    boolean preservePlanType =
+        aggregateConversion.outputTypeSource() == AggregateConversion.OutputTypeSource.PLAN_OUTPUT;
+    boolean opaqueSemantics =
+        carriesOpaqueSemantics(binding)
+            || (hasEnumArgument(binding)
+                && !AggregateFunctionConverter.encodesEnumArguments(aggFunction, binding));
+
+    // Calcite's return-type inference runs inside AggregateCall.create when no type is passed in.
+    // Under PLAN_OUTPUT its result only decides whether the plan's type must travel on a wrapper,
+    // so it is skipped when opaque semantics force the wrapper anyway, and a failure — an operand
+    // shape the operator's inference rule rejects, say an intermediate-state struct fed to a
+    // caller-supplied operator — counts as "diverges" instead of failing a conversion that never
+    // needed the inferred type. Under CALCITE_INFERENCE the inferred type is the output type, so
+    // there is nothing to fall back to and the failure propagates.
+    RelDataType inferredType = null;
+    if (!preservePlanType || !opaqueSemantics) {
+      try {
+        inferredType =
+            AggregateCall.create(
+                    aggFunction,
+                    distinct,
+                    false,
+                    false,
+                    Collections.emptyList(),
+                    argIndex,
+                    filterArg,
+                    null,
+                    relCollation,
+                    hasEmptyGroup,
+                    input,
+                    null,
+                    null)
+                .getType();
+      } catch (RuntimeException e) {
+        if (!preservePlanType) {
+          throw e;
+        }
+      }
+    }
+
+    // Convert the declared type only where it is used: CALCITE_INFERENCE promises to ignore it, and
+    // a type this converter cannot represent must not fail a conversion that never needed it.
+    RelDataType returnType =
+        preservePlanType
+            ? typeConverter.toCalcite(typeFactory, measure.getFunction().getType())
+            : inferredType;
+    boolean typeDiverges = preservePlanType && !returnType.equals(inferredType);
+    // The binding must also travel when dropping it would leave the declaration ambiguous: the
+    // reverse direction re-matches by signature key and by type-driven fallbacks, picking by
+    // registration order, so a declaration another variant can shadow for these argument types
+    // and output type — or one with no reverse mapping at all — is only plan-determined via the
+    // carried binding. The output type consulted is the one the converted call will carry.
+    boolean mustCarryBinding =
+        opaqueSemantics
+            || typeDiverges
+            || !aggregateFunctionConverter.reconstructsUniquely(
+                aggFunction,
+                measure.getFunction().declaration(),
+                binding.function().arguments(),
+                preservePlanType
+                    ? measure.getFunction().getType()
+                    : typeConverter.toSubstrait(returnType));
+    if (mustCarryBinding) {
+      // Calcite would either re-infer a different type, lose semantics its operator cannot
+      // express, or re-match an ambiguous declaration by load order; carry the binding and the
+      // chosen type on a transport wrapper so all of it survives Calcite's re-inference
+      // (RelBuilder / planner rules) and its call deduplication.
+      aggFunction = AggregateFunctions.bind(aggFunction, binding, returnType);
     }
 
     return AggregateCall.create(

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitToCalcite.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitToCalcite.java
@@ -35,6 +35,9 @@ public class SubstraitToCalcite {
   /** The converter provider containing configuration. */
   protected ConverterProvider converterProvider;
 
+  /** Controls how aggregate output types are chosen and validated. */
+  protected final AggregateConversion aggregateConversion;
+
   /**
    * Creates a Substrait-to-Calcite converter using configuration from the provider.
    *
@@ -52,9 +55,24 @@ public class SubstraitToCalcite {
    */
   public SubstraitToCalcite(
       ConverterProvider converterProvider, Prepare.CatalogReader catalogReader) {
+    this(converterProvider, catalogReader, AggregateConversion.DEFAULT);
+  }
+
+  /**
+   * Creates a Substrait-to-Calcite converter with an explicit aggregate-conversion configuration.
+   *
+   * @param converterProvider the converter provider containing configuration and converters
+   * @param catalogReader Calcite catalog reader for schema resolution
+   * @param aggregateConversion controls how aggregate output types are chosen and validated
+   */
+  public SubstraitToCalcite(
+      ConverterProvider converterProvider,
+      Prepare.CatalogReader catalogReader,
+      AggregateConversion aggregateConversion) {
     this.converterProvider = converterProvider;
     this.typeFactory = converterProvider.getTypeFactory();
     this.catalogReader = catalogReader;
+    this.aggregateConversion = aggregateConversion;
   }
 
   /**
@@ -76,8 +94,12 @@ public class SubstraitToCalcite {
       CalciteSchema rootSchema = converterProvider.getSchemaResolver().apply(rel);
       relBuilder = converterProvider.getRelBuilder(rootSchema);
     }
+    // Under the default policy, dispatch through the long-standing single-argument factory so a
+    // ConverterProvider subclass overriding it still customizes conversion.
     SubstraitRelNodeConverter converter =
-        converterProvider.getSubstraitRelNodeConverter(relBuilder);
+        aggregateConversion.isDefault()
+            ? converterProvider.getSubstraitRelNodeConverter(relBuilder)
+            : converterProvider.getSubstraitRelNodeConverter(relBuilder, aggregateConversion);
 
     return rel.accept(converter, Context.newContext());
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
@@ -2,10 +2,12 @@ package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
-import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FunctionArg;
 import io.substrait.expression.StatisticalDistribution;
+import io.substrait.extension.ResolvedAggregateBinding;
+import io.substrait.extension.ResolvedArgument;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.AggregateFunctions;
 import io.substrait.isthmus.SubstraitRelVisitor;
@@ -103,24 +105,127 @@ public class AggregateFunctionConverter
       Type outputType) {
     AggregateCall agg = call.getUnderlying();
 
-    List<Expression.SortField> sorts =
-        agg.getCollation() != null
-            ? agg.getCollation().getFieldCollations().stream()
-                .map(r -> SubstraitRelVisitor.toSortField(r, call.inputType))
-                .collect(java.util.stream.Collectors.toList())
-            : Collections.emptyList();
-    Expression.AggregationInvocation invocation =
-        agg.isDistinct()
-            ? Expression.AggregationInvocation.DISTINCT
-            : Expression.AggregationInvocation.ALL;
+    return AggregateFunctionInvocation.builder()
+        .declaration(function)
+        .outputType(outputType)
+        .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+        .sort(sortFields(agg, call.inputType))
+        .invocation(
+            agg.isDistinct()
+                ? Expression.AggregationInvocation.DISTINCT
+                : Expression.AggregationInvocation.ALL)
+        .addAllArguments(arguments)
+        .build();
+  }
 
-    return ExpressionCreator.aggregateFunction(
-        function,
-        outputType,
-        Expression.AggregationPhase.INITIAL_TO_RESULT,
-        sorts,
-        invocation,
-        arguments);
+  /**
+   * Rebuilds the invocation from the binding a converted call carries, when that binding still
+   * describes the call.
+   *
+   * <p>A binding names the exact declaration the plan used and the semantics Calcite cannot express
+   * — the function's options and its aggregation phase — so it beats re-matching: matching can only
+   * guess a declaration among equally-shaped candidates, always produces a full initial-to-result
+   * aggregation with no options, and for a phase that consumes an intermediate state cannot match
+   * at all, because the call's operands are then intermediate values rather than the declaration's
+   * arguments.
+   *
+   * <p>The binding describes the plan as it was converted, and a planner rule may have rewritten
+   * the call since. Staleness is therefore decided by comparing the arguments the binding recorded
+   * with the ones the call now has — not by re-validating against the declaration, which cannot
+   * judge a phase whose state is parameterized by the initial arguments it no longer sees (the
+   * intermediate {@code STRUCT<DECIMAL<38,S>,i64>} of a decimal average, say). When the arguments
+   * differ, this returns empty and the call is matched on its own terms, binding and all.
+   */
+  private Optional<AggregateFunctionInvocation> fromCarriedBinding(
+      RelNode input,
+      Type.Struct inputType,
+      AggregateCall call,
+      Function<RexNode, Expression> topLevelConverter) {
+    Optional<ResolvedAggregateBinding> bound =
+        AggregateFunctions.boundBinding(call.getAggregation());
+    if (!bound.isPresent()
+        || !(bound.get().function().declaration()
+            instanceof SimpleExtension.AggregateFunctionVariant)) {
+      return Optional.empty();
+    }
+    ResolvedAggregateBinding binding = bound.get();
+    SimpleExtension.AggregateFunctionVariant declaration =
+        (SimpleExtension.AggregateFunctionVariant) binding.function().declaration();
+
+    List<Expression> operands =
+        call.getArgList().stream()
+            .map(index -> topLevelConverter.apply(rexBuilder.makeInputRef(input, index)))
+            .collect(java.util.stream.Collectors.toList());
+    Optional<List<FunctionArg>> arguments = alignArguments(binding, declaration, operands);
+    if (!arguments.isPresent()) {
+      return Optional.empty();
+    }
+
+    AggregateFunctionInvocation invocation =
+        AggregateFunctionInvocation.builder()
+            .declaration(declaration)
+            .outputType(typeConverter.toSubstrait(call.getType()))
+            .aggregationPhase(binding.phase())
+            .sort(sortFields(call, inputType))
+            // The invocation comes from the Calcite call rather than from the binding: a planner
+            // rule may legitimately have dropped a redundant DISTINCT since the plan was converted.
+            .invocation(
+                call.isDistinct()
+                    ? Expression.AggregationInvocation.DISTINCT
+                    : Expression.AggregationInvocation.ALL)
+            .addAllArguments(arguments.get())
+            .options(binding.function().options())
+            .build();
+
+    List<ResolvedArgument> rebuilt =
+        ResolvedAggregateBinding.resolve(invocation).function().arguments();
+    return rebuilt.equals(binding.function().arguments())
+        ? Optional.of(invocation)
+        : Optional.empty();
+  }
+
+  /**
+   * Puts the call's operands back into the declaration's argument order, restoring the enum
+   * arguments — which are not Calcite operands — from the binding. Returns empty when the operands
+   * no longer fit the declaration, which again means the binding does not describe this call.
+   */
+  private static Optional<List<FunctionArg>> alignArguments(
+      ResolvedAggregateBinding binding,
+      SimpleExtension.AggregateFunctionVariant declaration,
+      List<Expression> operands) {
+    List<ResolvedArgument> resolved = binding.function().arguments();
+    List<FunctionArg> arguments = new ArrayList<>();
+    int operandIndex = 0;
+    for (int index = 0; index < declaration.args().size(); index++) {
+      if (declaration.args().get(index) instanceof SimpleExtension.EnumArgument) {
+        if (index >= resolved.size() || resolved.get(index).kind() != ResolvedArgument.Kind.ENUM) {
+          return Optional.empty();
+        }
+        arguments.add(
+            resolved.get(index).enumValue().map(EnumArg::of).orElse(EnumArg.UNSPECIFIED_ENUM_ARG));
+      } else {
+        if (operandIndex >= operands.size()) {
+          return Optional.empty();
+        }
+        arguments.add(operands.get(operandIndex++));
+      }
+    }
+    // A variadic declaration states its trailing argument once but accepts it repeatedly.
+    while (operandIndex < operands.size()) {
+      if (!declaration.variadic().isPresent()) {
+        return Optional.empty();
+      }
+      arguments.add(operands.get(operandIndex++));
+    }
+    return Optional.of(arguments);
+  }
+
+  private static List<Expression.SortField> sortFields(AggregateCall call, Type.Struct inputType) {
+    return call.getCollation() != null
+        ? call.getCollation().getFieldCollations().stream()
+            .map(collation -> SubstraitRelVisitor.toSortField(collation, inputType))
+            .collect(java.util.stream.Collectors.toList())
+        : Collections.emptyList();
   }
 
   /**
@@ -137,6 +242,14 @@ public class AggregateFunctionConverter
       Type.Struct inputType,
       AggregateCall call,
       Function<RexNode, Expression> topLevelConverter) {
+
+    // A call converted from Substrait may carry its resolved binding; that is a better source than
+    // re-matching the operator, and the only source for a phase Calcite cannot represent.
+    Optional<AggregateFunctionInvocation> carried =
+        fromCarriedBinding(input, inputType, call, topLevelConverter);
+    if (carried.isPresent()) {
+      return carried;
+    }
 
     FunctionFinder m = getFunctionFinder(call);
     if (m == null) {
@@ -195,7 +308,7 @@ public class AggregateFunctionConverter
   protected FunctionFinder getFunctionFinder(AggregateCall call) {
     // replace COUNT() + distinct == true and approximate == true with APPROX_COUNT_DISTINCT
     // before converting into substrait function
-    SqlAggFunction aggFunction = call.getAggregation();
+    SqlAggFunction aggFunction = AggregateFunctions.unwrapBound(call.getAggregation());
     if (aggFunction == SqlStdOperatorTable.COUNT && call.isDistinct() && call.isApproximate()) {
       aggFunction = SqlStdOperatorTable.APPROX_COUNT_DISTINCT;
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/AggregateFunctionConverter.java
@@ -2,10 +2,12 @@ package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
-import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FunctionArg;
 import io.substrait.expression.StatisticalDistribution;
+import io.substrait.extension.ResolvedAggregateBinding;
+import io.substrait.extension.ResolvedArgument;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.AggregateFunctions;
 import io.substrait.isthmus.SubstraitRelVisitor;
@@ -103,24 +105,173 @@ public class AggregateFunctionConverter
       Type outputType) {
     AggregateCall agg = call.getUnderlying();
 
-    List<Expression.SortField> sorts =
-        agg.getCollation() != null
-            ? agg.getCollation().getFieldCollations().stream()
-                .map(r -> SubstraitRelVisitor.toSortField(r, call.inputType))
-                .collect(java.util.stream.Collectors.toList())
-            : Collections.emptyList();
-    Expression.AggregationInvocation invocation =
-        agg.isDistinct()
-            ? Expression.AggregationInvocation.DISTINCT
-            : Expression.AggregationInvocation.ALL;
+    return AggregateFunctionInvocation.builder()
+        .declaration(function)
+        .outputType(outputType)
+        .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+        .sort(sortFields(agg, call.inputType))
+        .invocation(
+            agg.isDistinct()
+                ? Expression.AggregationInvocation.DISTINCT
+                : Expression.AggregationInvocation.ALL)
+        .addAllArguments(arguments)
+        .build();
+  }
 
-    return ExpressionCreator.aggregateFunction(
-        function,
-        outputType,
-        Expression.AggregationPhase.INITIAL_TO_RESULT,
-        sorts,
-        invocation,
-        arguments);
+  /**
+   * Rebuilds the invocation from the binding a converted call carries, when that binding still
+   * describes the call.
+   *
+   * <p>A binding names the exact declaration the plan used and the semantics Calcite cannot express
+   * — the function's options and its aggregation phase — so it beats re-matching: matching can only
+   * guess a declaration among equally-shaped candidates, always produces a full initial-to-result
+   * aggregation with no options, and for a phase that consumes an intermediate state cannot match
+   * at all, because the call's operands are then intermediate values rather than the declaration's
+   * arguments.
+   *
+   * <p>The binding describes the plan as it was converted, and a planner rule may have rewritten
+   * the call since. Staleness is therefore decided by comparing the arguments the binding recorded
+   * with the ones the call now has — not by re-validating against the declaration, which cannot
+   * judge a phase whose state is parameterized by the initial arguments it no longer sees (the
+   * intermediate {@code STRUCT<DECIMAL<38,S>,i64>} of a decimal average, say). When the arguments
+   * differ, this returns empty and the call is matched on its own terms, binding and all.
+   */
+  private Optional<AggregateFunctionInvocation> fromCarriedBinding(
+      RelNode input,
+      Type.Struct inputType,
+      AggregateCall call,
+      Function<RexNode, Expression> topLevelConverter) {
+    Optional<ResolvedAggregateBinding> bound =
+        AggregateFunctions.boundBinding(call.getAggregation());
+    if (!bound.isPresent()
+        || !(bound.get().function().declaration()
+            instanceof SimpleExtension.AggregateFunctionVariant)) {
+      return Optional.empty();
+    }
+    ResolvedAggregateBinding binding = bound.get();
+    SimpleExtension.AggregateFunctionVariant declaration =
+        (SimpleExtension.AggregateFunctionVariant) binding.function().declaration();
+
+    List<Expression> operands =
+        call.getArgList().stream()
+            .map(index -> topLevelConverter.apply(rexBuilder.makeInputRef(input, index)))
+            .collect(java.util.stream.Collectors.toList());
+    Optional<List<FunctionArg>> arguments = alignArguments(binding, declaration, operands);
+    if (!arguments.isPresent()) {
+      return Optional.empty();
+    }
+
+    AggregateFunctionInvocation invocation =
+        AggregateFunctionInvocation.builder()
+            .declaration(declaration)
+            .outputType(typeConverter.toSubstrait(call.getType()))
+            .aggregationPhase(binding.phase())
+            .sort(sortFields(call, inputType))
+            // The invocation comes from the Calcite call rather than from the binding: a planner
+            // rule may legitimately have dropped a redundant DISTINCT since the plan was converted.
+            .invocation(
+                call.isDistinct()
+                    ? Expression.AggregationInvocation.DISTINCT
+                    : Expression.AggregationInvocation.ALL)
+            .addAllArguments(arguments.get())
+            .options(binding.function().options())
+            .build();
+
+    List<ResolvedArgument> rebuilt =
+        ResolvedAggregateBinding.resolve(invocation).function().arguments();
+    return rebuilt.equals(binding.function().arguments())
+        ? Optional.of(invocation)
+        : Optional.empty();
+  }
+
+  /**
+   * Puts the call's operands back into the declaration's argument order, restoring the enum
+   * arguments — which are not Calcite operands — from the binding. Returns empty when the operands
+   * no longer fit the declaration, which again means the binding does not describe this call.
+   */
+  private static Optional<List<FunctionArg>> alignArguments(
+      ResolvedAggregateBinding binding,
+      SimpleExtension.AggregateFunctionVariant declaration,
+      List<Expression> operands) {
+    List<ResolvedArgument> resolved = binding.function().arguments();
+    // A phase that consumes the intermediate state takes exactly that state as its single value
+    // argument, whatever arity the declaration itself has. FunctionBindingResolver's
+    // validateIntermediateSignature already enforces that contract; aligning against
+    // declaration.args() here would contradict it, and silently drop the binding for a decomposable
+    // declaration whose arity is not 1 (e.g. the record-counting count() overload: zero declared
+    // arguments, intermediate i64).
+    if (binding.consumesIntermediateState()) {
+      return operands.size() == 1
+          ? Optional.of(new ArrayList<FunctionArg>(operands))
+          : Optional.empty();
+    }
+    List<FunctionArg> arguments = new ArrayList<>();
+    int operandIndex = 0;
+    for (int index = 0; index < declaration.args().size(); index++) {
+      SimpleExtension.Argument declaredArgument = declaration.args().get(index);
+      if (declaredArgument instanceof SimpleExtension.EnumArgument) {
+        if (index >= resolved.size() || resolved.get(index).kind() != ResolvedArgument.Kind.ENUM) {
+          return Optional.empty();
+        }
+        arguments.add(
+            resolved.get(index).enumValue().map(EnumArg::of).orElse(EnumArg.UNSPECIFIED_ENUM_ARG));
+      } else if (declaredArgument instanceof SimpleExtension.TypeArgument) {
+        // A type argument has no Calcite operand — only value arguments become operands — so it is
+        // restored from the binding without consuming an operand.
+        if (index >= resolved.size() || resolved.get(index).kind() != ResolvedArgument.Kind.TYPE) {
+          return Optional.empty();
+        }
+        arguments.add(resolved.get(index).type().orElseThrow(IllegalStateException::new));
+      } else {
+        if (operandIndex >= operands.size()) {
+          return Optional.empty();
+        }
+        arguments.add(operands.get(operandIndex++));
+      }
+    }
+    // A variadic declaration states its trailing argument once but accepts it repeatedly; repeated
+    // value arguments come from the operands, while repeated type and enum arguments — which are
+    // not Calcite operands — come from the binding.
+    List<SimpleExtension.Argument> declaredArgs = declaration.args();
+    SimpleExtension.Argument trailing =
+        declaredArgs.isEmpty() ? null : declaredArgs.get(declaredArgs.size() - 1);
+    boolean variadicFromBinding =
+        declaration.variadic().isPresent()
+            && (trailing instanceof SimpleExtension.TypeArgument
+                || trailing instanceof SimpleExtension.EnumArgument);
+    if (variadicFromBinding) {
+      ResolvedArgument.Kind expected =
+          trailing instanceof SimpleExtension.TypeArgument
+              ? ResolvedArgument.Kind.TYPE
+              : ResolvedArgument.Kind.ENUM;
+      for (int index = declaredArgs.size(); index < resolved.size(); index++) {
+        ResolvedArgument repeated = resolved.get(index);
+        if (repeated.kind() != expected) {
+          return Optional.empty();
+        }
+        FunctionArg repeatedArg =
+            expected == ResolvedArgument.Kind.TYPE
+                ? repeated.type().orElseThrow(IllegalStateException::new)
+                : repeated.enumValue().map(EnumArg::of).orElse(EnumArg.UNSPECIFIED_ENUM_ARG);
+        arguments.add(repeatedArg);
+      }
+    }
+    if (operandIndex < operands.size()
+        && (!declaration.variadic().isPresent() || variadicFromBinding)) {
+      return Optional.empty();
+    }
+    while (operandIndex < operands.size()) {
+      arguments.add(operands.get(operandIndex++));
+    }
+    return Optional.of(arguments);
+  }
+
+  private static List<Expression.SortField> sortFields(AggregateCall call, Type.Struct inputType) {
+    return call.getCollation() != null
+        ? call.getCollation().getFieldCollations().stream()
+            .map(collation -> SubstraitRelVisitor.toSortField(collation, inputType))
+            .collect(java.util.stream.Collectors.toList())
+        : Collections.emptyList();
   }
 
   /**
@@ -137,6 +288,14 @@ public class AggregateFunctionConverter
       Type.Struct inputType,
       AggregateCall call,
       Function<RexNode, Expression> topLevelConverter) {
+
+    // A call converted from Substrait may carry its resolved binding; that is a better source than
+    // re-matching the operator, and the only source for a phase Calcite cannot represent.
+    Optional<AggregateFunctionInvocation> carried =
+        fromCarriedBinding(input, inputType, call, topLevelConverter);
+    if (carried.isPresent()) {
+      return carried;
+    }
 
     FunctionFinder m = getFunctionFinder(call);
     if (m == null) {
@@ -187,6 +346,94 @@ public class AggregateFunctionConverter
   }
 
   /**
+   * Returns whether the reverse conversion can synthesize the enum operands this invocation
+   * carries. Only the statistical std_dev/variance family encodes an enum in the operator's {@link
+   * SqlKind}, and it encodes exactly one shape: a single leading {@code distribution} argument
+   * whose value is the one {@link #leadingEnumArgs} rebuilds from the kind itself — {@code SAMPLE}
+   * for the {@code *_SAMP} kinds, {@code POPULATION} for the {@code *_POP} kinds. An invocation
+   * carrying any other enum — an additional one, one in a non-leading position, one on a
+   * non-statistical operator, one whose value (or spelling) differs from what the kind synthesizes,
+   * or one whose declaration does not list the synthesized value in that exact spelling — has no
+   * Calcite representation and can come back only from a carried binding.
+   *
+   * @param aggFunction the Calcite operator the conversion emits
+   * @param binding the resolved binding of the invocation being converted
+   * @return {@code true} if re-matching rebuilds this invocation's enum arguments
+   */
+  public static boolean encodesEnumArguments(
+      SqlAggFunction aggFunction, ResolvedAggregateBinding binding) {
+    List<ResolvedArgument> arguments = binding.function().arguments();
+    int enumArguments = 0;
+    for (ResolvedArgument argument : arguments) {
+      if (argument.kind() == ResolvedArgument.Kind.ENUM) {
+        enumArguments++;
+      }
+    }
+    if (enumArguments != 1
+        || arguments.isEmpty()
+        || arguments.get(0).kind() != ResolvedArgument.Kind.ENUM) {
+      return false;
+    }
+    Optional<String> value = arguments.get(0).enumValue();
+    if (!value.isPresent()) {
+      return false;
+    }
+    String synthesized;
+    switch (AggregateFunctions.unwrapBound(aggFunction).getKind()) {
+      case STDDEV_SAMP:
+      case VAR_SAMP:
+        synthesized = StatisticalDistribution.SAMPLE.name();
+        break;
+      case STDDEV_POP:
+      case VAR_POP:
+        synthesized = StatisticalDistribution.POPULATION.name();
+        break;
+      default:
+        return false;
+    }
+    if (!synthesized.equals(value.get())) {
+      return false;
+    }
+    // The reverse path rebuilds the enum operand against the declaration's option list with an
+    // exact-spelling lookup (EnumArg.of throws otherwise), so the declaration must also spell the
+    // synthesized value exactly — validation accepts option values case-insensitively, so a
+    // declaration listing e.g. "population" is reachable here.
+    List<SimpleExtension.Argument> declaredArguments = binding.function().declaration().args();
+    if (declaredArguments.isEmpty()
+        || !(declaredArguments.get(0) instanceof SimpleExtension.EnumArgument)) {
+      return false;
+    }
+    return ((SimpleExtension.EnumArgument) declaredArguments.get(0))
+        .options()
+        .contains(synthesized);
+  }
+
+  /**
+   * Returns whether converting a call on the given operator back to Substrait would reconstruct
+   * exactly the given declaration, rather than an equally-keyed declaration another loaded
+   * extension provides. Reverse matching resolves by signature key and picks among equally-keyed
+   * variants by registration order, so a plan-determined reconstruction requires the key to be
+   * unique; a declaration with no reverse mapping at all cannot be reconstructed either.
+   *
+   * @param aggFunction the Calcite operator the conversion emits
+   * @param declaration the declaration the plan invoked
+   * @param arguments the invocation's resolved arguments
+   * @param outputType the Substrait output type the converted call will carry
+   * @return {@code true} if re-matching can only reconstruct that declaration
+   */
+  public boolean reconstructsUniquely(
+      SqlAggFunction aggFunction,
+      SimpleExtension.Function declaration,
+      List<ResolvedArgument> arguments,
+      Type outputType) {
+    SqlAggFunction unwrapped = AggregateFunctions.unwrapBound(aggFunction);
+    SqlAggFunction lookupFunction =
+        AggregateFunctions.toSubstraitAggVariant(unwrapped).orElse(unwrapped);
+    FunctionFinder finder = signatures.get(lookupFunction);
+    return finder != null && finder.uniquelyProvides(declaration, arguments, outputType);
+  }
+
+  /**
    * Resolves the appropriate function finder, applying Substrait-specific variants when needed.
    *
    * @param call Calcite aggregate call
@@ -195,7 +442,7 @@ public class AggregateFunctionConverter
   protected FunctionFinder getFunctionFinder(AggregateCall call) {
     // replace COUNT() + distinct == true and approximate == true with APPROX_COUNT_DISTINCT
     // before converting into substrait function
-    SqlAggFunction aggFunction = call.getAggregation();
+    SqlAggFunction aggFunction = AggregateFunctions.unwrapBound(call.getAggregation());
     if (aggFunction == SqlStdOperatorTable.COUNT && call.isDistinct() && call.isApproximate()) {
       aggFunction = SqlStdOperatorTable.APPROX_COUNT_DISTINCT;
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -3,6 +3,7 @@ package io.substrait.isthmus.expression;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -12,6 +13,7 @@ import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.FunctionArg;
 import io.substrait.expression.StatisticalDistribution;
+import io.substrait.extension.ResolvedArgument;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.extension.SimpleExtension.Argument;
 import io.substrait.function.ParameterizedType;
@@ -134,7 +136,9 @@ public abstract class FunctionConverter<
     signatures.addAll(additionalSignatures);
     signatures.addAll(getSigs());
     this.typeFactory = typeFactory;
-    this.substraitFuncKeyToSqlOperatorMap = ArrayListMultimap.create();
+    // Set-valued: two same-key declarations from different extensions map to the same operator,
+    // and a duplicate entry would make the lookup treat one operator as an ambiguity.
+    this.substraitFuncKeyToSqlOperatorMap = LinkedHashMultimap.create();
 
     ArrayListMultimap<String, F> nameToFn = ArrayListMultimap.<String, F>create();
     for (F f : functions) {
@@ -298,10 +302,14 @@ public abstract class FunctionConverter<
         .filter(
             operator -> {
               SqlKind kind = operator.getKind();
-              // Match distribution value to SqlKind
-              if (StatisticalDistribution.POPULATION.name().equals(distributionValue)) {
+              // Match distribution value to SqlKind. Enum option values are matched
+              // case-insensitively, per the spec — the exactness of the plan's spelling is a
+              // reverse-conversion concern the binding takes care of.
+              if (StatisticalDistribution.POPULATION.name().equalsIgnoreCase(distributionValue)) {
                 return kind == SqlKind.STDDEV_POP || kind == SqlKind.VAR_POP;
-              } else if (StatisticalDistribution.SAMPLE.name().equals(distributionValue)) {
+              } else if (StatisticalDistribution.SAMPLE
+                  .name()
+                  .equalsIgnoreCase(distributionValue)) {
                 return kind == SqlKind.STDDEV_SAMP || kind == SqlKind.VAR_SAMP;
               }
               throw new IllegalArgumentException(
@@ -378,6 +386,123 @@ public abstract class FunctionConverter<
      */
     public boolean allowedArgCount(int count) {
       return argRange.within(count);
+    }
+
+    /**
+     * Returns whether the reverse (Calcite → Substrait) direction would map a call carrying the
+     * given resolved arguments back to exactly the given declaration. Reverse matching first tries
+     * a direct signature-key lookup built from the operand types and takes the <em>last</em>
+     * variant registered under the key that hits — so a plan invoking {@code count(any)} with an
+     * {@code i32} operand reconstructs as {@code count(i32)} whenever that variant exists. Without
+     * a direct hit it consults the same matchers the reverse direction runs — {@code
+     * signatureMatch} over the argument types and output type, then the singular-wildcard chain
+     * over their least restrictive type — and requires the variant they select to be this
+     * declaration.
+     *
+     * <p>The key is built from the plan's arguments rather than from Calcite operands, so it
+     * mirrors the reverse direction only for the argument kinds that survive the round trip as an
+     * operand in the same position: value arguments, and an enum argument in the leading position
+     * the reverse direction prepends it to. A type argument spells itself as its concrete type here
+     * but as {@code type} in the declaration key, so it never matches one; an enum argument on an
+     * operator that does not encode it has no operand at all, and only the caller knows the
+     * operator. Callers must therefore exclude both — as the aggregate caller does before it
+     * reaches here. Where the consulted matchers cannot be reproduced faithfully — non-value
+     * operands past the direct lookup, an argument count the finder rejects, a matcher failure —
+     * this fails towards {@code false}, which costs only a carried binding.
+     *
+     * @param declaration the declaration a plan invoked
+     * @param arguments the invocation's resolved arguments
+     * @param outputType the Substrait output type the converted call will carry
+     * @return {@code true} if re-matching can only reconstruct that declaration
+     */
+    public boolean uniquelyProvides(
+        SimpleExtension.Function declaration, List<ResolvedArgument> arguments, Type outputType) {
+      boolean present = false;
+      for (F function : functions) {
+        if (function.getAnchor().equals(declaration.getAnchor())) {
+          present = true;
+          break;
+        }
+      }
+      if (!present) {
+        return false;
+      }
+      // Mirror of attemptMatch's direct lookup: the key is built from the operand type strings, an
+      // enum operand spelled "req" — candidateKeys also probes "opt", which no declaration key can
+      // contain — and the LAST variant registered under the first key that hits wins.
+      Optional<String> directKey =
+          candidateKeys(arguments).filter(directMap::containsKey).findFirst();
+      if (directKey.isPresent()) {
+        List<F> variants = directMap.get(directKey.get());
+        return variants.get(variants.size() - 1).getAnchor().equals(declaration.getAnchor());
+      }
+      // Without a direct hit the reverse direction runs the coerced and singular-wildcard paths;
+      // consult the same matchers it uses and require them to select this declaration. A call
+      // those matchers cannot be consulted for faithfully — non-value operands, an argument count
+      // the finder rejects outright, or a matcher failure — keeps its binding instead.
+      if (!allowedArgCount(arguments.size())) {
+        return false;
+      }
+      List<Type> valueTypes = new ArrayList<>();
+      for (ResolvedArgument argument : arguments) {
+        if (argument.kind() != ResolvedArgument.Kind.VALUE) {
+          return false;
+        }
+        valueTypes.add(argument.type().orElseThrow(IllegalStateException::new));
+      }
+      try {
+        // matchCoerced consults signatureMatch with the operand types as they are; note it checks
+        // neither per-variant arity (a shorter declaration matches by repeating its trailing
+        // argument) nor anything a wrapper could veto, so the selected variant is authoritative.
+        Optional<F> bySignature = signatureMatch(valueTypes, outputType);
+        if (bySignature.isPresent()) {
+          return bySignature.get().getAnchor().equals(declaration.getAnchor());
+        }
+        // matchByLeastRestrictive consults the singular-wildcard chain with the operands' least
+        // restrictive type; it ignores the output type entirely.
+        if (!singularInputType.isPresent()) {
+          return false;
+        }
+        List<RelDataType> calciteTypes = new ArrayList<>();
+        for (Type valueType : valueTypes) {
+          calciteTypes.add(typeConverter.toCalcite(typeFactory, valueType));
+        }
+        RelDataType leastRestrictive = typeFactory.leastRestrictive(calciteTypes);
+        if (leastRestrictive == null) {
+          return false;
+        }
+        Optional<F> bySingular =
+            singularInputType
+                .get()
+                .tryMatch(typeConverter.toSubstrait(leastRestrictive), outputType);
+        return bySingular.isPresent()
+            && bySingular.get().getAnchor().equals(declaration.getAnchor());
+      } catch (RuntimeException e) {
+        // If the selection cannot be reproduced, the reverse direction is not predictable either;
+        // carrying the binding sidesteps it entirely.
+        return false;
+      }
+    }
+
+    private Stream<String> candidateKeys(List<ResolvedArgument> arguments) {
+      if (arguments.isEmpty()) {
+        return Stream.of(substraitName + ":");
+      }
+      List<List<String>> argTypeLists = new ArrayList<>();
+      for (ResolvedArgument argument : arguments) {
+        if (argument.kind() == ResolvedArgument.Kind.ENUM) {
+          argTypeLists.add(List.of("req", "opt"));
+        } else {
+          argTypeLists.add(
+              List.of(
+                  argument
+                      .type()
+                      .orElseThrow(IllegalStateException::new)
+                      .accept(ToTypeString.INSTANCE)));
+        }
+      }
+      return Utils.crossProduct(argTypeLists)
+          .map(typeList -> substraitName + ":" + String.join("_", typeList));
     }
 
     /**

--- a/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CustomFunctionTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.Any;
 import io.substrait.expression.Expression.UserDefinedLiteral;
@@ -229,8 +230,59 @@ class CustomFunctionTest extends PlanTestBase {
           null,
           SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
 
+  static final SqlAggFunction customTypedAggregateFn =
+      new SqlAggFunction(
+          "custom_typed_aggregate",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.explicit(SqlTypeName.BIGINT),
+          null,
+          null,
+          SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+
+  static final SqlAggFunction customEnumAggregateFn =
+      new SqlAggFunction(
+          "custom_enum_aggregate",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.explicit(SqlTypeName.BIGINT),
+          null,
+          null,
+          SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+
+  static final SqlAggFunction customFlagsAggregateFn =
+      new SqlAggFunction(
+          "custom_flags_aggregate",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.explicit(SqlTypeName.BIGINT),
+          null,
+          null,
+          SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+
+  static final SqlAggFunction customOverlapFn =
+      new SqlAggFunction(
+          "custom_overlap",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.explicit(SqlTypeName.BIGINT),
+          null,
+          null,
+          SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+
+  static final SqlAggFunction customMixFn =
+      new SqlAggFunction(
+          "custom_mix",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.explicit(SqlTypeName.BIGINT),
+          null,
+          null,
+          SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+
   static final List<FunctionMappings.Sig> additionalAggregateSignatures =
-      List.of(FunctionMappings.s(customAggregateFn));
+      List.of(
+          FunctionMappings.s(customAggregateFn),
+          FunctionMappings.s(customTypedAggregateFn),
+          FunctionMappings.s(customEnumAggregateFn),
+          FunctionMappings.s(customFlagsAggregateFn),
+          FunctionMappings.s(customOverlapFn),
+          FunctionMappings.s(customMixFn));
 
   static TypeConverter typeConverter = new TypeConverter(userTypeMapper);
 
@@ -542,6 +594,277 @@ class CustomFunctionTest extends PlanTestBase {
     RelNode calciteRel = substraitToCalcite.convert(rel);
     Rel relReturned = calciteToSubstrait.apply(calciteRel);
     assertEquals(rel, relReturned);
+  }
+
+  @Test
+  void typeArgumentAggregateRoundtrip() {
+    // custom_typed_aggregate(<type: i32>, x: i64): only value arguments become Calcite operands,
+    // so the type argument can come back only from the carried binding — the wrapper is mandatory
+    // for such a declaration, and the reverse conversion restores the type argument without
+    // consuming an operand.
+    Rel input = sb.namedScan(List.of("example"), List.of("a"), List.of(R.I64));
+    Rel rel =
+        sb.aggregate(
+            i -> sb.grouping(i, 0),
+            i ->
+                List.of(
+                    io.substrait.relation.Aggregate.Measure.builder()
+                        .function(
+                            io.substrait.expression.AggregateFunctionInvocation.builder()
+                                .declaration(
+                                    CUSTOM_EXTENSIONS.getAggregateFunction(
+                                        SimpleExtension.FunctionAnchor.of(
+                                            URN, "custom_typed_aggregate:type_i64")))
+                                .outputType(R.I64)
+                                .aggregationPhase(
+                                    io.substrait.expression.Expression.AggregationPhase
+                                        .INITIAL_TO_RESULT)
+                                .invocation(
+                                    io.substrait.expression.Expression.AggregationInvocation.ALL)
+                                .addArguments(TypeCreator.REQUIRED.I32)
+                                .addArguments(sb.fieldReference(i, 0))
+                                .build())
+                        .build()),
+            input);
+
+    RelNode calciteRel = substraitToCalcite.convert(rel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
+    assertEquals(rel, relReturned);
+  }
+
+  @Test
+  void enumArgumentAggregateRoundtrip() {
+    // custom_enum_aggregate(EXACT|APPROXIMATE, x: i64): no Calcite operator kind encodes this
+    // enum (only the std_dev/variance distribution is operator-encoded), so it can come back only
+    // from the carried binding — the wrapper is mandatory even though the output type matches
+    // Calcite's inference.
+    Rel input = sb.namedScan(List.of("example"), List.of("a"), List.of(R.I64));
+    Rel rel =
+        sb.aggregate(
+            i -> sb.grouping(i, 0),
+            i ->
+                List.of(
+                    io.substrait.relation.Aggregate.Measure.builder()
+                        .function(
+                            io.substrait.expression.AggregateFunctionInvocation.builder()
+                                .declaration(
+                                    CUSTOM_EXTENSIONS.getAggregateFunction(
+                                        SimpleExtension.FunctionAnchor.of(
+                                            URN, "custom_enum_aggregate:req_i64")))
+                                .outputType(R.I64)
+                                .aggregationPhase(
+                                    io.substrait.expression.Expression.AggregationPhase
+                                        .INITIAL_TO_RESULT)
+                                .invocation(
+                                    io.substrait.expression.Expression.AggregationInvocation.ALL)
+                                .addArguments(io.substrait.expression.EnumArg.of("EXACT"))
+                                .addArguments(sb.fieldReference(i, 0))
+                                .build())
+                        .build()),
+            input);
+
+    RelNode calciteRel = substraitToCalcite.convert(rel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
+    assertEquals(rel, relReturned);
+  }
+
+  @Test
+  void argumentTypeMismatchedAggregateKeepsItsBinding() {
+    // Under the default FunctionBindingValidation.NONE a plan may invoke custom_aggregate(i64)
+    // with an i32 argument. The permissive Calcite operator accepts it and its explicit BIGINT
+    // return matches the declared i64, but re-matching would reject the i32 against the
+    // declaration's i64 — so the binding must travel for the round trip to reconstruct the
+    // invocation as the plan spelled it.
+    Rel input = sb.namedScan(List.of("example"), List.of("a"), List.of(R.I32));
+    Rel rel =
+        sb.aggregate(
+            i -> sb.grouping(i, 0),
+            i ->
+                List.of(
+                    sb.measure(
+                        sb.aggregateFn(
+                            URN, "custom_aggregate:i64", R.I64, sb.fieldReference(i, 0)))),
+            input);
+
+    RelNode calciteRel = substraitToCalcite.convert(rel);
+
+    org.apache.calcite.rel.core.Aggregate calciteAgg =
+        (org.apache.calcite.rel.core.Aggregate) calciteRel;
+    assertTrue(
+        AggregateFunctions.boundBinding(calciteAgg.getAggCallList().get(0).getAggregation())
+            .isPresent());
+    assertEquals(rel, calciteToSubstrait.apply(calciteRel));
+  }
+
+  @Test
+  void wildcardShadowedAggregateKeepsItsBinding() {
+    // custom_overlap declares both (i32) and (any, any). The reverse signature matcher checks no
+    // per-variant arity — a shorter declaration matches by repeating its trailing argument — so
+    // invoking the wildcard impl as f(i32, i32) would re-match the concrete (i32) impl first. The
+    // binding must travel for the plan's declaration to survive.
+    Rel input = sb.namedScan(List.of("example"), List.of("a", "b"), List.of(R.I32, R.I32));
+    Rel wildcard =
+        sb.aggregate(
+            i -> sb.grouping(i, 0),
+            i ->
+                List.of(
+                    sb.measure(
+                        sb.aggregateFn(
+                            URN,
+                            "custom_overlap:any_any",
+                            R.I64,
+                            sb.fieldReference(i, 0),
+                            sb.fieldReference(i, 1)))),
+            input);
+
+    RelNode wildcardRel = substraitToCalcite.convert(wildcard);
+    org.apache.calcite.rel.core.Aggregate wildcardAgg =
+        (org.apache.calcite.rel.core.Aggregate) wildcardRel;
+    assertTrue(
+        AggregateFunctions.boundBinding(wildcardAgg.getAggCallList().get(0).getAggregation())
+            .isPresent());
+    assertEquals(wildcard, calciteToSubstrait.apply(wildcardRel));
+
+    // The concrete impl itself is reconstructable by its direct key: no wrapper needed.
+    Rel concrete =
+        sb.aggregate(
+            i -> sb.grouping(i, 0),
+            i ->
+                List.of(
+                    sb.measure(
+                        sb.aggregateFn(URN, "custom_overlap:i32", R.I64, sb.fieldReference(i, 1)))),
+            input);
+    RelNode concreteRel = substraitToCalcite.convert(concrete);
+    org.apache.calcite.rel.core.Aggregate concreteAgg =
+        (org.apache.calcite.rel.core.Aggregate) concreteRel;
+    assertTrue(
+        AggregateFunctions.boundBinding(concreteAgg.getAggCallList().get(0).getAggregation())
+            .isEmpty());
+    assertEquals(concrete, calciteToSubstrait.apply(concreteRel));
+  }
+
+  @Test
+  void divergentReturnTypeAggregateKeepsItsBinding() {
+    // custom_mix(any, string) declares an i32 return, while the plan declares i64 — permitted
+    // under FunctionBindingValidation.NONE and equal to the operator's inference, so nothing about
+    // the type forces a wrapper. The reverse signature matcher would reject the declaration by its
+    // return type and the singular fallback finds no least-restrictive type for (i64, string), so
+    // without the binding the invocation could not be reconstructed at all.
+    Rel input = sb.namedScan(List.of("example"), List.of("a", "b"), List.of(R.I64, R.STRING));
+    Rel rel =
+        sb.aggregate(
+            i -> sb.grouping(i, 0),
+            i ->
+                List.of(
+                    sb.measure(
+                        sb.aggregateFn(
+                            URN,
+                            "custom_mix:any_str",
+                            R.I64,
+                            sb.fieldReference(i, 0),
+                            sb.fieldReference(i, 1)))),
+            input);
+
+    RelNode calciteRel = substraitToCalcite.convert(rel);
+    org.apache.calcite.rel.core.Aggregate calciteAgg =
+        (org.apache.calcite.rel.core.Aggregate) calciteRel;
+    assertTrue(
+        AggregateFunctions.boundBinding(calciteAgg.getAggCallList().get(0).getAggregation())
+            .isPresent());
+    assertEquals(rel, calciteToSubstrait.apply(calciteRel));
+  }
+
+  @Test
+  void variadicEnumAggregateRoundtrip() {
+    // custom_flags_aggregate(x: i64, flag: [A,B,C]...): the trailing enum repeats, and none of the
+    // repetitions is a Calcite operand — all of them can come back only from the carried binding.
+    Rel input = sb.namedScan(List.of("example"), List.of("a"), List.of(R.I64));
+    Rel rel =
+        sb.aggregate(
+            i -> sb.grouping(i, 0),
+            i ->
+                List.of(
+                    io.substrait.relation.Aggregate.Measure.builder()
+                        .function(
+                            io.substrait.expression.AggregateFunctionInvocation.builder()
+                                .declaration(
+                                    CUSTOM_EXTENSIONS.getAggregateFunction(
+                                        SimpleExtension.FunctionAnchor.of(
+                                            URN, "custom_flags_aggregate:i64_req")))
+                                .outputType(R.I64)
+                                .aggregationPhase(
+                                    io.substrait.expression.Expression.AggregationPhase
+                                        .INITIAL_TO_RESULT)
+                                .invocation(
+                                    io.substrait.expression.Expression.AggregationInvocation.ALL)
+                                .addArguments(sb.fieldReference(i, 0))
+                                .addArguments(io.substrait.expression.EnumArg.of("A"))
+                                .addArguments(io.substrait.expression.EnumArg.of("B"))
+                                .build())
+                        .build()),
+            input);
+
+    RelNode calciteRel = substraitToCalcite.convert(rel);
+    Rel relReturned = calciteToSubstrait.apply(calciteRel);
+    assertEquals(rel, relReturned);
+  }
+
+  @Test
+  void aggregateInferenceFailureFallsBackToThePlanTypeUnderPlanOutput() {
+    // custom_aggregate mapped to an operator whose return-type inference rejects its operands.
+    // Under PLAN_OUTPUT the inferred type only decides whether the plan's type must travel on a
+    // wrapper, so the failure counts as "diverges" and the conversion proceeds with the plan's
+    // type; under CALCITE_INFERENCE there is nothing to fall back to and the failure propagates.
+    SqlAggFunction throwingAggregateFn =
+        new SqlAggFunction(
+            "custom_aggregate",
+            SqlKind.OTHER_FUNCTION,
+            opBinding -> {
+              throw new IllegalStateException("this operator cannot infer a return type");
+            },
+            null,
+            null,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+    AggregateFunctionConverter throwingAggregateConverter =
+        new AggregateFunctionConverter(
+            CUSTOM_EXTENSIONS.aggregateFunctions(),
+            List.of(FunctionMappings.s(throwingAggregateFn)),
+            SubstraitTypeSystem.TYPE_FACTORY,
+            typeConverter);
+    Rel rel =
+        sb.aggregate(
+            input -> sb.grouping(input, 0),
+            input ->
+                List.of(
+                    sb.measure(
+                        sb.aggregateFn(
+                            URN, "custom_aggregate:i64", R.I64, sb.fieldReference(input, 0)))),
+            sb.namedScan(List.of("example"), List.of("a"), List.of(R.I64)));
+
+    ConverterProvider planOutput =
+        ConverterProvider.builder()
+            .typeFactory(SubstraitTypeSystem.TYPE_FACTORY)
+            .extensions(CUSTOM_EXTENSIONS)
+            .aggregateFunctionConverter(throwingAggregateConverter)
+            .typeConverter(typeConverter)
+            .build();
+    org.apache.calcite.rel.core.Aggregate calciteAgg =
+        (org.apache.calcite.rel.core.Aggregate) new SubstraitToCalcite(planOutput).convert(rel);
+    assertEquals(SqlTypeName.BIGINT, calciteAgg.getAggCallList().get(0).getType().getSqlTypeName());
+
+    ConverterProvider calciteInference =
+        ConverterProvider.builder()
+            .typeFactory(SubstraitTypeSystem.TYPE_FACTORY)
+            .extensions(CUSTOM_EXTENSIONS)
+            .aggregateFunctionConverter(throwingAggregateConverter)
+            .typeConverter(typeConverter)
+            .aggregateConversion(
+                new AggregateConversion(
+                    AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                    AggregateConversion.FunctionBindingValidation.NONE))
+            .build();
+    assertThrows(
+        IllegalStateException.class, () -> new SubstraitToCalcite(calciteInference).convert(rel));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -1,17 +1,43 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.EnumArg;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionArg;
+import io.substrait.expression.FunctionOption;
+import io.substrait.expression.ImmutableAggregateFunctionInvocation;
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.InvalidFunctionBindingException;
+import io.substrait.extension.ResolvedAggregateBinding;
+import io.substrait.extension.ResolvedArgument;
+import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.Plan;
 import io.substrait.relation.Join.JoinType;
 import io.substrait.relation.Rel;
 import io.substrait.relation.Set.SetOp;
 import io.substrait.type.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +64,14 @@ class SubstraitRelNodeConverterTest extends PlanTestBase {
 
       RelNode relNode = substraitToCalcite.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING, R.I64);
+
+      // The declared COUNT type matches Calcite's inference, so the call keeps the stock operator
+      // rather than a binding-carrying wrapper.
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Optional.empty(),
+          AggregateFunctions.boundBinding(calciteAgg.getAggCallList().get(0).getAggregation()));
     }
 
     @Test
@@ -52,6 +86,534 @@ class SubstraitRelNodeConverterTest extends PlanTestBase {
 
       RelNode relNode = substraitToCalcite.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), N.STRING, R.I64);
+    }
+
+    @Test
+    void declaredMeasureOutputTypes() {
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input ->
+                  List.of(
+                      withOutputType(sb.sum(input, 0), R.I64),
+                      withOutputType(sb.avg(input, 1), R.FP32)),
+              commonTable);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), N.STRING, R.I64, R.FP32);
+
+      // Both declared types diverge from Calcite's inference, so both calls carry a resolved
+      // binding on a wrapper (PLAN_OUTPUT preserves the plan's declared type).
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      for (AggregateCall call : calciteAgg.getAggCallList()) {
+        assertTrue(AggregateFunctions.boundBinding(call.getAggregation()).isPresent());
+      }
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void declaredDecimalWidthIsPreserved() {
+      Rel input =
+          sb.namedScan(List.of("example"), List.of("d", "g"), List.of(R.decimal(10, 2), R.STRING));
+      // The standard extension declarations for decimal sum and avg return DECIMAL<38,S>, while
+      // Calcite's inference keeps the argument's precision. The declared width must survive.
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1),
+              i ->
+                  List.of(
+                      sb.measure(
+                          sb.aggregateFn(
+                              DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL,
+                              "sum:dec",
+                              N.decimal(38, 2),
+                              sb.fieldReference(i, 0))),
+                      sb.measure(
+                          sb.aggregateFn(
+                              DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL,
+                              "avg:dec",
+                              N.decimal(38, 2),
+                              sb.fieldReference(i, 0)))),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), R.STRING, N.decimal(38, 2), N.decimal(38, 2));
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void declaredTypeOnGlobalAggregateWithoutGroupings() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a"), List.of(R.I32));
+      // An aggregate with no groupings at all (as opposed to one empty grouping) is a global
+      // aggregation; the declared type must be preserved for it as well.
+      Rel aggregate =
+          io.substrait.relation.Aggregate.builder()
+              .input(input)
+              .measures(List.of(withOutputType(sb.sum(input, 0), R.I64)))
+              .build();
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), R.I64);
+
+      // A global aggregation is one empty grouping set, not zero grouping sets. RelBuilder derives
+      // each measure's hasEmptyGroup from the grouping sets, so anything else would re-infer the
+      // measures against a group key the aggregate does not have.
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(List.of(ImmutableBitSet.of()), calciteAgg.getGroupSets());
+      assertEquals(org.apache.calcite.rel.core.Aggregate.Group.SIMPLE, calciteAgg.getGroupType());
+
+      // Converting back therefore normalizes "no groupings at all" to the equivalent single empty
+      // grouping — the same global aggregation, spelled the way Calcite spells it.
+      io.substrait.relation.Aggregate roundTripped =
+          (io.substrait.relation.Aggregate) SubstraitRelVisitor.convert(relNode, converterProvider);
+      assertEquals(1, roundTripped.getGroupings().size());
+      assertTrue(roundTripped.getGroupings().get(0).getExpressions().isEmpty());
+    }
+
+    @Test
+    void boundOperatorIdentityIgnoresDeclaredType() {
+      ResolvedAggregateBinding binding =
+          ResolvedAggregateBinding.resolve(sb.sum(commonTable, 0).getFunction());
+      RelDataType i64 = converterProvider.getTypeConverter().toCalcite(typeFactory, N.I64);
+      RelDataType fp64 = converterProvider.getTypeConverter().toCalcite(typeFactory, N.FP64);
+
+      SqlAggFunction boundToI64 = AggregateFunctions.bind(AggregateFunctions.SUM, binding, i64);
+      SqlAggFunction boundToFp64 = AggregateFunctions.bind(AggregateFunctions.SUM, binding, fp64);
+
+      // Operator identity answers "which Substrait function is this?", never "which type does it
+      // produce?", so matching on the operator stays type-agnostic.
+      assertEquals(boundToI64, boundToFp64);
+      assertEquals(boundToI64.hashCode(), boundToFp64.hashCode());
+
+      // The carried type is still readable, it is just not part of the identity.
+      assertEquals(Optional.of(i64), AggregateFunctions.declaredOutputType(boundToI64));
+      assertEquals(Optional.of(fp64), AggregateFunctions.declaredOutputType(boundToFp64));
+      assertEquals(Optional.empty(), AggregateFunctions.declaredOutputType(AggregateFunctions.SUM));
+
+      // A different Substrait function is a different operator.
+      ResolvedAggregateBinding countBinding =
+          ResolvedAggregateBinding.resolve(sb.count(commonTable, 0).getFunction());
+      assertNotEquals(
+          boundToI64, AggregateFunctions.bind(AggregateFunctions.SUM, countBinding, i64));
+    }
+
+    @Test
+    void enumArgumentDistinguishesMeasuresOfTheSameFunction() {
+      Rel input = sb.namedScan(List.of("example"), List.of("x", "g"), List.of(R.FP32, R.STRING));
+      // Both measures call std_dev:req_fp32 on the same column; only the leading "distribution"
+      // enum argument differs, so only the resolved binding tells them apart.
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1),
+              i -> List.of(stdDev(i, "POPULATION"), stdDev(i, "SAMPLE")),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), R.STRING, R.FP32, R.FP32);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      List<AggregateCall> calls = calciteAgg.getAggCallList();
+      assertEquals(2, calls.size());
+      ResolvedAggregateBinding population = boundBinding(calls.get(0));
+      ResolvedAggregateBinding sample = boundBinding(calls.get(1));
+      assertNotEquals(population, sample);
+      assertEquals(Optional.of("POPULATION"), enumArgument(population));
+      assertEquals(Optional.of("SAMPLE"), enumArgument(sample));
+    }
+
+    @Test
+    void functionOptionsSurviveConversion() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      // count(i32) -> i64 matches Calcite's inference exactly, so nothing about the type forces a
+      // wrapper — but the plan's "overflow" option has no place in a Calcite aggregate call, and
+      // dropping it would silently change what the plan asks for.
+      Rel aggregate = sb.aggregate(i -> sb.grouping(i, 1), i -> List.of(count(i, "ERROR")), input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      ResolvedAggregateBinding binding = boundBinding(calciteAgg.getAggCallList().get(0));
+      assertEquals(Optional.of(List.of("ERROR")), binding.function().option("overflow"));
+
+      // ... and the option comes back out on the way to Substrait, instead of being re-matched
+      // away.
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void measuresDifferingOnlyByOptionsStayDistinct() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1), i -> List.of(count(i, "ERROR"), count(i, "SILENT")), input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      // Both measures are COUNT(a) of type i64 and differ only in an option Calcite cannot express,
+      // so only the carried binding keeps them from being deduplicated into one column.
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(2, calciteAgg.getAggCallList().size());
+      assertNotEquals(
+          boundBinding(calciteAgg.getAggCallList().get(0)),
+          boundBinding(calciteAgg.getAggCallList().get(1)));
+      assertRowMatch(relNode.getRowType(), R.STRING, R.I64, R.I64);
+    }
+
+    @Test
+    void intermediatePhaseSurvivesBothDirections() {
+      Rel input = sb.namedScan(List.of("example"), List.of("partial"), List.of(R.I64));
+      // count accumulates into i64, and a final phase consumes that state. Calcite has no notion of
+      // aggregation phases, so only the carried binding can bring this back: matching would see
+      // COUNT(i64) and rebuild a full initial-to-result aggregation instead.
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i),
+              i -> List.of(count(i, null, Expression.AggregationPhase.INTERMEDIATE_TO_RESULT)),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Expression.AggregationPhase.INTERMEDIATE_TO_RESULT,
+          boundBinding(calciteAgg.getAggCallList().get(0)).phase());
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void parameterizedIntermediateStateSurvivesBothDirections() {
+      // avg:dec accumulates into STRUCT<DECIMAL<38,S>,i64>. A phase that consumes that state sees
+      // only the state, so S cannot be bound and the intermediate type cannot be re-derived — the
+      // binding has to be trusted as recorded instead of re-validated against the declaration.
+      Type state = R.struct(R.decimal(38, 2), R.I64);
+      // A NamedStruct names nested fields too, so the state column contributes three names.
+      Rel input =
+          sb.namedScan(List.of("example"), List.of("partial", "total", "count"), List.of(state));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i),
+              i ->
+                  List.of(
+                      io.substrait.relation.Aggregate.Measure.builder()
+                          .function(
+                              AggregateFunctionInvocation.builder()
+                                  .declaration(
+                                      extensions.getAggregateFunction(
+                                          SimpleExtension.FunctionAnchor.of(
+                                              DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL,
+                                              "avg:dec")))
+                                  .outputType(N.decimal(38, 2))
+                                  .aggregationPhase(
+                                      Expression.AggregationPhase.INTERMEDIATE_TO_RESULT)
+                                  .invocation(Expression.AggregationInvocation.ALL)
+                                  .addArguments(sb.fieldReference(i, 0))
+                                  .build())
+                          .build()),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Expression.AggregationPhase.INTERMEDIATE_TO_RESULT,
+          boundBinding(calciteAgg.getAggCallList().get(0)).phase());
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void calciteInferenceIgnoresAnUnrepresentablePlanType() {
+      // The declared type is a user-defined type this converter has no mapping for. Ignoring it is
+      // exactly what CALCITE_INFERENCE promises, so the conversion must not fail on it.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input ->
+                  List.of(
+                      withOutputType(
+                          sb.sum(input, 0),
+                          sb.userDefinedType("extension:test:unmapped", "opaque"))),
+              commonTable);
+      SubstraitToCalcite calciteInference =
+          new SubstraitToCalcite(
+              converterProvider,
+              null,
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                  AggregateConversion.FunctionBindingValidation.NONE));
+
+      assertRowMatch(calciteInference.convert(aggregate).getRowType(), N.STRING, N.I32);
+
+      // Preserving it, on the other hand, is impossible — and says so instead of substituting.
+      assertThrows(
+          UnsupportedOperationException.class, () -> substraitToCalcite.convert(aggregate));
+    }
+
+    @Test
+    void unwrappingRestoresTheDelegateAndKeepsTheType() {
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 2),
+              i -> List.of(withOutputType(sb.sum(i, 0), R.I64)),
+              commonTable);
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) substraitToCalcite.convert(aggregate);
+      AggregateCall bound = calciteAgg.getAggCallList().get(0);
+      assertTrue(AggregateFunctions.boundBinding(bound.getAggregation()).isPresent());
+
+      // What a consumer does before executing a converted plan: Calcite dispatches aggregate
+      // implementations by operator identity, and a bound operator has none.
+      AggregateCall unwrapped = AggregateFunctions.unwrapBound(bound);
+      assertEquals(AggregateFunctions.SUM, unwrapped.getAggregation());
+      assertEquals(bound.getType(), unwrapped.getType());
+      assertEquals(Optional.empty(), AggregateFunctions.boundBinding(unwrapped.getAggregation()));
+      // A call that carries no binding is returned untouched.
+      assertSame(unwrapped, AggregateFunctions.unwrapBound(unwrapped));
+    }
+
+    @Test
+    void converterFactoryDispatchDependsOnTheConfiguration() {
+      List<String> factories = new ArrayList<>();
+      ConverterProvider provider =
+          new ConverterProvider() {
+            @Override
+            public SubstraitRelNodeConverter getSubstraitRelNodeConverter(RelBuilder relBuilder) {
+              factories.add("single-argument");
+              return super.getSubstraitRelNodeConverter(relBuilder);
+            }
+
+            @Override
+            public SubstraitRelNodeConverter getSubstraitRelNodeConverter(
+                RelBuilder relBuilder, AggregateConversion aggregateConversion) {
+              factories.add("aggregate-aware");
+              return super.getSubstraitRelNodeConverter(relBuilder, aggregateConversion);
+            }
+          };
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2), input -> List.of(sb.count(input, 0)), commonTable);
+
+      // The default configuration goes through the long-standing single-argument factory, so a
+      // subclass that only overrides that one still customizes conversion.
+      new SubstraitToCalcite(provider).convert(aggregate);
+      assertEquals(List.of("single-argument", "aggregate-aware"), factories);
+
+      // A non-default configuration cannot: it has nowhere to pass the configuration but the
+      // two-argument factory.
+      factories.clear();
+      new SubstraitToCalcite(
+              provider,
+              null,
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                  AggregateConversion.FunctionBindingValidation.NONE))
+          .convert(aggregate);
+      assertEquals(List.of("aggregate-aware"), factories);
+    }
+
+    private io.substrait.relation.Aggregate.Measure count(Rel input, String overflow) {
+      return count(input, overflow, Expression.AggregationPhase.INITIAL_TO_RESULT);
+    }
+
+    private io.substrait.relation.Aggregate.Measure count(
+        Rel input, String overflow, Expression.AggregationPhase phase) {
+      SimpleExtension.AggregateFunctionVariant declaration =
+          extensions.getAggregateFunction(
+              SimpleExtension.FunctionAnchor.of(
+                  DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any"));
+      ImmutableAggregateFunctionInvocation.Builder function =
+          AggregateFunctionInvocation.builder()
+              .declaration(declaration)
+              .outputType(R.I64)
+              .aggregationPhase(phase)
+              .invocation(Expression.AggregationInvocation.ALL)
+              .addArguments(sb.fieldReference(input, 0));
+      if (overflow != null) {
+        function.addOptions(FunctionOption.builder().name("overflow").addValues(overflow).build());
+      }
+      return io.substrait.relation.Aggregate.Measure.builder().function(function.build()).build();
+    }
+
+    private ResolvedAggregateBinding boundBinding(AggregateCall call) {
+      return AggregateFunctions.boundBinding(call.getAggregation())
+          .orElseThrow(() -> new AssertionError("expected a bound aggregate function: " + call));
+    }
+
+    private Optional<String> enumArgument(ResolvedAggregateBinding binding) {
+      return binding.function().arguments().stream()
+          .filter(argument -> argument.kind() == ResolvedArgument.Kind.ENUM)
+          .findFirst()
+          .flatMap(ResolvedArgument::enumValue);
+    }
+
+    private io.substrait.relation.Aggregate.Measure stdDev(Rel input, String distribution) {
+      SimpleExtension.AggregateFunctionVariant declaration =
+          extensions.getAggregateFunction(
+              SimpleExtension.FunctionAnchor.of(
+                  DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "std_dev:req_fp32"));
+      return io.substrait.relation.Aggregate.Measure.builder()
+          .function(
+              AggregateFunctionInvocation.builder()
+                  .declaration(declaration)
+                  .arguments(
+                      List.<FunctionArg>of(EnumArg.of(distribution), sb.fieldReference(input, 0)))
+                  // The declaration returns fp32?; declaring it required diverges from Calcite's
+                  // inference, which is what makes the binding travel on a wrapper.
+                  .outputType(R.FP32)
+                  .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                  .invocation(Expression.AggregationInvocation.ALL)
+                  .build())
+          .build();
+    }
+
+    @Test
+    void differentDeclaredTypesOnDuplicateMeasuresArePreserved() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1),
+              i ->
+                  List.of(
+                      withOutputType(sb.sum(i, 0), R.I64), withOutputType(sb.sum(i, 0), R.FP64)),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      // The two SUM(a) measures are identical apart from their declared output type, and
+      // AggregateCall equality ignores that type. They survive as distinct columns because the
+      // converter opts such an aggregate out of RelBuilder's aggregate-call deduplication.
+      assertRowMatch(relNode.getRowType(), R.STRING, R.I64, R.FP64);
+      assertEquals(2, ((org.apache.calcite.rel.core.Aggregate) relNode).getAggCallList().size());
+    }
+
+    @Test
+    void declaredTypeSurvivesAggregateRollupRule() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      Rel filtered = sb.filter(i -> sb.equal(sb.fieldReference(i, 0), sb.i32(1)), input);
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1), i -> List.of(withOutputType(sb.sum(i, 0), R.I64)), filtered);
+
+      RelNode converted = substraitToCalcite.convert(aggregate);
+      RelNode optimized = optimize(converted, CoreRules.AGGREGATE_FILTER_TRANSPOSE);
+
+      // The filter references the non-grouped column, so the rule would roll the aggregate up. The
+      // wrapper opts out of rollup, so the declared type is left intact instead of being rederived
+      // as a nullable SUM on the rolled-up top aggregate.
+      assertRowMatch(optimized.getRowType(), R.STRING, R.I64);
+    }
+
+    @Test
+    void declaredTypeSurvivesAggregateSplitRule() {
+      Rel left = sb.namedScan(List.of("left"), List.of("a", "k"), List.of(R.I32, R.I32));
+      Rel right = sb.namedScan(List.of("right"), List.of("k"), List.of(R.I32));
+      Rel joined =
+          sb.innerJoin(
+              ji -> sb.equal(sb.fieldReference(ji, 1), sb.fieldReference(ji, 2)), left, right);
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(), i -> List.of(withOutputType(sb.sum(i, 0), R.I64)), joined);
+
+      RelNode converted = substraitToCalcite.convert(aggregate);
+      RelNode optimized = optimize(converted, CoreRules.AGGREGATE_JOIN_TRANSPOSE_EXTENDED);
+
+      // The wrapper opts out of splitting, so the rule leaves the declared type intact instead of
+      // rederiving a nullable SUM on the split top aggregate.
+      assertRowMatch(optimized.getRowType(), R.I64);
+    }
+
+    @Test
+    void strictValidationRejectsNonSpecOutputType() {
+      // sum(i32) derives i64? from its declaration; a plan declaring i32? is not spec-compliant.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I32)),
+              commonTable);
+      SubstraitToCalcite strict =
+          new SubstraitToCalcite(
+              converterProvider,
+              null,
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.PLAN_OUTPUT,
+                  AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION));
+      assertThrows(InvalidFunctionBindingException.class, () -> strict.convert(aggregate));
+    }
+
+    @Test
+    void strictValidationAcceptsAndPreservesSpecOutputType() {
+      // sum(i32) -> i64? is spec-compliant; STRICT accepts it and PLAN_OUTPUT preserves it.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              commonTable);
+      SubstraitToCalcite strict =
+          new SubstraitToCalcite(
+              converterProvider,
+              null,
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.PLAN_OUTPUT,
+                  AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION));
+      RelNode relNode = strict.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), N.STRING, N.I64);
+    }
+
+    @Test
+    void calciteInferenceModeIgnoresPlanType() {
+      // With CALCITE_INFERENCE the plan's declared type is ignored and Calcite's inference wins.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              commonTable);
+      SubstraitToCalcite calciteInference =
+          new SubstraitToCalcite(
+              converterProvider,
+              null,
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                  AggregateConversion.FunctionBindingValidation.NONE));
+
+      RelNode relNode = calciteInference.convert(aggregate);
+
+      // Calcite's SUM infers nullable i32 for sum(i32), not the plan's i64, and no wrapper is
+      // added.
+      assertRowMatch(relNode.getRowType(), N.STRING, N.I32);
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Optional.empty(),
+          AggregateFunctions.boundBinding(calciteAgg.getAggCallList().get(0).getAggregation()));
+    }
+
+    private RelNode optimize(RelNode relNode, RelOptRule rule) {
+      HepProgram program = new HepProgramBuilder().addRuleInstance(rule).build();
+      HepPlanner planner = new HepPlanner(program);
+      planner.setRoot(relNode);
+      return planner.findBestExp();
+    }
+
+    private io.substrait.relation.Aggregate.Measure withOutputType(
+        io.substrait.relation.Aggregate.Measure measure, Type outputType) {
+      AggregateFunctionInvocation function =
+          AggregateFunctionInvocation.builder()
+              .from(measure.getFunction())
+              .outputType(outputType)
+              .build();
+      return io.substrait.relation.Aggregate.Measure.builder()
+          .from(measure)
+          .function(function)
+          .build();
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitRelNodeConverterTest.java
@@ -1,17 +1,54 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.substrait.expression.AggregateFunctionInvocation;
+import io.substrait.expression.EnumArg;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionArg;
+import io.substrait.expression.FunctionOption;
+import io.substrait.expression.ImmutableAggregateFunctionInvocation;
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.InvalidFunctionBindingException;
+import io.substrait.extension.ResolvedAggregateBinding;
+import io.substrait.extension.ResolvedArgument;
+import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.Plan;
 import io.substrait.relation.Join.JoinType;
 import io.substrait.relation.Rel;
 import io.substrait.relation.Set.SetOp;
 import io.substrait.type.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSingletonAggFunction;
+import org.apache.calcite.sql.SqlStaticAggFunction;
+import org.apache.calcite.sql.fun.SqlBasicAggFunction;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +75,14 @@ class SubstraitRelNodeConverterTest extends PlanTestBase {
 
       RelNode relNode = substraitToCalcite.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), R.I32, N.STRING, R.I64);
+
+      // The declared COUNT type matches Calcite's inference, so the call keeps the stock operator
+      // rather than a binding-carrying wrapper.
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Optional.empty(),
+          AggregateFunctions.boundBinding(calciteAgg.getAggCallList().get(0).getAggregation()));
     }
 
     @Test
@@ -52,6 +97,1054 @@ class SubstraitRelNodeConverterTest extends PlanTestBase {
 
       RelNode relNode = substraitToCalcite.convert(root.getInput());
       assertRowMatch(relNode.getRowType(), N.STRING, R.I64);
+    }
+
+    @Test
+    void declaredMeasureOutputTypes() {
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input ->
+                  List.of(
+                      withOutputType(sb.sum(input, 0), R.I64),
+                      withOutputType(sb.avg(input, 1), R.FP32)),
+              commonTable);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), N.STRING, R.I64, R.FP32);
+
+      // Both declared types diverge from Calcite's inference, so both calls carry a resolved
+      // binding on a wrapper (PLAN_OUTPUT preserves the plan's declared type).
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      for (AggregateCall call : calciteAgg.getAggCallList()) {
+        assertTrue(AggregateFunctions.boundBinding(call.getAggregation()).isPresent());
+      }
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void declaredDecimalWidthIsPreserved() {
+      Rel input =
+          sb.namedScan(List.of("example"), List.of("d", "g"), List.of(R.decimal(10, 2), R.STRING));
+      // The standard extension declarations for decimal sum and avg return DECIMAL<38,S>, while
+      // Calcite's inference keeps the argument's precision. The declared width must survive.
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1),
+              i ->
+                  List.of(
+                      sb.measure(
+                          sb.aggregateFn(
+                              DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL,
+                              "sum:dec",
+                              N.decimal(38, 2),
+                              sb.fieldReference(i, 0))),
+                      sb.measure(
+                          sb.aggregateFn(
+                              DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL,
+                              "avg:dec",
+                              N.decimal(38, 2),
+                              sb.fieldReference(i, 0)))),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), R.STRING, N.decimal(38, 2), N.decimal(38, 2));
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void declaredTypeOnGlobalAggregateWithoutGroupings() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a"), List.of(R.I32));
+      // An aggregate with no groupings at all (as opposed to one empty grouping) is a global
+      // aggregation; the declared type must be preserved for it as well.
+      Rel aggregate =
+          io.substrait.relation.Aggregate.builder()
+              .input(input)
+              .measures(List.of(withOutputType(sb.sum(input, 0), R.I64)))
+              .build();
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), R.I64);
+
+      // A global aggregation is one empty grouping set, not zero grouping sets. RelBuilder derives
+      // each measure's hasEmptyGroup from the grouping sets, so anything else would re-infer the
+      // measures against a group key the aggregate does not have.
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(List.of(ImmutableBitSet.of()), calciteAgg.getGroupSets());
+      assertEquals(org.apache.calcite.rel.core.Aggregate.Group.SIMPLE, calciteAgg.getGroupType());
+
+      // Converting back therefore normalizes "no groupings at all" to the equivalent single empty
+      // grouping — the same global aggregation, spelled the way Calcite spells it.
+      io.substrait.relation.Aggregate roundTripped =
+          (io.substrait.relation.Aggregate) SubstraitRelVisitor.convert(relNode, converterProvider);
+      assertEquals(1, roundTripped.getGroupings().size());
+      assertTrue(roundTripped.getGroupings().get(0).getExpressions().isEmpty());
+    }
+
+    @Test
+    void boundOperatorIdentityIgnoresDeclaredType() {
+      ResolvedAggregateBinding binding =
+          ResolvedAggregateBinding.resolve(sb.sum(commonTable, 0).getFunction());
+      RelDataType i64 = converterProvider.getTypeConverter().toCalcite(typeFactory, N.I64);
+      RelDataType fp64 = converterProvider.getTypeConverter().toCalcite(typeFactory, N.FP64);
+
+      SqlAggFunction boundToI64 = AggregateFunctions.bind(AggregateFunctions.SUM, binding, i64);
+      SqlAggFunction boundToFp64 = AggregateFunctions.bind(AggregateFunctions.SUM, binding, fp64);
+
+      // Operator identity answers "which Substrait function is this?", never "which type does it
+      // produce?", so matching on the operator stays type-agnostic.
+      assertEquals(boundToI64, boundToFp64);
+      assertEquals(boundToI64.hashCode(), boundToFp64.hashCode());
+
+      // The carried type is still readable, it is just not part of the identity.
+      assertEquals(Optional.of(i64), AggregateFunctions.declaredOutputType(boundToI64));
+      assertEquals(Optional.of(fp64), AggregateFunctions.declaredOutputType(boundToFp64));
+      assertEquals(Optional.empty(), AggregateFunctions.declaredOutputType(AggregateFunctions.SUM));
+
+      // A different Substrait function is a different operator.
+      ResolvedAggregateBinding countBinding =
+          ResolvedAggregateBinding.resolve(sb.count(commonTable, 0).getFunction());
+      assertNotEquals(
+          boundToI64, AggregateFunctions.bind(AggregateFunctions.SUM, countBinding, i64));
+    }
+
+    @Test
+    void enumArgumentDistinguishesMeasuresOfTheSameFunction() {
+      Rel input = sb.namedScan(List.of("example"), List.of("x", "g"), List.of(R.FP32, R.STRING));
+      // Both measures call std_dev:req_fp32 on the same column; only the leading "distribution"
+      // enum argument differs, so only the resolved binding tells them apart.
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1),
+              i -> List.of(stdDev(i, "POPULATION"), stdDev(i, "SAMPLE")),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), R.STRING, R.FP32, R.FP32);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      List<AggregateCall> calls = calciteAgg.getAggCallList();
+      assertEquals(2, calls.size());
+      ResolvedAggregateBinding population = boundBinding(calls.get(0));
+      ResolvedAggregateBinding sample = boundBinding(calls.get(1));
+      assertNotEquals(population, sample);
+      assertEquals(Optional.of("POPULATION"), enumArgument(population));
+      assertEquals(Optional.of("SAMPLE"), enumArgument(sample));
+    }
+
+    @Test
+    void functionOptionsSurviveConversion() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      // count(i32) -> i64 matches Calcite's inference exactly, so nothing about the type forces a
+      // wrapper — but the plan's "overflow" option has no place in a Calcite aggregate call, and
+      // dropping it would silently change what the plan asks for.
+      Rel aggregate = sb.aggregate(i -> sb.grouping(i, 1), i -> List.of(count(i, "ERROR")), input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      ResolvedAggregateBinding binding = boundBinding(calciteAgg.getAggCallList().get(0));
+      assertEquals(Optional.of(List.of("ERROR")), binding.function().option("overflow"));
+
+      // ... and the option comes back out on the way to Substrait, instead of being re-matched
+      // away.
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void measuresDifferingOnlyByOptionsStayDistinct() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1), i -> List.of(count(i, "ERROR"), count(i, "SILENT")), input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      // Both measures are COUNT(a) of type i64 and differ only in an option Calcite cannot express,
+      // so only the carried binding keeps them from being deduplicated into one column.
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(2, calciteAgg.getAggCallList().size());
+      assertNotEquals(
+          boundBinding(calciteAgg.getAggCallList().get(0)),
+          boundBinding(calciteAgg.getAggCallList().get(1)));
+      assertRowMatch(relNode.getRowType(), R.STRING, R.I64, R.I64);
+    }
+
+    @Test
+    void intermediatePhaseSurvivesBothDirections() {
+      Rel input = sb.namedScan(List.of("example"), List.of("partial"), List.of(R.I64));
+      // count accumulates into i64, and a final phase consumes that state. Calcite has no notion of
+      // aggregation phases, so only the carried binding can bring this back: matching would see
+      // COUNT(i64) and rebuild a full initial-to-result aggregation instead.
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i),
+              i -> List.of(count(i, null, Expression.AggregationPhase.INTERMEDIATE_TO_RESULT)),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Expression.AggregationPhase.INTERMEDIATE_TO_RESULT,
+          boundBinding(calciteAgg.getAggCallList().get(0)).phase());
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void parameterizedIntermediateStateSurvivesBothDirections() {
+      // avg:dec accumulates into STRUCT<DECIMAL<38,S>,i64>. A phase that consumes that state sees
+      // only the state, so S cannot be bound and the intermediate type cannot be re-derived — the
+      // binding has to be trusted as recorded instead of re-validated against the declaration.
+      Type state = R.struct(R.decimal(38, 2), R.I64);
+      // A NamedStruct names nested fields too, so the state column contributes three names.
+      Rel input =
+          sb.namedScan(List.of("example"), List.of("partial", "total", "count"), List.of(state));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i),
+              i ->
+                  List.of(
+                      io.substrait.relation.Aggregate.Measure.builder()
+                          .function(
+                              AggregateFunctionInvocation.builder()
+                                  .declaration(
+                                      extensions.getAggregateFunction(
+                                          SimpleExtension.FunctionAnchor.of(
+                                              DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC_DECIMAL,
+                                              "avg:dec")))
+                                  .outputType(N.decimal(38, 2))
+                                  .aggregationPhase(
+                                      Expression.AggregationPhase.INTERMEDIATE_TO_RESULT)
+                                  .invocation(Expression.AggregationInvocation.ALL)
+                                  .addArguments(sb.fieldReference(i, 0))
+                                  .build())
+                          .build()),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Expression.AggregationPhase.INTERMEDIATE_TO_RESULT,
+          boundBinding(calciteAgg.getAggCallList().get(0)).phase());
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void zeroArgCountIntermediatePhaseSurvivesBothDirections() {
+      // The record-counting count() overload declares zero arguments but accumulates into i64; its
+      // final phase consumes that single state operand. Aligning the operands against the
+      // declaration's (empty) argument list would drop the binding, and re-matching would then
+      // silently rebuild a full count(i64) — the wrong declaration at the wrong phase.
+      Rel input = sb.namedScan(List.of("example"), List.of("partial"), List.of(R.I64));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i),
+              i ->
+                  List.of(
+                      io.substrait.relation.Aggregate.Measure.builder()
+                          .function(
+                              AggregateFunctionInvocation.builder()
+                                  .declaration(
+                                      extensions.getAggregateFunction(
+                                          SimpleExtension.FunctionAnchor.of(
+                                              DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC,
+                                              "count:")))
+                                  .outputType(R.I64)
+                                  .aggregationPhase(
+                                      Expression.AggregationPhase.INTERMEDIATE_TO_RESULT)
+                                  .invocation(Expression.AggregationInvocation.ALL)
+                                  .addArguments(sb.fieldReference(i, 0))
+                                  .build())
+                          .build()),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      ResolvedAggregateBinding binding = boundBinding(calciteAgg.getAggCallList().get(0));
+      assertEquals(Expression.AggregationPhase.INTERMEDIATE_TO_RESULT, binding.phase());
+      // The binding names the zero-argument declaration, not the unary count the operand resembles.
+      assertEquals("count:", binding.function().anchor().key());
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void unspecifiedPhaseIsTreatedAsIntermediateToResult() {
+      // The AggregationPhase proto enum states that an unspecified phase implies
+      // INTERMEDIATE_TO_RESULT, so it consumes intermediate state and must survive conversion the
+      // same way an explicit final phase does — not be treated as a full aggregation.
+      Rel input = sb.namedScan(List.of("example"), List.of("partial"), List.of(R.I64));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i),
+              i -> List.of(count(i, null, Expression.AggregationPhase.UNSPECIFIED)),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      ResolvedAggregateBinding binding = boundBinding(calciteAgg.getAggCallList().get(0));
+      assertEquals(Expression.AggregationPhase.UNSPECIFIED, binding.phase());
+      assertTrue(binding.consumesIntermediateState());
+
+      assertFullRoundTrip(aggregate);
+    }
+
+    @Test
+    void calciteInferenceIgnoresAnUnrepresentablePlanType() {
+      // The declared type is a user-defined type this converter has no mapping for. Ignoring it is
+      // exactly what CALCITE_INFERENCE promises, so the conversion must not fail on it.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input ->
+                  List.of(
+                      withOutputType(
+                          sb.sum(input, 0),
+                          sb.userDefinedType("extension:test:unmapped", "opaque"))),
+              commonTable);
+      SubstraitToCalcite calciteInference =
+          withAggregateConversion(
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                  AggregateConversion.FunctionBindingValidation.NONE));
+
+      assertRowMatch(calciteInference.convert(aggregate).getRowType(), N.STRING, N.I32);
+
+      // Preserving it, on the other hand, is impossible — and says so instead of substituting.
+      assertThrows(
+          UnsupportedOperationException.class, () -> substraitToCalcite.convert(aggregate));
+    }
+
+    @Test
+    void unwrappingRestoresTheDelegatesAndReinfersTypes() {
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 2),
+              i -> List.of(withOutputType(sb.sum(i, 0), R.I64)),
+              commonTable);
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) substraitToCalcite.convert(aggregate);
+      AggregateCall bound = calciteAgg.getAggCallList().get(0);
+      assertTrue(AggregateFunctions.boundBinding(bound.getAggregation()).isPresent());
+
+      // What a consumer does before executing a converted plan: Calcite dispatches aggregate
+      // implementations by operator identity, and a bound operator has none. The result is a real
+      // Calcite Aggregate again — its constructor asserts every call's type against the operator's
+      // inference (this test runs with assertions enabled), which is why the carried type cannot
+      // survive unwrapping and is honestly re-inferred instead.
+      org.apache.calcite.rel.core.Aggregate unwrapped = AggregateFunctions.unwrapBound(calciteAgg);
+      AggregateCall unwrappedCall = unwrapped.getAggCallList().get(0);
+      assertEquals(AggregateFunctions.SUM, unwrappedCall.getAggregation());
+      assertEquals(
+          Optional.empty(), AggregateFunctions.boundBinding(unwrappedCall.getAggregation()));
+      // sum(i32) re-infers as nullable INTEGER, not the plan's declared i64 — the same loss
+      // CALCITE_INFERENCE chooses up front.
+      assertEquals(SqlTypeName.INTEGER, unwrappedCall.getType().getSqlTypeName());
+      assertTrue(unwrappedCall.getType().isNullable());
+      // An aggregate with no bound calls is returned unchanged.
+      assertSame(unwrapped, AggregateFunctions.unwrapBound(unwrapped));
+    }
+
+    @Test
+    void factoryOverrideAppliesRegardlessOfConfiguration() {
+      // The configuration travels on the provider, so a subclass overriding the only converter
+      // factory is never bypassed, whatever AggregateConversion the provider was built with.
+      List<String> factories = new ArrayList<>();
+      ConverterProvider provider =
+          new ConverterProvider(
+              ConverterProvider.builder()
+                  .aggregateConversion(
+                      new AggregateConversion(
+                          AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                          AggregateConversion.FunctionBindingValidation.NONE))) {
+            @Override
+            public SubstraitRelNodeConverter getSubstraitRelNodeConverter(RelBuilder relBuilder) {
+              factories.add("overridden");
+              return super.getSubstraitRelNodeConverter(relBuilder);
+            }
+          };
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              commonTable);
+
+      RelNode relNode = new SubstraitToCalcite(provider).convert(aggregate);
+
+      assertEquals(List.of("overridden"), factories);
+      // ...and the configured conversion is applied: Calcite's inference wins over the plan's i64.
+      assertRowMatch(relNode.getRowType(), N.STRING, N.I32);
+    }
+
+    private io.substrait.relation.Aggregate.Measure count(Rel input, String overflow) {
+      return count(input, overflow, Expression.AggregationPhase.INITIAL_TO_RESULT);
+    }
+
+    private io.substrait.relation.Aggregate.Measure count(
+        Rel input, String overflow, Expression.AggregationPhase phase) {
+      SimpleExtension.AggregateFunctionVariant declaration =
+          extensions.getAggregateFunction(
+              SimpleExtension.FunctionAnchor.of(
+                  DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC, "count:any"));
+      ImmutableAggregateFunctionInvocation.Builder function =
+          AggregateFunctionInvocation.builder()
+              .declaration(declaration)
+              .outputType(R.I64)
+              .aggregationPhase(phase)
+              .invocation(Expression.AggregationInvocation.ALL)
+              .addArguments(sb.fieldReference(input, 0));
+      if (overflow != null) {
+        function.addOptions(FunctionOption.builder().name("overflow").addValues(overflow).build());
+      }
+      return io.substrait.relation.Aggregate.Measure.builder().function(function.build()).build();
+    }
+
+    private ResolvedAggregateBinding boundBinding(AggregateCall call) {
+      return AggregateFunctions.boundBinding(call.getAggregation())
+          .orElseThrow(() -> new AssertionError("expected a bound aggregate function: " + call));
+    }
+
+    private Optional<String> enumArgument(ResolvedAggregateBinding binding) {
+      return binding.function().arguments().stream()
+          .filter(argument -> argument.kind() == ResolvedArgument.Kind.ENUM)
+          .findFirst()
+          .flatMap(ResolvedArgument::enumValue);
+    }
+
+    private io.substrait.relation.Aggregate.Measure stdDev(Rel input, String distribution) {
+      // The declaration returns fp32?; declaring it required diverges from Calcite's inference,
+      // which is what makes the binding travel on a wrapper.
+      return stdDev(input, distribution, R.FP32);
+    }
+
+    private io.substrait.relation.Aggregate.Measure stdDev(
+        Rel input, String distribution, Type outputType) {
+      SimpleExtension.AggregateFunctionVariant declaration =
+          extensions.getAggregateFunction(
+              SimpleExtension.FunctionAnchor.of(
+                  DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "std_dev:req_fp32"));
+      return io.substrait.relation.Aggregate.Measure.builder()
+          .function(
+              AggregateFunctionInvocation.builder()
+                  .declaration(declaration)
+                  .arguments(
+                      List.<FunctionArg>of(EnumArg.of(distribution), sb.fieldReference(input, 0)))
+                  .outputType(outputType)
+                  .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                  .invocation(Expression.AggregationInvocation.ALL)
+                  .build())
+          .build();
+    }
+
+    @Test
+    void lowercaseDistributionSpellingSurvivesRoundTrip() {
+      // Enum option values are matched case-insensitively, so a plan may legally spell the
+      // distribution "population". The operator still resolves to STDDEV_POP, but the reverse
+      // path would re-synthesize the uppercase POPULATION — so the binding must travel and
+      // restore the plan's own spelling. The nullable output matches Calcite's inference, making
+      // the spelling the only reason a wrapper is needed.
+      Rel input = sb.namedScan(List.of("example"), List.of("x", "g"), List.of(R.FP32, R.STRING));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1), i -> List.of(stdDev(i, "population", N.FP32)), input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertTrue(
+          AggregateFunctions.boundBinding(calciteAgg.getAggCallList().get(0).getAggregation())
+              .isPresent());
+      // The Calcite round trip preserves the spelling verbatim. (The proto layer is stricter than
+      // the spec here — core's proto-to-POJO conversion rejects a non-exact option spelling
+      // outright — so this pins the Calcite path only.)
+      assertEquals(aggregate, SubstraitRelVisitor.convert(relNode, converterProvider));
+    }
+
+    @Test
+    void differentDeclaredTypesOnDuplicateMeasuresArePreserved() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1),
+              i ->
+                  List.of(
+                      withOutputType(sb.sum(i, 0), R.I64), withOutputType(sb.sum(i, 0), R.FP64)),
+              input);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+
+      // The two SUM(a) measures are identical apart from their declared output type, and
+      // AggregateCall equality ignores that type. They survive as distinct columns because the
+      // converter opts such an aggregate out of RelBuilder's aggregate-call deduplication.
+      assertRowMatch(relNode.getRowType(), R.STRING, R.I64, R.FP64);
+      assertEquals(2, ((org.apache.calcite.rel.core.Aggregate) relNode).getAggCallList().size());
+    }
+
+    @Test
+    void declaredTypeSurvivesAggregateRollupRule() {
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      Rel filtered = sb.filter(i -> sb.equal(sb.fieldReference(i, 0), sb.i32(1)), input);
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 1), i -> List.of(withOutputType(sb.sum(i, 0), R.I64)), filtered);
+
+      RelNode converted = substraitToCalcite.convert(aggregate);
+      RelNode optimized = optimize(converted, CoreRules.AGGREGATE_FILTER_TRANSPOSE);
+
+      // The filter references the non-grouped column, so the rule would roll the aggregate up. The
+      // wrapper opts out of rollup, so the declared type is left intact instead of being rederived
+      // as a nullable SUM on the rolled-up top aggregate.
+      assertRowMatch(optimized.getRowType(), R.STRING, R.I64);
+    }
+
+    @Test
+    void declaredTypeSurvivesAggregateSplitRule() {
+      Rel left = sb.namedScan(List.of("left"), List.of("a", "k"), List.of(R.I32, R.I32));
+      Rel right = sb.namedScan(List.of("right"), List.of("k"), List.of(R.I32));
+      Rel joined =
+          sb.innerJoin(
+              ji -> sb.equal(sb.fieldReference(ji, 1), sb.fieldReference(ji, 2)), left, right);
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(), i -> List.of(withOutputType(sb.sum(i, 0), R.I64)), joined);
+
+      RelNode converted = substraitToCalcite.convert(aggregate);
+      RelNode optimized = optimize(converted, CoreRules.AGGREGATE_JOIN_TRANSPOSE_EXTENDED);
+
+      // The wrapper opts out of splitting, so the rule leaves the declared type intact instead of
+      // rederiving a nullable SUM on the split top aggregate.
+      assertRowMatch(optimized.getRowType(), R.I64);
+    }
+
+    @Test
+    void explicitEmptyGroupingAmongGroupingSets() {
+      // GROUPING SETS ((c), ()): the empty grouping is explicit here, not the global-aggregation
+      // shorthand. Each measure's hasEmptyGroup must mirror the plan's groupings, and the empty
+      // set must survive the round trip alongside the non-empty one.
+      io.substrait.relation.Aggregate aggregate =
+          sb.aggregate(
+              input -> List.of(sb.grouping(input, 2), sb.grouping()),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              Optional.empty(),
+              commonTable);
+
+      RelNode relNode = substraitToCalcite.convert(aggregate);
+      // Multiple groupings convert to an Aggregate under a Project that emits the grouping-set
+      // identifier column; find the Aggregate itself.
+      RelNode node = relNode;
+      while (!(node instanceof org.apache.calcite.rel.core.Aggregate)) {
+        node = node.getInput(0);
+      }
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) node;
+      assertTrue(calciteAgg.getGroupSets().contains(ImmutableBitSet.of()));
+      assertTrue(calciteAgg.getGroupSets().contains(ImmutableBitSet.of(2)));
+
+      // Converting back materializes the grouping-set identifier column in an explicit Project on
+      // top, so the plans are not structurally identical — but the aggregate itself keeps both
+      // groupings, the empty one included, and the measure's declared type.
+      Rel back = SubstraitRelVisitor.convert(relNode, converterProvider);
+      io.substrait.relation.Aggregate aggregateBack =
+          (io.substrait.relation.Aggregate) ((io.substrait.relation.Project) back).getInput();
+      assertEquals(aggregate.getGroupings(), aggregateBack.getGroupings());
+      assertEquals(aggregate.getMeasures(), aggregateBack.getMeasures());
+    }
+
+    @Test
+    void strictValidationAppliesUnderCalciteInferenceToo() {
+      // The two settings are independent: EXTENSION_DECLARATION still checks the plan's declared
+      // type against the extension declaration even though CALCITE_INFERENCE then ignores it for
+      // the converted output.
+      SubstraitToCalcite strict =
+          withAggregateConversion(
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                  AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION));
+
+      // sum(i32) derives i64? from its declaration: a compliant plan converts (to the inferred
+      // type), a non-compliant one is rejected before any type is chosen.
+      Rel valid =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              commonTable);
+      assertRowMatch(strict.convert(valid).getRowType(), N.STRING, N.I32);
+
+      Rel invalid =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I32)),
+              commonTable);
+      assertThrows(InvalidFunctionBindingException.class, () -> strict.convert(invalid));
+    }
+
+    @Test
+    void aggregateReduceFunctionsStillDropsTheBinding() {
+      // Documented caveat, pinned so a Calcite upgrade that changes it is noticed:
+      // AGGREGATE_REDUCE_FUNCTIONS matches on SqlKind rather than an operator hook the wrapper
+      // could veto, so it rewrites a bound AVG into SUM/COUNT arithmetic. The declared type
+      // survives only through the cast the rule inserts; the binding is gone.
+      Rel aggregate =
+          sb.aggregate(
+              i -> sb.grouping(i, 2),
+              i -> List.of(withOutputType(sb.avg(i, 1), R.FP32)),
+              commonTable);
+
+      RelNode converted = substraitToCalcite.convert(aggregate);
+      RelNode optimized = optimize(converted, CoreRules.AGGREGATE_REDUCE_FUNCTIONS);
+
+      org.apache.calcite.rel.core.Project project = (org.apache.calcite.rel.core.Project) optimized;
+      org.apache.calcite.rel.core.Aggregate reduced =
+          (org.apache.calcite.rel.core.Aggregate) project.getInput();
+      for (AggregateCall call : reduced.getAggCallList()) {
+        assertEquals(Optional.empty(), AggregateFunctions.boundBinding(call.getAggregation()));
+      }
+      // The rewrite keeps the row type (via the inserted cast), so the loss is silent.
+      assertEquals(converted.getRowType(), optimized.getRowType());
+    }
+
+    @Test
+    void duplicateDeclarationAcrossExtensionsKeepsItsBinding() {
+      // A second loaded extension declares the same count(any) signature under its own URN.
+      // Reverse re-matching resolves by signature key and picks among equally-keyed variants by
+      // registration order, so without a carried binding the reconstructed URN would be decided by
+      // load order rather than by the plan.
+      String duplicate =
+          "%YAML 1.2\n"
+              + "---\n"
+              + "urn: extension:test:duplicate_count\n"
+              + "aggregate_functions:\n"
+              + "  - name: \"count\"\n"
+              + "    impls:\n"
+              + "      - args:\n"
+              + "          - name: x\n"
+              + "            value: any\n"
+              + "        return: i64\n";
+      SimpleExtension.ExtensionCollection merged =
+          extensions.merge(SimpleExtension.load(duplicate));
+      ConverterProvider provider = ConverterProvider.builder().extensions(merged).build();
+      io.substrait.dsl.SubstraitBuilder builder = new io.substrait.dsl.SubstraitBuilder(merged);
+      Rel input = builder.namedScan(List.of("example"), List.of("a"), List.of(R.I32));
+      Rel aggregate =
+          builder.aggregate(
+              i -> builder.grouping(i),
+              i ->
+                  List.of(
+                      builder.measure(
+                          builder.aggregateFn(
+                              "extension:test:duplicate_count",
+                              "count:any",
+                              R.I64,
+                              builder.fieldReference(i, 0)))),
+              input);
+
+      RelNode relNode = new SubstraitToCalcite(provider).convert(aggregate);
+
+      // The declared type matches Calcite's inference and nothing else is opaque; the ambiguity
+      // alone forces the binding to travel, and it names the plan's URN, not the catalog's.
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      ResolvedAggregateBinding binding = boundBinding(calciteAgg.getAggCallList().get(0));
+      assertEquals("extension:test:duplicate_count", binding.function().anchor().urn());
+      assertEquals(aggregate, SubstraitRelVisitor.convert(relNode, provider));
+
+      // The standard-catalog count in the same merged collection keeps its own URN as well.
+      Rel standard =
+          builder.aggregate(
+              i -> builder.grouping(i),
+              i ->
+                  List.of(
+                      builder.measure(
+                          builder.aggregateFn(
+                              DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC,
+                              "count:any",
+                              R.I64,
+                              builder.fieldReference(i, 0)))),
+              input);
+      assertEquals(
+          standard,
+          SubstraitRelVisitor.convert(
+              new SubstraitToCalcite(provider).convert(standard), provider));
+    }
+
+    @Test
+    void wildcardOverlapAcrossVariantsKeepsTheBinding() {
+      // The catalog also declares count(i32). A plan explicitly invoking the standard count(any)
+      // with an i32 operand would reverse-match count:i32 by direct signature key — a different
+      // declaration and URN — so the binding must travel even though the two keys differ.
+      String overlapping =
+          "%YAML 1.2\n"
+              + "---\n"
+              + "urn: extension:test:count_i32\n"
+              + "aggregate_functions:\n"
+              + "  - name: \"count\"\n"
+              + "    impls:\n"
+              + "      - args:\n"
+              + "          - name: x\n"
+              + "            value: i32\n"
+              + "        return: i64\n";
+      SimpleExtension.ExtensionCollection merged =
+          extensions.merge(SimpleExtension.load(overlapping));
+      ConverterProvider provider = ConverterProvider.builder().extensions(merged).build();
+      io.substrait.dsl.SubstraitBuilder builder = new io.substrait.dsl.SubstraitBuilder(merged);
+      Rel input = builder.namedScan(List.of("example"), List.of("a"), List.of(R.I32));
+      Rel wildcard =
+          builder.aggregate(
+              i -> builder.grouping(i),
+              i ->
+                  List.of(
+                      builder.measure(
+                          builder.aggregateFn(
+                              DefaultExtensionCatalog.FUNCTIONS_AGGREGATE_GENERIC,
+                              "count:any",
+                              R.I64,
+                              builder.fieldReference(i, 0)))),
+              input);
+
+      RelNode relNode = new SubstraitToCalcite(provider).convert(wildcard);
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      ResolvedAggregateBinding binding = boundBinding(calciteAgg.getAggCallList().get(0));
+      assertEquals("count:any", binding.function().anchor().key());
+      assertEquals(wildcard, SubstraitRelVisitor.convert(relNode, provider));
+
+      // Invoking count(i32) itself is uniquely reconstructable by its direct key: no wrapper, and
+      // the round trip still lands on the right declaration.
+      Rel concrete =
+          builder.aggregate(
+              i -> builder.grouping(i),
+              i ->
+                  List.of(
+                      builder.measure(
+                          builder.aggregateFn(
+                              "extension:test:count_i32",
+                              "count:i32",
+                              R.I64,
+                              builder.fieldReference(i, 0)))),
+              input);
+      RelNode concreteNode = new SubstraitToCalcite(provider).convert(concrete);
+      org.apache.calcite.rel.core.Aggregate concreteAgg =
+          (org.apache.calcite.rel.core.Aggregate) concreteNode;
+      assertEquals(
+          Optional.empty(),
+          AggregateFunctions.boundBinding(concreteAgg.getAggCallList().get(0).getAggregation()));
+      assertEquals(concrete, SubstraitRelVisitor.convert(concreteNode, provider));
+    }
+
+    @Test
+    void boundFunctionBlocksStaticFlattening() {
+      // A delegate exposing SqlStaticAggFunction lets RelBuilder's already-unique optimization and
+      // AggregateRemoveRule flatten the aggregate into a Project, which keeps the type but drops
+      // the binding; the wrapper must refuse that unwrap just as it refuses the singleton one.
+      ResolvedAggregateBinding binding =
+          ResolvedAggregateBinding.resolve(sb.count(commonTable, 0).getFunction());
+      SqlStaticAggFunction staticFun = (rexBuilder, groupSet, groupSets, aggCall) -> null;
+      SqlAggFunction delegate =
+          SqlBasicAggFunction.create(
+                  "static_count", SqlKind.OTHER_FUNCTION, ReturnTypes.BIGINT, OperandTypes.ANY)
+              .withStatic(staticFun);
+      RelDataType i64 = converterProvider.getTypeConverter().toCalcite(typeFactory, N.I64);
+
+      SqlAggFunction bound = AggregateFunctions.bind(delegate, binding, i64);
+
+      assertNotNull(delegate.unwrap(SqlStaticAggFunction.class));
+      assertNull(bound.unwrap(SqlStaticAggFunction.class));
+      assertNull(bound.unwrap(SqlSingletonAggFunction.class));
+    }
+
+    @Test
+    void boundFunctionPreservesDelegateVolatility() {
+      // A volatile delegate must stay volatile through the wrapper, or Calcite treats the call as
+      // stable and may cache or collapse its results.
+      ResolvedAggregateBinding binding =
+          ResolvedAggregateBinding.resolve(sb.count(commonTable, 0).getFunction());
+      SqlAggFunction volatileDelegate =
+          new SqlAggFunction(
+              "volatile_agg",
+              SqlKind.OTHER_FUNCTION,
+              ReturnTypes.BIGINT,
+              null,
+              null,
+              SqlFunctionCategory.USER_DEFINED_FUNCTION) {
+            @Override
+            public boolean isDeterministic() {
+              return false;
+            }
+
+            @Override
+            public boolean isDynamicFunction() {
+              return true;
+            }
+          };
+      RelDataType i64 = converterProvider.getTypeConverter().toCalcite(typeFactory, N.I64);
+
+      SqlAggFunction bound = AggregateFunctions.bind(volatileDelegate, binding, i64);
+
+      assertFalse(bound.isDeterministic());
+      assertTrue(bound.isDynamicFunction());
+    }
+
+    @Test
+    void statisticalOperatorEncodesOnlyASingleLeadingEnum() {
+      // The reverse conversion re-synthesizes exactly one leading distribution flag for the
+      // std_dev/variance kinds; an additional enum, an enum in a non-leading position, or an enum
+      // on a non-statistical operator has no Calcite representation and must ride the binding.
+      SimpleExtension.AggregateFunctionVariant stdDev =
+          extensions.getAggregateFunction(
+              SimpleExtension.FunctionAnchor.of(
+                  DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "std_dev:req_fp32"));
+      ResolvedAggregateBinding oneLeadingEnum =
+          bindingWithArguments(
+              stdDev,
+              List.of(ResolvedArgument.enumOption("POPULATION"), ResolvedArgument.value(R.FP32)));
+      ResolvedAggregateBinding twoEnums =
+          bindingWithArguments(
+              stdDev,
+              List.of(
+                  ResolvedArgument.enumOption("POPULATION"),
+                  ResolvedArgument.enumOption("EXACT"),
+                  ResolvedArgument.value(R.FP32)));
+      ResolvedAggregateBinding trailingEnum =
+          bindingWithArguments(
+              stdDev,
+              List.of(ResolvedArgument.value(R.FP32), ResolvedArgument.enumOption("POPULATION")));
+
+      assertTrue(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, oneLeadingEnum));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, twoEnums));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, trailingEnum));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.SUM, oneLeadingEnum));
+
+      // The kind also fixes the value it synthesizes: a *_POP kind rebuilds POPULATION, so any
+      // other value — a foreign enum like EXACT, the wrong distribution, a different spelling, or
+      // an unspecified one — must ride the binding.
+      ResolvedAggregateBinding foreignEnum =
+          bindingWithArguments(
+              stdDev,
+              List.of(ResolvedArgument.enumOption("EXACT"), ResolvedArgument.value(R.FP32)));
+      ResolvedAggregateBinding wrongDistribution =
+          bindingWithArguments(
+              stdDev,
+              List.of(ResolvedArgument.enumOption("SAMPLE"), ResolvedArgument.value(R.FP32)));
+      ResolvedAggregateBinding lowercaseSpelling =
+          bindingWithArguments(
+              stdDev,
+              List.of(ResolvedArgument.enumOption("population"), ResolvedArgument.value(R.FP32)));
+      ResolvedAggregateBinding unspecified =
+          bindingWithArguments(
+              stdDev,
+              List.of(ResolvedArgument.unspecifiedEnumOption(), ResolvedArgument.value(R.FP32)));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, foreignEnum));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, wrongDistribution));
+      assertTrue(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_SAMP, wrongDistribution));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, lowercaseSpelling));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, unspecified));
+
+      // The declaration must also spell the synthesized value exactly: validation accepts option
+      // values case-insensitively, but the reverse path rebuilds the enum operand with an
+      // exact-spelling lookup against the declaration's option list.
+      SimpleExtension.AggregateFunctionVariant lowercaseDeclaration =
+          SimpleExtension.load(
+                  "%YAML 1.2\n"
+                      + "---\n"
+                      + "urn: extension:test:lowercase_stat\n"
+                      + "aggregate_functions:\n"
+                      + "  - name: \"custom_stat\"\n"
+                      + "    impls:\n"
+                      + "      - args:\n"
+                      + "          - name: distribution\n"
+                      + "            options: [ population, sample ]\n"
+                      + "          - name: x\n"
+                      + "            value: fp32\n"
+                      + "        return: fp32\n")
+              .getAggregateFunction(
+                  SimpleExtension.FunctionAnchor.of(
+                      "extension:test:lowercase_stat", "custom_stat:req_fp32"));
+      ResolvedAggregateBinding lowercaseOptions =
+          bindingWithArguments(
+              lowercaseDeclaration,
+              List.of(ResolvedArgument.enumOption("POPULATION"), ResolvedArgument.value(R.FP32)));
+      assertFalse(
+          io.substrait.isthmus.expression.AggregateFunctionConverter.encodesEnumArguments(
+              AggregateFunctions.STDDEV_POP, lowercaseOptions));
+    }
+
+    private ResolvedAggregateBinding bindingWithArguments(
+        SimpleExtension.AggregateFunctionVariant declaration, List<ResolvedArgument> arguments) {
+      return ResolvedAggregateBinding.builder()
+          .function(
+              io.substrait.extension.ResolvedFunctionBinding.builder()
+                  .anchor(declaration.getAnchor())
+                  .declaration(declaration)
+                  .arguments(arguments)
+                  .options(List.of())
+                  .build())
+          .phase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+          .invocation(Expression.AggregationInvocation.ALL)
+          .intermediateType(Optional.empty())
+          .build();
+    }
+
+    @Test
+    void directConverterConstructorHonorsTheProviderPolicy() {
+      // The two-argument constructor takes its aggregate-conversion policy from the provider
+      // rather than silently discarding a non-default configuration.
+      ConverterProvider provider =
+          ConverterProvider.builder()
+              .aggregateConversion(
+                  new AggregateConversion(
+                      AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                      AggregateConversion.FunctionBindingValidation.NONE))
+              .build();
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              commonTable);
+      RelBuilder relBuilder = provider.getRelBuilder(provider.getSchemaResolver().apply(aggregate));
+      SubstraitRelNodeConverter converter = new SubstraitRelNodeConverter(relBuilder, provider);
+
+      RelNode relNode = aggregate.accept(converter, SubstraitRelNodeConverter.Context.newContext());
+
+      // Calcite's inference wins over the plan's i64: the provider's policy applied.
+      assertRowMatch(relNode.getRowType(), N.STRING, N.I32);
+    }
+
+    @Test
+    void bindingSurvivesAggregateRemoveRule() {
+      // The outer aggregate's input is already unique on its group key, so AGGREGATE_REMOVE would
+      // flatten it into a Project. The rule asks the operator for SqlSingletonAggFunction — a
+      // supertype of SqlSplittableAggFunction — so the opt-out must cover that lookup too:
+      // flattening keeps the call's type but drops the binding, and with it the "overflow" option.
+      Rel input = sb.namedScan(List.of("example"), List.of("a", "g"), List.of(R.I32, R.STRING));
+      Rel distinct = sb.aggregate(i -> sb.grouping(i, 0, 1), i -> List.of(), input);
+      Rel aggregate =
+          sb.aggregate(i -> sb.grouping(i, 0, 1), i -> List.of(count(i, "ERROR")), distinct);
+
+      RelNode converted = substraitToCalcite.convert(aggregate);
+      RelNode optimized = optimize(converted, CoreRules.AGGREGATE_REMOVE);
+
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) optimized;
+      ResolvedAggregateBinding binding = boundBinding(calciteAgg.getAggCallList().get(0));
+      assertEquals(Optional.of(List.of("ERROR")), binding.function().option("overflow"));
+    }
+
+    @Test
+    void strictValidationRejectsNonSpecOutputType() {
+      // sum(i32) derives i64? from its declaration; a plan declaring i32? is not spec-compliant.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I32)),
+              commonTable);
+      SubstraitToCalcite strict =
+          withAggregateConversion(
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.PLAN_OUTPUT,
+                  AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION));
+      assertThrows(InvalidFunctionBindingException.class, () -> strict.convert(aggregate));
+    }
+
+    @Test
+    void strictValidationAcceptsAndPreservesSpecOutputType() {
+      // sum(i32) -> i64? is spec-compliant; STRICT accepts it and PLAN_OUTPUT preserves it.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              commonTable);
+      SubstraitToCalcite strict =
+          withAggregateConversion(
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.PLAN_OUTPUT,
+                  AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION));
+      RelNode relNode = strict.convert(aggregate);
+      assertRowMatch(relNode.getRowType(), N.STRING, N.I64);
+    }
+
+    @Test
+    void calciteInferenceModeIgnoresPlanType() {
+      // With CALCITE_INFERENCE the plan's declared type is ignored and Calcite's inference wins.
+      Rel aggregate =
+          sb.aggregate(
+              input -> sb.grouping(input, 2),
+              input -> List.of(withOutputType(sb.sum(input, 0), N.I64)),
+              commonTable);
+      SubstraitToCalcite calciteInference =
+          withAggregateConversion(
+              new AggregateConversion(
+                  AggregateConversion.OutputTypeSource.CALCITE_INFERENCE,
+                  AggregateConversion.FunctionBindingValidation.NONE));
+
+      RelNode relNode = calciteInference.convert(aggregate);
+
+      // Calcite's SUM infers nullable i32 for sum(i32), not the plan's i64, and no wrapper is
+      // added.
+      assertRowMatch(relNode.getRowType(), N.STRING, N.I32);
+      org.apache.calcite.rel.core.Aggregate calciteAgg =
+          (org.apache.calcite.rel.core.Aggregate) relNode;
+      assertEquals(
+          Optional.empty(),
+          AggregateFunctions.boundBinding(calciteAgg.getAggCallList().get(0).getAggregation()));
+    }
+
+    private SubstraitToCalcite withAggregateConversion(AggregateConversion conversion) {
+      return new SubstraitToCalcite(
+          ConverterProvider.builder().aggregateConversion(conversion).build());
+    }
+
+    private RelNode optimize(RelNode relNode, RelOptRule rule) {
+      HepProgram program = new HepProgramBuilder().addRuleInstance(rule).build();
+      HepPlanner planner = new HepPlanner(program);
+      planner.setRoot(relNode);
+      return planner.findBestExp();
+    }
+
+    private io.substrait.relation.Aggregate.Measure withOutputType(
+        io.substrait.relation.Aggregate.Measure measure, Type outputType) {
+      AggregateFunctionInvocation function =
+          AggregateFunctionInvocation.builder()
+              .from(measure.getFunction())
+              .outputType(outputType)
+              .build();
+      return io.substrait.relation.Aggregate.Measure.builder()
+          .from(measure)
+          .function(function)
+          .build();
     }
   }
 

--- a/isthmus/src/test/resources/extensions/functions_custom.yaml
+++ b/isthmus/src/test/resources/extensions/functions_custom.yaml
@@ -115,3 +115,54 @@ aggregate_functions:
           - name: some_arg
             value: i64
         return: i64
+  - name: "custom_typed_aggregate"
+    description: "an aggregate carrying a type argument ahead of its value argument"
+    impls:
+      - args:
+          - name: t
+            type: i32
+          - name: some_arg
+            value: i64
+        return: i64
+  - name: "custom_enum_aggregate"
+    description: "an aggregate whose enum argument no Calcite operator kind encodes"
+    impls:
+      - args:
+          - name: mode
+            options: [ EXACT, APPROXIMATE ]
+          - name: some_arg
+            value: i64
+        return: i64
+  - name: "custom_flags_aggregate"
+    description: "an aggregate with a variadic trailing enum argument"
+    impls:
+      - args:
+          - name: some_arg
+            value: i64
+          - name: flag
+            options: [ A, B, C ]
+        variadic:
+          min: 1
+        return: i64
+  - name: "custom_overlap"
+    description: "a concrete impl shadowing a wildcard impl on the reverse path"
+    impls:
+      - args:
+          - name: x
+            value: i32
+        return: i64
+      - args:
+          - name: x
+            value: any
+          - name: y
+            value: any
+        return: i64
+  - name: "custom_mix"
+    description: "a declaration whose return type differs from what a plan may declare"
+    impls:
+      - args:
+          - name: x
+            value: any
+          - name: y
+            value: string
+        return: i32


### PR DESCRIPTION
Fixes #1016. Relates to #379.

## What

A Substrait aggregate used to lose part of itself on the way to Calcite, and could not be
recovered on the way back. This PR gives an aggregate a resolved binding that travels with it, so
the plan's declared output type, its function options, its aggregation phase and the exact
extension declaration all survive a `Substrait → Calcite → Substrait` round trip.

## Why — what was lost

| | Before | After |
| --- | --- | --- |
| **Declared output type** | Passed to `AggregateCall.create`, but `RelBuilder` re-infers a call's type from its operator, so Calcite's inference won. `sum(DECIMAL(10,2))`, which `sum:dec` declares as `DECIMAL(38,2)`, came back with the argument's own width. | The plan's type is preserved. |
| **Two measures, same shape, different types** | `AggregateCall.equals` ignores the stored type and `RelBuilder` deduplicates, so they collapsed into one column — the output arity changed. | Both survive; deduplication is switched off for exactly those aggregates. |
| **Function options** | No place for them in a Calcite aggregate call, so `count(a)` with `overflow: ERROR` came back without the option, and two counts differing only by an option were indistinguishable. | Carried on the binding and restored. |
| **Aggregation phase** | Converting back always produced `INITIAL_TO_RESULT`. A distributed plan with partial aggregates was silently turned into a plan of full aggregations. | The phase is carried and restored (`AGGREGATION_PHASE_UNSPECIFIED` is treated as `INTERMEDIATE_TO_RESULT`, as the proto specifies). |
| **Which declaration** | Re-matched against the extension catalog; among equally-shaped declarations it could only guess. A phase consuming an intermediate state could not be matched at all, because the call's operands are then accumulator state rather than the declaration's arguments — a partial zero-argument `count()` silently came back as a full `count(i64)`. | The exact declaration the plan used is taken from the binding; a phase that consumes intermediate state aligns on its single state operand, whatever the declaration's arity. |
| **Global aggregate with no groupings** | Built with zero grouping sets, so measures were re-inferred as if there were no empty group. | Built as one empty grouping set — the correct global aggregation. |

## How

Each converted measure resolves a `ResolvedAggregateBinding`, which captures the semantic identity
of the invocation: anchor, kind-aware arguments (value / type / enum, including the selected enum
option), options, phase and invocation semantics. Where Calcite cannot hold what the binding
carries — the chosen output type differs from its inference; the invocation has options, a phase
other than a full `INITIAL_TO_RESULT` aggregation, a type argument (only value arguments become
Calcite operands), or an enum argument no operator kind encodes (only a single leading std_dev/variance
distribution flag is operator-encoded); or the declaration is not uniquely reconstructable — reverse
re-matching resolves by signature key, falling back to wildcard/coercion matching, and picks by
registration order, so a declaration another variant can shadow for these argument types (e.g.
`count(any)` invoked with `i32` in a catalog that also declares `count(i32)`) would come back
decided by load order — the aggregate operator is wrapped so that both the binding and the type
travel with it. The type has to travel on the operator's
return-type inference, not just on the `AggregateCall`: `RelBuilder` re-creates every pre-built
call with no stored type, and `Aggregate`'s constructor asserts `typeMatchesInferred`, so a plain
operator carrying a divergent stored type is rejected outright. `AggregateFunctionConverter` then
rebuilds the invocation from that binding instead of re-matching the operator.

The binding records the plan as it was converted, so it is dropped again when a planner rule has
since changed the call's arguments, and `DISTINCT` is always read off the Calcite call, because a
rule may legitimately have removed a redundant one. The wrapper opts out of the type-rederiving
operator hooks until they are binding-aware: rollup (`getRollup()`), splitting
(`SqlSplittableAggFunction`), singleton flattening (`SqlSingletonAggFunction`, which
`AggregateRemoveRule` unwraps) and static flattening (`SqlStaticAggFunction`, through which that
rule and `RelBuilder`'s already-unique optimization rewrite a call into a constant) — and it
delegates the volatility traits (`isDeterministic` / `isDynamicFunction`) so a volatile aggregate
stays volatile.

Supporting this needed `TypeExpressionEvaluator` to actually work: it used to throw
`UnsupportedOperationException("NYI")` for anything but an already concrete return type. It now
binds numbered wildcards (the `any1` of `min(any1) -> any1`) and integer type parameters (the `P`
and `S` of `DECIMAL<P,S>`) from the actual argument types and substitutes them, honouring variadic
parameter consistency; a numeric token like the `0` of `DECIMAL<P,0>` is a literal constraint the
actual type must satisfy, not a parameter. `SimpleExtension.Function.resolveType` applies the
declaration's nullability policy (`MIRROR` over the value arguments), and the binding derivation
delegates to it, so there is one production path. Unsupported derivations stay fail-closed and
never fall back to a caller-supplied type — on the standard catalog that means the parameterized
type classes other than decimal (`varchar<L1>`, `fixedchar<L1>`, `precision_*<P>`,
`interval_day<P>`, `list<anyN>`, parameterized structs) and multi-line return programs; `concat`,
`assume_timezone` and `strptime_*` are rejected today. `quantile` is the one standard aggregate
whose output type cannot be derived at all: its `LIST?<any>` return uses a plain `any`, which
carries no identity to bind (substrait-io/substrait#1150 tracks the spec fix). For phases that
consume intermediate state, `:core` follows the argument model upstream intended
(substrait-io/substrait#1151): such an invocation carries exactly the accumulator state, not the
declaration's arguments.

## Commits

1. **`feat(core)`** — the resolved-binding model (`ResolvedArgument`, `ResolvedFunctionBinding`,
   `ResolvedAggregateBinding`), `FunctionBindingResolver` (resolve vs. opt-in validate), and a
   working `TypeExpressionEvaluator`. Self-contained; `:core:build` and `:isthmus:build` are green
   at this commit alone.
2. **`feat(isthmus)!`** — conversion changes: the `AggregateConversion` configuration on
   `ConverterProvider`, the transport wrapper in `AggregateFunctions`, and the two conversion
   fixes (deduplication, global aggregate).

## New configuration

`AggregateConversion` is configured on the provider —
`ConverterProvider.builder().aggregateConversion(...)` — and has two independent settings:

- `OutputTypeSource` — `PLAN_OUTPUT` (**new default**) preserves the plan's declared type;
  `CALCITE_INFERENCE` restores the previous type behavior.
- `FunctionBindingValidation` — `NONE` (default) does not check the plan against the extension
  declaration; `EXTENSION_DECLARATION` requires the declared output type to match the derived one
  and rejects the plan otherwise. Validation fails closed: a shape it cannot check structurally
  (e.g. a declared `list<any1>`) is rejected, not silently accepted.

The default is `PLAN_OUTPUT` + `NONE`: conversion never silently changes a type, but it also does
not assert that the plan is spec-compliant.

Note that `CALCITE_INFERENCE` does not make the wrapper fully opt-in: an invocation carrying
options, a non-full aggregation phase, a type argument or a non-operator-encoded enum argument —
or naming a declaration another variant can shadow on the reverse path — is wrapped in every mode, since no stock Calcite
operator can express those. The output-type setting governs only the wrappers caused by a type
divergence.

## Default: `PLAN_OUTPUT` (resolved per review discussion)

A converter silently changing a plan's declared type is a correctness problem —
`DECIMAL(38,2)` becoming `DECIMAL(10,2)` changes results — and it is what #1016 asks to fix by
default; the PR is marked breaking accordingly. The compatibility costs are real and remain:
operator identity changes for wrapped calls (`call.getAggregation() == SUM`-style comparisons
fail; use `AggregateFunctions.boundBinding` / `unwrapBound`), and rollup / splitting / singleton
flattening are disabled for them. `CALCITE_INFERENCE` restores the previous type behavior for
callers that prefer it.

## Breaking changes / migration

- A converted aggregate now carries the plan's declared output type instead of Calcite's inferred
  one. Configure `ConverterProvider.builder().aggregateConversion(new AggregateConversion(
  OutputTypeSource.CALCITE_INFERENCE, FunctionBindingValidation.NONE))` to restore the previous
  behavior.
- The resulting `AggregateCall` may carry a wrapper operator rather than the plain `SqlAggFunction`.
  Consumers comparing the operator by identity should inspect `AggregateFunctions.boundBinding`;
  before executing a converted plan, `AggregateFunctions.unwrapBound(Aggregate)` replaces bound
  calls with their delegates and honestly re-infers their types (the carried type cannot survive
  unwrapping — `Aggregate`'s constructor asserts the stored type against the operator's inference).
- Rollup, splitting, singleton flattening and static flattening are disabled for a wrapped call:
  all of them re-infer the transformed call's type from the underlying function or discard the
  call, losing the carried type or binding. Rules that match on `SqlKind` instead (e.g. `AGGREGATE_REDUCE_FUNCTIONS`) have
  no operator hook to veto and may still rewrite the call and drop the binding; this is pinned by
  a test so a Calcite upgrade that changes it is noticed.
- Converting a plan whose aggregate has no groupings back to Substrait now yields a single empty
  grouping instead of none — the same global aggregation, spelled the way Calcite spells it.
- `ParameterizedType.StringLiteral.isWildcard()` now follows the type grammar exactly
  (`any` / `any0`–`any9`, case-insensitive). A third-party declaration using an ordinary parameter
  name that merely starts with `any` (e.g. `f(anything)`) previously matched every argument type
  and computed the same signature key as `f(any)`; it now behaves like any other named parameter.
  No shipped extension is affected — the standard catalog only uses `any`, `any1`, `any2`.

## Spark

`spark`'s `ToAggregateFunction` / `ToLogicalPlan` implement a third argument model for phases
(declared arguments in every phase, phase as orthogonal metadata, with a
`count()` → `count(1)` rewrite hack). This PR does not touch it; aligning Spark with the
intermediate-state model that `:core` now enforces is follow-up work.

## Relation to #379

Aggregate function conversion is one of the four Substrait-vs-Calcite type-mismatch points listed
in #379 (scalars and windows were addressed by #1015 and #1059 via `TypeObserver`). This PR
resolves the *consequence* of the mismatch for aggregates — the plan's declared type is preserved
instead of silently replaced — but does not wire the aggregate observation point itself:
`TypeObservation` carries an `Expression`, which an `AggregateFunctionInvocation` is not, so
widening it is deferred to a #379 follow-up. The declared-vs-inferred comparison lives in one
place in `SubstraitRelNodeConverter` so that follow-up can attach the observer without recomputing
the inference (note it is skipped when opaque semantics force the wrapper regardless, and an
inference failure under `PLAN_OUTPUT` counts as "diverges" instead of failing the conversion).

## Testing

- `:core` — `FunctionBindingResolverTest`, `ResolvedAggregateBindingTest`,
  `TypeExpressionEvaluatorTest`, `ToTypeStringTest` wildcard boundaries, plus a small
  `binding_extensions.yaml` for wildcard / literal / option-collision / nested-shape cases.
- `:isthmus` — cases in `SubstraitRelNodeConverterTest.Aggregate` covering declared decimal width,
  global aggregation and explicit empty grouping sets, operator identity, enum arguments, options,
  phases (including a parameterized intermediate state, a zero-argument `count()` at
  `INTERMEDIATE_TO_RESULT`, and `UNSPECIFIED`), duplicate measures, the rollup / split / remove /
  reduce rules, both validation modes and their combination, and unwrapping under assertions; a
  `CustomFunctionTest` case covers an operator whose return-type inference fails.
