### PR TITLE
fix(isthmus): route native-image metadata queries through reflective provider

### DIFF
--- a/isthmus-cli/src/main/resources/META-INF/native-image/io.substrait/isthmus-cli/reachability-metadata.json
+++ b/isthmus-cli/src/main/resources/META-INF/native-image/io.substrait/isthmus-cli/reachability-metadata.json
@@ -16,7 +16,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$AllPredicates"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$Collation$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Collation"
         ]
       }
     },
@@ -30,7 +44,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnOrigin"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnUniqueness$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$ColumnUniqueness"
         ]
       }
     },
@@ -44,7 +72,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$CumulativeCost"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$DistinctRowCount$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$DistinctRowCount"
         ]
       }
     },
@@ -58,7 +100,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Distribution"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$ExplainVisibility$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$ExplainVisibility"
         ]
       }
     },
@@ -72,7 +128,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$ExpressionLineage"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$FunctionalDependency$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$FunctionalDependency"
         ]
       }
     },
@@ -86,7 +156,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$InputFieldsUsed"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$LowerBoundCost$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$LowerBoundCost"
         ]
       }
     },
@@ -100,7 +184,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$MaxRowCount"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$Measure$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Measure"
         ]
       }
     },
@@ -114,7 +212,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Memory"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$MinRowCount$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$MinRowCount"
         ]
       }
     },
@@ -128,7 +240,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$NodeTypes"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$NonCumulativeCost$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$NonCumulativeCost"
         ]
       }
     },
@@ -142,7 +268,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Parallelism"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$PercentageOriginalRows$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$PercentageOriginalRows"
         ]
       }
     },
@@ -156,7 +296,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$PopulationSize"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$Predicates$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Predicates"
         ]
       }
     },
@@ -170,7 +324,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$RowCount"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$Selectivity$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Selectivity"
         ]
       }
     },
@@ -184,6 +352,13 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$Size"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$TableReferences$Handler"
         ]
       }
@@ -191,7 +366,21 @@
     {
       "type": {
         "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$TableReferences"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
           "org.apache.calcite.rel.metadata.BuiltInMetadata$UniqueKeys$Handler"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.apache.calcite.rel.metadata.BuiltInMetadata$UniqueKeys"
         ]
       }
     },

--- a/isthmus-cli/src/test/script/smoke.sh
+++ b/isthmus-cli/src/test/script/smoke.sh
@@ -18,6 +18,13 @@ echo "${LINEITEM}"
 # SQL Query - Aggregate
 "${CMD}" 'select l_orderkey, count(l_partkey) from lineitem group by l_orderkey' --create "${LINEITEM}"
 
+# SQL Query - Grouping-only aggregate (no aggregate function; exercises the column-uniqueness
+# metadata query that must not fall back to Janino runtime codegen in the native image)
+"${CMD}" 'select l_orderkey from lineitem group by l_orderkey' --create "${LINEITEM}"
+
+# SQL Query - DISTINCT (same metadata-query path as grouping-only aggregate)
+"${CMD}" 'select distinct l_orderkey from lineitem' --create "${LINEITEM}"
+
 # SQL Expression - Literal expression
 "${CMD}" --expression '10'
 

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -343,11 +343,14 @@ public class ConverterProvider {
    * @return a new RelBuilder instance
    */
   public RelBuilder getRelBuilder(CalciteSchema schema) {
-    return RelBuilder.create(
-        Frameworks.newConfigBuilder()
-            .defaultSchema(schema.plus())
-            .typeSystem(getTypeSystem())
-            .build());
+    RelBuilder relBuilder =
+        RelBuilder.create(
+            Frameworks.newConfigBuilder()
+                .defaultSchema(schema.plus())
+                .typeSystem(getTypeSystem())
+                .build());
+    Utils.useReflectiveMetadataProvider(relBuilder.getCluster());
+    return relBuilder;
   }
 
   // Utility Getters

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlConverterBase.java
@@ -6,9 +6,6 @@ import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptCostImpl;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
-import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
-import org.apache.calcite.rel.metadata.ProxyingMetadataHandlerProvider;
-import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -57,12 +54,7 @@ public class SqlConverterBase {
     this.converterConfig = converterProvider.getSqlToRelConverterConfig();
     VolcanoPlanner planner = new VolcanoPlanner(RelOptCostImpl.FACTORY, Contexts.of("hello"));
     this.relOptCluster = RelOptCluster.create(planner, new RexBuilder(factory));
-    relOptCluster.setMetadataQuerySupplier(
-        () -> {
-          ProxyingMetadataHandlerProvider handler =
-              new ProxyingMetadataHandlerProvider(DefaultRelMetadataProvider.INSTANCE);
-          return new RelMetadataQuery(handler);
-        });
+    Utils.useReflectiveMetadataProvider(relOptCluster);
     parserConfig = converterProvider.getSqlParserConfig();
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -164,6 +164,7 @@ public class SubstraitRelNodeConverter
                 .typeSystem(converterProvider.getTypeSystem())
                 .programs()
                 .build());
+    Utils.useReflectiveMetadataProvider(relBuilder.getCluster());
     // Normalize any offset-based outer references (steps_out) to the id-based form (rel_anchor /
     // rel_reference) so the conversion below resolves correlations purely by anchor. Plans that are
     // already id-based are left unchanged.

--- a/isthmus/src/main/java/io/substrait/isthmus/Utils.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/Utils.java
@@ -10,6 +10,10 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
+import org.apache.calcite.rel.metadata.ProxyingMetadataHandlerProvider;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -98,5 +102,29 @@ public class Utils {
     }
 
     return schema;
+  }
+
+  /**
+   * Configures {@code cluster} to answer relational-metadata queries with handlers built via {@link
+   * java.lang.reflect.Proxy reflection} rather than runtime code generation.
+   *
+   * <p>Calcite's default {@link RelMetadataQuery} obtains its handlers from {@code
+   * JaninoRelMetadataProvider}, which compiles a handler class at runtime with Janino. Runtime code
+   * generation is unavailable in a GraalVM native image (closed-world, ahead-of-time compiled), so
+   * any metadata query — e.g. the column-uniqueness check {@code RelBuilder} runs for a grouping
+   * {@code aggregate} or {@code DISTINCT} — fails there. {@link ProxyingMetadataHandlerProvider}
+   * builds the same handlers with dynamic proxies, which are supported in native images once the
+   * handler interfaces are registered.
+   *
+   * <p>Apply this to every {@link RelOptCluster} used while converting to or from Calcite so the
+   * native image never reaches the Janino-backed path.
+   *
+   * @param cluster the cluster to configure
+   */
+  public static void useReflectiveMetadataProvider(final RelOptCluster cluster) {
+    cluster.setMetadataQuerySupplier(
+        () ->
+            new RelMetadataQuery(
+                new ProxyingMetadataHandlerProvider(DefaultRelMetadataProvider.INSTANCE)));
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlToCalcite.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlToCalcite.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus.sql;
 
 import io.substrait.isthmus.ConverterProvider;
 import io.substrait.isthmus.SubstraitTypeSystem;
+import io.substrait.isthmus.Utils;
 import io.substrait.isthmus.calcite.rel.DdlSqlToRelConverter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -256,6 +257,8 @@ public class SubstraitSqlToCalcite {
         new RexBuilder(new JavaTypeFactoryImpl(SubstraitTypeSystem.TYPE_SYSTEM));
     HepProgram program = HepProgram.builder().build();
     RelOptPlanner emptyPlanner = new HepPlanner(program);
-    return RelOptCluster.create(emptyPlanner, rexBuilder);
+    RelOptCluster cluster = RelOptCluster.create(emptyPlanner, rexBuilder);
+    Utils.useReflectiveMetadataProvider(cluster);
+    return cluster;
   }
 }


### PR DESCRIPTION
## Problem

Queries like the following crash in the isthmus native image (#251):

```
./isthmus -c 'CREATE TABLE foo(a VARCHAR);' "SELECT a FROM foo GROUP BY a"
./isthmus -c 'CREATE TABLE foo(a VARCHAR);' "SELECT DISTINCT a FROM foo"
```

A grouping-only `GROUP BY` (and `SELECT DISTINCT`) goes through
`RelBuilder.aggregate_` → `alreadyUnique()` → `RelMetadataQuery.areColumnsUnique()`.
Calcite's default `RelMetadataQuery` obtains its handlers from
`JaninoRelMetadataProvider`, which **compiles a handler class at runtime with Janino**.
Runtime code generation is unavailable in a GraalVM native image (closed-world,
ahead-of-time compiled), so the query fails:

```
java.lang.AssertionError: Required type "Ljava/lang/AssertionError;" not found
    at org.codehaus.janino.IClassLoader.requireType
    at org.apache.calcite.rel.metadata.JaninoRelMetadataProvider.compile
```

An aggregate *with* a function (`count(...)`) skips the uniqueness check, so the
existing smoke test never exercised the broken path — which is why this stayed
uncaught.

## Fix

Calcite ships `ProxyingMetadataHandlerProvider`, a reflection-based (dynamic-proxy)
alternative to the Janino code generator. Dynamic proxies are supported in native
images once their interfaces are registered. `SqlConverterBase` already used this
provider — but only the SQL-expression path used that cluster. The SQL-query path
(`SubstraitSqlToCalcite`) and the Substrait→Calcite path
(`ConverterProvider.getRelBuilder`, `SubstraitRelNodeConverter.convert`) built
clusters with no metadata supplier and fell back to Janino.

- Extract the setup into `Utils.useReflectiveMetadataProvider(RelOptCluster)` and
  apply it to every cluster / `RelBuilder` used for Calcite conversion (removing the
  duplicated inline lambda in `SqlConverterBase`).
- The reflective provider proxies the **bare** `BuiltInMetadata$*` interfaces, not
  just the `$Handler` sub-interfaces already present, so register those in
  `reachability-metadata.json` (the safe superset — unused proxy registrations are
  harmless).
- Add grouping-only `GROUP BY` and `SELECT DISTINCT` cases to `smoke.sh` so the
  native image exercises the uniqueness path in CI.

Closes #251

🤖 Generated with AI