### PR TITLE
feat(core)!: bump substrait to v0.99.0

### DIFF
--- a/core/src/main/java/io/substrait/dialect/TypeKind.java
+++ b/core/src/main/java/io/substrait/dialect/TypeKind.java
@@ -44,6 +44,8 @@ public enum TypeKind {
   INTERVAL_YEAR,
   /** The UUID type. */
   UUID,
+  /** The unbound type: a placeholder for a type that has not yet been bound to a concrete type. */
+  UNBOUND,
   /** The fixed-point decimal type. */
   DECIMAL,
   /** The struct (record) type. */

--- a/core/src/main/java/io/substrait/type/NamedFieldCountingTypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/NamedFieldCountingTypeVisitor.java
@@ -127,6 +127,11 @@ public final class NamedFieldCountingTypeVisitor implements TypeVisitor<Integer,
   }
 
   @Override
+  public Integer visit(Type.Unbound type) {
+    return 0;
+  }
+
+  @Override
   public Integer visit(Type.FixedChar type) {
     return 0;
   }

--- a/core/src/main/java/io/substrait/type/StringTypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/StringTypeVisitor.java
@@ -84,6 +84,12 @@ public class StringTypeVisitor implements TypeVisitor<String, RuntimeException> 
   }
 
   @Override
+  public String visit(Type.Unbound type) throws RuntimeException {
+    // The unbound type carries no nullability, so there is no trailing "?".
+    return "unbound";
+  }
+
+  @Override
   public String visit(Type.FixedChar type) throws RuntimeException {
     return String.format("char<%d>%s", type.length(), n(type));
   }

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -319,6 +319,60 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     }
   }
 
+  /**
+   * The unbound type: a placeholder for a type that has not yet been bound to a concrete type.
+   *
+   * <p>An unbound type may appear wherever a concrete type would normally appear (for example as a
+   * field type within a read relation's schema), allowing a producer to serialize the shape of a
+   * plan — its relations and the names and ordering of its fields — before the concrete types of
+   * those fields are known. A plan that contains an unbound type anywhere within it is <i>partially
+   * bound</i>: it may be serialized and exchanged, but it must be bound to concrete types before
+   * execution.
+   *
+   * <p>Unlike every other {@link Type}, the unbound type carries no nullability and no parameters;
+   * those properties are determined only when it is bound to a concrete type. Consequently {@link
+   * #nullable()} throws and {@link #withNullable(boolean)} is a no-op. The unbound type is not a
+   * wildcard, is distinct from {@code any}, and has no literal form.
+   */
+  @Value.Immutable
+  abstract class Unbound implements Type {
+    /**
+     * Creates a builder for {@link Unbound}.
+     *
+     * @return a new builder
+     */
+    public static ImmutableType.Unbound.Builder builder() {
+      return ImmutableType.Unbound.builder();
+    }
+
+    /**
+     * The unbound type has no nullability, so this always throws.
+     *
+     * @return never returns
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public boolean nullable() {
+      throw new UnsupportedOperationException("The unbound type has no nullability");
+    }
+
+    /**
+     * Returns this unbound type unchanged; an unbound type has no nullability to change.
+     *
+     * @param nullable ignored
+     * @return this unbound type
+     */
+    @Override
+    public Type withNullable(boolean nullable) {
+      return this;
+    }
+
+    @Override
+    public <R, E extends Throwable> R accept(final TypeVisitor<R, E> typeVisitor) throws E {
+      return typeVisitor.visit(this);
+    }
+  }
+
   /** The fixed-length character type. */
   @Value.Immutable
   abstract class FixedChar implements Type {

--- a/core/src/main/java/io/substrait/type/TypeVisitor.java
+++ b/core/src/main/java/io/substrait/type/TypeVisitor.java
@@ -161,6 +161,15 @@ public interface TypeVisitor<R, E extends Throwable> {
   R visit(Type.UUID type) throws E;
 
   /**
+   * Visits an unbound type.
+   *
+   * @param type the type being visited
+   * @return the visit result
+   * @throws E if the visit fails
+   */
+  R visit(Type.Unbound type) throws E;
+
+  /**
    * Visits a fixed-length character type.
    *
    * @param type the type being visited
@@ -337,6 +346,11 @@ public interface TypeVisitor<R, E extends Throwable> {
 
     @Override
     public R visit(Type.UUID type) throws E {
+      throw t();
+    }
+
+    @Override
+    public R visit(Type.Unbound type) throws E {
       throw t();
     }
 

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoConverter.java
@@ -107,6 +107,13 @@ abstract class BaseProtoConverter<T, I>
   }
 
   @Override
+  public final T visit(final Type.Unbound expr) {
+    // The unbound type carries no nullability; pick either container (they are identical) rather
+    // than typeContainer(expr), whose nullability lookup would call Type.Unbound.nullable().
+    return typeContainer(false).UNBOUND;
+  }
+
+  @Override
   public final T visit(final Type.FixedChar expr) {
     return typeContainer(expr).fixedChar(expr.length());
   }

--- a/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
+++ b/core/src/main/java/io/substrait/type/proto/BaseProtoTypes.java
@@ -18,6 +18,7 @@ abstract class BaseProtoTypes<T, I> {
   public final T DATE;
   public final T INTERVAL_YEAR;
   public final T UUID;
+  public final T UNBOUND;
 
   public BaseProtoTypes(Type.Nullability nullability) {
     this.nullability = nullability;
@@ -33,6 +34,8 @@ abstract class BaseProtoTypes<T, I> {
     DATE = wrap(Type.Date.newBuilder().setNullability(nullability).build());
     INTERVAL_YEAR = wrap(Type.IntervalYear.newBuilder().setNullability(nullability).build());
     UUID = wrap(Type.UUID.newBuilder().setNullability(nullability).build());
+    // The unbound type carries no nullability, so this value is identical in every container.
+    UNBOUND = wrap(Type.Unbound.newBuilder().build());
   }
 
   public abstract T fixedChar(I len);

--- a/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/ProtoTypeConverter.java
@@ -66,6 +66,9 @@ public class ProtoTypeConverter {
             .intervalCompound(type.getIntervalCompound().getPrecision());
       case UUID:
         return n(type.getUuid().getNullability()).UUID;
+      case UNBOUND:
+        // The unbound type carries no nullability.
+        return Type.Unbound.builder().build();
       case FIXED_CHAR:
         return n(type.getFixedChar().getNullability()).fixedChar(type.getFixedChar().getLength());
       case VARCHAR:

--- a/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
+++ b/core/src/main/java/io/substrait/type/proto/TypeProtoConverter.java
@@ -268,6 +268,8 @@ public class TypeProtoConverter extends BaseProtoConverter<Type, Integer> {
         return bldr.setMap((Type.Map) o).build();
       } else if (o instanceof Type.UUID) {
         return bldr.setUuid((Type.UUID) o).build();
+      } else if (o instanceof Type.Unbound) {
+        return bldr.setUnbound((Type.Unbound) o).build();
       } else if (o instanceof Type.UserDefined) {
         return bldr.setUserDefined((Type.UserDefined) o).build();
       }

--- a/core/src/test/java/io/substrait/extension/DefaultExtensionCatalogTest.java
+++ b/core/src/test/java/io/substrait/extension/DefaultExtensionCatalogTest.java
@@ -39,10 +39,7 @@ class DefaultExtensionCatalogTest {
           "functions_geometry.yaml",
           // type_variations.yaml only defines type variations, which are not tracked by
           // ExtensionCollection (no functions or types), so containsUrn cannot verify it.
-          "type_variations.yaml",
-          // unknown.yaml uses an "unknown" type that is not a recognized type literal or
-          // parameterized type, causing Function.constructKey to fail at load time.
-          "unknown.yaml");
+          "type_variations.yaml");
 
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 

--- a/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
+++ b/core/src/test/java/io/substrait/type/proto/TestTypeRoundtrip.java
@@ -65,6 +65,17 @@ class TestTypeRoundtrip {
   }
 
   @Test
+  @DisplayName("unbound type round trip")
+  void roundtripUnbound() {
+    // The unbound type carries no nullability, so it is not part of the nullability-parameterized
+    // types() source above.
+    Type type = Type.Unbound.builder().build();
+    io.substrait.proto.Type converted = type.accept(typeProtoConverter);
+    Type actual = protoTypeConverter.from(converted);
+    assertEquals(type, actual);
+  }
+
+  @Test
   @DisplayName("interval day type with an unset precision is rejected")
   void intervalDayWithoutPrecisionIsRejected() {
     io.substrait.proto.Type protoType =

--- a/core/src/test/java/io/substrait/type/proto/UnboundTypeRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/UnboundTypeRoundtripTest.java
@@ -1,0 +1,40 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a partially bound plan — one whose schema carries the unbound type — survives a
+ * POJO &rarr; proto &rarr; POJO round trip at the relation level, exercising the unbound type in
+ * its intended position (a field type within a read relation's schema) rather than only as a bare
+ * {@link Type}.
+ */
+class UnboundTypeRoundtripTest extends TestBase {
+
+  @Test
+  @DisplayName("named scan whose schema mixes bound and unbound field types round trips")
+  void namedScanWithUnboundField() {
+    List<Type> fieldTypes = Arrays.asList(R.I64, Type.Unbound.builder().build());
+    Rel rel =
+        sb.namedScan(
+            Arrays.asList("partially_bound_table"),
+            Arrays.asList("bound_col", "unbound_col"),
+            fieldTypes);
+    verifyRoundTrip(rel);
+  }
+
+  @Test
+  @DisplayName("named scan whose schema is entirely unbound round trips")
+  void namedScanWithOnlyUnboundFields() {
+    List<Type> fieldTypes =
+        Arrays.asList(Type.Unbound.builder().build(), Type.Unbound.builder().build());
+    Rel rel =
+        sb.namedScan(Arrays.asList("unbound_table"), Arrays.asList("col_a", "col_b"), fieldTypes);
+    verifyRoundTrip(rel);
+  }
+}

--- a/examples/substrait-spark/src/main/java/io/substrait/examples/util/TypeStringify.java
+++ b/examples/substrait-spark/src/main/java/io/substrait/examples/util/TypeStringify.java
@@ -115,6 +115,11 @@ public class TypeStringify extends ParentStringify
   }
 
   @Override
+  public String visit(Type.Unbound type) throws RuntimeException {
+    return type.getClass().getSimpleName();
+  }
+
+  @Override
   public String visit(FixedChar type) throws RuntimeException {
     return type.getClass().getSimpleName();
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ spark-3-5 = "3.5.4"
 spark-4-0 = "4.0.2"
 spotless = "8.8.0"
 # substrait-packaging artifacts, versioned by the Substrait spec release they are generated from.
-substrait-packaging = "0.98.0"
+substrait-packaging = "0.99.0"
 testcontainers = "2.0.5"
 validator = "3.0.6"
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/IgnoreNullableAndParameters.java
@@ -189,6 +189,17 @@ public class IgnoreNullableAndParameters
   }
 
   /**
+   * Compares {@link Type.Unbound}.
+   *
+   * @param type unbound type
+   * @return {@code true} if {@code typeToMatch} is {@link Type.Unbound}
+   */
+  @Override
+  public Boolean visit(Type.Unbound type) {
+    return typeToMatch instanceof Type.Unbound;
+  }
+
+  /**
    * Compares {@link Type.UserDefined} for exact equality (URI and name).
    *
    * @param type user-defined type

--- a/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/IgnoreNullableAndParameters.scala
@@ -57,6 +57,8 @@ class IgnoreNullableAndParameters(val typeToMatch: ParameterizedType)
 
   override def visit(`type`: Type.UUID): Boolean = typeToMatch.isInstanceOf[Type.UUID]
 
+  override def visit(`type`: Type.Unbound): Boolean = typeToMatch.isInstanceOf[Type.Unbound]
+
   override def visit(`type`: Type.FixedChar): Boolean =
     typeToMatch.isInstanceOf[Type.FixedChar] || typeToMatch
       .isInstanceOf[ParameterizedType.FixedChar]


### PR DESCRIPTION
## Summary

Bumps the `substrait-packaging` artifacts to [v0.99.0](https://github.com/substrait-io/substrait/releases/tag/v0.99.0) and implements its one feature — the new built-in `unbound` type ([substrait-io/substrait#1081](https://github.com/substrait-io/substrait/pull/1081)).

`unbound` is a placeholder for a type that has not yet been bound to a concrete type. It lets a producer serialize the shape of a plan — its relations and the names and ordering of its fields — before the concrete field types are known; a downstream binder fills them in before execution. A plan that contains an `unbound` type anywhere within it is *partially bound*.

## Changes

- **`substrait-packaging`** bumped `0.98.0` → `0.99.0` in `gradle/libs.versions.toml`. This pulls in the regenerated proto (adds `Type.Unbound`), the repackaged extension YAMLs (the old `extensions/unknown.yaml` placeholder is dropped upstream), and the dialect schema with `UNBOUND`. The spec version reported by `io.substrait.SubstraitVersion.VERSION` follows from the same catalog bump.
- New **`Type.Unbound`** POJO, wired through `TypeVisitor` and both proto converters (`TypeProtoConverter` / `ProtoTypeConverter`), plus the remaining direct `TypeVisitor` implementors (`StringTypeVisitor`, `NamedFieldCountingTypeVisitor`, Isthmus/Spark `IgnoreNullableAndParameters`, examples `TypeStringify`).
- **`TypeKind.UNBOUND`** added to the dialect model for parity with the updated dialect schema.
- **Tests**: a bare `Type.Unbound` proto round-trip, and a `NamedScan` whose schema carries unbound field types (the partially-bound-plan use case).

## A note on nullability

Unlike every other Substrait type, `unbound`'s proto message is empty: it carries no nullability and no parameters (both are determined only when it is bound). So `Type.Unbound.nullable()` throws `UnsupportedOperationException` and `withNullable()` is a no-op, rather than falsely reporting the type as non-nullable. Isthmus and Spark reject unbound types — their type visitors inherit the throwing default — matching the spec guidance that consumers which do not support partially bound plans should reject them.

Closes #1038

BREAKING CHANGE: adds `Type.Unbound` and a new `TypeVisitor.visit(Type.Unbound)` method that direct `TypeVisitor` implementors must handle.

🤖 Generated with AI
