### PR TITLE
build!: source spec inputs from substrait-packaging artifacts, drop the submodule

### DIFF
--- a/.github/workflows/native-image-macos.yml
+++ b/.github/workflows/native-image-macos.yml
@@ -28,8 +28,6 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v7
-      with:
-        submodules: recursive
     - uses: actions/setup-java@v5
       with:
         java-version: 25
@@ -40,9 +38,6 @@ jobs:
       run: java -version
     - name: Build with Gradle
       run: |
-        # fetch submodule tags since actions/checkout@v7 does not
-        git submodule foreach 'git fetch --unshallow || true'
-
         # Full optimization (no --quick-build-native) so this mirrors the
         # release build and catches anything that would break shipping.
         ./gradlew nativeCompile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,8 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          submodules: recursive
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -69,18 +67,12 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Build with Gradle
-        run: |
-          # fetch submodule tags since actions/checkout@v7 does not
-          git submodule foreach 'git fetch --unshallow || true'
-
-          ./gradlew build --rerun-tasks
+        run: ./gradlew build --rerun-tasks
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-        with:
-          submodules: recursive
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
@@ -89,11 +81,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Build with Gradle
-        run: |
-          # fetch submodule tags since actions/checkout@v7 does not
-          git submodule foreach 'git fetch --unshallow || true'
-
-          ./gradlew integrationTest
+        run: ./gradlew integrationTest
   isthmus-native-image-linux:
     # Only the Linux native image is built per PR: it validates the GraalVM
     # configuration and runs the smoke tests, and its binary is throwaway (only
@@ -108,8 +96,6 @@ jobs:
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v7
-      with:
-        submodules: recursive
     - uses: actions/setup-java@v5
       with:
         java-version: 25
@@ -120,9 +106,6 @@ jobs:
       run: java -version
     - name: Build with Gradle
       run: |
-        # fetch submodule tags since actions/checkout@v7 does not
-        git submodule foreach 'git fetch --unshallow || true'
-
         # --quick-build-native (-Ob) trades binary runtime performance for a
         # much faster build; the PR binary is only smoke-tested, so this is free.
         ./gradlew nativeCompile --quick-build-native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v7
-        with:
-          submodules: recursive
       - uses: actions/setup-java@v5
         with:
           java-version: 25
@@ -31,11 +29,7 @@ jobs:
       - name: Report Java Version
         run: java -version
       - name: Build with Gradle
-        run: |
-          # fetch submodule tags since actions/checkout@v7 does not
-          git submodule foreach 'git fetch --unshallow || true'
-
-          ./gradlew nativeCompile
+        run: ./gradlew nativeCompile
       - name: Smoke Test
         run: |
           ./isthmus-cli/src/test/script/smoke.sh
@@ -64,7 +58,6 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           persist-credentials: false
-          submodules: recursive
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "spec"]
-	path = substrait
-	url = https://github.com/substrait-io/substrait.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,21 +23,26 @@ Spark).
 | `:isthmus-cli` | `isthmus-cli/` | CLI over `:isthmus`, compiled to a GraalVM **native image** (`nativeCompile`) — the `isthmus` binary + smoke tests. |
 | `build-logic` | `build-logic/` | Gradle **included build**: Kotlin-DSL convention plugins (`substrait.java-conventions` → shared Java config + PMD). Has its own `gradle.properties`; does not inherit the root's. |
 
-The `substrait/` directory is a **git submodule** of the upstream spec, and several
-`:core` build inputs are read from it — none are vendored in this repo, so don't look
-for them under `core/src`:
+The spec inputs `:core` needs are **not** generated or vendored in this repo — they come
+from the `substrait-packaging` Maven artifacts (`io.substrait:{protobuf,antlr,extensions}`),
+pinned via the `substrait-packaging` version in `gradle/libs.versions.toml`. Don't look for
+these under `core/src`:
 
-- **Proto**: `substrait/proto/substrait/*.proto` → generated Java in package `io.substrait.proto`.
-- **ANTLR grammars**: `substrait/grammar/*.g4` (notably `SubstraitType.g4`, the type /
-  function-signature grammar) → parser generated under `io.substrait.type`.
-- **Standard extension YAMLs**: `substrait/extensions/*.yaml` (e.g. `functions_arithmetic.yaml`)
-  → packaged into `:core` resources at `substrait/extensions/`.
-- **Validation schemas**: `substrait/text/simple_extensions_schema.yaml` and
-  `dialect_schema.yaml` → validate extensions/dialects (mainly in tests).
+- **Proto**: compiled `io.substrait.proto.*` bindings ship in the `protobuf` artifact
+  (`api(libs.substrait.protobuf)` in `core/build.gradle.kts`).
+- **ANTLR parsers**: the generated `io.substrait.antlr` parser ships in the `antlr`
+  artifact (shadowed so its ANTLR runtime is relocated).
+- **Standard extension YAMLs**, **function test cases**, **validation schemas**
+  (`simple_extensions_schema.yaml`, `dialect_schema.yaml`), and the **per-section dialect
+  fixtures**: all ship in the `extensions` artifact as classpath resources under
+  `substrait/` (e.g. `/substrait/extensions/functions_arithmetic.yaml`,
+  `/substrait/text/dialect_schema.yaml`, `/substrait/dialects/tests/*_test.yaml`).
 
-`:core:submodulesUpdate` (submodule init/update) therefore gates proto and grammar
-generation. These files are owned by the upstream spec — to change them, update
-`substrait` upstream and bump the submodule pin, don't edit them in-tree.
+These resources are owned by the upstream spec — to change them, update the spec and cut a
+new `substrait-packaging` release, then bump the `substrait-packaging` version in the
+catalog. The spec version reported by `io.substrait.SubstraitVersion.VERSION` is derived
+from that same catalog version (with any `-SNAPSHOT` suffix stripped) in
+`core/build.gradle.kts`, so it stays in lockstep with the artifacts.
 
 ## Core architecture (the pattern most changes follow)
 
@@ -147,10 +152,6 @@ Proto conversion is split into two directions, and the class name tells you whic
 - `javadoc` runs doclint that **fails the build**, but only via `build`/`javadocJar` —
   not via `compileJava` / `test` / `spotlessCheck`. So Javadoc errors surface only on
   the PR; run `./gradlew :core:javadoc` before pushing.
-- The `substrait` proto submodule needs its **tags** fetched: the generated
-  `SubstraitVersion` derives from `git describe --tags` on the submodule, so a
-  shallow/tagless checkout yields a malformed version that throws at *runtime* (not
-  build time). CI fetches them explicitly because `actions/checkout` doesn't.
 
 When you add to the public expression/visitor API, verify the dependent modules still
 compile — they have their own visitor implementors:

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,16 +1,12 @@
-import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import org.gradle.plugins.ide.idea.model.IdeaModel
-import org.slf4j.LoggerFactory
 
 plugins {
   `maven-publish`
   signing
   id("java-library")
   id("idea")
-  id("antlr")
   id("eclipse")
-  alias(libs.plugins.protobuf)
   alias(libs.plugins.spotless)
   alias(libs.plugins.shadow)
   alias(libs.plugins.nmcp)
@@ -98,70 +94,33 @@ dependencies {
   implementation(platform(libs.jackson.bom))
   implementation(libs.bundles.jackson)
 
-  api(libs.protobuf.java)
+  // Compiled protobuf bindings (io.substrait.proto) from the substrait-packaging artifact,
+  // which transitively brings protobuf-java.
+  api(libs.substrait.protobuf)
   api(libs.jspecify)
 
-  antlr(libs.antlr4)
-  shadowImplementation(libs.antlr4.runtime)
+  // Compiled ANTLR parsers (io.substrait.antlr) from the substrait-packaging artifact.
+  // It is shadowed so the ANTLR runtime it pulls in is relocated (see shadowJar below) and
+  // does not leak onto consumers' classpaths. Exclude the ANTLR tool (antlr4): only the
+  // runtime is needed to run the generated parsers.
+  shadowImplementation(libs.substrait.antlr) { exclude(group = "org.antlr", module = "antlr4") }
+  // Extension YAMLs, text schemas and function test cases (under substrait/ on the classpath).
+  implementation(libs.substrait.extensions)
   implementation(libs.slf4j.api)
   annotationProcessor(libs.immutables.value)
   compileOnly(libs.immutables.annotations)
 }
 
-configurations[JavaPlugin.API_CONFIGURATION_NAME].let { apiConfiguration ->
-  // Workaround for https://github.com/gradle/gradle/issues/820
-  apiConfiguration.setExtendsFrom(apiConfiguration.extendsFrom.filter { it.name != "antlr" })
-}
-
-abstract class SubstraitSpecVersionValueSource :
-  ValueSource<String, SubstraitSpecVersionValueSource.Parameters> {
-  companion object {
-    val logger = LoggerFactory.getLogger("SubstraitSpecVersionValueSource")
-  }
-
-  interface Parameters : ValueSourceParameters {
-    val substraitDirectory: Property<File>
-  }
-
-  @get:Inject abstract val execOperations: ExecOperations
-
-  override fun obtain(): String {
-    val stdOutput = ByteArrayOutputStream()
-    val errOutput = ByteArrayOutputStream()
-    execOperations.exec {
-      commandLine("git", "describe", "--tags")
-      standardOutput = stdOutput
-      errorOutput = errOutput
-      setIgnoreExitValue(true)
-      workingDir = parameters.substraitDirectory.get()
-    }
-
-    // capturing the error output and logging it to avoid issues with VS Code Spotless plugin
-    val error = String(errOutput.toByteArray())
-    if (error != "") {
-      logger.warn(error)
-    }
-
-    var cmdOut = String(stdOutput.toByteArray()).trim()
-
-    if (cmdOut == "") {
-      cmdOut = "0.0.0"
-    } else if (cmdOut.startsWith("v")) {
-      return cmdOut.substring(1)
-    }
-
-    return cmdOut
-  }
-}
+// The Substrait spec version is the version of the substrait-packaging artifacts consumed
+// (see the version catalog), with any -SNAPSHOT suffix stripped. This is the spec release the
+// generated proto/ANTLR/extension resources come from, so it is the single source of truth for
+// SubstraitVersion and the manifest's Specification-Version.
+val substraitSpecVersion = libs.versions.substrait.packaging.get().removeSuffix("-SNAPSHOT")
 
 tasks.register("writeManifest") {
   val version = project.version
+  val specVersion = substraitSpecVersion
   doLast {
-    val substraitSpecVersionProvider =
-      providers.of(SubstraitSpecVersionValueSource::class) {
-        parameters.substraitDirectory.set(project(":").file("substrait"))
-      }
-
     val manifestFile =
       layout.buildDirectory
         .file("generated/sources/manifest/META-INF/MANIFEST.MF")
@@ -174,7 +133,7 @@ tasks.register("writeManifest") {
       it.println("Implementation-Title: substrait-java")
       it.println("Implementation-Version: " + version)
       it.println("Specification-Title: substrait")
-      it.println("Specification-Version: " + substraitSpecVersionProvider.get())
+      it.println("Specification-Version: " + specVersion)
     }
 
     val substraitVersionClass =
@@ -187,9 +146,7 @@ tasks.register("writeManifest") {
     substraitVersionClass.printWriter(StandardCharsets.UTF_8).use {
       it.println("package io.substrait;\n")
       it.println("public class SubstraitVersion {")
-      it.println(
-        "  public static final String VERSION = \"" + substraitSpecVersionProvider.get() + "\";"
-      )
+      it.println("  public static final String VERSION = \"" + specVersion + "\";")
       it.println("}")
     }
   }
@@ -223,116 +180,27 @@ java {
 
 configurations { runtimeClasspath { resolutionStrategy.activateDependencyLocking() } }
 
-tasks.named<Jar>("sourcesJar") {
-  mustRunAfter("generateGrammarSource")
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}
+tasks.named<Jar>("sourcesJar") { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
 
 sourceSets {
   main {
-    antlr { setSrcDirs(listOf(file("${rootProject.projectDir}/substrait/grammar"))) }
-    proto.srcDir("../substrait/proto")
-    // Extension YAMLs are relocated into substrait/extensions/ on the classpath
-    // via processResources below, rather than landing at the classpath root.
     resources.srcDir("build/generated/sources/manifest/")
-    java.srcDir(file("build/generated/sources/antlr/main/java/"))
     java.srcDir("build/generated/sources/version/")
   }
 }
 
-tasks.named<ProcessResources>("processResources") {
-  from("../substrait/extensions") { into("substrait/extensions") }
-}
-
 tasks.named<ProcessResources>("processTestResources") {
-  // Dialect schema, used to validate dialects produced by the Dialect model in tests.
-  from("../substrait/text") { into("substrait/text") }
-  // A real-world dialect to exercise parsing against.
+  // A real-world dialect to exercise parsing against. The dialect schema, the per-section
+  // dialect fixtures and the extension YAMLs are on the test classpath from the
+  // substrait-packaging extensions artifact under substrait/.
   from("../spark/spark_dialect.yaml") { into("dialect") }
-  // Per-section dialect fixtures published by the substrait spec.
-  from("../substrait/dialects/tests") { into("dialect/tests") }
 }
 
 project.configure<IdeaModel> {
-  module {
-    resourceDirs.addAll(
-      listOf(file("../substrait/text"), file("../substrait/extensions"), file("../substrait/proto"))
-    )
-    generatedSourceDirs.addAll(
-      listOf(
-        file("build/generated/sources/antlr/main"),
-        file("build/generated/sources/proto/main/java"),
-      )
-    )
-  }
+  module { generatedSourceDirs.addAll(listOf(file("build/generated/sources/version"))) }
 }
-
-val submodulesUpdate =
-  tasks.register<Exec>("submodulesUpdate") {
-    group = "Build Setup"
-    description = "Updates (and inits) substrait git submodule"
-    commandLine = listOf("git", "submodule", "update", "--init", "--recursive")
-    workingDir = rootProject.projectDir
-  }
-
-tasks.named<AntlrTask>("generateGrammarSource") {
-  dependsOn(submodulesUpdate)
-  arguments.add("-package")
-  arguments.add("io.substrait.type")
-  arguments.add("-visitor")
-  arguments.add("-long-messages")
-  arguments.add("-Xlog")
-  arguments.add("-Werror")
-  arguments.add("-Xexact-output-dir")
-  exclude("FuncTestCaseLexer.g4", "FuncTestCaseParser.g4")
-  outputDirectory =
-    layout.buildDirectory.dir("generated/sources/antlr/main/java/io/substrait/type").get().asFile
-}
-
-protobuf {
-  generateProtoTasks { all().configureEach { dependsOn(submodulesUpdate) } }
-  protoc { artifact = "com.google.protobuf:protoc:" + libs.protoc.get().getVersion() }
-}
-
-val protoJavaDir = layout.buildDirectory.dir("generated/sources/proto/main/java")
 
 val immuteableJavaDir = layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main")
-
-// First pass: Javadoc for generated protobufs — ignore warnings.
-tasks.register<Javadoc>("javadocProto") {
-  dependsOn("generateProto", "compileJava")
-
-  group = JavaBasePlugin.DOCUMENTATION_GROUP
-  description = "Generate Javadoc for protobuf-generated sources (warnings suppressed)."
-
-  // Only the generated proto sources
-  setSource(fileTree(protoJavaDir) { include("**/*.java") })
-
-  // Use the main source set classpath to resolve types referenced by the generated code
-  classpath = sourceSets["main"].compileClasspath
-
-  // Destination separate from main Javadoc
-  setDestinationDir(
-    rootProject.layout.buildDirectory.dir("docs/${version}/core-proto").get().asFile
-  )
-
-  // Make sure protobufs are generated before Javadoc runs
-  dependsOn("generateProto")
-
-  // Suppress warnings/doclint for protobuf pass
-  options {
-    require(this is StandardJavadocDocletOptions)
-    // Generated proto bindings are missing javadoc
-    addBooleanOption("Xdoclint:all,-missing", true)
-    addBooleanOption("Xwerror", true)
-    // Encoding is good practice
-    encoding = "UTF-8"
-    addStringOption(
-      "overview",
-      "${rootProject.projectDir}/core/src/main/javadoc/overview-proto.html",
-    )
-  }
-}
 
 tasks.register<Javadoc>("javadocImmutable") {
   dependsOn("compileJava", "javadoc")
@@ -340,7 +208,7 @@ tasks.register<Javadoc>("javadocImmutable") {
   group = JavaBasePlugin.DOCUMENTATION_GROUP
   description = "Generate Javadoc for immutable-generated sources (warnings suppressed)."
 
-  // Only the generated proto sources
+  // Only the Immutables-generated sources
   setSource(fileTree(immuteableJavaDir) { include("**/*.java") })
 
   // Use the main source set classpath + compiled output to resolve types referenced by the
@@ -351,7 +219,7 @@ tasks.register<Javadoc>("javadocImmutable") {
   // Destination separate from main Javadoc
   setDestinationDir(rootProject.layout.buildDirectory.dir("docs/${version}/immutable").get().asFile)
 
-  // Suppress warnings/doclint for protobuf pass
+  // Suppress warnings/doclint for the immutable pass
   options {
     require(this is StandardJavadocDocletOptions)
     addBooleanOption("Xdoclint:all", true)
@@ -363,24 +231,18 @@ tasks.register<Javadoc>("javadocImmutable") {
       "${rootProject.projectDir}/core/src/main/javadoc/overview-immutable.html",
     )
     links("../core/")
-    links("../core-proto/")
   }
 }
 
-// Second pass: Javadoc for main code, excluding the generated protobuf sources.
+// Javadoc for main code. Only the version-generated directory needs excluding from the
+// hand-written pass; proto and ANTLR classes come compiled from the substrait-packaging artifacts.
 tasks.named<Javadoc>("javadoc") {
-  dependsOn("javadocProto")
-  description = "Generate Javadoc for main sources (excludes protobuf-generated sources)."
+  description = "Generate Javadoc for main sources."
 
-  // Exclude the protobuf-, ANTLR- and version-generated directories from the main pass.
-  // These sources are regenerated on every build and cannot carry hand-written Javadoc.
+  // Exclude the version-generated directory from the main pass. These sources are regenerated
+  // on every build and cannot carry hand-written Javadoc.
   val generatedDirs =
-    listOf(
-        protoJavaDir,
-        layout.buildDirectory.dir("generated/sources/antlr/main/java"),
-        layout.buildDirectory.dir("generated/sources/version"),
-      )
-      .map { it.get().asFile.toPath() }
+    listOf(layout.buildDirectory.dir("generated/sources/version")).map { it.get().asFile.toPath() }
   exclude { spec -> generatedDirs.any { spec.file.toPath().startsWith(it) } }
   source(fileTree(immuteableJavaDir) { include("**/*.java") })
 
@@ -392,7 +254,6 @@ tasks.named<Javadoc>("javadoc") {
     encoding = "UTF-8"
     setDestinationDir(rootProject.layout.buildDirectory.dir("docs/${version}/core").get().asFile)
     addStringOption("overview", "${rootProject.projectDir}/core/src/main/javadoc/overview.html")
-    links("../core-proto/")
   }
 }
 
@@ -404,7 +265,6 @@ tasks.named<Jar>("javadocJar") {
 
   // Add the outputs of the Javadoc tasks to this JAR
   // Using 'from' on a task automatically adds the 'dependsOn'
-  from(tasks.named("javadocProto"))
   from(tasks.named("javadoc"))
   from(tasks.named("javadocImmutable"))
 

--- a/core/src/main/java/io/substrait/type/Deserializers.java
+++ b/core/src/main/java/io/substrait/type/Deserializers.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.substrait.antlr.SubstraitTypeParser;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;

--- a/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
+++ b/core/src/main/java/io/substrait/type/parser/ParseToPojo.java
@@ -1,5 +1,7 @@
 package io.substrait.type.parser;
 
+import io.substrait.antlr.SubstraitTypeParser;
+import io.substrait.antlr.SubstraitTypeVisitor;
 import io.substrait.function.ImmutableParameterizedType;
 import io.substrait.function.ImmutableTypeExpression;
 import io.substrait.function.ParameterizedType;
@@ -7,8 +9,6 @@ import io.substrait.function.ParameterizedTypeCreator;
 import io.substrait.function.TypeExpression;
 import io.substrait.function.TypeExpressionCreator;
 import io.substrait.type.ImmutableType;
-import io.substrait.type.SubstraitTypeParser;
-import io.substrait.type.SubstraitTypeVisitor;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.ArrayList;

--- a/core/src/main/java/io/substrait/type/parser/ThrowVisitor.java
+++ b/core/src/main/java/io/substrait/type/parser/ThrowVisitor.java
@@ -1,6 +1,6 @@
 package io.substrait.type.parser;
 
-import io.substrait.type.SubstraitTypeBaseVisitor;
+import io.substrait.antlr.SubstraitTypeBaseVisitor;
 import org.antlr.v4.runtime.tree.RuleNode;
 
 class ThrowVisitor<T> extends SubstraitTypeBaseVisitor<T> {

--- a/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
+++ b/core/src/main/java/io/substrait/type/parser/TypeStringParser.java
@@ -1,9 +1,9 @@
 package io.substrait.type.parser;
 
+import io.substrait.antlr.SubstraitTypeLexer;
+import io.substrait.antlr.SubstraitTypeParser;
 import io.substrait.function.ParameterizedType;
 import io.substrait.function.TypeExpression;
-import io.substrait.type.SubstraitTypeLexer;
-import io.substrait.type.SubstraitTypeParser;
 import io.substrait.type.Type;
 import java.util.function.BiFunction;
 import org.antlr.v4.runtime.BaseErrorListener;
@@ -55,7 +55,7 @@ public class TypeStringParser {
     lexer.removeErrorListeners();
     lexer.addErrorListener(TypeErrorListener.INSTANCE);
     CommonTokenStream tokenStream = new CommonTokenStream(lexer);
-    SubstraitTypeParser parser = new io.substrait.type.SubstraitTypeParser(tokenStream);
+    SubstraitTypeParser parser = new io.substrait.antlr.SubstraitTypeParser(tokenStream);
     parser.removeErrorListeners();
     parser.addErrorListener(TypeErrorListener.INSTANCE);
     return parser.startRule();

--- a/core/src/test/java/io/substrait/dialect/SpecDialectFixturesTest.java
+++ b/core/src/test/java/io/substrait/dialect/SpecDialectFixturesTest.java
@@ -13,9 +13,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Exercises the per-section dialect fixtures published by the substrait spec (copied onto the test
- * classpath by the build). For each fixture we confirm it is schema-valid, parses, and survives a
- * lossless serialize/parse round-trip whose output is itself schema-valid.
+ * Exercises the per-section dialect fixtures published by the substrait spec (on the test classpath
+ * via the substrait-packaging extensions artifact). For each fixture we confirm it is schema-valid,
+ * parses, and survives a lossless serialize/parse round-trip whose output is itself schema-valid.
  */
 class SpecDialectFixturesTest {
 
@@ -40,7 +40,7 @@ class SpecDialectFixturesTest {
         "execution_behavior_test.yaml"
       })
   void roundTrips(String fixture) {
-    String resourcePath = "/dialect/tests/" + fixture;
+    String resourcePath = "/substrait/dialects/tests/" + fixture;
     String original = readResource(resourcePath);
 
     // The published fixture is itself schema-valid.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,8 @@ spark-3-4 = "3.4.4"
 spark-3-5 = "3.5.4"
 spark-4-0 = "4.0.2"
 spotless = "8.8.0"
+# substrait-packaging artifacts, versioned by the Substrait spec release they are generated from.
+substrait-packaging = "0.98.0"
 testcontainers = "2.0.5"
 validator = "3.0.6"
 
@@ -83,6 +85,9 @@ spark-catalyst-4-0-2-13 = { module = "org.apache.spark:spark-catalyst_2.13", ver
 spark-core-4-0-2-13 = { module = "org.apache.spark:spark-core_2.13", version.ref = "spark-4-0" }
 spark-hive-4-0-2-13 = { module = "org.apache.spark:spark-hive_2.13", version.ref = "spark-4-0" }
 spark-sql-4-0-2-13 = { module = "org.apache.spark:spark-sql_2.13", version.ref = "spark-4-0" }
+substrait-antlr = { module = "io.substrait:antlr", version.ref = "substrait-packaging" }
+substrait-extensions = { module = "io.substrait:extensions", version.ref = "substrait-packaging" }
+substrait-protobuf = { module = "io.substrait:protobuf", version.ref = "substrait-packaging" }
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-junit5 = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
 testcontainers-postgres = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -169,7 +169,7 @@ sourceSets { test { proto.srcDirs("src/test/resources/extensions") } }
 protobuf { protoc { artifact = "com.google.protobuf:protoc:" + libs.protoc.get().getVersion() } }
 
 tasks.named<Javadoc>("javadoc") {
-  dependsOn(":core:javadoc", ":core:javadocProto")
+  dependsOn(":core:javadoc")
   description = "Generate Javadoc for main sources."
 
   // Keep normal behavior for main javadoc (warnings allowed to show/fail if you want)
@@ -180,7 +180,6 @@ tasks.named<Javadoc>("javadoc") {
     addStringOption("overview", "${rootProject.projectDir}/isthmus/src/main/javadoc/overview.html")
     addBooleanOption("Xdoclint:all", true)
     addBooleanOption("Xwerror", true)
-    links("../core-proto/")
     links("../core/")
     links("https://calcite.apache.org/javadocAggregate/")
   }

--- a/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.networknt.schema.{InputFormat, SchemaRegistry, SpecificationVersion}
 import io.substrait.extension.SimpleExtension
 
-import java.io.{File, FileInputStream, FileWriter, OutputStreamWriter}
+import java.io.{File, FileWriter, InputStream, OutputStreamWriter}
 
 import scala.jdk.CollectionConverters._
 
@@ -40,7 +40,16 @@ case class SupportedFunction(
     supported_impls: Seq[String])
 
 class DialectGenerator {
-  val schemaPath = "../../substrait/text/dialect_schema.yaml"
+  // The dialect schema ships on the classpath in the substrait-packaging extensions artifact.
+  val schemaResource = "/substrait/text/dialect_schema.yaml"
+
+  def schemaStream(): InputStream = {
+    val stream = getClass.getResourceAsStream(schemaResource)
+    if (stream == null) {
+      throw new IllegalStateException(s"Dialect schema not found on classpath: $schemaResource")
+    }
+    stream
+  }
 
   private val sourceURNs = Map(
     "extension:io.substrait:functions_aggregate_approx" -> "aggregate_approx",
@@ -95,7 +104,7 @@ class DialectGenerator {
     val jsonSchemaFactory = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12)
 
     val schema =
-      jsonSchemaFactory.getSchema(new FileInputStream(new File(schemaPath)), InputFormat.YAML)
+      jsonSchemaFactory.getSchema(schemaStream(), InputFormat.YAML)
     val errors = schema.validate(yaml, InputFormat.YAML)
     if (!errors.isEmpty) {
       throw new Exception(errors.toString)

--- a/spark/src/test/scala/io/substrait/spark/DialectSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/DialectSuite.scala
@@ -1,7 +1,6 @@
 package io.substrait.spark
 
 import io.substrait.spark.utils.{Dialect, DialectGenerator}
-import io.substrait.spark.utils.DialectGenerator.schemaPath
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
@@ -11,7 +10,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.networknt.schema.{InputFormat, SchemaRegistry, SpecificationVersion}
 
-import java.io.{File, FileInputStream}
+import java.io.File
 
 import scala.io.Source
 
@@ -27,7 +26,7 @@ class DialectSuite extends SparkFunSuite with SharedSparkSession with SubstraitP
     val jsonSchemaFactory = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12)
 
     val schema =
-      jsonSchemaFactory.getSchema(new FileInputStream(new File(schemaPath)), InputFormat.YAML)
+      jsonSchemaFactory.getSchema(DialectGenerator.schemaStream(), InputFormat.YAML)
     val dialect = Source.fromFile(dialectPath).mkString
     val errors = schema.validate(dialect, InputFormat.YAML)
     assertResult(java.util.List.of())(errors)


### PR DESCRIPTION
## What

Migrates `substrait-java` to consume the generated protobuf bindings, ANTLR parsers, extension YAMLs and per-section dialect fixtures from the [`substrait-packaging`](https://github.com/substrait-io/substrait-packaging) Maven artifacts, instead of generating/bundling them in-tree, and **removes the `substrait` git submodule** entirely.

The three artifacts (group `io.substrait`) are:
- `protobuf` — compiled protobuf bindings (`io.substrait.proto`), brings `protobuf-java` transitively
- `antlr` — compiled ANTLR parsers (`io.substrait.antlr`)
- `extensions` — extension YAMLs, text schemas, function test cases and per-section dialect fixtures (under `substrait/` on the classpath)

They are versioned by the Substrait spec release they are generated from, pinned via the `substrait-packaging` version in the catalog (`0.98.0`).

## Notes for reviewers

A few things that aren't obvious from the diff:

- **Spec version:** now derived from the `substrait-packaging` catalog version (with any `-SNAPSHOT` stripped) instead of `git describe --tags` on the submodule. That catalog entry is the single source of truth for both the artifacts and the spec version reported by `SubstraitVersion` / the manifest's `Specification-Version`.
- **ANTLR import rename:** the packaging artifact generates the type parsers into `io.substrait.antlr.*`, so the hand-written parser imports move from `io.substrait.type.*` to match.
- **Dialect fixtures:** the `extensions` artifact ships the per-section fixtures under `substrait/dialects/tests/` as of substrait-io/substrait-packaging#49, so tests read them from the classpath and nothing touches the submodule working tree anymore.
- `:core:shadowJar` still relocates the ANTLR runtime that now arrives transitively (`org.antlr:antlr4` tool excluded — only the runtime is needed).

## Validation

Full reactor build passes with tests, PMD and Javadoc — `:core`, `:isthmus`, all three Spark variants and the examples. Verified with the `substrait/` directory physically removed and dependency caches purged, so the build provably resolves everything (including the dialect fixtures) from the published `0.98.0` artifacts on Maven Central.

Not covered: `:isthmus-cli:nativeCompile` (needs a GraalVM daemon; not built on macOS PRs).

## Breaking change footer

Include this footer in the squash-merge commit message:

```
BREAKING CHANGE: the substrait git submodule is gone. Checkouts no longer need
`--recurse-submodules`; the spec inputs come entirely from the substrait-packaging
artifacts pinned in the version catalog.
```

🤖 Generated with AI
