### PR TITLE
refactor(isthmus): derive CREATE-statement table types from the provider

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitCreateStatementParser.java
@@ -1,8 +1,6 @@
 package io.substrait.isthmus.sql;
 
 import io.substrait.isthmus.ConverterProvider;
-import io.substrait.isthmus.SqlConverterBase;
-import io.substrait.isthmus.SubstraitTypeSystem;
 import io.substrait.isthmus.Utils;
 import io.substrait.isthmus.calcite.SubstraitTable;
 import java.util.ArrayList;
@@ -11,6 +9,7 @@ import java.util.List;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.ddl.SqlColumnDeclaration;
@@ -25,19 +24,18 @@ import org.jspecify.annotations.Nullable;
 /** Utility class for parsing CREATE statements into a {@link CalciteCatalogReader} */
 public class SubstraitCreateStatementParser {
 
-  /** An empty catalog reader used for validating CREATE statements. */
+  /**
+   * An empty catalog reader used for validating CREATE statements, configured from {@link
+   * ConverterProvider#DEFAULT}.
+   */
   public static final CalciteCatalogReader EMPTY_CATALOG =
-      new CalciteCatalogReader(
-          CalciteSchema.createRootSchema(false),
-          List.of(),
-          SubstraitTypeSystem.TYPE_FACTORY,
-          SqlConverterBase.CONNECTION_CONFIG);
+      createEmptyCatalog(ConverterProvider.DEFAULT);
 
-  /** SQL validator configured for validating CREATE statements against the empty catalog. */
-  public static final SqlValidator VALIDATOR =
-      new SubstraitSqlValidator(
-          // as we are validating CREATE statements, an empty catalog suffices
-          EMPTY_CATALOG);
+  /**
+   * SQL validator configured for validating CREATE statements against the empty catalog, using
+   * {@link ConverterProvider#DEFAULT}.
+   */
+  public static final SqlValidator VALIDATOR = createValidator(ConverterProvider.DEFAULT);
 
   /**
    * Parses a SQL string containing only CREATE statements into a list of {@link SubstraitTable}s.
@@ -71,6 +69,7 @@ public class SubstraitCreateStatementParser {
       @NonNull final ConverterProvider converterProvider, @NonNull final String createStatements)
       throws SqlParseException {
     final List<SubstraitTable> tableList = new ArrayList<>();
+    final SqlValidator validator = createValidator(converterProvider);
 
     final List<SqlNode> sqlNode =
         SubstraitSqlStatementParser.parseStatements(createStatements, converterProvider);
@@ -89,7 +88,12 @@ public class SubstraitCreateStatementParser {
         throw fail("CTAS not supported.", create.name.getParserPosition());
       }
 
-      tableList.add(createSubstraitTable(create.name.names.get(0), create.columnList));
+      tableList.add(
+          createSubstraitTable(
+              converterProvider.getTypeFactory(),
+              validator,
+              create.name.names.get(0),
+              create.columnList));
     }
 
     return tableList;
@@ -200,6 +204,7 @@ public class SubstraitCreateStatementParser {
       @NonNull final ConverterProvider converterProvider, @NonNull final String... createStatements)
       throws SqlParseException {
     final CalciteSchema rootSchema = CalciteSchema.createRootSchema(false);
+    final SqlValidator validator = createValidator(converterProvider);
 
     for (final String statement : createStatements) {
       final List<SqlNode> sqlNode =
@@ -219,7 +224,10 @@ public class SubstraitCreateStatementParser {
         final String tableName = names.get(names.size() - 1);
         final CalciteSchema.TableEntry table = schema.getTable(tableName, false);
         if (table == null) {
-          schema.add(tableName, createSubstraitTable(tableName, create.columnList));
+          schema.add(
+              tableName,
+              createSubstraitTable(
+                  converterProvider.getTypeFactory(), validator, tableName, create.columnList));
         } else {
           throw fail("Table must not be defined more than once", parsed.getParserPosition());
         }
@@ -233,6 +241,8 @@ public class SubstraitCreateStatementParser {
    * Creates a new {@link SubstraitTable} with the given table name and the table schema from the
    * given {@link SqlNodeList} containing {@link SqlColumnDeclaration}s.
    *
+   * @param typeFactory the type factory used to build the table's row type; must not be null
+   * @param validator the validator used to derive the column types; must not be null
    * @param tableName the table name to use; must not be null
    * @param columnList the {@link SqlNodeList} containing {@link SqlColumnDeclaration}s to build the
    *     table schema from; must not be null
@@ -240,7 +250,10 @@ public class SubstraitCreateStatementParser {
    * @throws SqlParseException if the column list contains unexpected nodes or invalid names
    */
   private static SubstraitTable createSubstraitTable(
-      @NonNull final String tableName, @NonNull final SqlNodeList columnList)
+      @NonNull final RelDataTypeFactory typeFactory,
+      @NonNull final SqlValidator validator,
+      @NonNull final String tableName,
+      @NonNull final SqlNodeList columnList)
       throws SqlParseException {
     final List<String> names = new ArrayList<>();
     final List<RelDataType> columnTypes = new ArrayList<>();
@@ -263,10 +276,40 @@ public class SubstraitCreateStatementParser {
       }
 
       names.add(col.name.names.get(0));
-      columnTypes.add(col.dataType.deriveType(VALIDATOR));
+      columnTypes.add(col.dataType.deriveType(validator));
     }
 
-    return new SubstraitTable(
-        tableName, SubstraitTypeSystem.TYPE_FACTORY.createStructType(columnTypes, names));
+    return new SubstraitTable(tableName, typeFactory.createStructType(columnTypes, names));
+  }
+
+  /**
+   * Creates an empty catalog reader for validating CREATE statements, using the type factory and
+   * connection configuration from the given {@link ConverterProvider}.
+   *
+   * @param converterProvider the converter provider supplying the type factory and connection
+   *     configuration; must not be null
+   * @return an empty {@link CalciteCatalogReader}
+   */
+  private static CalciteCatalogReader createEmptyCatalog(
+      @NonNull final ConverterProvider converterProvider) {
+    return new CalciteCatalogReader(
+        CalciteSchema.createRootSchema(false),
+        List.of(),
+        converterProvider.getTypeFactory(),
+        converterProvider.getCalciteConnectionConfig());
+  }
+
+  /**
+   * Creates a SQL validator for deriving the column types of CREATE statements, configured from the
+   * given {@link ConverterProvider}. As only CREATE statements are validated, an empty catalog
+   * suffices.
+   *
+   * @param converterProvider the converter provider supplying the validator configuration; must not
+   *     be null
+   * @return a {@link SqlValidator} for validating CREATE statements
+   */
+  private static SqlValidator createValidator(@NonNull final ConverterProvider converterProvider) {
+    return new SubstraitSqlValidator(
+        createEmptyCatalog(converterProvider), converterProvider.getSqlOperatorTable());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/sql/CreateStatementParserProviderConfigTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/sql/CreateStatementParserProviderConfigTest.java
@@ -8,11 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.substrait.isthmus.ConverterProvider;
 import io.substrait.isthmus.SubstraitTypeSystem;
 import io.substrait.isthmus.calcite.SubstraitTable;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -26,13 +28,18 @@ class CreateStatementParserProviderConfigTest {
       "CREATE TABLE employees (id BIGINT, name VARCHAR, salary DECIMAL(10, 2))";
 
   /**
-   * A type factory that records the struct types it is asked to build, so a test can tell which
-   * factory produced a table's row type and where its column types came from.
+   * A type factory that records the row types it is asked to build and the SQL types it is asked to
+   * create, so a test can tell which factory produced a table's row type and which one the
+   * validator derived its column types through.
+   *
+   * <p>Recording the requests is what makes the column-derivation check meaningful: {@code
+   * RelDataTypeFactoryImpl.canonize} interns through a {@code static} cache shared by every factory
+   * instance, so comparing interned type instances cannot distinguish one factory from another.
    */
   static final class RecordingTypeFactory extends SqlTypeFactoryImpl {
 
     private boolean createStructTypeCalled;
-    private List<RelDataType> recordedFieldTypes = List.of();
+    private final List<SqlTypeName> requestedSqlTypeNames = new ArrayList<>();
 
     RecordingTypeFactory() {
       super(SubstraitTypeSystem.TYPE_SYSTEM);
@@ -42,21 +49,34 @@ class CreateStatementParserProviderConfigTest {
     public RelDataType createStructType(
         final List<RelDataType> typeList, final List<String> fieldNameList) {
       createStructTypeCalled = true;
-      recordedFieldTypes = List.copyOf(typeList);
       return super.createStructType(typeList, fieldNameList);
+    }
+
+    @Override
+    public RelDataType createSqlType(final SqlTypeName typeName) {
+      requestedSqlTypeNames.add(typeName);
+      return super.createSqlType(typeName);
+    }
+
+    @Override
+    public RelDataType createSqlType(final SqlTypeName typeName, final int precision) {
+      requestedSqlTypeNames.add(typeName);
+      return super.createSqlType(typeName, precision);
+    }
+
+    @Override
+    public RelDataType createSqlType(
+        final SqlTypeName typeName, final int precision, final int scale) {
+      requestedSqlTypeNames.add(typeName);
+      return super.createSqlType(typeName, precision, scale);
     }
 
     boolean wasUsedForStructType() {
       return createStructTypeCalled;
     }
 
-    List<RelDataType> recordedFieldTypes() {
-      return recordedFieldTypes;
-    }
-
-    /** Exposes the protected interning hook so a test can check a type belongs to this factory. */
-    RelDataType canonizeType(final RelDataType type) {
-      return canonize(type);
+    List<SqlTypeName> requestedSqlTypeNames() {
+      return List.copyOf(requestedSqlTypeNames);
     }
   }
 
@@ -89,8 +109,9 @@ class CreateStatementParserProviderConfigTest {
   }
 
   /**
-   * The column types are derived through a validator built from the provider, so they are interned
-   * in the provider's type factory too — not just the enclosing struct type.
+   * The validator that derives the column types is built from the provider, so the declared column
+   * types are requested from the provider's type factory — covering the validator path, not just
+   * the enclosing struct type.
    */
   @Test
   void columnTypesAreDerivedWithProviderTypeFactory() throws SqlParseException {
@@ -99,14 +120,13 @@ class CreateStatementParserProviderConfigTest {
 
     SubstraitCreateStatementParser.processCreateStatementsToCatalog(provider, CREATE_STATEMENT);
 
-    List<RelDataType> fieldTypes = typeFactory.recordedFieldTypes();
-    assertEquals(3, fieldTypes.size());
-    for (RelDataType fieldType : fieldTypes) {
-      assertSame(
-          fieldType,
-          typeFactory.canonizeType(fieldType),
-          "column types should be interned in the provider's type factory");
-    }
+    assertTrue(
+        typeFactory
+            .requestedSqlTypeNames()
+            .containsAll(List.of(SqlTypeName.BIGINT, SqlTypeName.VARCHAR, SqlTypeName.DECIMAL)),
+        "the validator should derive the declared column types through the provider's type "
+            + "factory, but it only saw "
+            + typeFactory.requestedSqlTypeNames());
   }
 
   /** The default entry points keep working off {@link ConverterProvider#DEFAULT}. */

--- a/isthmus/src/test/java/io/substrait/isthmus/sql/CreateStatementParserProviderConfigTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/sql/CreateStatementParserProviderConfigTest.java
@@ -1,0 +1,121 @@
+package io.substrait.isthmus.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.isthmus.ConverterProvider;
+import io.substrait.isthmus.SubstraitTypeSystem;
+import io.substrait.isthmus.calcite.SubstraitTable;
+import java.util.List;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the CREATE-statement parser sources its type factory and connection configuration
+ * from the injected {@link ConverterProvider} rather than from global defaults, for both the
+ * catalog-reader and the {@link SubstraitTable} entry points.
+ */
+class CreateStatementParserProviderConfigTest {
+
+  private static final String CREATE_STATEMENT =
+      "CREATE TABLE employees (id BIGINT, name VARCHAR, salary DECIMAL(10, 2))";
+
+  /**
+   * A type factory that records the struct types it is asked to build, so a test can tell which
+   * factory produced a table's row type and where its column types came from.
+   */
+  static final class RecordingTypeFactory extends SqlTypeFactoryImpl {
+
+    private boolean createStructTypeCalled;
+    private List<RelDataType> recordedFieldTypes = List.of();
+
+    RecordingTypeFactory() {
+      super(SubstraitTypeSystem.TYPE_SYSTEM);
+    }
+
+    @Override
+    public RelDataType createStructType(
+        final List<RelDataType> typeList, final List<String> fieldNameList) {
+      createStructTypeCalled = true;
+      recordedFieldTypes = List.copyOf(typeList);
+      return super.createStructType(typeList, fieldNameList);
+    }
+
+    boolean wasUsedForStructType() {
+      return createStructTypeCalled;
+    }
+
+    List<RelDataType> recordedFieldTypes() {
+      return recordedFieldTypes;
+    }
+
+    /** Exposes the protected interning hook so a test can check a type belongs to this factory. */
+    RelDataType canonizeType(final RelDataType type) {
+      return canonize(type);
+    }
+  }
+
+  @Test
+  void catalogPathUsesProviderTypeFactory() throws SqlParseException {
+    RecordingTypeFactory typeFactory = new RecordingTypeFactory();
+    ConverterProvider provider = ConverterProvider.builder().typeFactory(typeFactory).build();
+
+    CalciteCatalogReader catalog =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(provider, CREATE_STATEMENT);
+
+    assertSame(typeFactory, catalog.getTypeFactory());
+    assertTrue(
+        typeFactory.wasUsedForStructType(),
+        "the provider's type factory should build the table row type");
+  }
+
+  @Test
+  void tableListPathUsesProviderTypeFactory() throws SqlParseException {
+    RecordingTypeFactory typeFactory = new RecordingTypeFactory();
+    ConverterProvider provider = ConverterProvider.builder().typeFactory(typeFactory).build();
+
+    List<SubstraitTable> tables =
+        SubstraitCreateStatementParser.processCreateStatements(provider, CREATE_STATEMENT);
+
+    assertEquals(1, tables.size());
+    assertTrue(
+        typeFactory.wasUsedForStructType(),
+        "the provider's type factory should build the table row type");
+  }
+
+  /**
+   * The column types are derived through a validator built from the provider, so they are interned
+   * in the provider's type factory too — not just the enclosing struct type.
+   */
+  @Test
+  void columnTypesAreDerivedWithProviderTypeFactory() throws SqlParseException {
+    RecordingTypeFactory typeFactory = new RecordingTypeFactory();
+    ConverterProvider provider = ConverterProvider.builder().typeFactory(typeFactory).build();
+
+    SubstraitCreateStatementParser.processCreateStatementsToCatalog(provider, CREATE_STATEMENT);
+
+    List<RelDataType> fieldTypes = typeFactory.recordedFieldTypes();
+    assertEquals(3, fieldTypes.size());
+    for (RelDataType fieldType : fieldTypes) {
+      assertSame(
+          fieldType,
+          typeFactory.canonizeType(fieldType),
+          "column types should be interned in the provider's type factory");
+    }
+  }
+
+  /** The default entry points keep working off {@link ConverterProvider#DEFAULT}. */
+  @Test
+  void defaultPathStillUsesSystemDefaults() throws SqlParseException {
+    CalciteCatalogReader catalog =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(CREATE_STATEMENT);
+
+    assertSame(SubstraitTypeSystem.TYPE_FACTORY, catalog.getTypeFactory());
+    assertFalse(catalog.nameMatcher().isCaseSensitive(), "default config is case-insensitive");
+  }
+}


### PR DESCRIPTION
## Summary

Finishes the deferred half of @vbarua's [comment on #1035](https://github.com/substrait-io/substrait-java/pull/1035#discussion_r3646273565) —
*"I wonder if it would make sense to get the RelTypeFactory and SqlConverterBase from the
ConverterProvider as well"*. #1036 threaded the provider into the `CalciteCatalogReader`
construction; this covers the type derivation underneath it.

## The gap

On the provider-injected path (`processCreateStatementsToCatalog(provider, …)` →
`processCreateStatementsToSchema(provider, …)` → `createSubstraitTable(…)`):

- `createSubstraitTable` built the row type with `SubstraitTypeSystem.TYPE_FACTORY`, not the
  provider's type factory.
- Column types came from `col.dataType.deriveType(VALIDATOR)`, where `VALIDATOR` and
  `EMPTY_CATALOG` are `static final`, built on the global type factory plus
  `SqlConverterBase.CONNECTION_CONFIG`.

So a builder-configured `typeFactory` produced a catalog reader that used it while the tables
inside were typed by the global one. That is harmless today — `getCalciteConnectionConfig()`
returns the same case-insensitive config as `SqlConverterBase.CONNECTION_CONFIG` — but a custom
type factory carrying a different type system (different decimal precision limits, say) was
silently bypassed for table column types.

## Changes

- New private `createEmptyCatalog(ConverterProvider)` and `createValidator(ConverterProvider)`
  helpers. Because `SubstraitSqlValidator` takes its type factory from the catalog reader, fixing
  the empty catalog fixes column derivation as well.
- The validator is built once per call and passed, with the provider's type factory, into
  `createSubstraitTable`.
- `EMPTY_CATALOG` and `VALIDATOR` are kept and now defined via the same helpers against
  `ConverterProvider.DEFAULT`, so their values are unchanged and nothing public was removed.

## Note on scope

Two things worth calling out explicitly, both easy to drop if you would rather they were separate:

1. The validator is now built with `converterProvider.getSqlOperatorTable()` instead of a
   hardcoded `SubstraitOperatorTable.INSTANCE`, matching how #1035 made the query path source its
   operator table. Identical for the default provider; it only matters for a provider that adds
   operators.
2. `EMPTY_CATALOG` and `VALIDATOR` now have no callers inside the class either (each entry point
   derives its own from the provider). They are still `public`, so they are retained — but if you
   want them deprecated in favour of the provider-derived path, that is a one-line follow-up.

Independent of #1037 — no overlapping files, so the two can merge in either order.

🤖 Generated with AI

