### PR TITLE
feat(core)!: bump substrait to v0.93.0

### DIFF
--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -350,9 +350,6 @@ public class ProtoExpressionConverter {
                       + ecv.getExecutionContextVariableTypeCase());
           }
         }
-      // TODO enum.
-      case ENUM:
-        throw new UnsupportedOperationException("Unsupported type: " + expr.getRexTypeCase());
       default:
         throw new IllegalArgumentException("Unknown type: " + expr.getRexTypeCase());
     }

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -233,7 +233,9 @@ public class ParseToPojo {
 
     @Override
     public TypeExpression visitUserDefined(SubstraitTypeParser.UserDefinedContext ctx) {
-      String name = ctx.Identifier().getSymbol().getText();
+      // The optional dependency-alias prefix (alias.u!Name) added to the grammar in spec v0.92.1
+      // contributes a leading Identifier; the user-defined type name is always the last Identifier.
+      String name = ctx.Identifier(ctx.Identifier().size() - 1).getSymbol().getText();
       boolean nullable = ctx.isnull != null;
       List<SubstraitTypeParser.ExprContext> paramExprs = ctx.expr();
       if (paramExprs.isEmpty()) {


### PR DESCRIPTION
Bump the `substrait` submodule from v0.91.0 to v0.93.0, covering the v0.92.0, v0.92.1, and v0.93.0 spec releases.

## v0.92.0
Only the upstream test-case grammar changed. No code changes.

## v0.92.1
Aligns the type-expression grammar (`SubstraitType.g4`) with the extension YAML format:
- The user-defined type rule gains an optional dependency-alias prefix (`alias.u!Name`), which adds a leading `Identifier`. `ParseToPojo.visitUserDefined` now reads the type name as the last `Identifier`, preserving existing behavior when no alias is present.
- The named-struct rule gains required colons; this doesn't affect substrait-java (named structs are not consumed — `visitNStruct` is unimplemented).

## v0.93.0 (breaking)
Removes the long-deprecated `Expression.Enum` message and the `args` fields on `ScalarFunction`, `WindowFunction`, and `AggregateFunction`. The only consumer was the unreachable `ENUM` branch in `ProtoExpressionConverter` (removed); substrait-java already uses the `arguments` field exclusively.

**BREAKING CHANGE:** the generated protobuf API drops `Expression.Enum` and the deprecated `args` accessors on the scalar, window, and aggregate function messages. Use `FunctionArgument` (the `arguments` field) instead.

## Verification
`./gradlew :core:check :isthmus:check :core:javadoc`, both Spark Scala variants (`spark-3.5_2.12`, `spark-4.0_2.13`), and `examples:substrait-spark` all pass.

Closes #872
Closes #873
Closes #868

🤖 Generated with AI