### PR TITLE
fix(core): type outer references against the enclosing scope on proto import

### DIFF
--- a/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ProtoExpressionConverter.java
@@ -95,10 +95,15 @@ public class ProtoExpressionConverter {
           switch (outerReference.getOuterReferenceTypeCase()) {
             case STEPS_OUT:
               return FieldReference.newRootStructOuterReference(
-                  field, rootType, outerReference.getStepsOut());
+                  field,
+                  protoRelConverter.outerScopeForStepsOut(outerReference.getStepsOut(), rootType),
+                  outerReference.getStepsOut());
             case REL_REFERENCE:
               return FieldReference.newRootStructOuterReferenceByRelReference(
-                  field, rootType, outerReference.getRelReference());
+                  field,
+                  protoRelConverter.outerScopeForRelReference(
+                      outerReference.getRelReference(), rootType),
+                  outerReference.getRelReference());
             case OUTERREFERENCETYPE_NOT_SET:
             default:
               throw new IllegalArgumentException(
@@ -261,7 +266,8 @@ public class ProtoExpressionConverter {
             case SET_PREDICATE:
               {
                 io.substrait.relation.Rel rel =
-                    protoRelConverter.from(expr.getSubquery().getSetPredicate().getTuples());
+                    protoRelConverter.fromSubqueryRel(
+                        expr.getSubquery().getSetPredicate().getTuples(), rootType);
                 return Expression.SetPredicate.builder()
                     .tuples(rel)
                     .predicateOp(
@@ -272,7 +278,8 @@ public class ProtoExpressionConverter {
             case SCALAR:
               {
                 io.substrait.relation.Rel rel =
-                    protoRelConverter.from(expr.getSubquery().getScalar().getInput());
+                    protoRelConverter.fromSubqueryRel(
+                        expr.getSubquery().getScalar().getInput(), rootType);
                 return Expression.ScalarSubquery.builder()
                     .input(rel)
                     .type(
@@ -294,8 +301,11 @@ public class ProtoExpressionConverter {
               }
             case IN_PREDICATE:
               {
+                // The haystack is a subquery boundary; the needles are evaluated in the current
+                // (outer) scope and so are converted without pushing a new enclosing scope.
                 io.substrait.relation.Rel rel =
-                    protoRelConverter.from(expr.getSubquery().getInPredicate().getHaystack());
+                    protoRelConverter.fromSubqueryRel(
+                        expr.getSubquery().getInPredicate().getHaystack(), rootType);
                 List<Expression> needles =
                     expr.getSubquery().getInPredicate().getNeedlesList().stream()
                         .map(e -> this.from(e))

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -66,7 +66,9 @@ import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.proto.ProtoTypeConverter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -86,6 +88,20 @@ public class ProtoRelConverter {
 
   /** Converts advanced extension information from proto. */
   @NonNull protected final ProtoExtensionConverter protoExtensionConverter;
+
+  /**
+   * Enclosing correlation scopes encountered while converting nested relations, innermost last. A
+   * scope is pushed at each subquery boundary (see {@link #fromSubqueryRel}); an offset-based outer
+   * reference ({@code steps_out=N}) is typed against the entry {@code N} from the end.
+   */
+  private final List<Type.Struct> outerScopeStack = new ArrayList<>();
+
+  /**
+   * The correlation-scope schema exposed by each {@code rel_anchor} seen so far, keyed by anchor.
+   * An id-based outer reference ({@code rel_reference}) is typed against the matching entry. Rel
+   * anchors are plan-wide unique, so entries do not collide within a single plan.
+   */
+  private final Map<Integer, Type.Struct> anchorScopes = new HashMap<>();
 
   /**
    * Constructor with custom {@link ExtensionLookup}.
@@ -163,6 +179,17 @@ public class ProtoRelConverter {
    * @return the converted result
    */
   public Rel from(io.substrait.proto.Rel rel) {
+    Rel converted = dispatch(rel);
+    // Track the correlation scope each rel_anchor exposes so that id-based outer references
+    // (rel_reference) nested deeper in the plan are typed against the correct enclosing schema
+    // rather than the schema of the relation that lexically hosts them.
+    converted
+        .getRelAnchor()
+        .ifPresent(anchor -> anchorScopes.put(anchor, outerReferenceScope(converted)));
+    return converted;
+  }
+
+  private Rel dispatch(io.substrait.proto.Rel rel) {
     io.substrait.proto.Rel.RelTypeCase relType = rel.getRelTypeCase();
     switch (relType) {
       case READ:
@@ -214,6 +241,71 @@ public class ProtoRelConverter {
       default:
         throw new UnsupportedOperationException("Unsupported RelTypeCase of " + relType);
     }
+  }
+
+  /**
+   * Returns the schema an outer reference sees when it resolves to {@code rel} via {@code rel}'s
+   * {@link Rel#getRelAnchor() rel anchor}. This is {@code rel}'s own record type for every relation
+   * except a {@link LateralJoin}, whose right input references only the current left row and so
+   * sees the left input's schema rather than the joined output.
+   *
+   * @param rel the relation carrying the anchor
+   * @return the correlation-scope schema exposed by that anchor
+   */
+  private static Type.Struct outerReferenceScope(Rel rel) {
+    if (rel instanceof LateralJoin) {
+      return ((LateralJoin) rel).getLeft().getRecordType();
+    }
+    return rel.getRecordType();
+  }
+
+  /**
+   * Converts a subquery's input relation, tracking {@code outerScope} (the hosting relation's
+   * schema) as a new enclosing correlation scope for the duration of the conversion. This lets
+   * offset-based outer references ({@code steps_out}) nested inside the subquery resolve to the
+   * correct enclosing type.
+   *
+   * @param rel the subquery input relation to convert
+   * @param outerScope the schema of the relation hosting the subquery
+   * @return the converted relation
+   */
+  public Rel fromSubqueryRel(io.substrait.proto.Rel rel, Type.Struct outerScope) {
+    outerScopeStack.add(outerScope);
+    try {
+      return from(rel);
+    } finally {
+      outerScopeStack.remove(outerScopeStack.size() - 1);
+    }
+  }
+
+  /**
+   * Resolves the enclosing schema that an offset-based outer reference ({@code steps_out}) is typed
+   * against. Falls back to {@code fallback} when the reference does not resolve to a tracked
+   * enclosing scope, e.g. an expression converted standalone rather than within its relation tree.
+   *
+   * @param stepsOut the number of subquery boundaries the reference steps out
+   * @param fallback the schema to use when no enclosing scope is tracked
+   * @return the resolved enclosing schema, or {@code fallback}
+   */
+  public Type.Struct outerScopeForStepsOut(int stepsOut, Type.Struct fallback) {
+    int index = outerScopeStack.size() - stepsOut;
+    if (index < 0 || index >= outerScopeStack.size()) {
+      return fallback;
+    }
+    return outerScopeStack.get(index);
+  }
+
+  /**
+   * Resolves the enclosing schema that an id-based outer reference ({@code rel_reference}) is typed
+   * against. Falls back to {@code fallback} when the referenced anchor has not been seen, e.g. an
+   * expression converted standalone or a reference to an out-of-scope anchor.
+   *
+   * @param relReference the {@code rel_anchor} the reference resolves to
+   * @param fallback the schema to use when the anchor is unknown
+   * @return the resolved enclosing schema, or {@code fallback}
+   */
+  public Type.Struct outerScopeForRelReference(int relReference, Type.Struct fallback) {
+    return anchorScopes.getOrDefault(relReference, fallback);
   }
 
   /**
@@ -1072,6 +1164,10 @@ public class ProtoRelConverter {
    */
   protected Rel newLateralJoin(LateralJoinRel rel) {
     Rel left = from(rel.getLeft());
+    // The right input's outer references resolve to the current left row via this join's anchor, so
+    // register that scope before converting the right input (which is where those references live).
+    optionalRelAnchor(rel.getCommon())
+        .ifPresent(anchor -> anchorScopes.put(anchor, left.getRecordType()));
     Rel right = from(rel.getRight());
     Type.Struct leftStruct = left.getRecordType();
     Type.Struct rightStruct = right.getRecordType();

--- a/core/src/test/java/io/substrait/type/proto/NestedOuterReferenceRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/NestedOuterReferenceRoundtripTest.java
@@ -1,0 +1,189 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.expression.FieldReference;
+import io.substrait.relation.Join;
+import io.substrait.relation.LateralJoin;
+import io.substrait.relation.Rel;
+import io.substrait.relation.Rel.Remap;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trip tests for outer references that resolve to an enclosing scope reached through nested
+ * relation conversion: a lateral join's left row, or a correlated subquery's outer query. These
+ * exercise the schema threading that types an outer reference against the referenced enclosing
+ * relation rather than the relation that lexically hosts the reference.
+ *
+ * <p>The two standalone (non-nested) forms are covered by {@link OuterReferenceRoundtripTest};
+ * these cases only round-trip correctly once the enclosing schema is threaded through {@code
+ * ProtoRelConverter} / {@code ProtoExpressionConverter}.
+ */
+class NestedOuterReferenceRoundtripTest extends TestBase {
+
+  final Rel leftTable =
+      sb.namedScan(
+          Arrays.asList("T1"),
+          Arrays.asList("a", "b", "c"),
+          Arrays.asList(R.I64, R.FP64, R.STRING));
+
+  final Rel rightTable =
+      sb.namedScan(
+          Arrays.asList("T2"),
+          Arrays.asList("d", "e", "f"),
+          Arrays.asList(R.FP64, R.STRING, R.I64));
+
+  final Rel customer =
+      sb.namedScan(
+          Arrays.asList("customer"),
+          Arrays.asList("c_custkey", "c_nationkey"),
+          Arrays.asList(R.I64, R.I64));
+
+  final Rel orders =
+      sb.namedScan(
+          Arrays.asList("orders"),
+          Arrays.asList("o_orderkey", "o_custkey"),
+          Arrays.asList(R.I64, R.I64));
+
+  final Rel nation =
+      sb.namedScan(
+          Arrays.asList("nation"),
+          Arrays.asList("n_nationkey", "n_name"),
+          Arrays.asList(R.I64, R.STRING));
+
+  @Test
+  void idBasedOuterReferenceIntoLateralJoinLeftRow() {
+    // The right input references field 0 of the current left row via an id-based outer reference to
+    // the lateral join's anchor. On the way back from proto the reference must be typed against the
+    // LEFT schema (T1), not the right input's own schema (T2).
+    int anchor = 1;
+    FieldReference outerRef =
+        FieldReference.newRootStructOuterReferenceByRelReference(
+            0, leftTable.getRecordType(), anchor);
+
+    Rel right = sb.filter(input -> sb.equal(outerRef, sb.fieldReference(input, 2)), rightTable);
+
+    LateralJoin lateralJoin =
+        LateralJoin.builder()
+            .left(leftTable)
+            .right(right)
+            .joinType(Join.JoinType.INNER)
+            .relAnchor(anchor)
+            .build();
+
+    verifyRoundTrip(lateralJoin);
+  }
+
+  @Test
+  void offsetBasedOuterReferenceIntoEnclosingSubquery() {
+    // A correlated scalar subquery whose filter steps out one boundary to the enclosing orders
+    // scan; the reference must be typed against orders, not the customer scan hosting it.
+    FieldReference outerRef =
+        FieldReference.newRootStructOuterReference(1, orders.getRecordType(), 1);
+
+    Rel subquery =
+        sb.project(
+            input -> List.of(sb.fieldReference(input, 1)),
+            Remap.of(List.of(2)),
+            sb.filter(input -> sb.equal(sb.fieldReference(input, 0), outerRef), customer));
+
+    Rel plan =
+        sb.project(
+            input -> List.of(sb.fieldReference(input, 0), sb.scalarSubquery(subquery, R.I64)),
+            Remap.of(List.of(2, 3)),
+            orders);
+
+    verifyRoundTrip(plan);
+  }
+
+  @Test
+  void offsetBasedOuterReferenceStepsOutTwoLevels() {
+    // The innermost subquery steps out two boundaries, past the intervening nation scope, to the
+    // orders scan.
+    FieldReference outerRef =
+        FieldReference.newRootStructOuterReference(1, orders.getRecordType(), 2);
+
+    Rel innerSubquery =
+        sb.project(
+            input -> List.of(sb.fieldReference(input, 1)),
+            Remap.of(List.of(2)),
+            sb.filter(input -> sb.equal(sb.fieldReference(input, 0), outerRef), customer));
+
+    Rel outerSubquery =
+        sb.project(
+            input -> List.of(sb.fieldReference(input, 1)),
+            Remap.of(List.of(2)),
+            sb.filter(
+                input ->
+                    sb.equal(sb.fieldReference(input, 0), sb.scalarSubquery(innerSubquery, R.I64)),
+                nation));
+
+    Rel plan =
+        sb.project(
+            input ->
+                List.of(sb.fieldReference(input, 0), sb.scalarSubquery(outerSubquery, R.STRING)),
+            Remap.of(List.of(2, 3)),
+            orders);
+
+    verifyRoundTrip(plan);
+  }
+
+  @Test
+  void idBasedOuterReferenceIntoEnclosingSubquery() {
+    // The same correlation as the offset-based case, but the enclosing orders scan carries a
+    // rel_anchor and the reference resolves to it by id rather than by boundary count.
+    int anchor = 1;
+    Rel anchoredOrders = orders.withRelAnchor(anchor);
+
+    FieldReference outerRef =
+        FieldReference.newRootStructOuterReferenceByRelReference(
+            1, anchoredOrders.getRecordType(), anchor);
+
+    Rel subquery =
+        sb.project(
+            input -> List.of(sb.fieldReference(input, 1)),
+            Remap.of(List.of(2)),
+            sb.filter(input -> sb.equal(sb.fieldReference(input, 0), outerRef), customer));
+
+    Rel plan =
+        sb.project(
+            input -> List.of(sb.fieldReference(input, 0), sb.scalarSubquery(subquery, R.I64)),
+            Remap.of(List.of(2, 3)),
+            anchoredOrders);
+
+    verifyRoundTrip(plan);
+  }
+
+  @Test
+  void idBasedLateralReferenceFromSubqueryNestedInRight() {
+    // The lateral join's left row is referenced from inside a correlated subquery nested in the
+    // right input, exercising id-based resolution across a subquery boundary.
+    int anchor = 1;
+    FieldReference outerRef =
+        FieldReference.newRootStructOuterReferenceByRelReference(
+            0, leftTable.getRecordType(), anchor);
+
+    Rel subqueryInRight =
+        sb.project(
+            input -> List.of(sb.fieldReference(input, 1)),
+            Remap.of(List.of(2)),
+            sb.filter(input -> sb.equal(sb.fieldReference(input, 0), outerRef), customer));
+
+    Rel right =
+        sb.filter(
+            input ->
+                sb.equal(sb.fieldReference(input, 2), sb.scalarSubquery(subqueryInRight, R.I64)),
+            rightTable);
+
+    LateralJoin lateralJoin =
+        LateralJoin.builder()
+            .left(leftTable)
+            .right(right)
+            .joinType(Join.JoinType.INNER)
+            .relAnchor(anchor)
+            .build();
+
+    verifyRoundTrip(lateralJoin);
+  }
+}


### PR DESCRIPTION
## Problem

On proto → POJO conversion, `ProtoExpressionConverter` typed an outer `FieldReference` (the `OUTER_REFERENCE` case) against the **current** relation's own root type. When the reference resolves to an **enclosing** scope, that is the wrong schema:

- a lateral join's left row, referenced by id (`rel_reference` → the join's `rel_anchor`), or
- a correlated subquery's outer query, referenced by offset (`steps_out`).

Concretely, a `LateralJoin` with `left = T1(a i64, b fp64, c string)` and `right = Filter(T2, outerRef(left, field 0) == T2.f)` did **not** round-trip: the outer reference came back typed as the right input's schema `Struct{fp64, string, i64}` instead of the left's `Struct{i64, fp64, string}`. This is a pre-existing, general limitation that lateral joins simply make easy to hit.

## Fix

Thread the enclosing schema through nested relation/expression conversion (as suggested in the issue):

- `ProtoRelConverter` now tracks, per conversion:
  - each `rel_anchor`'s correlation scope (`rel_anchor → schema`), registering a lateral join's anchor to its **left-row** schema *before* the right input — where the references live — is converted;
  - the stack of enclosing subquery scopes, pushed around each subquery-input conversion.
- `ProtoExpressionConverter` resolves both outer-reference forms (`rel_reference`, `steps_out`) against that state, falling back to the hosting relation's root type when an expression is converted standalone (so existing behavior is preserved).

No wire-format or public-model changes; this only corrects the type reconstructed on import.

## Testing

- New `NestedOuterReferenceRoundtripTest`: the id-based lateral case from the issue, an id-based correlated subquery, one- and two-level `steps_out`, and a lateral reference reached from a subquery nested in the right input.
- `./gradlew :core:check :core:javadoc` pass; `:isthmus`, `:spark` (3.5/2.12 and 4.0/2.13) and `:examples:substrait-spark` compile; the full `:isthmus:test` suite passes.

Closes #1031

🤖 Generated with AI
