### PR TITLE
feat(core)!: bump substrait to v0.98.0

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -283,14 +283,110 @@ public class SubstraitBuilder {
     return fetch(offset, OptionalLong.empty(), Optional.of(remap), input);
   }
 
+  /**
+   * Creates a fetch relation that skips {@code offset} rows and returns {@code count} rows, where
+   * offset and count are built from the input relation and each evaluate to a non-negative integer.
+   *
+   * @param offset builds the offset expression from the input relation
+   * @param count builds the row-count expression from the input relation
+   * @param input the input relation
+   * @return a new {@link Fetch} relation
+   */
+  public Fetch fetch(Function<Rel, Expression> offset, Function<Rel, Expression> count, Rel input) {
+    return fetch(
+        Optional.of(offset.apply(input)), Optional.of(count.apply(input)), Optional.empty(), input);
+  }
+
+  /**
+   * Creates a fetch relation that skips {@code offset} rows and returns {@code count} rows, where
+   * offset and count are built from the input relation and each evaluate to a non-negative integer,
+   * with output field remapping.
+   *
+   * @param offset builds the offset expression from the input relation
+   * @param count builds the row-count expression from the input relation
+   * @param remap the output field remapping specification
+   * @param input the input relation
+   * @return a new {@link Fetch} relation
+   */
+  public Fetch fetch(
+      Function<Rel, Expression> offset,
+      Function<Rel, Expression> count,
+      Rel.Remap remap,
+      Rel input) {
+    return fetch(
+        Optional.of(offset.apply(input)),
+        Optional.of(count.apply(input)),
+        Optional.of(remap),
+        input);
+  }
+
+  /**
+   * Creates a fetch relation that limits the number of rows returned to a count expression built
+   * from the input relation.
+   *
+   * @param count builds the row-count expression from the input relation
+   * @param input the input relation
+   * @return a new {@link Fetch} relation
+   */
+  public Fetch limit(Function<Rel, Expression> count, Rel input) {
+    return fetch(Optional.empty(), Optional.of(count.apply(input)), Optional.empty(), input);
+  }
+
+  /**
+   * Creates a fetch relation that limits the number of rows returned to a count expression built
+   * from the input relation, with output field remapping.
+   *
+   * @param count builds the row-count expression from the input relation
+   * @param remap the output field remapping specification
+   * @param input the input relation
+   * @return a new {@link Fetch} relation
+   */
+  public Fetch limit(Function<Rel, Expression> count, Rel.Remap remap, Rel input) {
+    return fetch(Optional.empty(), Optional.of(count.apply(input)), Optional.of(remap), input);
+  }
+
+  /**
+   * Creates a fetch relation that skips a number of rows given by an offset expression built from
+   * the input relation.
+   *
+   * @param offset builds the offset expression from the input relation
+   * @param input the input relation
+   * @return a new {@link Fetch} relation
+   */
+  public Fetch offset(Function<Rel, Expression> offset, Rel input) {
+    return fetch(Optional.of(offset.apply(input)), Optional.empty(), Optional.empty(), input);
+  }
+
+  /**
+   * Creates a fetch relation that skips a number of rows given by an offset expression built from
+   * the input relation, with output field remapping.
+   *
+   * @param offset builds the offset expression from the input relation
+   * @param remap the output field remapping specification
+   * @param input the input relation
+   * @return a new {@link Fetch} relation
+   */
+  public Fetch offset(Function<Rel, Expression> offset, Rel.Remap remap, Rel input) {
+    return fetch(Optional.of(offset.apply(input)), Optional.empty(), Optional.of(remap), input);
+  }
+
   private Fetch fetch(long offset, OptionalLong count, Optional<Rel.Remap> remap, Rel input) {
-    ImmutableFetch.Builder builder = Fetch.builder().input(input).remap(remap);
     // Offset/count are expressions; wrap the given values as i64 literals. An unset offset is
     // treated as 0, and an unset count signals LIMIT ALL.
-    if (offset != 0) {
-      builder.offset(i64(offset));
-    }
-    count.ifPresent(c -> builder.count(i64(c)));
+    Optional<Expression> offsetExpr = offset == 0 ? Optional.empty() : Optional.of(i64(offset));
+    Optional<Expression> countExpr =
+        count.isPresent() ? Optional.of(i64(count.getAsLong())) : Optional.empty();
+    return fetch(offsetExpr, countExpr, remap, input);
+  }
+
+  private Fetch fetch(
+      Optional<Expression> offset,
+      Optional<Expression> count,
+      Optional<Rel.Remap> remap,
+      Rel input) {
+    ImmutableFetch.Builder builder = Fetch.builder().input(input).remap(remap);
+    offset.ifPresent(o -> builder.offset(o));
+    count.ifPresent(c -> builder.count(c));
     return builder.build();
   }
 

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -29,6 +29,7 @@ import io.substrait.relation.Cross;
 import io.substrait.relation.Expand;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
+import io.substrait.relation.ImmutableFetch;
 import io.substrait.relation.Join;
 import io.substrait.relation.NamedScan;
 import io.substrait.relation.NamedUpdate;
@@ -283,7 +284,14 @@ public class SubstraitBuilder {
   }
 
   private Fetch fetch(long offset, OptionalLong count, Optional<Rel.Remap> remap, Rel input) {
-    return Fetch.builder().offset(offset).count(count).input(input).remap(remap).build();
+    ImmutableFetch.Builder builder = Fetch.builder().input(input).remap(remap);
+    // Offset/count are expressions; wrap the given values as i64 literals. An unset offset is
+    // treated as 0, and an unset count signals LIMIT ALL.
+    if (offset != 0) {
+      builder.offset(i64(offset));
+    }
+    count.ifPresent(c -> builder.count(i64(c)));
+    return builder.build();
   }
 
   /**

--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -540,39 +540,21 @@ public class ProtoExpressionConverter {
             literal.getIntervalYearToMonth().getYears(),
             literal.getIntervalYearToMonth().getMonths());
       case INTERVAL_DAY_TO_SECOND:
-        {
-          // Handle deprecated version that doesn't provide precision and that uses microseconds
-          // instead of subseconds, for backwards compatibility
-          int precision =
-              literal.getIntervalDayToSecond().hasPrecision()
-                  ? literal.getIntervalDayToSecond().getPrecision()
-                  : 6; // microseconds
-          long subseconds =
-              literal.getIntervalDayToSecond().hasPrecision()
-                  ? literal.getIntervalDayToSecond().getSubseconds()
-                  : literal.getIntervalDayToSecond().getMicroseconds();
-          return ExpressionCreator.intervalDay(
-              literal.getNullable(),
-              literal.getIntervalDayToSecond().getDays(),
-              literal.getIntervalDayToSecond().getSeconds(),
-              subseconds,
-              precision);
-        }
+        return ExpressionCreator.intervalDay(
+            literal.getNullable(),
+            literal.getIntervalDayToSecond().getDays(),
+            literal.getIntervalDayToSecond().getSeconds(),
+            literal.getIntervalDayToSecond().getSubseconds(),
+            literal.getIntervalDayToSecond().getPrecision());
       case INTERVAL_COMPOUND:
-        {
-          if (!literal.getIntervalCompound().getIntervalDayToSecond().hasPrecision()) {
-            throw new UnsupportedOperationException(
-                "Interval compound with deprecated version of interval day (ie. no precision) is not supported");
-          }
-          return ExpressionCreator.intervalCompound(
-              literal.getNullable(),
-              literal.getIntervalCompound().getIntervalYearToMonth().getYears(),
-              literal.getIntervalCompound().getIntervalYearToMonth().getMonths(),
-              literal.getIntervalCompound().getIntervalDayToSecond().getDays(),
-              literal.getIntervalCompound().getIntervalDayToSecond().getSeconds(),
-              literal.getIntervalCompound().getIntervalDayToSecond().getSubseconds(),
-              literal.getIntervalCompound().getIntervalDayToSecond().getPrecision());
-        }
+        return ExpressionCreator.intervalCompound(
+            literal.getNullable(),
+            literal.getIntervalCompound().getIntervalYearToMonth().getYears(),
+            literal.getIntervalCompound().getIntervalYearToMonth().getMonths(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getDays(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getSeconds(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getSubseconds(),
+            literal.getIntervalCompound().getIntervalDayToSecond().getPrecision());
       case FIXED_CHAR:
         return ExpressionCreator.fixedChar(literal.getNullable(), literal.getFixedChar());
       case VAR_CHAR:

--- a/core/src/main/java/io/substrait/relation/Fetch.java
+++ b/core/src/main/java/io/substrait/relation/Fetch.java
@@ -1,8 +1,9 @@
 package io.substrait.relation;
 
+import io.substrait.expression.Expression;
 import io.substrait.type.Type;
 import io.substrait.util.VisitationContext;
-import java.util.OptionalLong;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 /**
@@ -13,18 +14,20 @@ import org.immutables.value.Value;
 public abstract class Fetch extends SingleInputRel implements HasExtension {
 
   /**
-   * Returns the number of leading input rows to skip.
+   * Returns the expression evaluated into the number of leading input rows to skip, if any. An
+   * empty value (or an expression evaluating to null) is treated as {@code 0}.
    *
-   * @return the offset
+   * @return the optional offset expression
    */
-  public abstract long getOffset();
+  public abstract Optional<Expression> getOffset();
 
   /**
-   * Returns the maximum number of rows to return, or empty to return all remaining rows.
+   * Returns the expression evaluated into the maximum number of rows to return, if any. An empty
+   * value signals that all remaining rows should be returned.
    *
-   * @return the optional row count limit
+   * @return the optional row count expression
    */
-  public abstract OptionalLong getCount();
+  public abstract Optional<Expression> getCount();
 
   @Override
   protected Type.Struct deriveRecordType() {

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -906,11 +906,15 @@ public class ProtoRelConverter {
    */
   protected Fetch newFetch(FetchRel rel) {
     Rel input = from(rel.getInput());
-    ImmutableFetch.Builder builder = Fetch.builder().input(input).offset(rel.getOffset());
-    if (rel.getCount() != -1) {
-      // -1 is used as a sentinel value to signal LIMIT ALL
-      // count only needs to be set when it is not -1
-      builder.count(rel.getCount());
+    ProtoExpressionConverter converter =
+        new ProtoExpressionConverter(lookup, extensions, input.getRecordType(), this);
+    ImmutableFetch.Builder builder = Fetch.builder().input(input);
+    if (rel.hasOffsetExpr()) {
+      builder.offset(converter.from(rel.getOffsetExpr()));
+    }
+    if (rel.hasCountExpr()) {
+      // An unset count signals LIMIT ALL.
+      builder.count(converter.from(rel.getCountExpr()));
     }
 
     builder

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -71,7 +71,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.jspecify.annotations.NonNull;
 
 /** Converts from {@link io.substrait.proto.Rel} to {@link io.substrait.relation.Rel} */
@@ -826,28 +825,6 @@ public class ProtoRelConverter {
   }
 
   /**
-   * Converts StructLiteral instances to NestedStruct for VirtualTableScan. This is a convenience
-   * method for migrating from the legacy StructLiteral-based VirtualTable API to the new
-   * NestedStruct-based API.
-   *
-   * @param nullable whether the resulting NestedStruct instances should be nullable
-   * @param structs the StructLiteral instances to convert
-   * @return a list of NestedStruct instances with the same field structure
-   */
-  private static List<Expression.NestedStruct> nestedStruct(
-      boolean nullable, Expression.StructLiteral... structs) {
-    List<Expression.NestedStruct> nestedStructs = new ArrayList<>();
-    for (Expression.StructLiteral struct : structs) {
-      nestedStructs.add(
-          Expression.NestedStruct.builder()
-              .nullable(nullable)
-              .addAllFields(struct.fields())
-              .build());
-    }
-    return nestedStructs;
-  }
-
-  /**
    * Converts the corresponding protobuf message to its POJO representation.
    *
    * @param rel the protobuf value to convert
@@ -855,24 +832,11 @@ public class ProtoRelConverter {
    */
   protected VirtualTableScan newVirtualTable(ReadRel rel) {
     ReadRel.VirtualTable virtualTable = rel.getVirtualTable();
-    // If both values and expressions are set, raise an error
-    if (virtualTable.getValuesCount() > 0 && virtualTable.getExpressionsCount() > 0) {
-      throw new IllegalArgumentException(
-          "VirtualTable cannot have both values and expressions set");
-    }
     NamedStruct virtualTableSchema = newNamedStruct(rel);
     ProtoExpressionConverter converter =
         new ProtoExpressionConverter(lookup, extensions, virtualTableSchema.struct(), this);
 
-    List<Expression.NestedStruct> expressions =
-        new ArrayList<>(virtualTable.getValuesCount() + virtualTable.getExpressionsCount());
-
-    // We cannot have a null row in VirtualTable, therefore we set the nullability to false
-    // nullability is also not supported at the Expression.Nested.Struct level
-    for (io.substrait.proto.Expression.Literal.Struct struct : virtualTable.getValuesList()) {
-      expressions.addAll(nestedStruct(false, converter.from(struct)));
-    }
-
+    List<Expression.NestedStruct> expressions = new ArrayList<>(virtualTable.getExpressionsCount());
     for (io.substrait.proto.Expression.Nested.Struct expr : virtualTable.getExpressionsList()) {
       expressions.add(converter.from(expr));
     }
@@ -1270,13 +1234,7 @@ public class ProtoRelConverter {
         HashJoin.builder()
             .left(left)
             .right(right)
-            .keys(
-                comparisonJoinKeys(
-                    rel.getKeysList(),
-                    rel.getLeftKeysList(),
-                    rel.getRightKeysList(),
-                    leftConverter,
-                    rightConverter))
+            .keys(comparisonJoinKeys(rel.getKeysList(), leftConverter, rightConverter))
             .joinType(HashJoin.JoinType.fromProto(rel.getType()))
             .postJoinFilter(
                 Optional.ofNullable(
@@ -1320,13 +1278,7 @@ public class ProtoRelConverter {
         MergeJoin.builder()
             .left(left)
             .right(right)
-            .keys(
-                comparisonJoinKeys(
-                    rel.getKeysList(),
-                    rel.getLeftKeysList(),
-                    rel.getRightKeysList(),
-                    leftConverter,
-                    rightConverter))
+            .keys(comparisonJoinKeys(rel.getKeysList(), leftConverter, rightConverter))
             .joinType(MergeJoin.JoinType.fromProto(rel.getType()))
             .postJoinFilter(
                 Optional.ofNullable(
@@ -1356,25 +1308,10 @@ public class ProtoRelConverter {
    */
   private List<ComparisonJoinKey> comparisonJoinKeys(
       List<io.substrait.proto.ComparisonJoinKey> keys,
-      List<io.substrait.proto.Expression.FieldReference> leftKeys,
-      List<io.substrait.proto.Expression.FieldReference> rightKeys,
       ProtoExpressionConverter leftConverter,
       ProtoExpressionConverter rightConverter) {
-    if (!keys.isEmpty()) {
-      return keys.stream()
-          .map(key -> comparisonJoinKey(key, leftConverter, rightConverter))
-          .collect(Collectors.toList());
-    }
-    if (leftKeys.size() != rightKeys.size()) {
-      throw new IllegalArgumentException("Number of left and right keys must be equal.");
-    }
-    return IntStream.range(0, leftKeys.size())
-        .mapToObj(
-            i ->
-                ComparisonJoinKey.of(
-                    leftConverter.from(leftKeys.get(i)),
-                    rightConverter.from(rightKeys.get(i)),
-                    ComparisonJoinKey.SimpleComparisonType.EQ))
+    return keys.stream()
+        .map(key -> comparisonJoinKey(key, leftConverter, rightConverter))
         .collect(Collectors.toList());
   }
 

--- a/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
+++ b/core/src/main/java/io/substrait/relation/RelCopyOnWriteVisitor.java
@@ -154,10 +154,20 @@ public class RelCopyOnWriteVisitor<E extends Exception>
 
   @Override
   public Optional<Rel> visit(Fetch fetch, EmptyVisitationContext context) throws E {
-    return fetch
-        .getInput()
-        .accept(this, context)
-        .map(input -> Fetch.builder().from(fetch).input(input).build());
+    Optional<Rel> input = fetch.getInput().accept(this, context);
+    Optional<Expression> offset = visitOptionalExpression(fetch.getOffset(), context);
+    Optional<Expression> count = visitOptionalExpression(fetch.getCount(), context);
+
+    if (allEmpty(input, offset, count)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        Fetch.builder()
+            .from(fetch)
+            .input(input.orElse(fetch.getInput()))
+            .offset(or(offset, fetch::getOffset))
+            .count(or(count, fetch::getCount))
+            .build());
   }
 
   @Override

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -233,35 +233,6 @@ public class RelProtoConverter
         .build();
   }
 
-  /**
-   * Returns {@code true} when every key is a plain {@link
-   * ComparisonJoinKey.SimpleComparisonType#EQ} comparison, i.e. the only case the deprecated {@code
-   * left_keys}/{@code right_keys} fields can represent without losing information. {@code
-   * IS_NOT_DISTINCT_FROM}, {@code MIGHT_EQUAL} and custom comparisons cannot be expressed by the
-   * deprecated fields, where an old consumer would silently interpret them as equality.
-   */
-  private boolean isLosslessAsDeprecatedKeys(List<ComparisonJoinKey> keys) {
-    return keys.stream()
-        .allMatch(
-            key ->
-                key.getComparison()
-                    .accept(
-                        new ComparisonJoinKey.ComparisonTypeVisitor<Boolean, RuntimeException>() {
-                          @Override
-                          public Boolean visit(
-                              ComparisonJoinKey.SimpleComparison simpleComparison) {
-                            return simpleComparison.getType()
-                                == ComparisonJoinKey.SimpleComparisonType.EQ;
-                          }
-
-                          @Override
-                          public Boolean visit(
-                              ComparisonJoinKey.CustomComparison customComparison) {
-                            return false;
-                          }
-                        }));
-  }
-
   @Override
   public Rel visit(Aggregate aggregate, EmptyVisitationContext context) throws RuntimeException {
     final List<Expression> uniqueGroupingExpressions =
@@ -479,7 +450,6 @@ public class RelProtoConverter
   }
 
   @Override
-  @SuppressWarnings("deprecation") // intentionally also writes the deprecated left_keys/right_keys
   public Rel visit(HashJoin hashJoin, EmptyVisitationContext context) throws RuntimeException {
     HashJoinRel.Builder builder =
         HashJoinRel.newBuilder()
@@ -490,16 +460,6 @@ public class RelProtoConverter
 
     List<ComparisonJoinKey> keys = hashJoin.getKeys();
     builder.addAllKeys(keys.stream().map(this::toProto).collect(Collectors.toList()));
-
-    // Also populate the deprecated left_keys/right_keys when every key is a plain EQ comparison so
-    // that consumers which have not yet adopted the new keys field keep working. Lossy comparison
-    // types are intentionally left out of the deprecated fields.
-    if (isLosslessAsDeprecatedKeys(keys)) {
-      builder.addAllLeftKeys(
-          keys.stream().map(k -> toProto(k.getLeft())).collect(Collectors.toList()));
-      builder.addAllRightKeys(
-          keys.stream().map(k -> toProto(k.getRight())).collect(Collectors.toList()));
-    }
 
     hashJoin.getPostJoinFilter().ifPresent(t -> builder.setPostJoinFilter(toProto(t)));
 
@@ -512,7 +472,6 @@ public class RelProtoConverter
   }
 
   @Override
-  @SuppressWarnings("deprecation") // intentionally also writes the deprecated left_keys/right_keys
   public Rel visit(MergeJoin mergeJoin, EmptyVisitationContext context) throws RuntimeException {
     MergeJoinRel.Builder builder =
         MergeJoinRel.newBuilder()
@@ -523,16 +482,6 @@ public class RelProtoConverter
 
     List<ComparisonJoinKey> keys = mergeJoin.getKeys();
     builder.addAllKeys(keys.stream().map(this::toProto).collect(Collectors.toList()));
-
-    // Also populate the deprecated left_keys/right_keys when every key is a plain EQ comparison so
-    // that consumers which have not yet adopted the new keys field keep working. Lossy comparison
-    // types are intentionally left out of the deprecated fields.
-    if (isLosslessAsDeprecatedKeys(keys)) {
-      builder.addAllLeftKeys(
-          keys.stream().map(k -> toProto(k.getLeft())).collect(Collectors.toList()));
-      builder.addAllRightKeys(
-          keys.stream().map(k -> toProto(k.getRight())).collect(Collectors.toList()));
-    }
 
     mergeJoin.getPostJoinFilter().ifPresent(t -> builder.setPostJoinFilter(toProto(t)));
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -334,12 +334,10 @@ public class RelProtoConverter
   @Override
   public Rel visit(Fetch fetch, EmptyVisitationContext context) throws RuntimeException {
     FetchRel.Builder builder =
-        FetchRel.newBuilder()
-            .setCommon(common(fetch))
-            .setInput(toProto(fetch.getInput()))
-            .setOffset(fetch.getOffset())
-            // -1 is used as a sentinel value to signal LIMIT ALL
-            .setCount(fetch.getCount().orElse(-1));
+        FetchRel.newBuilder().setCommon(common(fetch)).setInput(toProto(fetch.getInput()));
+
+    fetch.getOffset().ifPresent(offset -> builder.setOffsetExpr(toProto(offset)));
+    fetch.getCount().ifPresent(count -> builder.setCountExpr(toProto(count)));
 
     fetch
         .getExtension()

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -55,10 +55,12 @@ public class ProtoTypeConverter {
       case INTERVAL_YEAR:
         return n(type.getIntervalYear().getNullability()).INTERVAL_YEAR;
       case INTERVAL_DAY:
+        // The precision is required; reject an interval day type that leaves it unset.
+        if (!type.getIntervalDay().hasPrecision()) {
+          throw new IllegalArgumentException("Interval day type must have its precision set");
+        }
         return n(type.getIntervalDay().getNullability())
-            // precision defaults to 6 (micros) for backwards compatibility, see protobuf
-            .intervalDay(
-                type.getIntervalDay().hasPrecision() ? type.getIntervalDay().getPrecision() : 6);
+            .intervalDay(type.getIntervalDay().getPrecision());
       case INTERVAL_COMPOUND:
         return n(type.getIntervalCompound().getNullability())
             .intervalCompound(type.getIntervalCompound().getPrecision());

--- a/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
+++ b/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
@@ -24,6 +24,7 @@ import io.substrait.relation.Rel.Remap;
 import io.substrait.relation.Sort;
 import io.substrait.type.Type;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -133,16 +134,17 @@ class SubstraitBuilderTest extends TestBase {
     void testFetchAndLimit() {
       final NamedScan scan = createSimpleScan();
       Fetch limit = builder.limit(10, scan);
-      assertEquals(10, limit.getCount().getAsLong());
-      assertEquals(0, limit.getOffset());
+      // offset/count are i64-literal expressions; offset 0 is left unset.
+      assertEquals(Optional.of(builder.i64(10)), limit.getCount());
+      assertEquals(Optional.empty(), limit.getOffset());
       limit = builder.limit(10, Remap.of(List.of(0, 1)), scan);
       assertNotNull(limit);
 
       Fetch offset = builder.offset(5, scan);
-      assertEquals(5, offset.getOffset());
+      assertEquals(Optional.of(builder.i64(5)), offset.getOffset());
 
       offset = builder.offset(5, Remap.of(List.of(0, 1)), scan);
-      assertEquals(5, offset.getOffset());
+      assertEquals(Optional.of(builder.i64(5)), offset.getOffset());
     }
 
     @Test

--- a/core/src/test/java/io/substrait/extension/AdvancedExtensionRelProtoConversionTest.java
+++ b/core/src/test/java/io/substrait/extension/AdvancedExtensionRelProtoConversionTest.java
@@ -148,8 +148,7 @@ class AdvancedExtensionRelProtoConversionTest extends TestBase {
                     .initialSchema(
                         NamedStruct.builder().struct(TypeCreator.REQUIRED.struct()).build())
                     .build())
-            .offset(0)
-            .count(10)
+            .count(ExpressionCreator.i64(false, 10))
             .extension(extension)
             .build();
 

--- a/core/src/test/java/io/substrait/relation/VirtualTableScanTest.java
+++ b/core/src/test/java/io/substrait/relation/VirtualTableScanTest.java
@@ -9,7 +9,6 @@ import static io.substrait.expression.ExpressionCreator.string;
 import static io.substrait.expression.ExpressionCreator.struct;
 import static io.substrait.expression.ExpressionCreator.typedNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.TestBase;
@@ -83,37 +82,9 @@ class VirtualTableScanTest extends TestBase {
   }
 
   @Test
-  void virtualTableUsingValuesShouldBeConvertedToFields() {
-    // Create 2 virtual tables with the same contents, but different encodings (values vs fields)
-    io.substrait.proto.Rel virtualTableWithValuesSet = virtualTableUsingValues(schema, literal);
+  void virtualTableUsingFieldsRoundTrips() {
     io.substrait.proto.Rel virtualTableWithFieldsSet = virtualTableUsingFields(schema, expression);
-
-    Rel rel1 = protoRelConverter.from(virtualTableWithFieldsSet);
-    Rel rel2 = protoRelConverter.from(virtualTableWithValuesSet);
-
-    // The relations should be equivalent
-    assertEquals(rel1, rel2);
-  }
-
-  @Test
-  void rejectVirtualTablesWhenBothValuesAndFieldsAreSet() {
-    io.substrait.proto.Expression.Literal.Struct literalStruct =
-        io.substrait.proto.Expression.Literal.Struct.newBuilder().addFields(literal).build();
-    io.substrait.proto.Expression.Nested.Struct nestedStruct =
-        io.substrait.proto.Expression.Nested.Struct.newBuilder().addFields(expression).build();
-
-    io.substrait.proto.ReadRel readRel =
-        ReadRel.newBuilder()
-            .setVirtualTable(
-                ReadRel.VirtualTable.newBuilder()
-                    .addExpressions(nestedStruct)
-                    .addValues(literalStruct)
-                    .build())
-            .setBaseSchema(schema)
-            .build();
-
-    io.substrait.proto.Rel rel = io.substrait.proto.Rel.newBuilder().setRead(readRel).build();
-    assertThrows(IllegalArgumentException.class, () -> protoRelConverter.from(rel));
+    assertDoesNotThrow(() -> protoRelConverter.from(virtualTableWithFieldsSet));
   }
 
   io.substrait.proto.Rel virtualTableUsingFields(
@@ -124,20 +95,6 @@ class VirtualTableScanTest extends TestBase {
     io.substrait.proto.ReadRel readRel =
         ReadRel.newBuilder()
             .setVirtualTable(ReadRel.VirtualTable.newBuilder().addExpressions(struct).build())
-            .setBaseSchema(schema)
-            .build();
-
-    return io.substrait.proto.Rel.newBuilder().setRead(readRel).build();
-  }
-
-  io.substrait.proto.Rel virtualTableUsingValues(
-      io.substrait.proto.NamedStruct schema, io.substrait.proto.Expression.Literal value) {
-    io.substrait.proto.Expression.Literal.Struct struct =
-        io.substrait.proto.Expression.Literal.Struct.newBuilder().addFields(literal).build();
-
-    io.substrait.proto.ReadRel readRel =
-        ReadRel.newBuilder()
-            .setVirtualTable(ReadRel.VirtualTable.newBuilder().addValues(struct).build())
             .setBaseSchema(schema)
             .build();
 

--- a/core/src/test/java/io/substrait/type/proto/FetchRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/FetchRoundtripTest.java
@@ -35,4 +35,11 @@ class FetchRoundtripTest extends TestBase {
     Rel rel = Fetch.builder().input(table).offset(sb.i64(3)).count(sb.i64(7)).build();
     verifyRoundTrip(rel);
   }
+
+  @Test
+  void dslExpressionOverloads() {
+    verifyRoundTrip(sb.fetch(rel -> sb.i64(2), rel -> sb.i64(8), table));
+    verifyRoundTrip(sb.limit(rel -> sb.i64(8), table));
+    verifyRoundTrip(sb.offset(rel -> sb.i64(2), table));
+  }
 }

--- a/core/src/test/java/io/substrait/type/proto/FetchRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/FetchRoundtripTest.java
@@ -1,0 +1,38 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.relation.Fetch;
+import io.substrait.relation.Rel;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trip tests for {@link Fetch}, whose offset/count are optional expressions (an unset offset
+ * is treated as 0, an unset count as LIMIT ALL).
+ */
+class FetchRoundtripTest extends TestBase {
+
+  final Rel table =
+      sb.namedScan(Arrays.asList("T"), Arrays.asList("a", "b"), Arrays.asList(R.I64, R.STRING));
+
+  @Test
+  void limitOnly() {
+    verifyRoundTrip(sb.limit(10, table));
+  }
+
+  @Test
+  void offsetOnly() {
+    verifyRoundTrip(sb.offset(5, table));
+  }
+
+  @Test
+  void offsetAndCount() {
+    verifyRoundTrip(sb.fetch(5, 10, table));
+  }
+
+  @Test
+  void expressionOffsetAndCount() {
+    Rel rel = Fetch.builder().input(table).offset(sb.i64(3)).count(sb.i64(7)).build();
+    verifyRoundTrip(rel);
+  }
+}

--- a/core/src/test/java/io/substrait/type/proto/HashMergeJoinKeysTest.java
+++ b/core/src/test/java/io/substrait/type/proto/HashMergeJoinKeysTest.java
@@ -1,7 +1,6 @@
 package io.substrait.type.proto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.TestBase;
 import io.substrait.relation.Rel;
@@ -15,10 +14,9 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 /**
- * Verifies that {@link HashJoin}/{@link MergeJoin} consume both the deprecated {@code
- * left_keys}/{@code right_keys} proto fields and the new {@code keys} field, always produce the new
- * {@code keys} field, and additionally produce the deprecated fields when (and only when) every key
- * is a plain {@code EQ} comparison they can represent without loss.
+ * Verifies that {@link HashJoin}/{@link MergeJoin} round-trip their {@code keys} field, including
+ * non-equality and custom comparisons, and that the deprecated {@link HashJoin#getLeftKeys()}
+ * convenience views derive from {@code keys}.
  */
 class HashMergeJoinKeysTest extends TestBase {
 
@@ -65,150 +63,6 @@ class HashMergeJoinKeysTest extends TestBase {
     assertEquals(
         hashJoin.getKeys().stream().map(ComparisonJoinKey::getRight).collect(Collectors.toList()),
         hashJoin.getRightKeys());
-  }
-
-  // A plain EQ join must populate the new keys field and, for backwards compatibility with
-  // consumers that have not yet adopted it, the deprecated left_keys/right_keys as well.
-  @Test
-  void producesBothKeysForEqJoins() {
-    io.substrait.proto.HashJoinRel proto = relProtoConverter.toProto(hashJoin).getHashJoin();
-    assertEquals(2, proto.getKeysCount());
-    assertEquals(
-        proto.getKeysList().stream()
-            .map(io.substrait.proto.ComparisonJoinKey::getLeft)
-            .collect(Collectors.toList()),
-        proto.getLeftKeysList());
-    assertEquals(
-        proto.getKeysList().stream()
-            .map(io.substrait.proto.ComparisonJoinKey::getRight)
-            .collect(Collectors.toList()),
-        proto.getRightKeysList());
-
-    io.substrait.proto.MergeJoinRel mergeProto =
-        relProtoConverter.toProto(mergeJoin).getMergeJoin();
-    assertEquals(2, mergeProto.getKeysCount());
-    assertEquals(
-        mergeProto.getKeysList().stream()
-            .map(io.substrait.proto.ComparisonJoinKey::getLeft)
-            .collect(Collectors.toList()),
-        mergeProto.getLeftKeysList());
-    assertEquals(
-        mergeProto.getKeysList().stream()
-            .map(io.substrait.proto.ComparisonJoinKey::getRight)
-            .collect(Collectors.toList()),
-        mergeProto.getRightKeysList());
-  }
-
-  // The deprecated fields cannot represent IS_NOT_DISTINCT_FROM, MIGHT_EQUAL or custom comparisons,
-  // so a join containing any such key must only populate the new keys field. Otherwise an old
-  // consumer would silently misinterpret those keys as plain equality.
-  @Test
-  void producesOnlyNewKeysForLossyComparisons() {
-    List<ComparisonJoinKey> keys =
-        Arrays.asList(
-            ComparisonJoinKey.of(
-                sb.fieldReference(leftTable, 0),
-                sb.fieldReference(rightTable, 2),
-                SimpleComparisonType.EQ),
-            ComparisonJoinKey.of(
-                sb.fieldReference(leftTable, 1),
-                sb.fieldReference(rightTable, 0),
-                SimpleComparisonType.IS_NOT_DISTINCT_FROM));
-
-    HashJoin hash =
-        HashJoin.builder()
-            .left(leftTable)
-            .right(rightTable)
-            .keys(keys)
-            .joinType(HashJoin.JoinType.INNER)
-            .build();
-    io.substrait.proto.HashJoinRel proto = relProtoConverter.toProto(hash).getHashJoin();
-    assertEquals(2, proto.getKeysCount());
-    assertTrue(proto.getLeftKeysList().isEmpty());
-    assertTrue(proto.getRightKeysList().isEmpty());
-
-    MergeJoin merge =
-        MergeJoin.builder()
-            .left(leftTable)
-            .right(rightTable)
-            .keys(keys)
-            .joinType(MergeJoin.JoinType.INNER)
-            .build();
-    io.substrait.proto.MergeJoinRel mergeProto = relProtoConverter.toProto(merge).getMergeJoin();
-    assertEquals(2, mergeProto.getKeysCount());
-    assertTrue(mergeProto.getLeftKeysList().isEmpty());
-    assertTrue(mergeProto.getRightKeysList().isEmpty());
-  }
-
-  // A plan from a legacy producer (only deprecated fields set) is consumed and mapped to EQ keys.
-  @Test
-  void consumesLegacyHashJoin() {
-    io.substrait.proto.HashJoinRel modern = relProtoConverter.toProto(hashJoin).getHashJoin();
-    io.substrait.proto.HashJoinRel legacy =
-        modern.toBuilder()
-            .clearKeys()
-            .clearLeftKeys()
-            .clearRightKeys()
-            .addAllLeftKeys(
-                modern.getKeysList().stream()
-                    .map(io.substrait.proto.ComparisonJoinKey::getLeft)
-                    .collect(Collectors.toList()))
-            .addAllRightKeys(
-                modern.getKeysList().stream()
-                    .map(io.substrait.proto.ComparisonJoinKey::getRight)
-                    .collect(Collectors.toList()))
-            .build();
-
-    Rel result =
-        protoRelConverter.from(io.substrait.proto.Rel.newBuilder().setHashJoin(legacy).build());
-    assertEquals(hashJoin, result);
-    assertEquals(2, ((HashJoin) result).getKeys().size());
-    ((HashJoin) result)
-        .getKeys()
-        .forEach(
-            k ->
-                assertEquals(
-                    ComparisonJoinKey.SimpleComparison.of(SimpleComparisonType.EQ),
-                    k.getComparison()));
-  }
-
-  @Test
-  void consumesLegacyMergeJoin() {
-    io.substrait.proto.MergeJoinRel modern = relProtoConverter.toProto(mergeJoin).getMergeJoin();
-    io.substrait.proto.MergeJoinRel legacy =
-        modern.toBuilder()
-            .clearKeys()
-            .clearLeftKeys()
-            .clearRightKeys()
-            .addAllLeftKeys(
-                modern.getKeysList().stream()
-                    .map(io.substrait.proto.ComparisonJoinKey::getLeft)
-                    .collect(Collectors.toList()))
-            .addAllRightKeys(
-                modern.getKeysList().stream()
-                    .map(io.substrait.proto.ComparisonJoinKey::getRight)
-                    .collect(Collectors.toList()))
-            .build();
-
-    Rel result =
-        protoRelConverter.from(io.substrait.proto.Rel.newBuilder().setMergeJoin(legacy).build());
-    assertEquals(mergeJoin, result);
-  }
-
-  // When both the deprecated fields and the new keys are present, keys wins.
-  @Test
-  void prefersNewKeysOverDeprecated() {
-    io.substrait.proto.HashJoinRel modern = relProtoConverter.toProto(hashJoin).getHashJoin();
-    // Add bogus deprecated keys that point at different fields than the real keys.
-    io.substrait.proto.HashJoinRel both =
-        modern.toBuilder()
-            .addLeftKeys(modern.getKeys(0).getRight())
-            .addRightKeys(modern.getKeys(0).getLeft())
-            .build();
-
-    Rel result =
-        protoRelConverter.from(io.substrait.proto.Rel.newBuilder().setHashJoin(both).build());
-    assertEquals(hashJoin, result);
   }
 
   // Non-EQ simple comparisons and custom comparison functions survive a round trip.

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -1,6 +1,7 @@
 package io.substrait.type.proto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.SimpleExtension;
@@ -8,6 +9,7 @@ import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -60,5 +62,17 @@ class TestTypeRoundtrip {
     io.substrait.proto.Type converted = type.accept(typeProtoConverter);
     Type actual = protoTypeConverter.from(converted);
     assertEquals(type, actual);
+  }
+
+  @Test
+  @DisplayName("interval day type with an unset precision is rejected")
+  void intervalDayWithoutPrecisionIsRejected() {
+    io.substrait.proto.Type protoType =
+        io.substrait.proto.Type.newBuilder()
+            .setIntervalDay(
+                io.substrait.proto.Type.IntervalDay.newBuilder()
+                    .setNullability(io.substrait.proto.Type.Nullability.NULLABILITY_REQUIRED))
+            .build();
+    assertThrows(IllegalArgumentException.class, () -> protoTypeConverter.from(protoType));
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -51,7 +51,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -484,18 +483,14 @@ public class SubstraitRelNodeConverter
   @Override
   public RelNode visit(Fetch fetch, Context context) throws RuntimeException {
     RelNode child = fetch.getInput().accept(this, context);
-    OptionalLong optCount = fetch.getCount();
-    long count = optCount.orElse(-1L);
-    long offset = fetch.getOffset();
-    if (offset > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          String.format("offset is overflowed as an integer: %d", offset));
-    }
-    if (count > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException(
-          String.format("count is overflowed as an integer: %d", count));
-    }
-    RelNode node = relBuilder.push(child).limit((int) offset, (int) count).build();
+    // Offset/count are expressions; pass them through to Calcite as RexNodes so non-literal (e.g.
+    // dynamic-parameter) offset/count are preserved. An unset offset means 0 and an unset count
+    // means LIMIT ALL.
+    RexNode offset =
+        fetch.getOffset().map(e -> e.accept(expressionRexConverter, context)).orElse(null);
+    RexNode count =
+        fetch.getCount().map(e -> e.accept(expressionRexConverter, context)).orElse(null);
+    RelNode node = relBuilder.push(child).sortLimit(offset, count, ImmutableList.of()).build();
     return applyRemap(node, fetch.getRemap());
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -712,27 +711,19 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     }
 
     if (sort.fetch != null || sort.offset != null) {
-      Long offset = Optional.ofNullable(sort.offset).map(this::asLong).orElse(0L);
-      OptionalLong count =
-          Optional.ofNullable(sort.fetch)
-              .map(r -> OptionalLong.of(asLong(r)))
-              .orElse(OptionalLong.empty());
-
-      ImmutableFetch.Builder builder = Fetch.builder().input(output).offset(offset).count(count);
+      // Offset/count are expressions; pass the Calcite RexNodes through so non-literal (e.g.
+      // dynamic-parameter) offset/count are preserved.
+      ImmutableFetch.Builder builder = Fetch.builder().input(output);
+      if (sort.offset != null) {
+        builder.offset(toExpression(sort.offset));
+      }
+      if (sort.fetch != null) {
+        builder.count(toExpression(sort.fetch));
+      }
       output = builder.build();
     }
 
     return output;
-  }
-
-  private long asLong(RexNode rex) {
-    Expression expr = toExpression(rex);
-    if (expr instanceof Expression.I64Literal) {
-      return ((Expression.I64Literal) expr).value();
-    } else if (expr instanceof Expression.I32Literal) {
-      return ((Expression.I32Literal) expr).value();
-    }
-    throw new UnsupportedOperationException("Unknown type: " + rex);
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FetchTest.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus;
 
+import io.substrait.expression.Expression;
 import io.substrait.relation.Rel;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,18 @@ class FetchTest extends PlanTestBase {
   @Test
   void offsetAndLimit() {
     Rel rel = sb.fetch(50, 10, TABLE);
+    assertFullRoundTrip(rel);
+  }
+
+  @Test
+  void limitWithDynamicParameterCount() {
+    // Substrait models fetch offset/count as expressions, so a non-literal (dynamic-parameter)
+    // count must pass through to Calcite as a RexDynamicParam and back.
+    Rel rel =
+        sb.limit(
+            input ->
+                Expression.DynamicParameter.builder().type(R.I64).parameterReference(0).build(),
+            TABLE);
     assertFullRoundTrip(rel);
   }
 }

--- a/spark/src/main/scala/io/substrait/debug/RelToVerboseString.scala
+++ b/spark/src/main/scala/io/substrait/debug/RelToVerboseString.scala
@@ -18,6 +18,7 @@ package io.substrait.debug
 
 import io.substrait.spark.DefaultRelVisitor
 
+import io.substrait.expression.{Expression => SExpression}
 import io.substrait.relation._
 import io.substrait.relation.physical.{BroadcastExchange, MultiBucketExchange, RoundRobinExchange, ScatterExchange, SingleBucketExchange}
 import io.substrait.util.EmptyVisitationContext
@@ -49,13 +50,22 @@ class RelToVerboseString(addSuffix: Boolean) extends DefaultRelVisitor[String] {
   override def visit(fetch: Fetch, context: EmptyVisitationContext): String = {
     withBuilder(fetch, 7)(
       builder => {
-        builder.append("offset=").append(fetch.getOffset)
+        // offset/count are expressions; render their numeric value, and an unset offset as 0.
+        builder
+          .append("offset=")
+          .append(if (fetch.getOffset.isPresent) fetchValue(fetch.getOffset.get) else "0")
         fetch.getCount.ifPresent(
           count => {
             builder.append(", ")
-            builder.append("count=").append(count)
+            builder.append("count=").append(fetchValue(count))
           })
       })
+  }
+
+  private def fetchValue(e: SExpression): String = e match {
+    case l: SExpression.I64Literal => l.value().toString
+    case l: SExpression.I32Literal => l.value().toString
+    case other => other.toString
   }
   override def visit(sort: Sort, context: EmptyVisitationContext): String = {
     withBuilder(sort, 5)(

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -258,8 +258,9 @@ class ToLogicalPlan(val spark: AnyRef = SparkCompat.instance.getOrCreateSparkSes
 
   override def visit(fetch: relation.Fetch, context: EmptyVisitationContext): LogicalPlan = {
     val child = fetch.getInput.accept(this, context)
-    val limit = fetch.getCount.orElse(-1).intValue() // -1 means unassigned here
-    val offset = fetch.getOffset.intValue()
+    // Offset/count are expressions; an unset count means LIMIT ALL (-1) and an unset offset means 0.
+    val limit = if (fetch.getCount.isPresent) asLong(fetch.getCount.get).toInt else -1
+    val offset = if (fetch.getOffset.isPresent) asLong(fetch.getOffset.get).toInt else 0
     val toLiteral = (i: Int) => Literal(i, IntegerType)
     val plan = if (limit >= 0) {
       val limitExpr = toLiteral(limit)
@@ -274,6 +275,13 @@ class ToLogicalPlan(val spark: AnyRef = SparkCompat.instance.getOrCreateSparkSes
       Offset(toLiteral(offset), child)
     }
     remap(plan, fetch.getRemap)
+  }
+
+  private def asLong(e: SExpression): Long = e match {
+    case l: SExpression.I64Literal => l.value()
+    case l: SExpression.I32Literal => l.value().toLong
+    case other =>
+      throw new UnsupportedOperationException(s"Unsupported fetch offset/count expression: $other")
   }
 
   override def visit(sort: relation.Sort, context: EmptyVisitationContext): LogicalPlan = {

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -259,8 +259,8 @@ class ToLogicalPlan(val spark: AnyRef = SparkCompat.instance.getOrCreateSparkSes
   override def visit(fetch: relation.Fetch, context: EmptyVisitationContext): LogicalPlan = {
     val child = fetch.getInput.accept(this, context)
     // Offset/count are expressions; an unset count means LIMIT ALL (-1) and an unset offset means 0.
-    val limit = if (fetch.getCount.isPresent) asLong(fetch.getCount.get).toInt else -1
-    val offset = if (fetch.getOffset.isPresent) asLong(fetch.getOffset.get).toInt else 0
+    val limit = if (fetch.getCount.isPresent) asInt(fetch.getCount.get) else -1
+    val offset = if (fetch.getOffset.isPresent) asInt(fetch.getOffset.get) else 0
     val toLiteral = (i: Int) => Literal(i, IntegerType)
     val plan = if (limit >= 0) {
       val limitExpr = toLiteral(limit)
@@ -277,9 +277,9 @@ class ToLogicalPlan(val spark: AnyRef = SparkCompat.instance.getOrCreateSparkSes
     remap(plan, fetch.getRemap)
   }
 
-  private def asLong(e: SExpression): Long = e match {
-    case l: SExpression.I64Literal => l.value()
-    case l: SExpression.I32Literal => l.value().toLong
+  private def asInt(e: SExpression): Int = e match {
+    case l: SExpression.I64Literal => l.value().toInt
+    case l: SExpression.I32Literal => l.value().toInt
     case other =>
       throw new UnsupportedOperationException(s"Unsupported fetch offset/count expression: $other")
   }

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -269,12 +269,16 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
   }
 
   private def fetch(child: LogicalPlan, offset: Long, limit: Long = -1): relation.Fetch = {
+    // Offset/count are i64-literal expressions; offset 0 is left unset and an unset count signals
+    // LIMIT ALL.
     val builder = relation.Fetch
       .builder()
       .input(visit(child))
-      .offset(offset)
+    if (offset != 0) {
+      builder.offset(ExpressionCreator.i64(false, offset))
+    }
     if (limit != -1) {
-      builder.count(limit)
+      builder.count(ExpressionCreator.i64(false, limit))
     }
 
     builder.build()


### PR DESCRIPTION
Bump the `substrait` submodule from v0.97.0 to v0.98.0, which removes several long-deprecated proto fields.

## `FetchRel` → expression-based offset/count (breaking)
v0.98.0 removed `FetchRel`'s int64 `offset`/`count` in favor of the `offset_expr`/`count_expr` expression fields. `Fetch` now models these as `Optional<Expression> getOffset()`/`getCount()`, matching the existing `TopN`. Updated across both proto converters, `RelCopyOnWriteVisitor`, the DSL, and the **isthmus** and **spark** integrations (read + write). An unset offset is treated as `0`; an unset count signals `LIMIT ALL`.

**DSL** — `SubstraitBuilder` keeps the `long`-based `fetch`/`limit`/`offset` helpers (they wrap `i64` literals; offset `0` is left unset) and adds lambda `Function<Rel, Expression>` overloads that build the offset/count expression from the input relation (matching `filter`/`nestedLoopJoin`).

**Isthmus** — now passes offset/count **expressions** through to Calcite as `RexNode`s (via `sortLimit`) and back (via `toExpression`), instead of extracting integer literals. Non-literal offset/count (e.g. a dynamic-parameter `LIMIT ?`) now round-trips (covered by `FetchTest.limitWithDynamicParameterCount`).

## Other removed fields
- `HashJoinRel`/`MergeJoinRel` `left_keys`/`right_keys` — dropped the write, the read fallback, and the lossy-key helper (use `keys`).
- `ReadRel.VirtualTable.values` — dropped the value-conversion path (use `expressions`).
- `Expression.Literal.IntervalDayToSecond` `microseconds` and the `precision_mode` oneof — `precision` is now a plain, always-present field.

## IntervalDay type precision (spec v0.97.0)
The `IntervalDay` **type**'s `precision` is the only `optional` precision field, and v0.97.0 changed its guidance to "implementations should reject an unset precision." `ProtoTypeConverter` now rejects an `IntervalDay` type with an unset precision instead of defaulting to `6` (substrait-java always *emits* a precision, so this only affects reading externally-produced plans).

**BREAKING CHANGE:** `Fetch.getOffset()`/`getCount()` now return `Optional<Expression>` instead of `long`/`OptionalLong`. The generated protobuf API also drops `FetchRel.offset`/`count`, `HashJoinRel`/`MergeJoinRel.left_keys`/`right_keys`, `ReadRel.VirtualTable.values`, and `Expression.Literal.IntervalDayToSecond.microseconds`. Reading an `IntervalDay` type with an unset precision now throws instead of defaulting to 6.

## Verification
`./gradlew :core:check :isthmus:check :core:javadoc spotlessCheck`, both Spark Scala variants (`spark-3.5_2.12`, `spark-4.0_2.13`), the `:spark:spark-3.5_2.12:test` suite (TPC-H/DS limit queries round-trip), and `examples:substrait-spark` all pass. Adds `FetchRoundtripTest`, `FetchTest.limitWithDynamicParameterCount`, and `TestTypeRoundtrip.intervalDayWithoutPrecisionIsRejected`.

Closes #1018

🤖 Generated with AI