### PR TITLE
feat(isthmus): map Substrait concat to Calcite CONCAT_FUNCTION

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ConcatFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ConcatFunctionMapper.java
@@ -1,0 +1,47 @@
+package io.substrait.isthmus.expression;
+
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionArg;
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.SimpleExtension.ScalarFunctionVariant;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+/**
+ * Maps the SQL {@code ||} binary concatenation operator ({@link SqlStdOperatorTable#CONCAT}) to the
+ * Substrait {@code concat} function. This allows {@code ||} to continue working in the Calcite to
+ * Substrait direction while {@link org.apache.calcite.sql.fun.SqlLibraryOperators#CONCAT_FUNCTION}
+ * serves as the canonical Substrait-Calcite mapping via {@link FunctionMappings#SCALAR_SIGS}.
+ */
+final class ConcatFunctionMapper implements ScalarFunctionMapper {
+  private static final String CONCAT_FUNCTION_NAME = "concat";
+  private final List<ScalarFunctionVariant> concatFunctions;
+
+  ConcatFunctionMapper(List<ScalarFunctionVariant> functions) {
+    this.concatFunctions =
+        functions.stream()
+            .filter(
+                f ->
+                    CONCAT_FUNCTION_NAME.equals(f.name())
+                        && DefaultExtensionCatalog.FUNCTIONS_STRING.equals(f.urn()))
+            .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  public Optional<SubstraitFunctionMapping> toSubstrait(RexCall call) {
+    if (concatFunctions.isEmpty() || !SqlStdOperatorTable.CONCAT.equals(call.getOperator())) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new SubstraitFunctionMapping(CONCAT_FUNCTION_NAME, call.getOperands(), concatFunctions));
+  }
+
+  @Override
+  public Optional<List<FunctionArg>> getExpressionArguments(
+      Expression.ScalarFunctionInvocation expression) {
+    return Optional.empty();
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -521,13 +521,6 @@ public class ExpressionRexConverter
             .collect(Collectors.toList());
 
     RelDataType returnType = typeConverter.toCalcite(typeFactory, expr.outputType());
-    if (operator == SqlStdOperatorTable.CONCAT && args.size() > 2) {
-      return args.stream()
-          .skip(1)
-          .reduce(
-              args.get(0),
-              (left, right) -> rexBuilder.makeCall(returnType, operator, List.of(left, right)));
-    }
     return rexBuilder.makeCall(returnType, operator, args);
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -107,7 +107,7 @@ public class FunctionMappings {
               s(SqlStdOperatorTable.LIKE),
               s(SqlStdOperatorTable.REPLACE, "replace"),
               s(SqlStdOperatorTable.SUBSTRING, "substring"),
-              s(SqlStdOperatorTable.CONCAT, "concat"),
+              s(SqlLibraryOperators.CONCAT_FUNCTION, "concat"),
               s(SqlStdOperatorTable.CHAR_LENGTH, "char_length"),
               s(SqlStdOperatorTable.LOWER, "lower"),
               s(SqlStdOperatorTable.UPPER, "upper"),

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -65,6 +65,7 @@ public class ScalarFunctionConverter
 
     mappers =
         List.of(
+            new ConcatFunctionMapper(functions),
             new TrimFunctionMapper(functions),
             new SqrtFunctionMapper(functions),
             new ExtractDateFunctionMapper(functions),

--- a/isthmus/src/test/java/io/substrait/isthmus/DuplicateFunctionUrnTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DuplicateFunctionUrnTest.java
@@ -44,24 +44,24 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
       collection2 = SimpleExtension.load(extensions2);
       collection = collection1.merge(collection2);
 
-      // Verify that the merged collection contains duplicate concat functions with different URNs
-      // This is a precondition for the tests - if this fails, the tests don't make sense
-      List<SimpleExtension.ScalarFunctionVariant> concatFunctions =
+      // Verify that the merged collection contains duplicate concatenate functions with different
+      // URNs. This is a precondition for the tests - if this fails, the tests don't make sense
+      List<SimpleExtension.ScalarFunctionVariant> concatenateFunctions =
           collection.scalarFunctions().stream()
               .filter(f -> f.name().equals("concatenate"))
               .toList();
 
-      if (concatFunctions.size() != 2) {
+      if (concatenateFunctions.size() != 2) {
         throw new IllegalStateException(
-            "Expected 2 concat functions in merged collection, but found: "
-                + concatFunctions.size());
+            "Expected 2 concatenate functions in merged collection, but found: "
+                + concatenateFunctions.size());
       }
 
-      String urn1 = concatFunctions.get(0).getAnchor().urn();
-      String urn2 = concatFunctions.get(1).getAnchor().urn();
+      String urn1 = concatenateFunctions.get(0).getAnchor().urn();
+      String urn2 = concatenateFunctions.get(1).getAnchor().urn();
       if (urn1.equals(urn2)) {
         throw new IllegalStateException(
-            "Expected different URNs for the two concat functions, but both were: " + urn1);
+            "Expected different URNs for the two concatenate functions, but both were: " + urn1);
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -104,7 +104,7 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
             reverseCollection.scalarFunctions(), testSig, typeFactory, TypeConverter.DEFAULT);
 
     RexBuilder rexBuilder = new RexBuilder(typeFactory);
-    RexCall concatCall =
+    RexCall concatenateCall =
         (RexCall)
             rexBuilder.makeCall(
                 TEST_CONCATENATE, rexBuilder.makeLiteral("hello"), rexBuilder.makeLiteral("world"));
@@ -119,8 +119,8 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
               .build();
         };
 
-    Optional<Expression> exprA = converterA.convert(concatCall, topLevelConverter);
-    Optional<Expression> exprB = converterB.convert(concatCall, topLevelConverter);
+    Optional<Expression> exprA = converterA.convert(concatenateCall, topLevelConverter);
+    Optional<Expression> exprB = converterB.convert(concatenateCall, topLevelConverter);
 
     Expression.ScalarFunctionInvocation funcA = (Expression.ScalarFunctionInvocation) exprA.get();
     Expression.ScalarFunctionInvocation funcB = (Expression.ScalarFunctionInvocation) exprB.get();
@@ -128,12 +128,12 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
     assertEquals(
         "extension:com.domain:string2",
         funcA.declaration().getAnchor().urn(),
-        "converterA should use last concat function (from collection2)");
+        "converterA should use last concatenate function (from collection2)");
 
     assertEquals(
         "extension:com.domain:string1",
         funcB.declaration().getAnchor().urn(),
-        "converterB should use last concat function (from collection1)");
+        "converterB should use last concatenate function (from collection1)");
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/DuplicateFunctionUrnTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DuplicateFunctionUrnTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.substrait.expression.Expression;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.expression.AggregateFunctionConverter;
+import io.substrait.isthmus.expression.FunctionMappings;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
 import java.io.IOException;
@@ -15,12 +16,21 @@ import java.util.Optional;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlBasicFunction;
+import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.fun.SqlTrimFunction.Flag;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
 import org.junit.jupiter.api.Test;
 
 /** Tests to reproduce #562 */
 class DuplicateFunctionUrnTest extends PlanTestBase {
+
+  /** Test-only operator that maps to the {@code concatenate} function in the test extensions. */
+  static final SqlFunction TEST_CONCATENATE =
+      SqlBasicFunction.create(
+          "TEST_CONCATENATE", ReturnTypes.ARG0_NULLABLE, OperandTypes.STRING_SAME_SAME);
 
   static final SimpleExtension.ExtensionCollection collection1;
   static final SimpleExtension.ExtensionCollection collection2;
@@ -37,7 +47,9 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
       // Verify that the merged collection contains duplicate concat functions with different URNs
       // This is a precondition for the tests - if this fails, the tests don't make sense
       List<SimpleExtension.ScalarFunctionVariant> concatFunctions =
-          collection.scalarFunctions().stream().filter(f -> f.name().equals("concat")).toList();
+          collection.scalarFunctions().stream()
+              .filter(f -> f.name().equals("concatenate"))
+              .toList();
 
       if (concatFunctions.size() != 2) {
         throw new IllegalStateException(
@@ -82,18 +94,20 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
     // extension collection will be matched when converting from Calcite to Substrait.
 
     SimpleExtension.ExtensionCollection reverseCollection = collection2.merge(collection1);
+    List<FunctionMappings.Sig> testSig =
+        List.of(new FunctionMappings.Sig(TEST_CONCATENATE, "concatenate"));
     ScalarFunctionConverter converterA =
-        new ScalarFunctionConverter(collection.scalarFunctions(), typeFactory);
+        new ScalarFunctionConverter(
+            collection.scalarFunctions(), testSig, typeFactory, TypeConverter.DEFAULT);
     ScalarFunctionConverter converterB =
-        new ScalarFunctionConverter(reverseCollection.scalarFunctions(), typeFactory);
+        new ScalarFunctionConverter(
+            reverseCollection.scalarFunctions(), testSig, typeFactory, TypeConverter.DEFAULT);
 
     RexBuilder rexBuilder = new RexBuilder(typeFactory);
     RexCall concatCall =
         (RexCall)
             rexBuilder.makeCall(
-                SqlStdOperatorTable.CONCAT,
-                rexBuilder.makeLiteral("hello"),
-                rexBuilder.makeLiteral("world"));
+                TEST_CONCATENATE, rexBuilder.makeLiteral("hello"), rexBuilder.makeLiteral("world"));
 
     // Create a simple topLevelConverter that converts literals to Substrait expressions
     java.util.function.Function<RexNode, Expression> topLevelConverter =
@@ -112,12 +126,12 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
     Expression.ScalarFunctionInvocation funcB = (Expression.ScalarFunctionInvocation) exprB.get();
 
     assertEquals(
-        "extension:com.domain:string",
+        "extension:com.domain:string2",
         funcA.declaration().getAnchor().urn(),
         "converterA should use last concat function (from collection2)");
 
     assertEquals(
-        "extension:io.substrait:functions_string",
+        "extension:com.domain:string1",
         funcB.declaration().getAnchor().urn(),
         "converterB should use last concat function (from collection1)");
   }
@@ -125,7 +139,7 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
   @Test
   void testLtrimMergeOrderWithDefaultExtensions() {
     // This test verifies precedence between a custom ltrim (from collection2 with
-    // extension:com.domain:string) and the default extension catalog's ltrim
+    // extension:com.domain:string2) and the default extension catalog's ltrim
     // (extension:io.substrait:functions_string).
     // The FunctionConverter uses a "last-wins" strategy.
 
@@ -167,7 +181,7 @@ class DuplicateFunctionUrnTest extends PlanTestBase {
     Expression.ScalarFunctionInvocation funcA = (Expression.ScalarFunctionInvocation) exprA.get();
     // converterA should use collection2's custom ltrim (last)
     assertEquals(
-        "extension:com.domain:string",
+        "extension:com.domain:string2",
         funcA.declaration().getAnchor().urn(),
         "converterA should use last ltrim (custom from collection2)");
 

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -224,18 +224,14 @@ class FunctionConversionTest extends PlanTestBase {
             Expression.StrLiteral.builder().value("b").build(),
             Expression.StrLiteral.builder().value("c").build());
 
-    RexCall outer =
+    RexCall result =
         assertInstanceOf(
             RexCall.class, concat.accept(expressionRexConverter, Context.newContext()));
-    assertEquals(SqlStdOperatorTable.CONCAT, outer.getOperator());
-    assertEquals(2, outer.getOperands().size());
-
-    RexCall inner = assertInstanceOf(RexCall.class, outer.getOperands().get(0));
-    assertEquals(SqlStdOperatorTable.CONCAT, inner.getOperator());
-    assertEquals(2, inner.getOperands().size());
-    assertEquals("'a':VARCHAR", inner.getOperands().get(0).toString());
-    assertEquals("'b':VARCHAR", inner.getOperands().get(1).toString());
-    assertEquals("'c':VARCHAR", outer.getOperands().get(1).toString());
+    assertEquals(SqlLibraryOperators.CONCAT_FUNCTION, result.getOperator());
+    assertEquals(3, result.getOperands().size());
+    assertEquals("'a':VARCHAR", result.getOperands().get(0).toString());
+    assertEquals("'b':VARCHAR", result.getOperands().get(1).toString());
+    assertEquals("'c':VARCHAR", result.getOperands().get(2).toString());
   }
 
   @Test

--- a/isthmus/src/test/resources/extensions/functions_duplicate_urn1.yaml
+++ b/isthmus/src/test/resources/extensions/functions_duplicate_urn1.yaml
@@ -1,9 +1,9 @@
 %YAML 1.2
 ---
-urn: extension:io.substrait:functions_string
+urn: extension:com.domain:string1
 
 scalar_functions:
-  - name: "concat"
+  - name: "concatenate"
     description: "concatenate strings"
     impls:
       - args:

--- a/isthmus/src/test/resources/extensions/functions_duplicate_urn2.yaml
+++ b/isthmus/src/test/resources/extensions/functions_duplicate_urn2.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-urn: extension:com.domain:string
+urn: extension:com.domain:string2
 
 scalar_functions:
   - name: "ltrim"
@@ -12,7 +12,7 @@ scalar_functions:
           - name: chars
             value: string
         return: string
-  - name: "concat"
+  - name: "concatenate"
     description: "concatenate strings from custom domain"
     impls:
       - args:


### PR DESCRIPTION
Updates the Substrait-Calcite mapping for the 
`extension:io.substrait:functions_string` `concat` from
`SqlStdOperatorTable.CONCAT` to `SqlLibraryOperators.CONCAT_FUNCTION`.
`CONCAT_FUNCTION` has the same semantics as `CONCAT`, but is variadic, like the
Substrait function.

Additionally, adds `ConcatFunctionMapper` to map
`SqlStdOperatorTable.CONCAT` (`||`) to `CONCAT_FUNCTION` when processing SQL,
which allows us to avoid special handling in the ExpressionRexConverter

Note that ONLY string concatenation (||) is mapped.