### PR TITLE
feat(core): bump substrait to v0.97.0

### DIFF
--- a/core/src/main/java/io/substrait/dialect/RelationKind.java
+++ b/core/src/main/java/io/substrait/dialect/RelationKind.java
@@ -14,6 +14,8 @@ public enum RelationKind {
   SORT,
   /** The join relation. */
   JOIN,
+  /** The lateral join relation. */
+  LATERAL_JOIN,
   /** The project relation. */
   PROJECT,
   /** The set-operation relation. */

--- a/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/AbstractRelVisitor.java
@@ -51,6 +51,11 @@ public abstract class AbstractRelVisitor<O, C extends VisitationContext, E exten
   }
 
   @Override
+  public O visit(LateralJoin lateralJoin, C context) throws E {
+    return visitFallback(lateralJoin, context);
+  }
+
+  @Override
   public O visit(Set set, C context) throws E {
     return visitFallback(set, context);
   }

--- a/core/src/main/java/io/substrait/relation/Join.java
+++ b/core/src/main/java/io/substrait/relation/Join.java
@@ -100,51 +100,64 @@ public abstract class Join extends BiRel implements HasExtension {
 
   @Override
   protected Type.Struct deriveRecordType() {
-    Stream<Type> leftTypes = getLeftTypes();
-    Stream<Type> rightTypes = getRightTypes();
-    Stream<Type> markType = getMarkType();
+    return deriveRecordType(getJoinType(), getLeft(), getRight());
+  }
+
+  /**
+   * Derives the output record type of a join from its type and inputs. Shared with {@link
+   * LateralJoin}, which has the same output-schema semantics.
+   *
+   * @param joinType the join type
+   * @param left the left input
+   * @param right the right input
+   * @return the derived output record type
+   */
+  static Type.Struct deriveRecordType(JoinType joinType, Rel left, Rel right) {
+    Stream<Type> leftTypes = leftTypes(joinType, left);
+    Stream<Type> rightTypes = rightTypes(joinType, right);
+    Stream<Type> markType = markType(joinType);
     return TypeCreator.REQUIRED.struct(Stream.of(leftTypes, rightTypes, markType).flatMap(s -> s));
   }
 
-  private Stream<Type> getLeftTypes() {
-    switch (getJoinType()) {
+  private static Stream<Type> leftTypes(JoinType joinType, Rel left) {
+    switch (joinType) {
       case RIGHT:
       case OUTER:
       case RIGHT_SINGLE:
-        return getLeft().getRecordType().fields().stream().map(TypeCreator::asNullable);
+        return left.getRecordType().fields().stream().map(TypeCreator::asNullable);
       case RIGHT_SEMI:
       case RIGHT_ANTI:
       case RIGHT_MARK:
         // these joins ignore left side columns
         return Stream.of();
       default:
-        return getLeft().getRecordType().fields().stream();
+        return left.getRecordType().fields().stream();
     }
   }
 
-  private Stream<Type> getRightTypes() {
-    switch (getJoinType()) {
+  private static Stream<Type> rightTypes(JoinType joinType, Rel right) {
+    switch (joinType) {
       case LEFT:
       case OUTER:
       case LEFT_SINGLE:
-        return getRight().getRecordType().fields().stream().map(TypeCreator::asNullable);
+        return right.getRecordType().fields().stream().map(TypeCreator::asNullable);
       case LEFT_SEMI:
       case LEFT_ANTI:
       case LEFT_MARK:
         // these joins ignore right side columns
         return Stream.of();
       default:
-        return getRight().getRecordType().fields().stream();
+        return right.getRecordType().fields().stream();
     }
   }
 
-  private Stream<Type> getMarkType() {
+  private static Stream<Type> markType(JoinType joinType) {
     // Mark joins append a nullable boolean "mark" column at the end of the
     // emitted side. The column is nullable because the match state is 3-valued:
     //  - true  : at least one partner matched
     //  - false : no partner, and no NULL-producing comparisons
     //  - NULL  : no partner, but some comparison produced NULL
-    switch (getJoinType()) {
+    switch (joinType) {
       case LEFT_MARK:
       case RIGHT_MARK:
         return Stream.of(TypeCreator.NULLABLE.BOOLEAN);

--- a/core/src/main/java/io/substrait/relation/LateralJoin.java
+++ b/core/src/main/java/io/substrait/relation/LateralJoin.java
@@ -1,0 +1,88 @@
+package io.substrait.relation;
+
+import io.substrait.expression.Expression;
+import io.substrait.type.Type;
+import io.substrait.util.VisitationContext;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+/**
+ * A binary lateral join relation. Semantically identical to a {@link Join}, except the right input
+ * is evaluated once per row of the left input and may reference fields of the current left row via
+ * an outer reference to this relation's {@link #getRelAnchor() rel anchor}.
+ *
+ * <p>Only inner and left-oriented {@link Join.JoinType join types} are valid for lateral joins:
+ * {@code INNER}, {@code LEFT}, {@code LEFT_SEMI}, {@code LEFT_ANTI}, {@code LEFT_SINGLE}, and
+ * {@code LEFT_MARK}.
+ */
+@Value.Immutable
+public abstract class LateralJoin extends BiRel implements HasExtension {
+
+  /**
+   * Returns the join condition evaluated against pairs of left and right rows, if any.
+   *
+   * @return the optional join condition
+   */
+  public abstract Optional<Expression> getCondition();
+
+  /**
+   * Returns the filter applied to the join output after the join is performed, if any.
+   *
+   * @return the optional post-join filter
+   */
+  public abstract Optional<Expression> getPostJoinFilter();
+
+  /**
+   * Returns the type of join to perform.
+   *
+   * @return the join type
+   */
+  public abstract Join.JoinType getJoinType();
+
+  /**
+   * Validates the lateral-join-specific invariants: the join type must be inner or left-oriented,
+   * and a rel anchor must be set so the right input can reference the current left row.
+   */
+  @Value.Check
+  protected void check() {
+    switch (getJoinType()) {
+      case INNER:
+      case LEFT:
+      case LEFT_SEMI:
+      case LEFT_ANTI:
+      case LEFT_SINGLE:
+      case LEFT_MARK:
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Lateral join only supports INNER and left-oriented join types "
+                + "(INNER, LEFT, LEFT_SEMI, LEFT_ANTI, LEFT_SINGLE, LEFT_MARK); got "
+                + getJoinType());
+    }
+    if (!getRelAnchor().isPresent()) {
+      throw new IllegalArgumentException(
+          "Lateral join must set a rel anchor so its right input can reference the current "
+              + "left row via an outer reference");
+    }
+  }
+
+  @Override
+  protected Type.Struct deriveRecordType() {
+    return Join.deriveRecordType(getJoinType(), getLeft(), getRight());
+  }
+
+  @Override
+  public <O, C extends VisitationContext, E extends Exception> O accept(
+      RelVisitor<O, C, E> visitor, C context) throws E {
+    return visitor.visit(this, context);
+  }
+
+  /**
+   * Creates a builder for {@link LateralJoin}.
+   *
+   * @return a new builder
+   */
+  public static ImmutableLateralJoin.Builder builder() {
+    return ImmutableLateralJoin.builder();
+  }
+}

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -30,6 +30,7 @@ import io.substrait.proto.FetchRel;
 import io.substrait.proto.FilterRel;
 import io.substrait.proto.HashJoinRel;
 import io.substrait.proto.JoinRel;
+import io.substrait.proto.LateralJoinRel;
 import io.substrait.proto.MergeJoinRel;
 import io.substrait.proto.NestedLoopJoinRel;
 import io.substrait.proto.ProjectRel;
@@ -176,6 +177,8 @@ public class ProtoRelConverter {
         return newSort(rel.getSort());
       case JOIN:
         return newJoin(rel.getJoin());
+      case LATERAL_JOIN:
+        return newLateralJoin(rel.getLateralJoin());
       case SET:
         return newSet(rel.getSet());
       case PROJECT:
@@ -1045,6 +1048,43 @@ public class ProtoRelConverter {
             .left(left)
             .right(right)
             .condition(converter.from(rel.getExpression()))
+            .joinType(Join.JoinType.fromProto(rel.getType()))
+            .postJoinFilter(
+                Optional.ofNullable(
+                    rel.hasPostJoinFilter() ? converter.from(rel.getPostJoinFilter()) : null));
+
+    builder
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()))
+        .relAnchor(optionalRelAnchor(rel.getCommon()));
+    if (rel.hasAdvancedExtension()) {
+      builder.extension(protoExtensionConverter.fromProto(rel.getAdvancedExtension()));
+    }
+    return builder.build();
+  }
+
+  /**
+   * Converts the corresponding protobuf message to its POJO representation.
+   *
+   * @param rel the protobuf value to convert
+   * @return the converted result
+   */
+  protected Rel newLateralJoin(LateralJoinRel rel) {
+    Rel left = from(rel.getLeft());
+    Rel right = from(rel.getRight());
+    Type.Struct leftStruct = left.getRecordType();
+    Type.Struct rightStruct = right.getRecordType();
+    Type.Struct unionedStruct = Type.Struct.builder().from(leftStruct).from(rightStruct).build();
+    ProtoExpressionConverter converter =
+        new ProtoExpressionConverter(lookup, extensions, unionedStruct, this);
+    ImmutableLateralJoin.Builder builder =
+        LateralJoin.builder()
+            .left(left)
+            .right(right)
+            .condition(
+                Optional.ofNullable(
+                    rel.hasExpression() ? converter.from(rel.getExpression()) : null))
             .joinType(Join.JoinType.fromProto(rel.getType()))
             .postJoinFilter(
                 Optional.ofNullable(

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -198,6 +198,27 @@ public class RelCopyOnWriteVisitor<E extends Exception>
   }
 
   @Override
+  public Optional<Rel> visit(LateralJoin lateralJoin, EmptyVisitationContext context) throws E {
+    Optional<Rel> left = lateralJoin.getLeft().accept(this, context);
+    Optional<Rel> right = lateralJoin.getRight().accept(this, context);
+    Optional<Expression> condition = visitOptionalExpression(lateralJoin.getCondition(), context);
+    Optional<Expression> postFilter =
+        visitOptionalExpression(lateralJoin.getPostJoinFilter(), context);
+
+    if (allEmpty(left, right, condition, postFilter)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        ImmutableLateralJoin.builder()
+            .from(lateralJoin)
+            .left(left.orElse(lateralJoin.getLeft()))
+            .right(right.orElse(lateralJoin.getRight()))
+            .condition(or(condition, lateralJoin::getCondition))
+            .postJoinFilter(or(postFilter, lateralJoin::getPostJoinFilter))
+            .build());
+  }
+
+  @Override
   public Optional<Rel> visit(Set set, EmptyVisitationContext context) throws E {
     return transformList(set.getInputs(), context, (t, c) -> t.accept(this, c))
         .map(s -> Set.builder().from(set).inputs(s).build());

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -25,6 +25,7 @@ import io.substrait.proto.FetchRel;
 import io.substrait.proto.FilterRel;
 import io.substrait.proto.HashJoinRel;
 import io.substrait.proto.JoinRel;
+import io.substrait.proto.LateralJoinRel;
 import io.substrait.proto.MergeJoinRel;
 import io.substrait.proto.NamedObjectWrite;
 import io.substrait.proto.NamedTable;
@@ -376,6 +377,26 @@ public class RelProtoConverter
     join.getExtension()
         .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
     return Rel.newBuilder().setJoin(builder).build();
+  }
+
+  @Override
+  public Rel visit(LateralJoin lateralJoin, EmptyVisitationContext context)
+      throws RuntimeException {
+    LateralJoinRel.Builder builder =
+        LateralJoinRel.newBuilder()
+            .setCommon(common(lateralJoin))
+            .setLeft(toProto(lateralJoin.getLeft()))
+            .setRight(toProto(lateralJoin.getRight()))
+            .setType(lateralJoin.getJoinType().toProto());
+
+    lateralJoin.getCondition().ifPresent(t -> builder.setExpression(toProto(t)));
+
+    lateralJoin.getPostJoinFilter().ifPresent(t -> builder.setPostJoinFilter(toProto(t)));
+
+    lateralJoin
+        .getExtension()
+        .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
+    return Rel.newBuilder().setLateralJoin(builder).build();
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/RelVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelVisitor.java
@@ -61,6 +61,16 @@ public interface RelVisitor<O, C extends VisitationContext, E extends Exception>
   O visit(Join join, C context) throws E;
 
   /**
+   * Visit a lateral join relation.
+   *
+   * @param lateralJoin the lateral join node
+   * @param context visitation context
+   * @return visit result
+   * @throws E on visit failure
+   */
+  O visit(LateralJoin lateralJoin, C context) throws E;
+
+  /**
    * Visit a set operation relation (e.g., UNION/INTERSECT).
    *
    * @param set the set node

--- a/core/src/test/java/io/substrait/relation/LateralJoinTest.java
+++ b/core/src/test/java/io/substrait/relation/LateralJoinTest.java
@@ -1,0 +1,93 @@
+package io.substrait.relation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.TestBase;
+import io.substrait.util.EmptyVisitationContext;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class LateralJoinTest extends TestBase {
+
+  final Rel leftTable =
+      sb.namedScan(
+          Arrays.asList("T1"),
+          Arrays.asList("a", "b", "c"),
+          Arrays.asList(R.I64, R.FP64, R.STRING));
+
+  final Rel rightTable =
+      sb.namedScan(
+          Arrays.asList("T2"),
+          Arrays.asList("d", "e", "f"),
+          Arrays.asList(R.FP64, R.STRING, R.I64));
+
+  @Test
+  void rejectsNonLateralJoinType() {
+    // The spec forbids RIGHT-oriented and OUTER join types for lateral joins.
+    ImmutableLateralJoin.Builder builder =
+        LateralJoin.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .joinType(Join.JoinType.RIGHT)
+            .relAnchor(1);
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
+  void requiresRelAnchor() {
+    // A lateral join must carry a rel anchor for the right input to reference the left row.
+    ImmutableLateralJoin.Builder builder =
+        LateralJoin.builder().left(leftTable).right(rightTable).joinType(Join.JoinType.INNER);
+    assertThrows(IllegalArgumentException.class, builder::build);
+  }
+
+  @Test
+  void copyOnWritePreservesLateralJoinFields() {
+    LateralJoin lateralJoin =
+        LateralJoin.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .condition(
+                sb.equal(
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 0),
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 5)))
+            .postJoinFilter(
+                sb.equal(
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 2),
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 4)))
+            .joinType(Join.JoinType.LEFT)
+            .relAnchor(7)
+            .build();
+
+    // Same schema, different table name, so the rewritten join stays valid.
+    final Rel replacementLeft =
+        sb.namedScan(
+            Arrays.asList("T1_MODIFIED"),
+            Arrays.asList("a", "b", "c"),
+            Arrays.asList(R.I64, R.FP64, R.STRING));
+
+    RelCopyOnWriteVisitor<RuntimeException> visitor =
+        new RelCopyOnWriteVisitor<RuntimeException>() {
+          @Override
+          public Optional<Rel> visit(NamedScan namedScan, EmptyVisitationContext context) {
+            return namedScan.equals(leftTable) ? Optional.of(replacementLeft) : Optional.empty();
+          }
+        };
+
+    Optional<Rel> result = lateralJoin.accept(visitor, EmptyVisitationContext.INSTANCE);
+
+    assertTrue(result.isPresent());
+    LateralJoin rewritten = (LateralJoin) result.get();
+    assertEquals(replacementLeft, rewritten.getLeft());
+    assertEquals(rightTable, rewritten.getRight());
+    assertEquals(Join.JoinType.LEFT, rewritten.getJoinType());
+    assertEquals(Optional.of(7), rewritten.getRelAnchor());
+    assertEquals(lateralJoin.getCondition(), rewritten.getCondition());
+    // The rewrite must preserve the post-join filter, not drop it or alias it to the condition.
+    assertEquals(lateralJoin.getPostJoinFilter(), rewritten.getPostJoinFilter());
+    assertTrue(rewritten.getPostJoinFilter().isPresent());
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -15,6 +15,7 @@ import io.substrait.relation.ExtensionTable;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
 import io.substrait.relation.Join;
+import io.substrait.relation.LateralJoin;
 import io.substrait.relation.LocalFiles;
 import io.substrait.relation.NamedScan;
 import io.substrait.relation.Project;
@@ -168,6 +169,21 @@ class ExtensionRoundtripTest extends TestBase {
     Rel rel =
         Join.builder()
             .from(sb.innerJoin(__ -> sb.bool(true), commonTable, commonTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void lateralJoin() {
+    Rel rel =
+        LateralJoin.builder()
+            .left(commonTable)
+            .right(commonTable)
+            .condition(sb.bool(true))
+            .joinType(Join.JoinType.INNER)
+            .relAnchor(1)
             .commonExtension(commonExtension)
             .extension(relExtension)
             .build();

--- a/core/src/test/java/io/substrait/type/proto/JoinRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/JoinRoundtripTest.java
@@ -1,6 +1,8 @@
 package io.substrait.type.proto;
 
 import io.substrait.TestBase;
+import io.substrait.relation.Join;
+import io.substrait.relation.LateralJoin;
 import io.substrait.relation.Rel;
 import io.substrait.relation.physical.HashJoin;
 import io.substrait.relation.physical.MergeJoin;
@@ -92,6 +94,59 @@ class JoinRoundtripTest extends TestBase {
                     NestedLoopJoin.JoinType.INNER,
                     leftTable,
                     rightTable))
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void lateralJoin() {
+    // Condition over the combined left+right schema: left.a (I64, index 0) == right.f (I64,
+    // index 5).
+    Rel rel =
+        LateralJoin.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .condition(
+                sb.equal(
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 0),
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 5)))
+            .joinType(Join.JoinType.INNER)
+            .relAnchor(1)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void lateralJoinWithoutCondition() {
+    // A lateral join with no join condition (the correlation lives inside the right input); the
+    // unset expression must round-trip as an empty condition, not throw.
+    Rel rel =
+        LateralJoin.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .joinType(Join.JoinType.INNER)
+            .relAnchor(1)
+            .build();
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  void lateralJoinWithAnchorAndPostFilter() {
+    // A lateral join sets a rel anchor so the right input can reference the current left row.
+    Rel rel =
+        LateralJoin.builder()
+            .left(leftTable)
+            .right(rightTable)
+            .condition(
+                sb.equal(
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 0),
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 5)))
+            .postJoinFilter(
+                sb.equal(
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 2),
+                    sb.fieldReference(Arrays.asList(leftTable, rightTable), 4)))
+            .joinType(Join.JoinType.LEFT)
+            .relAnchor(1)
             .build();
     verifyRoundTrip(rel);
   }

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/SubstraitStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/SubstraitStringify.java
@@ -13,6 +13,7 @@ import io.substrait.relation.ExtensionWrite;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
 import io.substrait.relation.Join;
+import io.substrait.relation.LateralJoin;
 import io.substrait.relation.LocalFiles;
 import io.substrait.relation.NamedDdl;
 import io.substrait.relation.NamedScan;
@@ -193,6 +194,27 @@ public class SubstraitStringify extends ParentStringify
 
     sb.append(join.getLeft().accept(this, context));
     sb.append(join.getRight().accept(this, context));
+
+    return getOutdent(sb);
+  }
+
+  @Override
+  public String visit(LateralJoin lateralJoin, EmptyVisitationContext context)
+      throws RuntimeException {
+
+    StringBuilder sb =
+        getIndent()
+            .append("LateralJoin:: ")
+            .append(lateralJoin.getJoinType())
+            .append(" ")
+            .append(getRemap(lateralJoin));
+
+    if (lateralJoin.getCondition().isPresent()) {
+      sb.append(lateralJoin.getCondition().get().accept(new ExpressionStringify(indent), context));
+    }
+
+    sb.append(lateralJoin.getLeft().accept(this, context));
+    sb.append(lateralJoin.getRight().accept(this, context));
 
     return getOutdent(sb);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlKindFromRel.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlKindFromRel.java
@@ -13,6 +13,7 @@ import io.substrait.relation.ExtensionWrite;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
 import io.substrait.relation.Join;
+import io.substrait.relation.LateralJoin;
 import io.substrait.relation.LocalFiles;
 import io.substrait.relation.NamedDdl;
 import io.substrait.relation.NamedScan;
@@ -64,6 +65,12 @@ public class SqlKindFromRel
 
   @Override
   public SqlKind visit(Join join, EmptyVisitationContext context) throws RuntimeException {
+    return SqlKind.JOIN;
+  }
+
+  @Override
+  public SqlKind visit(LateralJoin lateralJoin, EmptyVisitationContext context)
+      throws RuntimeException {
     return SqlKind.JOIN;
   }
 


### PR DESCRIPTION
Bump the `substrait` submodule from v0.95.0 to v0.97.0, covering the v0.96.0 and v0.97.0 spec releases.

## v0.96.0 — `LateralJoinRel`
Adds the lateral join relation, modelled in core as `io.substrait.relation.LateralJoin`:

- New `LateralJoin` POJO (a `BiRel` reusing `Join.JoinType`), wired through `RelVisitor` / `AbstractRelVisitor`, both proto converters (`RelProtoConverter` / `ProtoRelConverter`), `RelCopyOnWriteVisitor`, and the dialect `RelationKind.LATERAL_JOIN` (the v0.96.0 dialect schema adds `LATERAL_JOIN`).
- A lateral join is semantically identical to a join except the right input is evaluated once per left row and may reference the current left row via an outer reference to the join's `rel_anchor`. `LateralJoin` enforces (via `@Value.Check`) that it carries a rel anchor and uses only inner/left-oriented join types (`INNER`, `LEFT`, `LEFT_SEMI`, `LEFT_ANTI`, `LEFT_SINGLE`, `LEFT_MARK`), per the spec.
- The join output-schema derivation is now shared with `Join` via a static `Join.deriveRecordType(...)` helper (no behavior change to `Join`).
- Tests: round-trip (with/without condition, with anchor + post-join filter), advanced-extension round-trip, join-type/anchor validation, and copy-on-write.

Adding a `RelVisitor` method is source-compatible for implementors that extend `AbstractRelVisitor` (they inherit the fallback).

## v0.97.0
Comment-only proto changes plus a dialect-schema widening of interval-day max precision (9 → 12); no code changes.

## Not included (follow-ups)
- Isthmus lateral-join conversion — #1029 (`SqlKindFromRel` returns a placeholder; the Substrait→Calcite visitor falls back).
- Spark lateral-join conversion — #1030.
- Correct outer-reference typing across nested/lateral conversion — #1031. Outer references in a lateral join's right input currently round-trip typed against the right's schema rather than the enclosing left's; this is a pre-existing, general outer-reference-typing limitation that `LateralJoin` surfaces, and the fix is cross-cutting.

## Verification
`./gradlew :core:check :isthmus:check :core:javadoc`, both Spark Scala variants (`spark-3.5_2.12`, `spark-4.0_2.13`), and `examples:substrait-spark` all pass.

Closes #987
Closes #1002

🤖 Generated with AI