### PR TITLE
build(isthmus)!: stop publishing the isthmus fat jar

### DIFF
--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
   id("java-library")
   id("idea")
   id("eclipse")
-  alias(libs.plugins.shadow)
   alias(libs.plugins.spotless)
   alias(libs.plugins.protobuf)
   alias(libs.plugins.nmcp)
@@ -127,11 +126,6 @@ dependencies {
 }
 
 tasks {
-  shadowJar {
-    archiveBaseName.set("isthmus")
-    manifest { attributes(mapOf("Main-Class" to "io.substrait.isthmus.PlanEntryPoint")) }
-  }
-
   classes { dependsOn(":core:shadowJar") }
 
   jar {
@@ -140,8 +134,6 @@ tasks {
       attributes("Implementation-Title" to "isthmus")
     }
   }
-
-  build { dependsOn(shadowJar) }
 
   // Only set the compile release since JUnit 6 requires Java 17 to run tests.
   compileJava { options.release = 11 }


### PR DESCRIPTION
The `:isthmus` module applies the shadow plugin only to build an uber jar (`isthmus-<version>-all.jar`), whose manifest still declares the long-removed `io.substrait.isthmus.PlanEntryPoint` as its `Main-Class`. The CLI was extracted into the `:isthmus-cli` module (built as a GraalVM native image) years ago, so:

- nothing in the repo consumes this jar, and
- `:isthmus` shades/relocates nothing of its own — the ANTLR-runtime relocation that prevents version clashes with consumers lives in `:core` (`relocate("org.antlr.v4.runtime", …)`) and is untouched here.

The GradleUp shadow plugin injects a `shadowRuntimeElements` variant into the `java` component by default (`addShadowVariantIntoJavaComponent`), so `from(components["java"])` has been publishing this fat jar to Maven Central as an `all`-classified artifact on every release. Confirmed via the publication's Gradle module metadata:

```
before                                   after
apiElements       -> isthmus.jar         apiElements       -> isthmus.jar
runtimeElements   -> isthmus.jar         runtimeElements   -> isthmus.jar
shadowRuntimeElements -> isthmus-all.jar  (removed)
javadocElements   -> isthmus-javadoc.jar javadocElements   -> isthmus-javadoc.jar
sourcesElements   -> isthmus-sources.jar sourcesElements   -> isthmus-sources.jar
```

## Change

Remove the shadow plugin (and its `shadowJar`/`build` wiring) from `:isthmus`. The `classes { dependsOn(":core:shadowJar") }` line is retained — compiling isthmus needs core's relocated jar.

## Impact

Standard consumers (`implementation("io.substrait:isthmus:<version>")`) resolve `runtimeElements` (the plain jar) and are unaffected. Only a consumer that explicitly requested the `all` classifier / shadowed variant is affected — see the breaking-change note below.

BREAKING CHANGE: the isthmus fat jar (`isthmus-<version>-all.jar` — the `all` classifier / `shadowRuntimeElements` variant) is no longer published to Maven Central. Consumers that referenced it explicitly should depend on the regular `isthmus` artifact and its transitive dependencies instead.

🤖 Generated with AI