### PR TITLE
feat(core)!: bump substrait to v0.95.0

### DIFF
--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -624,13 +624,42 @@ public class ParseToPojo {
     }
 
     @Override
-    public TypeExpression visitBinaryExpr(final SubstraitTypeParser.BinaryExprContext ctx) {
+    public TypeExpression visitMulDiv(final SubstraitTypeParser.MulDivContext ctx) {
+      return binaryOperation(ctx.op, ctx.left, ctx.right);
+    }
+
+    @Override
+    public TypeExpression visitAddSub(final SubstraitTypeParser.AddSubContext ctx) {
+      return binaryOperation(ctx.op, ctx.left, ctx.right);
+    }
+
+    @Override
+    public TypeExpression visitComparison(final SubstraitTypeParser.ComparisonContext ctx) {
+      return binaryOperation(ctx.op, ctx.left, ctx.right);
+    }
+
+    @Override
+    public TypeExpression visitEquality(final SubstraitTypeParser.EqualityContext ctx) {
+      return binaryOperation(ctx.op, ctx.left, ctx.right);
+    }
+
+    @Override
+    public TypeExpression visitAnd(final SubstraitTypeParser.AndContext ctx) {
+      return binaryOperation(ctx.op, ctx.left, ctx.right);
+    }
+
+    @Override
+    public TypeExpression visitOr(final SubstraitTypeParser.OrContext ctx) {
+      return binaryOperation(ctx.op, ctx.left, ctx.right);
+    }
+
+    private TypeExpression binaryOperation(
+        Token op, SubstraitTypeParser.ExprContext left, SubstraitTypeParser.ExprContext right) {
       checkExpression();
-      TypeExpression.BinaryOperation.OpType type = getBinaryExpressionType(ctx.op);
       return TypeExpression.BinaryOperation.builder()
-          .opType(type)
-          .left(ctx.left.accept(this))
-          .right(ctx.right.accept(this))
+          .opType(getBinaryExpressionType(op))
+          .left(left.accept(this))
+          .right(right.accept(this))
           .build();
     }
 

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -116,8 +116,6 @@ public class ProtoTypeConverter {
               .typeVariationReference(userDefined.getTypeVariationReference())
               .build();
         }
-      case USER_DEFINED_TYPE_REFERENCE:
-        throw new UnsupportedOperationException("Unsupported user defined reference: " + type);
       case KIND_NOT_SET:
         throw new UnsupportedOperationException("Type is not set: " + type);
       default:

--- a/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
+++ b/core/src/test/java/io/substrait/type/parser/TestTypeParser.java
@@ -2,6 +2,7 @@ package io.substrait.type.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.substrait.function.ParameterizedType;
 import io.substrait.function.ParameterizedTypeCreator;
 import io.substrait.function.TypeExpression;
 import io.substrait.function.TypeExpressionCreator;
@@ -72,6 +73,64 @@ class TestTypeParser {
         ParseToPojo.Visitor.expression(URN),
         eo.program(pr.fixedCharE("L1"), new TypeExpressionCreator.Assign("L1", eo.i(1))),
         "L1=1\nFIXEDCHAR<L1>");
+  }
+
+  @Test
+  void operatorPrecedence() {
+    // Binary operators must bind with conventional precedence (spec v0.95.0 grammar fix):
+    // '*' '/' tighter than '+' '-', tighter than comparisons, then 'and', then 'or'. Parentheses
+    // override. Each case is rendered fully parenthesized from the parsed expression tree.
+    assertPrecedence("1 + 2 * 3", "(1 + (2 * 3))");
+    assertPrecedence("1 + 2 * 3 - 4 / 5", "((1 + (2 * 3)) - (4 / 5))");
+    assertPrecedence("1 * 2 + 3", "((1 * 2) + 3)");
+    assertPrecedence("(1 + 2) * 3", "((1 + 2) * 3)");
+    assertPrecedence("1 + 2 < 3 * 4", "((1 + 2) < (3 * 4))");
+    assertPrecedence("a and b or c", "((a and b) or c)");
+  }
+
+  private static void assertPrecedence(String toParse, String expected) {
+    TypeExpression parsed = TypeStringParser.parse(toParse, ParseToPojo.Visitor.expression(URN));
+    assertEquals(expected, render(parsed), toParse);
+  }
+
+  /** Renders a parsed type expression as a fully-parenthesized string reflecting its structure. */
+  private static String render(TypeExpression e) {
+    if (e instanceof TypeExpression.BinaryOperation) {
+      TypeExpression.BinaryOperation op = (TypeExpression.BinaryOperation) e;
+      return "(" + render(op.left()) + " " + symbol(op.opType()) + " " + render(op.right()) + ")";
+    }
+    if (e instanceof TypeExpression.IntegerLiteral) {
+      return Integer.toString(((TypeExpression.IntegerLiteral) e).value());
+    }
+    if (e instanceof ParameterizedType.StringLiteral) {
+      return ((ParameterizedType.StringLiteral) e).value();
+    }
+    throw new IllegalStateException("Unexpected type expression: " + e);
+  }
+
+  private static String symbol(TypeExpression.BinaryOperation.OpType op) {
+    switch (op) {
+      case ADD:
+        return "+";
+      case SUBTRACT:
+        return "-";
+      case MULTIPLY:
+        return "*";
+      case DIVIDE:
+        return "/";
+      case LT:
+        return "<";
+      case GT:
+        return ">";
+      case EQ:
+        return "=";
+      case AND:
+        return "and";
+      case OR:
+        return "or";
+      default:
+        throw new IllegalStateException("Unexpected operator: " + op);
+    }
   }
 
   private <T> void simpleTests(ParseToPojo.Visitor v) {


### PR DESCRIPTION
Bump the `substrait` submodule from v0.93.0 to v0.95.0, covering the v0.94.0 and v0.95.0 spec releases.

## v0.94.0
Only comment text changed in `algebra.proto`. No code changes.

## v0.95.0 (breaking)
Two changes:

- **Operator precedence** — the type-expression grammar (`SubstraitType.g4`) now gives binary operators conventional precedence, splitting the single binary-operator rule into per-tier labeled alternatives (multiplicative, additive, comparison, equality, `and`, `or`). `ParseToPojo`'s single `visitBinaryExpr` is rewritten into the six generated labeled-alternative visitors over a shared helper. Adds an `operatorPrecedence` test mirroring the upstream spec PR's precedence cases (substrait #1107).
- **Removed `Type.user_defined_type_reference`** — the deprecated field is dropped; the corresponding branch in `ProtoTypeConverter` is removed.

**BREAKING CHANGE:** type expressions in extension YAMLs are now parsed with conventional operator precedence, changing the parse of expressions that relied on the previous uniform left-to-right precedence. The generated protobuf API also drops `Type.user_defined_type_reference`.

## Verification
`./gradlew :core:check :isthmus:check :core:javadoc`, both Spark Scala variants (`spark-3.5_2.12`, `spark-4.0_2.13`), and `examples:substrait-spark` all pass.

Closes #863
Closes #965

🤖 Generated with AI