### PR TITLE
feat(core): bump substrait to v0.91.0

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -1140,7 +1140,12 @@ public class ProtoRelConverter {
             .joinType(HashJoin.JoinType.fromProto(rel.getType()))
             .postJoinFilter(
                 Optional.ofNullable(
-                    rel.hasPostJoinFilter() ? unionConverter.from(rel.getPostJoinFilter()) : null));
+                    rel.hasPostJoinFilter() ? unionConverter.from(rel.getPostJoinFilter()) : null))
+            .residualExpression(
+                Optional.ofNullable(
+                    rel.hasResidualExpression()
+                        ? unionConverter.from(rel.getResidualExpression())
+                        : null));
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()))
@@ -1185,7 +1190,12 @@ public class ProtoRelConverter {
             .joinType(MergeJoin.JoinType.fromProto(rel.getType()))
             .postJoinFilter(
                 Optional.ofNullable(
-                    rel.hasPostJoinFilter() ? unionConverter.from(rel.getPostJoinFilter()) : null));
+                    rel.hasPostJoinFilter() ? unionConverter.from(rel.getPostJoinFilter()) : null))
+            .residualExpression(
+                Optional.ofNullable(
+                    rel.hasResidualExpression()
+                        ? unionConverter.from(rel.getResidualExpression())
+                        : null));
 
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -513,8 +513,10 @@ public class RelCopyOnWriteVisitor<E extends Exception>
         transformList(hashJoin.getKeys(), context, this::visitComparisonJoinKey);
     Optional<Expression> postFilter =
         visitOptionalExpression(hashJoin.getPostJoinFilter(), context);
+    Optional<Expression> residual =
+        visitOptionalExpression(hashJoin.getResidualExpression(), context);
 
-    if (allEmpty(left, right, keys, postFilter)) {
+    if (allEmpty(left, right, keys, postFilter, residual)) {
       return Optional.empty();
     }
     return Optional.of(
@@ -524,6 +526,7 @@ public class RelCopyOnWriteVisitor<E extends Exception>
             .right(right.orElse(hashJoin.getRight()))
             .keys(keys.orElse(hashJoin.getKeys()))
             .postJoinFilter(or(postFilter, hashJoin::getPostJoinFilter))
+            .residualExpression(or(residual, hashJoin::getResidualExpression))
             .build());
   }
 
@@ -535,8 +538,10 @@ public class RelCopyOnWriteVisitor<E extends Exception>
         transformList(mergeJoin.getKeys(), context, this::visitComparisonJoinKey);
     Optional<Expression> postFilter =
         visitOptionalExpression(mergeJoin.getPostJoinFilter(), context);
+    Optional<Expression> residual =
+        visitOptionalExpression(mergeJoin.getResidualExpression(), context);
 
-    if (allEmpty(left, right, keys, postFilter)) {
+    if (allEmpty(left, right, keys, postFilter, residual)) {
       return Optional.empty();
     }
     return Optional.of(
@@ -546,6 +551,7 @@ public class RelCopyOnWriteVisitor<E extends Exception>
             .right(right.orElse(mergeJoin.getRight()))
             .keys(keys.orElse(mergeJoin.getKeys()))
             .postJoinFilter(or(postFilter, mergeJoin::getPostJoinFilter))
+            .residualExpression(or(residual, mergeJoin::getResidualExpression))
             .build());
   }
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -484,6 +484,8 @@ public class RelProtoConverter
 
     hashJoin.getPostJoinFilter().ifPresent(t -> builder.setPostJoinFilter(toProto(t)));
 
+    hashJoin.getResidualExpression().ifPresent(t -> builder.setResidualExpression(toProto(t)));
+
     hashJoin
         .getExtension()
         .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
@@ -514,6 +516,8 @@ public class RelProtoConverter
     }
 
     mergeJoin.getPostJoinFilter().ifPresent(t -> builder.setPostJoinFilter(toProto(t)));
+
+    mergeJoin.getResidualExpression().ifPresent(t -> builder.setResidualExpression(toProto(t)));
 
     mergeJoin
         .getExtension()

--- a/core/src/main/java/io/substrait/relation/physical/HashJoin.java
+++ b/core/src/main/java/io/substrait/relation/physical/HashJoin.java
@@ -66,6 +66,15 @@ public abstract class HashJoin extends BiRel implements HasExtension {
    */
   public abstract Optional<Expression> getPostJoinFilter();
 
+  /**
+   * Returns the residual filter evaluated on each candidate key-match, if any. A candidate is only
+   * considered a match when every {@link #getKeys() key} comparison and this expression evaluate to
+   * true.
+   *
+   * @return the optional residual filter expression
+   */
+  public abstract Optional<Expression> getResidualExpression();
+
   /** The kinds of join supported by a {@link HashJoin} relation. */
   public enum JoinType {
     /** Unspecified or unknown join type. */

--- a/core/src/main/java/io/substrait/relation/physical/MergeJoin.java
+++ b/core/src/main/java/io/substrait/relation/physical/MergeJoin.java
@@ -66,6 +66,15 @@ public abstract class MergeJoin extends BiRel implements HasExtension {
    */
   public abstract Optional<Expression> getPostJoinFilter();
 
+  /**
+   * Returns the residual filter evaluated on each candidate key-match, if any. A candidate is only
+   * considered a match when every {@link #getKeys() key} comparison and this expression evaluate to
+   * true.
+   *
+   * @return the optional residual filter expression
+   */
+  public abstract Optional<Expression> getResidualExpression();
+
   /** The kinds of join supported by a {@link MergeJoin} relation. */
   public enum JoinType {
     /** Unspecified or unknown join type. */

--- a/core/src/test/java/io/substrait/type/proto/JoinRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/JoinRoundtripTest.java
@@ -35,6 +35,23 @@ class JoinRoundtripTest extends TestBase {
   }
 
   @Test
+  void hashJoinWithResidualExpression() {
+    List<Integer> leftKeys = Arrays.asList(0, 1);
+    List<Integer> rightKeys = Arrays.asList(2, 0);
+    // Residual filter over the combined left+right schema: left.a (I64, index 0) == right.f (I64,
+    // index 5).
+    Rel rel =
+        HashJoin.builder()
+            .from(sb.hashJoin(leftKeys, rightKeys, HashJoin.JoinType.INNER, leftTable, rightTable))
+            .residualExpression(
+                sb.equal(
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 0),
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 5)))
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
   void mergeJoin() {
     List<Integer> leftKeys = Arrays.asList(0, 1);
     List<Integer> rightKeys = Arrays.asList(2, 0);
@@ -44,6 +61,24 @@ class JoinRoundtripTest extends TestBase {
                 sb.mergeJoin(leftKeys, rightKeys, MergeJoin.JoinType.INNER, leftTable, rightTable))
             .build();
     verifyRoundTrip(relWithoutKeys);
+  }
+
+  @Test
+  void mergeJoinWithResidualExpression() {
+    List<Integer> leftKeys = Arrays.asList(0, 1);
+    List<Integer> rightKeys = Arrays.asList(2, 0);
+    // Residual filter over the combined left+right schema: left.a (I64, index 0) == right.f (I64,
+    // index 5).
+    Rel rel =
+        MergeJoin.builder()
+            .from(
+                sb.mergeJoin(leftKeys, rightKeys, MergeJoin.JoinType.INNER, leftTable, rightTable))
+            .residualExpression(
+                sb.equal(
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 0),
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 5)))
+            .build();
+    verifyRoundTrip(rel);
   }
 
   @Test


### PR DESCRIPTION
Bump the `substrait` submodule from v0.89.0 to v0.91.0, covering both the v0.90.0 and v0.91.0 spec releases in one change.

## v0.90.0
Only comment text changed in the consumed build inputs (`algebra.proto` docstrings on the extension relations; the `FuncTestCaseLexer.g4` change is excluded from grammar generation). No code changes.

## v0.91.0
- **`residual_expression` on hash/merge joins** — v0.91.0 adds an optional `residual_expression` to `HashJoinRel` and `MergeJoinRel`, evaluated on each candidate key-match to decide whether it is a true match. Modeled as an `Optional<Expression>` on `HashJoin`/`MergeJoin` (mirroring `post_join_filter`) and wired through both proto converters and `RelCopyOnWriteVisitor`, with round-trip test coverage.
- **`subtract:date_iday` return type** changed from `date` to `precision_timestamp<P>` in the standard extension. This needs no substrait-java code change — existing date-subtraction tests pass unchanged.

## Verification
`./gradlew :core:check :isthmus:check :core:javadoc`, both Spark Scala variants (`spark-3.5_2.12`, `spark-4.0_2.13`), and `examples:substrait-spark` all pass.

Closes #870
Closes #871

🤖 Generated with AI