### PR TITLE
test(isthmus): use loose round-trip comparison for statistical aggregate tests

### DIFF
--- a/isthmus/src/test/java/io/substrait/isthmus/StatisticalFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StatisticalFunctionTest.java
@@ -37,14 +37,16 @@ class StatisticalFunctionTest extends PlanTestBase {
   }
 
   // Integer arguments are cast to fp64 (and the result cast back) since std_dev/variance only have
-  // fp32/fp64 signatures. This rewrite (castStatisticalAggregatesToFloatingPoint) inserts a cast
-  // projection that Calcite normalizes (project merge/column pruning) on the first round trip, so
-  // these use the identity-projection workaround, which asserts stability after normalization.
+  // fp32/fp64 signatures. The cast rewrite stacks a cast projection over the aggregate's input
+  // projection, which Calcite merges (and prunes the redundant column) when it rebuilds the plan on
+  // the Substrait -> Calcite leg. The plan straight from SQL therefore differs from the one after a
+  // Calcite -> Substrait -> Calcite round trip, so these compare loosely: they assert stability of
+  // the normalized plan rather than equality with the initial plan.
 
   @ParameterizedTest
   @CsvSource({"STDDEV_POP", "STDDEV_SAMP", "VAR_POP", "VAR_SAMP"})
   void roundTripIntegerInput(String fn) throws Exception {
-    assertFullRoundTripWithIdentityProjectionWorkaround(
+    assertSqlSubstraitRelRoundTripLoosePojoComparison(
         String.format("SELECT %s(i32) FROM numbers", fn),
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(CREATES));
   }
@@ -53,14 +55,14 @@ class StatisticalFunctionTest extends PlanTestBase {
   void roundTripIntegerInputSharedWithOtherAggregate() throws Exception {
     // The integer column is shared by SUM (which must keep operating on the integer) and STDDEV_POP
     // (which is cast to fp64); the cast must be appended, not applied in place.
-    assertFullRoundTripWithIdentityProjectionWorkaround(
+    assertSqlSubstraitRelRoundTripLoosePojoComparison(
         "SELECT SUM(i32), STDDEV_POP(i32) FROM numbers",
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(CREATES));
   }
 
   @Test
   void roundTripIntegerInputWithGrouping() throws Exception {
-    assertFullRoundTripWithIdentityProjectionWorkaround(
+    assertSqlSubstraitRelRoundTripLoosePojoComparison(
         "SELECT i8, VAR_POP(i32) FROM numbers GROUP BY i8",
         SubstraitCreateStatementParser.processCreateStatementsToCatalog(CREATES));
   }


### PR DESCRIPTION
## Problem

The round-trip helper that `StatisticalFunctionTest`'s integer-input cases relied on (`assertFullRoundTripWithIdentityProjectionWorkaround`) was removed in #1009, but those cases were added in #780. Because #1009 branched before #780 merged, it did not see the new call sites, leaving the `:isthmus` test module **uncompilable on `main`**.

## Why not just use `assertFullRoundTrip`

These cases can't use the standard `assertFullRoundTrip`. The statistical-aggregate cast rewrite (`castStatisticalAggregatesToFloatingPoint`) stacks a `cast(... AS fp64)` projection over the aggregate's input projection. When the plan is rebuilt on the Substrait → Calcite leg, Calcite **merges those projections and prunes the redundant pass-through column** — project-merge/column-pruning, distinct from the redundant identity projections #1009 now elides. So the plan produced straight from SQL differs structurally from the one produced after a Calcite → Substrait → Calcite round trip, and a strict equality assertion fails.

## Fix

Switch the three integer-input cases to the existing `assertSqlSubstraitRelRoundTripLoosePojoComparison` helper, which is documented for exactly this optimizer-normalization situation: it asserts that the **normalized** plan is stable across a round trip rather than requiring equality with the initial plan. No new helper is reintroduced.

The fp32/fp64 cases keep the stronger `assertFullRoundTrip`, and `usesEnumArgSignature` still pins the Substrait function structure.

## Verification

- `./gradlew :isthmus:test --tests "io.substrait.isthmus.StatisticalFunctionTest"` → 14/14 pass
- `./gradlew :isthmus:spotlessCheck :isthmus:pmdTest` → clean

🤖 Generated with AI