### PR TITLE
fix!: replace assert-based validation with real exceptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,10 @@ CI — build the whole thing before pushing:
 * **PMD** (`substrait.java-conventions`, ruleset
   `build-logic/src/main/resources/substrait-pmd.xml`) runs via `check` / `build` and fails on
   violations. Common tripwires: missing `@Override`, unused private fields/methods/locals,
-  `var` (rule `UseExplicitTypes` — use explicit types), and `public` JUnit 5 test
-  classes/methods (they must be package-private).
+  `var` (rule `UseExplicitTypes` — use explicit types), `assert` (rule `AvoidAssertStatement` —
+  assertions are disabled unless the JVM runs with `-ea`, so throw `IllegalArgumentException`
+  for caller-facing invariants and `IllegalStateException` for internal ones), and `public`
+  JUnit 5 test classes/methods (they must be package-private).
 * **javadoc** doclint fails the build, but only via `build` / `javadocJar` — run
   `./gradlew :core:javadoc` before pushing.
 * **CI** runs the full `./gradlew build --rerun-tasks` plus `yamllint`, `editorconfig-checker`,

--- a/build-logic/src/main/resources/substrait-pmd.xml
+++ b/build-logic/src/main/resources/substrait-pmd.xml
@@ -21,4 +21,22 @@
   <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
   <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" />
   <rule ref="category/java/errorprone.xml/MissingSerialVersionUID" />
+
+  <rule name="AvoidAssertStatement" language="java"
+    message="Do not validate with assert: assertions only run when the JVM is started with -ea. Throw IllegalArgumentException for caller-facing invariants or IllegalStateException for internal ones."
+    class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Java assertions are disabled unless the host JVM runs with -ea, which is the case for
+      Gradle's test JVMs and for almost nothing else. An assert-based check is therefore
+      enforced in CI and silently skipped in every real deployment, and AssertionError is an
+      Error rather than an Exception, so callers that catch Exception to report a bad plan
+      never see it.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>//AssertStatement</value>
+      </property>
+    </properties>
+  </rule>
 </ruleset>

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -1790,7 +1790,11 @@ public interface Expression extends FunctionArg {
     public abstract List<Expression> values();
 
     /**
-     * Validates that the nested list is not empty and all values have the same type.
+     * Validates that the nested list is not empty and all values have the same type, disregarding
+     * nullability. Values of mixed nullability are allowed, because SQL list constructors do not
+     * cast their values to a common type: {@code ARRAY[not_null_column, nullable_column]} produces
+     * values that differ only in nullability. The list's element type is that of its first value,
+     * as {@link #getType()} shows.
      *
      * @throws IllegalArgumentException if the list is empty or its values have differing types
      */
@@ -1801,15 +1805,11 @@ public interface Expression extends FunctionArg {
             "To specify an empty list, use ExpressionCreator.emptyList()");
       }
 
-      List<Type> distinctTypes =
-          values().stream()
-              .map(Expression::getType)
-              .distinct()
-              .collect(java.util.stream.Collectors.toList());
-      if (distinctTypes.size() > 1) {
+      List<Type> types =
+          values().stream().map(Expression::getType).collect(java.util.stream.Collectors.toList());
+      if (types.stream().map(TypeCreator::asNullable).distinct().limit(2).count() > 1) {
         throw new IllegalArgumentException(
-            String.format(
-                "All values in NestedList must have the same type, found: %s", distinctTypes));
+            String.format("All values in NestedList must have the same type, found: %s", types));
       }
     }
 

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -1789,13 +1789,28 @@ public interface Expression extends FunctionArg {
      */
     public abstract List<Expression> values();
 
-    /** Validates that the nested list is not empty and all values have the same type. */
+    /**
+     * Validates that the nested list is not empty and all values have the same type.
+     *
+     * @throws IllegalArgumentException if the list is empty or its values have differing types
+     */
     @Value.Check
     protected void check() {
-      assert !values().isEmpty() : "To specify an empty list, use ExpressionCreator.emptyList()";
+      if (values().isEmpty()) {
+        throw new IllegalArgumentException(
+            "To specify an empty list, use ExpressionCreator.emptyList()");
+      }
 
-      assert values().stream().map(Expression::getType).distinct().count() <= 1
-          : "All values in NestedList must have the same type";
+      List<Type> distinctTypes =
+          values().stream()
+              .map(Expression::getType)
+              .distinct()
+              .collect(java.util.stream.Collectors.toList());
+      if (distinctTypes.size() > 1) {
+        throw new IllegalArgumentException(
+            String.format(
+                "All values in NestedList must have the same type, found: %s", distinctTypes));
+      }
     }
 
     @Override

--- a/core/src/main/java/io/substrait/expression/VariadicParameterConsistencyValidator.java
+++ b/core/src/main/java/io/substrait/expression/VariadicParameterConsistencyValidator.java
@@ -20,7 +20,7 @@ class VariadicParameterConsistencyValidator {
    *
    * @param func the function declaration
    * @param arguments the function arguments to validate
-   * @throws AssertionError if validation fails
+   * @throws IllegalArgumentException if validation fails
    */
   public static void validate(SimpleExtension.Function func, List<FunctionArg> arguments) {
     Optional<SimpleExtension.VariadicBehavior> variadic = func.variadic();
@@ -85,7 +85,7 @@ class VariadicParameterConsistencyValidator {
     for (int i = firstVariadicArgIdx + 1; i < argumentTypes.size(); i++) {
       Type currentType = argumentTypes.get(i);
       if (!firstVariadicType.equalsIgnoringNullability(currentType)) {
-        throw new AssertionError(
+        throw new IllegalArgumentException(
             String.format(
                 "Variadic arguments must have consistent types when parameterConsistency is CONSISTENT. "
                     + "Argument at index %d has type %s but argument at index %d has type %s",

--- a/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
+++ b/core/src/main/java/io/substrait/expression/proto/ExpressionProtoConverter.java
@@ -477,7 +477,12 @@ public class ExpressionProtoConverter
 
   private Expression.Literal toLiteral(io.substrait.expression.Expression expression) {
     Expression e = toProto(expression);
-    assert e.getRexTypeCase() == Expression.RexTypeCase.LITERAL;
+    if (e.getRexTypeCase() != Expression.RexTypeCase.LITERAL) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected a literal expression, but %s was converted to a %s",
+              expression.getClass().getSimpleName(), e.getRexTypeCase()));
+    }
     return e.getLiteral();
   }
 

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -5,7 +5,6 @@ import io.substrait.type.NamedFieldCountingTypeVisitor;
 import io.substrait.type.Type;
 import io.substrait.util.VisitationContext;
 import java.util.List;
-import java.util.Objects;
 import org.immutables.value.Value;
 
 /** A read relation that produces an inline table from a fixed list of literal rows. */
@@ -23,8 +22,6 @@ public abstract class VirtualTableScan extends AbstractReadRel {
    * Checks the following invariants when construction a VirtualTableScan
    *
    * <ul>
-   *   <li>no null field names
-   *   <li>no null rows
    *   <li>row shape must match field-list
    *   <li>row field types must match schema types
    * </ul>
@@ -43,16 +40,10 @@ public abstract class VirtualTableScan extends AbstractReadRel {
               "VirtualTableScan schema names count (%d) does not match the depth-first named-field count of the schema struct (%d)",
               names.size(), schemaNameCount));
     }
-    if (names.stream().anyMatch(Objects::isNull)) {
-      throw new IllegalArgumentException("VirtualTableScan schema names must not contain null");
-    }
 
-    List<Expression.NestedStruct> rows = getRows();
-    if (rows.stream().anyMatch(Objects::isNull)) {
-      throw new IllegalArgumentException("VirtualTableScan rows must not contain null");
-    }
+    List<Type> schemaFieldTypes = getInitialSchema().struct().fields();
 
-    for (Expression.NestedStruct row : rows) {
+    for (Expression.NestedStruct row : getRows()) {
       // At the PROTOBUF layer, the Nested.Struct message does not carry nullability information.
       // Nullability is attached to the Nested message, which can contain a Nested.Struct.
       // The NestedStruct POJO flattens the Nested and Nested.Struct messages together, allowing
@@ -75,7 +66,7 @@ public abstract class VirtualTableScan extends AbstractReadRel {
                 rowNameCount, names.size()));
       }
 
-      validateRowConformsToSchema(row);
+      validateRowConformsToSchema(row, schemaFieldTypes);
     }
   }
 
@@ -83,11 +74,11 @@ public abstract class VirtualTableScan extends AbstractReadRel {
    * Validates that a row's field types conform to the table's schema.
    *
    * @param row the row to validate
+   * @param schemaFieldTypes the field types of the table's schema
    * @throws IllegalArgumentException if the row does not conform to the schema
    */
-  private void validateRowConformsToSchema(Expression.NestedStruct row) {
-    Type.Struct schemaStruct = getInitialSchema().struct();
-    List<Type> schemaFieldTypes = schemaStruct.fields();
+  private static void validateRowConformsToSchema(
+      Expression.NestedStruct row, List<Type> schemaFieldTypes) {
     List<Expression> rowFields = row.fields();
 
     if (rowFields.size() != schemaFieldTypes.size()) {

--- a/core/src/main/java/io/substrait/relation/VirtualTableScan.java
+++ b/core/src/main/java/io/substrait/relation/VirtualTableScan.java
@@ -28,34 +28,53 @@ public abstract class VirtualTableScan extends AbstractReadRel {
    *   <li>row shape must match field-list
    *   <li>row field types must match schema types
    * </ul>
+   *
+   * @throws IllegalArgumentException if any of these invariants is violated
    */
   @Value.Check
   protected void check() {
     List<String> names = getInitialSchema().names();
 
-    assert names.size()
-        == NamedFieldCountingTypeVisitor.countNames(this.getInitialSchema().struct());
-    List<Expression.NestedStruct> rows = getRows();
-
-    // At the PROTOBUF layer, the Nested.Struct message does not carry nullability information.
-    // Nullability is attached to the Nested message, which can contain a Nested.Struct.
-    // The NestedStruct POJO flattens the Nested and Nested.Struct messages together, allowing the
-    // nullability of a NestedStruct to be set directly.
-    //
-    // HOWEVER, the VirtualTable message contains a list of Nested.Struct messages, and as such
-    // the nullability cannot be set at the protobuf layer. To avoid users attaching meaningless
-    // nullability information in the POJOs, we restrict the nullability of NestedStructs to false
-    // when used in VirtualTableScans.
-    for (Expression.NestedStruct row : rows) {
-      assert !row.nullable();
+    int schemaNameCount =
+        NamedFieldCountingTypeVisitor.countNames(this.getInitialSchema().struct());
+    if (names.size() != schemaNameCount) {
+      throw new IllegalArgumentException(
+          String.format(
+              "VirtualTableScan schema names count (%d) does not match the depth-first named-field count of the schema struct (%d)",
+              names.size(), schemaNameCount));
+    }
+    if (names.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("VirtualTableScan schema names must not contain null");
     }
 
-    assert names.stream().noneMatch(Objects::isNull)
-        && rows.stream().noneMatch(Objects::isNull)
-        && rows.stream()
-            .allMatch(r -> NamedFieldCountingTypeVisitor.countNames(r.getType()) == names.size());
+    List<Expression.NestedStruct> rows = getRows();
+    if (rows.stream().anyMatch(Objects::isNull)) {
+      throw new IllegalArgumentException("VirtualTableScan rows must not contain null");
+    }
 
     for (Expression.NestedStruct row : rows) {
+      // At the PROTOBUF layer, the Nested.Struct message does not carry nullability information.
+      // Nullability is attached to the Nested message, which can contain a Nested.Struct.
+      // The NestedStruct POJO flattens the Nested and Nested.Struct messages together, allowing
+      // the nullability of a NestedStruct to be set directly.
+      //
+      // HOWEVER, the VirtualTable message contains a list of Nested.Struct messages, and as such
+      // the nullability cannot be set at the protobuf layer. To avoid users attaching meaningless
+      // nullability information in the POJOs, we restrict the nullability of NestedStructs to
+      // false when used in VirtualTableScans.
+      if (row.nullable()) {
+        throw new IllegalArgumentException(
+            "VirtualTableScan rows must not be nullable; nullability cannot be represented for the Nested.Struct messages of a VirtualTable");
+      }
+
+      int rowNameCount = NamedFieldCountingTypeVisitor.countNames(row.getType());
+      if (rowNameCount != names.size()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Row named-field count (%d) does not match schema names count (%d)",
+                rowNameCount, names.size()));
+      }
+
       validateRowConformsToSchema(row);
     }
   }
@@ -64,26 +83,30 @@ public abstract class VirtualTableScan extends AbstractReadRel {
    * Validates that a row's field types conform to the table's schema.
    *
    * @param row the row to validate
-   * @throws AssertionError if the row does not conform to the schema
+   * @throws IllegalArgumentException if the row does not conform to the schema
    */
   private void validateRowConformsToSchema(Expression.NestedStruct row) {
     Type.Struct schemaStruct = getInitialSchema().struct();
     List<Type> schemaFieldTypes = schemaStruct.fields();
     List<Expression> rowFields = row.fields();
 
-    assert rowFields.size() == schemaFieldTypes.size()
-        : String.format(
-            "Row field count (%d) does not match schema field count (%d)",
-            rowFields.size(), schemaFieldTypes.size());
+    if (rowFields.size() != schemaFieldTypes.size()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Row field count (%d) does not match schema field count (%d)",
+              rowFields.size(), schemaFieldTypes.size()));
+    }
 
     for (int i = 0; i < rowFields.size(); i++) {
       Type rowFieldType = rowFields.get(i).getType();
       Type schemaFieldType = schemaFieldTypes.get(i);
 
-      assert rowFieldType.equals(schemaFieldType)
-          : String.format(
-              "Row field type (%s) does not match schema field type (%s)",
-              rowFieldType, schemaFieldType);
+      if (!rowFieldType.equals(schemaFieldType)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Row field type (%s) does not match schema field type (%s)",
+                rowFieldType, schemaFieldType));
+      }
     }
   }
 

--- a/core/src/test/java/io/substrait/expression/VariadicParameterConsistencyTest.java
+++ b/core/src/test/java/io/substrait/expression/VariadicParameterConsistencyTest.java
@@ -85,7 +85,7 @@ class VariadicParameterConsistencyTest extends TestBase {
             .build();
 
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             createScalarFunctionInvocation(
                 args,
@@ -97,7 +97,7 @@ class VariadicParameterConsistencyTest extends TestBase {
         "Consistent variadic with different types should fail");
 
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             createScalarFunctionInvocation(
                 args,
@@ -181,7 +181,7 @@ class VariadicParameterConsistencyTest extends TestBase {
         "Consistent variadic with wildcard type and same concrete types should pass");
 
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             createScalarFunctionInvocation(
                 args,
@@ -218,7 +218,7 @@ class VariadicParameterConsistencyTest extends TestBase {
         "Consistent variadic with min=2 and same types should pass");
 
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             createScalarFunctionInvocation(
                 args,

--- a/core/src/test/java/io/substrait/relation/VirtualTableScanTest.java
+++ b/core/src/test/java/io/substrait/relation/VirtualTableScanTest.java
@@ -112,7 +112,7 @@ class VirtualTableScanTest extends TestBase {
                     .addFields(ExpressionCreator.i64(true, 1))
                     .nullable(true) // can't have nullable rows
                     .build());
-    assertThrows(AssertionError.class, bldr::build);
+    assertThrows(IllegalArgumentException.class, bldr::build);
   }
 
   @Test
@@ -134,7 +134,7 @@ class VirtualTableScanTest extends TestBase {
   void checkInvalidRowTypeMismatch() {
     // Row has I32 where schema expects STRING
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             ImmutableVirtualTableScan.builder()
                 .initialSchema(
@@ -153,7 +153,7 @@ class VirtualTableScanTest extends TestBase {
   void checkInvalidRowWrongFieldCount() {
     // Row has wrong number of fields
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             ImmutableVirtualTableScan.builder()
                 .initialSchema(
@@ -169,7 +169,7 @@ class VirtualTableScanTest extends TestBase {
   void checkInvalidNestedStructTypeMismatch() {
     // Nested struct has wrong field type
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             ImmutableVirtualTableScan.builder()
                 .initialSchema(
@@ -191,7 +191,7 @@ class VirtualTableScanTest extends TestBase {
   void checkInvalidListElementTypeMismatch() {
     // List has wrong element type
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             ImmutableVirtualTableScan.builder()
                 .initialSchema(
@@ -208,7 +208,7 @@ class VirtualTableScanTest extends TestBase {
   void checkInvalidNullabilityMismatch() {
     // Nullability must match exactly
     assertThrows(
-        AssertionError.class,
+        IllegalArgumentException.class,
         () ->
             ImmutableVirtualTableScan.builder()
                 .initialSchema(

--- a/core/src/test/java/io/substrait/type/proto/NestedListExpressionTest.java
+++ b/core/src/test/java/io/substrait/type/proto/NestedListExpressionTest.java
@@ -1,10 +1,12 @@
 package io.substrait.type.proto;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.TestBase;
 import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.ImmutableExpression;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +31,26 @@ class NestedListExpressionTest extends TestBase {
     io.substrait.relation.Project project =
         io.substrait.relation.Project.builder()
             .addExpressions(builder.build())
+            .input(sb.emptyVirtualTableScan())
+            .build();
+    verifyRoundTrip(project);
+  }
+
+  @Test
+  void acceptNestedListWithElementsOfMixedNullability() {
+    // A list of values that differ only in nullability is valid; SQL builds such lists from
+    // ARRAY[not_null_column, nullable_column].
+    Expression.NestedList mixedNullability =
+        Expression.NestedList.builder()
+            .addValues(sb.i32(12))
+            .addValues(ExpressionCreator.typedNull(N.I32))
+            .build();
+    // The element type is the type of the first value, nullability included.
+    assertEquals(R.list(R.I32), mixedNullability.getType());
+
+    io.substrait.relation.Project project =
+        io.substrait.relation.Project.builder()
+            .addExpressions(mixedNullability)
             .input(sb.emptyVirtualTableScan())
             .build();
     verifyRoundTrip(project);

--- a/core/src/test/java/io/substrait/type/proto/NestedListExpressionTest.java
+++ b/core/src/test/java/io/substrait/type/proto/NestedListExpressionTest.java
@@ -17,7 +17,7 @@ class NestedListExpressionTest extends TestBase {
   void rejectNestedListWithElementsOfDifferentTypes() {
     ImmutableExpression.NestedList.Builder builder =
         Expression.NestedList.builder().addValues(literalExpression).addValues(sb.i32(12));
-    assertThrows(AssertionError.class, builder::build);
+    assertThrows(IllegalArgumentException.class, builder::build);
   }
 
   @Test
@@ -37,7 +37,7 @@ class NestedListExpressionTest extends TestBase {
   @Test
   void rejectEmptyNestedListTest() {
     ImmutableExpression.NestedList.Builder builder = Expression.NestedList.builder();
-    assertThrows(AssertionError.class, builder::build);
+    assertThrows(IllegalArgumentException.class, builder::build);
   }
 
   @Test

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.prepare.Prepare;
@@ -548,15 +549,13 @@ public class SubstraitRelNodeConverter
           transform.getTransformation().accept(expressionRexConverter, context));
     }
 
-    assert relBuilder.getRelOptSchema() != null;
-    final RelOptTable table = relBuilder.getRelOptSchema().getTableForMember(update.getNames());
+    final RelOptTable table = requireRelOptSchema().getTableForMember(update.getNames());
 
     if (table == null) {
       throw new IllegalStateException("Table not found in Calcite catalog: " + update.getNames());
     }
     final Prepare.CatalogReader catalogReader = (Prepare.CatalogReader) table.getRelOptSchema();
 
-    assert catalogReader != null;
     return LogicalTableModify.create(
         table,
         catalogReader,
@@ -713,9 +712,8 @@ public class SubstraitRelNodeConverter
   @Override
   public RelNode visit(NamedWrite write, Context context) {
     RelNode input = write.getInput().accept(this, context);
-    assert relBuilder.getRelOptSchema() != null;
-    final RelOptTable targetTable =
-        relBuilder.getRelOptSchema().getTableForMember(write.getNames());
+    final RelOptSchema relOptSchema = requireRelOptSchema();
+    final RelOptTable targetTable = relOptSchema.getTableForMember(write.getNames());
 
     TableModify.Operation operation;
     switch (write.getOperation()) {
@@ -734,17 +732,28 @@ public class SubstraitRelNodeConverter
                 write.getOperation()));
     }
 
-    // checked by validation
-    assert targetTable != null;
+    if (targetTable == null) {
+      throw new IllegalStateException("Table not found in Calcite catalog: " + write.getNames());
+    }
 
     return LogicalTableModify.create(
-        targetTable,
-        (Prepare.CatalogReader) relBuilder.getRelOptSchema(),
-        input,
-        operation,
-        null,
-        null,
-        false);
+        targetTable, (Prepare.CatalogReader) relOptSchema, input, operation, null, null, false);
+  }
+
+  /**
+   * Returns the {@link RelOptSchema} backing the {@link org.apache.calcite.tools.RelBuilder} used
+   * by this converter.
+   *
+   * @return the Calcite catalog to resolve table names against
+   * @throws IllegalStateException if the RelBuilder was created without a RelOptSchema
+   */
+  private RelOptSchema requireRelOptSchema() {
+    RelOptSchema relOptSchema = relBuilder.getRelOptSchema();
+    if (relOptSchema == null) {
+      throw new IllegalStateException(
+          "The RelBuilder of this converter has no RelOptSchema; a catalog-backed RelBuilder is required to resolve table names");
+    }
+    return relOptSchema;
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -57,6 +57,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.prepare.Prepare;
@@ -705,15 +706,13 @@ public class SubstraitRelNodeConverter
           transform.getTransformation().accept(expressionRexConverter, context));
     }
 
-    assert relBuilder.getRelOptSchema() != null;
-    final RelOptTable table = relBuilder.getRelOptSchema().getTableForMember(update.getNames());
+    final RelOptTable table = requireRelOptSchema().getTableForMember(update.getNames());
 
     if (table == null) {
       throw new IllegalStateException("Table not found in Calcite catalog: " + update.getNames());
     }
     final Prepare.CatalogReader catalogReader = (Prepare.CatalogReader) table.getRelOptSchema();
 
-    assert catalogReader != null;
     return LogicalTableModify.create(
         table,
         catalogReader,
@@ -870,9 +869,8 @@ public class SubstraitRelNodeConverter
   @Override
   public RelNode visit(NamedWrite write, Context context) {
     RelNode input = write.getInput().accept(this, context);
-    assert relBuilder.getRelOptSchema() != null;
-    final RelOptTable targetTable =
-        relBuilder.getRelOptSchema().getTableForMember(write.getNames());
+    final RelOptSchema relOptSchema = requireRelOptSchema();
+    final RelOptTable targetTable = relOptSchema.getTableForMember(write.getNames());
 
     TableModify.Operation operation;
     switch (write.getOperation()) {
@@ -891,17 +889,28 @@ public class SubstraitRelNodeConverter
                 write.getOperation()));
     }
 
-    // checked by validation
-    assert targetTable != null;
+    if (targetTable == null) {
+      throw new IllegalStateException("Table not found in Calcite catalog: " + write.getNames());
+    }
 
     return LogicalTableModify.create(
-        targetTable,
-        (Prepare.CatalogReader) relBuilder.getRelOptSchema(),
-        input,
-        operation,
-        null,
-        null,
-        false);
+        targetTable, (Prepare.CatalogReader) relOptSchema, input, operation, null, null, false);
+  }
+
+  /**
+   * Returns the {@link RelOptSchema} backing the {@link org.apache.calcite.tools.RelBuilder} used
+   * by this converter.
+   *
+   * @return the Calcite catalog to resolve table names against
+   * @throws IllegalStateException if the RelBuilder was created without a RelOptSchema
+   */
+  private RelOptSchema requireRelOptSchema() {
+    RelOptSchema relOptSchema = relBuilder.getRelOptSchema();
+    if (relOptSchema == null) {
+      throw new IllegalStateException(
+          "The RelBuilder of this converter has no RelOptSchema; a catalog-backed RelBuilder is required to resolve table names");
+    }
+    return relOptSchema;
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -554,7 +554,8 @@ public class SubstraitRelNodeConverter
     if (table == null) {
       throw new IllegalStateException("Table not found in Calcite catalog: " + update.getNames());
     }
-    final Prepare.CatalogReader catalogReader = (Prepare.CatalogReader) table.getRelOptSchema();
+    final Prepare.CatalogReader catalogReader =
+        requireCatalogReader(table.getRelOptSchema(), update.getNames());
 
     return LogicalTableModify.create(
         table,
@@ -737,7 +738,13 @@ public class SubstraitRelNodeConverter
     }
 
     return LogicalTableModify.create(
-        targetTable, (Prepare.CatalogReader) relOptSchema, input, operation, null, null, false);
+        targetTable,
+        requireCatalogReader(relOptSchema, write.getNames()),
+        input,
+        operation,
+        null,
+        null,
+        false);
   }
 
   /**
@@ -754,6 +761,34 @@ public class SubstraitRelNodeConverter
           "The RelBuilder of this converter has no RelOptSchema; a catalog-backed RelBuilder is required to resolve table names");
     }
     return relOptSchema;
+  }
+
+  /**
+   * Narrows a {@link RelOptSchema} to the {@link org.apache.calcite.prepare.Prepare.CatalogReader}
+   * that Calcite's table-modification relations require.
+   *
+   * <p>{@link RelOptTable#getRelOptSchema()} is nullable and a {@link RelOptSchema} is not
+   * necessarily a catalog reader, while {@link TableModify} stores the reader without checking it
+   * and only dereferences it later (e.g. from {@code getExpectedInputRowType()}). Validating here
+   * reports the misconfigured catalog instead of failing as a {@link NullPointerException} or
+   * {@link ClassCastException} further downstream.
+   *
+   * @param relOptSchema the schema to narrow, possibly null
+   * @param names the table name being resolved, for the error message
+   * @return the schema as a catalog reader
+   * @throws IllegalStateException if the schema is null or is not a catalog reader
+   */
+  private static Prepare.CatalogReader requireCatalogReader(
+      RelOptSchema relOptSchema, List<String> names) {
+    if (!(relOptSchema instanceof Prepare.CatalogReader)) {
+      throw new IllegalStateException(
+          String.format(
+              "Cannot read table metadata for %s: expected a %s, but got %s",
+              names,
+              Prepare.CatalogReader.class.getName(),
+              relOptSchema == null ? "null" : relOptSchema.getClass().getName()));
+    }
+    return (Prepare.CatalogReader) relOptSchema;
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -911,7 +911,7 @@ public class SubstraitRelNodeConverter
    * @return the Calcite catalog to resolve table names against
    * @throws IllegalStateException if the RelBuilder was created without a RelOptSchema
    */
-  private RelOptSchema requireRelOptSchema() {
+  protected RelOptSchema requireRelOptSchema() {
     RelOptSchema relOptSchema = relBuilder.getRelOptSchema();
     if (relOptSchema == null) {
       throw new IllegalStateException(
@@ -935,7 +935,7 @@ public class SubstraitRelNodeConverter
    * @return the schema as a catalog reader
    * @throws IllegalStateException if the schema is null or is not a catalog reader
    */
-  private static Prepare.CatalogReader requireCatalogReader(
+  protected static Prepare.CatalogReader requireCatalogReader(
       RelOptSchema relOptSchema, List<String> names) {
     if (!(relOptSchema instanceof Prepare.CatalogReader)) {
       throw new IllegalStateException(

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -711,7 +711,8 @@ public class SubstraitRelNodeConverter
     if (table == null) {
       throw new IllegalStateException("Table not found in Calcite catalog: " + update.getNames());
     }
-    final Prepare.CatalogReader catalogReader = (Prepare.CatalogReader) table.getRelOptSchema();
+    final Prepare.CatalogReader catalogReader =
+        requireCatalogReader(table.getRelOptSchema(), update.getNames());
 
     return LogicalTableModify.create(
         table,
@@ -894,7 +895,13 @@ public class SubstraitRelNodeConverter
     }
 
     return LogicalTableModify.create(
-        targetTable, (Prepare.CatalogReader) relOptSchema, input, operation, null, null, false);
+        targetTable,
+        requireCatalogReader(relOptSchema, write.getNames()),
+        input,
+        operation,
+        null,
+        null,
+        false);
   }
 
   /**
@@ -911,6 +918,34 @@ public class SubstraitRelNodeConverter
           "The RelBuilder of this converter has no RelOptSchema; a catalog-backed RelBuilder is required to resolve table names");
     }
     return relOptSchema;
+  }
+
+  /**
+   * Narrows a {@link RelOptSchema} to the {@link org.apache.calcite.prepare.Prepare.CatalogReader}
+   * that Calcite's table-modification relations require.
+   *
+   * <p>{@link RelOptTable#getRelOptSchema()} is nullable and a {@link RelOptSchema} is not
+   * necessarily a catalog reader, while {@link TableModify} stores the reader without checking it
+   * and only dereferences it later (e.g. from {@code getExpectedInputRowType()}). Validating here
+   * reports the misconfigured catalog instead of failing as a {@link NullPointerException} or
+   * {@link ClassCastException} further downstream.
+   *
+   * @param relOptSchema the schema to narrow, possibly null
+   * @param names the table name being resolved, for the error message
+   * @return the schema as a catalog reader
+   * @throws IllegalStateException if the schema is null or is not a catalog reader
+   */
+  private static Prepare.CatalogReader requireCatalogReader(
+      RelOptSchema relOptSchema, List<String> names) {
+    if (!(relOptSchema instanceof Prepare.CatalogReader)) {
+      throw new IllegalStateException(
+          String.format(
+              "Cannot read table metadata for %s: expected a %s, but got %s",
+              names,
+              Prepare.CatalogReader.class.getName(),
+              relOptSchema == null ? "null" : relOptSchema.getClass().getName()));
+    }
+    return (Prepare.CatalogReader) relOptSchema;
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -778,7 +778,6 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
    *
    * @param modify Calcite table modify node
    * @return Substrait write/update relation
-   * @throws IllegalArgumentException if the node has no target table.
    * @throws IllegalStateException if an update column is not found in the table schema.
    */
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -45,6 +45,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rel.RelNode;
@@ -777,6 +778,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
    *
    * @param modify Calcite table modify node
    * @return Substrait write/update relation
+   * @throws IllegalArgumentException if the node has no target table.
    * @throws IllegalStateException if an update column is not found in the table schema.
    */
   @Override
@@ -791,20 +793,20 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
                   ? AbstractWriteRel.WriteOp.INSERT
                   : AbstractWriteRel.WriteOp.DELETE;
 
-          assert modify.getTable() != null;
+          final RelOptTable table = requireTable(modify);
           return NamedWrite.builder()
               .input(input)
-              .tableSchema(typeConverter.toNamedStruct(modify.getTable().getRowType()))
+              .tableSchema(typeConverter.toNamedStruct(table.getRowType()))
               .operation(op)
               .createMode(AbstractWriteRel.CreateMode.UNSPECIFIED)
               .outputMode(AbstractWriteRel.OutputMode.MODIFIED_RECORDS)
-              .names(modify.getTable().getQualifiedName())
+              .names(table.getQualifiedName())
               .build();
         }
 
       case UPDATE:
         {
-          assert modify.getTable() != null;
+          final RelOptTable table = requireTable(modify);
 
           RelNode input = modify.getInput();
           final Expression condition;
@@ -817,7 +819,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
           List<String> updateColumnNames = modify.getUpdateColumnList();
           List<RexNode> sourceExpressions = getSourceExpressions(modify);
-          List<String> allTableColumnNames = modify.getTable().getRowType().getFieldNames();
+          List<String> allTableColumnNames = table.getRowType().getFieldNames();
           List<NamedUpdate.TransformExpression> transformations = new ArrayList<>();
 
           for (int i = 0; i < updateColumnNames.size(); i++) {
@@ -840,8 +842,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
           }
 
           return NamedUpdate.builder()
-              .tableSchema(typeConverter.toNamedStruct(modify.getTable().getRowType()))
-              .names(modify.getTable().getQualifiedName())
+              .tableSchema(typeConverter.toNamedStruct(table.getRowType()))
+              .names(table.getQualifiedName())
               .condition(condition)
               .transformations(transformations)
               .build();
@@ -850,6 +852,16 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
       default:
         return super.visit(modify);
     }
+  }
+
+  private static RelOptTable requireTable(TableModify modify) {
+    RelOptTable table = modify.getTable();
+    if (table == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "TableModify with operation %s has no target table", modify.getOperation()));
+    }
+    return table;
   }
 
   private List<RexNode> getSourceExpressions(TableModify modify) {

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
@@ -40,11 +40,11 @@ public class CreateTable extends SingleRel {
   }
 
   /**
-   * Returns the inputs to this node (single input).
+   * Copies this node with the given traits and input.
    *
    * @param traitSet the RelTraitSet
    * @param inputs List of RelNodes
-   * @return the input relation
+   * @return a copy of this node with the given input
    * @throws IllegalArgumentException if given anything but exactly one input
    */
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
@@ -45,10 +45,14 @@ public class CreateTable extends SingleRel {
    * @param traitSet the RelTraitSet
    * @param inputs List of RelNodes
    * @return the input relation
+   * @throws IllegalArgumentException if given anything but exactly one input
    */
   @Override
   public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-    assert inputs.size() == 1;
+    if (inputs.size() != 1) {
+      throw new IllegalArgumentException(
+          "CreateTable requires exactly one input, but got " + inputs.size());
+    }
     return new CreateTable(getCluster(), traitSet, tableName, inputs.get(0));
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
@@ -39,9 +39,11 @@ public class CreateView extends SingleRel {
   }
 
   /**
-   * Returns the inputs to this node (single input).
+   * Copies this node with the given traits and input.
    *
-   * @return a list containing the input relation
+   * @param traitSet the RelTraitSet
+   * @param inputs List of RelNodes
+   * @return a copy of this node with the given input
    * @throws IllegalArgumentException if given anything but exactly one input
    */
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
@@ -42,10 +42,14 @@ public class CreateView extends SingleRel {
    * Returns the inputs to this node (single input).
    *
    * @return a list containing the input relation
+   * @throws IllegalArgumentException if given anything but exactly one input
    */
   @Override
   public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
-    assert inputs.size() == 1;
+    if (inputs.size() != 1) {
+      throw new IllegalArgumentException(
+          "CreateView requires exactly one input, but got " + inputs.size());
+    }
     return new CreateView(getCluster(), traitSet, viewName, inputs.get(0));
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -197,7 +197,12 @@ public class CallConverters {
 
         // number of arguments are always going to be odd (each condition/then combination plus
         // else)
-        assert call.getOperands().size() % 2 == 1;
+        if (call.getOperands().size() % 2 != 1) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "CASE requires an odd number of operands (WHEN/THEN pairs plus ELSE), but got %d",
+                  call.getOperands().size()));
+        }
 
         List<Expression> caseArgs =
             call.getOperands().stream().map(visitor).collect(Collectors.toList());

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -559,10 +559,16 @@ public abstract class FunctionConverter<
      * @param rexOperands operand RexNodes
      * @param opTypes operand type strings (Substrait)
      * @return stream of candidate key suffixes to test
+     * @throws IllegalStateException if the operand and operand type counts differ
      */
     private Stream<String> matchKeys(List<RexNode> rexOperands, List<String> opTypes) {
 
-      assert (rexOperands.size() == opTypes.size());
+      if (rexOperands.size() != opTypes.size()) {
+        throw new IllegalStateException(
+            String.format(
+                "Operand count (%d) does not match operand type count (%d)",
+                rexOperands.size(), opTypes.size()));
+      }
 
       if (rexOperands.isEmpty()) {
         return Stream.of("");

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionConverter.java
@@ -684,10 +684,16 @@ public abstract class FunctionConverter<
      * @param rexOperands operand RexNodes
      * @param opTypes operand type strings (Substrait)
      * @return stream of candidate key suffixes to test
+     * @throws IllegalStateException if the operand and operand type counts differ
      */
     private Stream<String> matchKeys(List<RexNode> rexOperands, List<String> opTypes) {
 
-      assert (rexOperands.size() == opTypes.size());
+      if (rexOperands.size() != opTypes.size()) {
+        throw new IllegalStateException(
+            String.format(
+                "Operand count (%d) does not match operand type count (%d)",
+                rexOperands.size(), opTypes.size()));
+      }
 
       if (rexOperands.isEmpty()) {
         return Stream.of("");

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
@@ -3,7 +3,7 @@ package io.substrait.isthmus.expression;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.CallConverter;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,17 +50,18 @@ public class SqlMapValueConstructorCallConverter implements CallConverter {
 
   private Optional<Expression> toMapLiteral(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
+    if (call.operands.size() % 2 != 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "SqlMapValueConstructor requires an even number of operands (key/value pairs), but got %d",
+              call.operands.size()));
+    }
     List<Expression.Literal> literals =
         call.operands.stream()
             .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
             .collect(java.util.stream.Collectors.toList());
-    if (literals.size() % 2 != 0) {
-      throw new IllegalArgumentException(
-          String.format(
-              "SqlMapValueConstructor requires an even number of operands (key/value pairs), but got %d",
-              literals.size()));
-    }
-    Map<Expression.Literal, Expression.Literal> items = new HashMap<>();
+    // Insertion-ordered so that the map literal keeps the key order written in the query.
+    Map<Expression.Literal, Expression.Literal> items = new LinkedHashMap<>();
     for (int i = 0; i < literals.size(); i += 2) {
       items.put(literals.get(i), literals.get(i + 1));
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
@@ -35,7 +35,8 @@ public class SqlMapValueConstructorCallConverter implements CallConverter {
    *     {@link SqlMapValueConstructor}; otherwise {@link Optional#empty()}.
    * @throws ClassCastException if operands converted by {@code topLevelConverter} are not {@link
    *     Expression.Literal} instances.
-   * @throws AssertionError if the number of operands is not even (expecting key/value pairs).
+   * @throws IllegalArgumentException if the number of operands is not even (expecting key/value
+   *     pairs).
    */
   @Override
   public Optional<Expression> convert(
@@ -53,8 +54,13 @@ public class SqlMapValueConstructorCallConverter implements CallConverter {
         call.operands.stream()
             .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
             .collect(java.util.stream.Collectors.toList());
+    if (literals.size() % 2 != 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "SqlMapValueConstructor requires an even number of operands (key/value pairs), but got %d",
+              literals.size()));
+    }
     Map<Expression.Literal, Expression.Literal> items = new HashMap<>();
-    assert literals.size() % 2 == 0;
     for (int i = 0; i < literals.size(); i += 2) {
       items.put(literals.get(i), literals.get(i + 1));
     }

--- a/isthmus/src/test/java/io/substrait/isthmus/CatalogReaderValidationTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CatalogReaderValidationTest.java
@@ -13,6 +13,7 @@ import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.NamedStruct;
 import java.util.List;
 import java.util.function.UnaryOperator;
+import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -20,26 +21,20 @@ import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.prepare.Prepare;
-import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelDistribution;
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.RelReferentialConstraint;
-import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.prepare.RelOptTableImpl;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
-import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.jupiter.api.Test;
 
 /**
- * Substrait to Calcite conversion of the table-modification relations needs a {@link
- * Prepare.CatalogReader}, not merely a {@link RelOptSchema}. {@link
- * org.apache.calcite.rel.core.TableModify} stores the reader without checking it and only
- * dereferences it later, so an unvalidated one surfaces as a confusing failure elsewhere.
+ * Substrait to Calcite conversion of the table-modification relations needs a catalog to resolve
+ * the target table, and that catalog must be a {@link Prepare.CatalogReader}, not merely a {@link
+ * RelOptSchema}. {@link org.apache.calcite.rel.core.TableModify} stores the reader without checking
+ * it and only dereferences it later, so an unvalidated one surfaces as a confusing failure
+ * elsewhere.
  */
 class CatalogReaderValidationTest extends PlanTestBase {
 
@@ -51,18 +46,40 @@ class CatalogReaderValidationTest extends PlanTestBase {
   CatalogReaderValidationTest() throws SqlParseException {}
 
   @Test
-  void namedWriteRejectsSchemaThatIsNotACatalogReader() {
-    NamedWrite write =
-        sb.namedWrite(
-            TABLE,
-            List.of("A"),
-            AbstractWriteRel.WriteOp.INSERT,
-            AbstractWriteRel.CreateMode.UNSPECIFIED,
-            AbstractWriteRel.OutputMode.MODIFIED_RECORDS,
-            oneRowInput());
+  void namedWriteRequiresACatalogBackedRelBuilder() {
+    // A RelBuilder can be built without a catalog at all; RelBuilder.getRelOptSchema() is nullable.
+    SubstraitRelNodeConverter converter =
+        new SubstraitRelNodeConverter(relBuilderWith(schema -> null), converterProvider);
 
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> write(TABLE).accept(converter, SubstraitRelNodeConverter.Context.newContext()));
+    assertTrue(
+        e.getMessage().contains("has no RelOptSchema"),
+        () -> "unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  void namedWriteRejectsUnknownTable() {
+    SubstraitRelNodeConverter converter =
+        new SubstraitRelNodeConverter(relBuilderWith(UnaryOperator.identity()), converterProvider);
+
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                write(List.of("MISSING"))
+                    .accept(converter, SubstraitRelNodeConverter.Context.newContext()));
+    assertTrue(
+        e.getMessage().contains("Table not found in Calcite catalog"),
+        () -> "unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  void namedWriteRejectsSchemaThatIsNotACatalogReader() {
     // The write path takes its catalog reader from the RelBuilder's schema.
-    assertRejects(write, schema -> new DelegatingRelOptSchema(schema, TableSchema.SELF));
+    assertRejects(write(TABLE), schema -> new DelegatingRelOptSchema(schema, TableSchema.SELF));
   }
 
   @Test
@@ -88,6 +105,16 @@ class CatalogReaderValidationTest extends PlanTestBase {
     assertTrue(
         e.getMessage().contains(Prepare.CatalogReader.class.getName()),
         () -> "unexpected message: " + e.getMessage());
+  }
+
+  private NamedWrite write(List<String> names) {
+    return sb.namedWrite(
+        names,
+        List.of("A"),
+        AbstractWriteRel.WriteOp.INSERT,
+        AbstractWriteRel.CreateMode.UNSPECIFIED,
+        AbstractWriteRel.OutputMode.MODIFIED_RECORDS,
+        oneRowInput());
   }
 
   private NamedUpdate update() {
@@ -162,7 +189,12 @@ class CatalogReaderValidationTest extends PlanTestBase {
       if (table == null) {
         return null;
       }
-      return new DelegatingRelOptTable(table, tableSchema == TableSchema.SELF ? this : null);
+      // Re-create the resolved table so that the schema it reports is this one (or none).
+      return RelOptTableImpl.create(
+          tableSchema == TableSchema.SELF ? this : null,
+          table.getRowType(),
+          table.getQualifiedName(),
+          Expressions.constant(null));
     }
 
     @Override
@@ -173,87 +205,6 @@ class CatalogReaderValidationTest extends PlanTestBase {
     @Override
     public void registerRules(RelOptPlanner planner) {
       delegate.registerRules(planner);
-    }
-  }
-
-  /** A {@link RelOptTable} that delegates everything but the schema it claims to belong to. */
-  private static final class DelegatingRelOptTable implements RelOptTable {
-    private final RelOptTable delegate;
-    private final RelOptSchema relOptSchema;
-
-    DelegatingRelOptTable(RelOptTable delegate, RelOptSchema relOptSchema) {
-      this.delegate = delegate;
-      this.relOptSchema = relOptSchema;
-    }
-
-    @Override
-    public RelOptSchema getRelOptSchema() {
-      return relOptSchema;
-    }
-
-    @Override
-    public List<String> getQualifiedName() {
-      return delegate.getQualifiedName();
-    }
-
-    @Override
-    public double getRowCount() {
-      return delegate.getRowCount();
-    }
-
-    @Override
-    public RelDataType getRowType() {
-      return delegate.getRowType();
-    }
-
-    @Override
-    public RelNode toRel(ToRelContext context) {
-      return delegate.toRel(context);
-    }
-
-    @Override
-    public List<RelCollation> getCollationList() {
-      return delegate.getCollationList();
-    }
-
-    @Override
-    public RelDistribution getDistribution() {
-      return delegate.getDistribution();
-    }
-
-    @Override
-    public boolean isKey(ImmutableBitSet columns) {
-      return delegate.isKey(columns);
-    }
-
-    @Override
-    public List<ImmutableBitSet> getKeys() {
-      return delegate.getKeys();
-    }
-
-    @Override
-    public List<RelReferentialConstraint> getReferentialConstraints() {
-      return delegate.getReferentialConstraints();
-    }
-
-    @Override
-    public org.apache.calcite.linq4j.tree.Expression getExpression(Class clazz) {
-      return delegate.getExpression(clazz);
-    }
-
-    @Override
-    public RelOptTable extend(List<RelDataTypeField> extendedFields) {
-      return delegate.extend(extendedFields);
-    }
-
-    @Override
-    public List<ColumnStrategy> getColumnStrategies() {
-      return delegate.getColumnStrategies();
-    }
-
-    @Override
-    public <C> C unwrap(Class<C> aClass) {
-      return delegate.unwrap(aClass);
     }
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CatalogReaderValidationTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CatalogReaderValidationTest.java
@@ -1,0 +1,259 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import io.substrait.relation.AbstractWriteRel;
+import io.substrait.relation.NamedUpdate;
+import io.substrait.relation.NamedWrite;
+import io.substrait.relation.Rel;
+import io.substrait.relation.VirtualTableScan;
+import io.substrait.type.NamedStruct;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import org.apache.calcite.plan.Context;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelReferentialConstraint;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.schema.ColumnStrategy;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Substrait to Calcite conversion of the table-modification relations needs a {@link
+ * Prepare.CatalogReader}, not merely a {@link RelOptSchema}. {@link
+ * org.apache.calcite.rel.core.TableModify} stores the reader without checking it and only
+ * dereferences it later, so an unvalidated one surfaces as a confusing failure elsewhere.
+ */
+class CatalogReaderValidationTest extends PlanTestBase {
+
+  private static final List<String> TABLE = List.of("FOO");
+
+  private final CalciteCatalogReader catalogReader =
+      SubstraitCreateStatementParser.processCreateStatementsToCatalog("CREATE TABLE FOO (A INT)");
+
+  CatalogReaderValidationTest() throws SqlParseException {}
+
+  @Test
+  void namedWriteRejectsSchemaThatIsNotACatalogReader() {
+    NamedWrite write =
+        sb.namedWrite(
+            TABLE,
+            List.of("A"),
+            AbstractWriteRel.WriteOp.INSERT,
+            AbstractWriteRel.CreateMode.UNSPECIFIED,
+            AbstractWriteRel.OutputMode.MODIFIED_RECORDS,
+            oneRowInput());
+
+    // The write path takes its catalog reader from the RelBuilder's schema.
+    assertRejects(write, schema -> new DelegatingRelOptSchema(schema, TableSchema.SELF));
+  }
+
+  @Test
+  void namedUpdateRejectsTableWithoutASchema() {
+    // The update path takes its catalog reader from RelOptTable.getRelOptSchema(), which Calcite
+    // declares @Nullable.
+    assertRejects(update(), schema -> new DelegatingRelOptSchema(schema, TableSchema.NULL));
+  }
+
+  @Test
+  void namedUpdateRejectsTableSchemaThatIsNotACatalogReader() {
+    assertRejects(update(), schema -> new DelegatingRelOptSchema(schema, TableSchema.SELF));
+  }
+
+  private void assertRejects(Rel rel, UnaryOperator<RelOptSchema> schemaWrapper) {
+    SubstraitRelNodeConverter converter =
+        new SubstraitRelNodeConverter(relBuilderWith(schemaWrapper), converterProvider);
+
+    IllegalStateException e =
+        assertThrows(
+            IllegalStateException.class,
+            () -> rel.accept(converter, SubstraitRelNodeConverter.Context.newContext()));
+    assertTrue(
+        e.getMessage().contains(Prepare.CatalogReader.class.getName()),
+        () -> "unexpected message: " + e.getMessage());
+  }
+
+  private NamedUpdate update() {
+    return sb.namedUpdate(
+        TABLE,
+        List.of("A"),
+        List.of(
+            NamedUpdate.TransformExpression.builder()
+                .columnTarget(0)
+                .transformation(ExpressionCreator.i32(false, 1))
+                .build()),
+        ExpressionCreator.bool(false, true),
+        false);
+  }
+
+  private VirtualTableScan oneRowInput() {
+    return VirtualTableScan.builder()
+        .initialSchema(NamedStruct.of(List.of("A"), R.struct(R.I32)))
+        .addRows(ExpressionCreator.nestedStruct(false, ExpressionCreator.i32(false, 1)))
+        .build();
+  }
+
+  /** Builds a RelBuilder whose {@link RelOptSchema} is replaced by the given wrapper. */
+  private RelBuilder relBuilderWith(UnaryOperator<RelOptSchema> schemaWrapper) {
+    FrameworkConfig config =
+        Frameworks.newConfigBuilder()
+            .defaultSchema(catalogReader.getRootSchema().plus())
+            .typeSystem(converterProvider.getTypeSystem())
+            .build();
+    RelBuilder relBuilder =
+        Frameworks.withPrepare(
+            config,
+            (cluster, relOptSchema, rootSchema, statement) ->
+                new SchemaOverridingRelBuilder(
+                    config.getContext(), cluster, schemaWrapper.apply(relOptSchema)));
+    Utils.useReflectiveMetadataProvider(relBuilder.getCluster());
+    return relBuilder;
+  }
+
+  /** Exposes RelBuilder's schema-accepting constructor. */
+  private static final class SchemaOverridingRelBuilder extends RelBuilder {
+    private SchemaOverridingRelBuilder(
+        Context context, RelOptCluster cluster, RelOptSchema relOptSchema) {
+      super(context, cluster, relOptSchema);
+    }
+  }
+
+  /** What the tables handed out by {@link DelegatingRelOptSchema} report as their schema. */
+  private enum TableSchema {
+    /** The (non-catalog-reader) schema itself. */
+    SELF,
+    /** Nothing, which {@link RelOptTable#getRelOptSchema()} permits. */
+    NULL
+  }
+
+  /**
+   * A {@link RelOptSchema} that resolves tables through a real catalog but is deliberately not a
+   * {@link Prepare.CatalogReader}.
+   */
+  private static final class DelegatingRelOptSchema implements RelOptSchema {
+    private final RelOptSchema delegate;
+    private final TableSchema tableSchema;
+
+    DelegatingRelOptSchema(RelOptSchema delegate, TableSchema tableSchema) {
+      this.delegate = delegate;
+      this.tableSchema = tableSchema;
+    }
+
+    @Override
+    public RelOptTable getTableForMember(List<String> names) {
+      RelOptTable table = delegate.getTableForMember(names);
+      if (table == null) {
+        return null;
+      }
+      return new DelegatingRelOptTable(table, tableSchema == TableSchema.SELF ? this : null);
+    }
+
+    @Override
+    public RelDataTypeFactory getTypeFactory() {
+      return delegate.getTypeFactory();
+    }
+
+    @Override
+    public void registerRules(RelOptPlanner planner) {
+      delegate.registerRules(planner);
+    }
+  }
+
+  /** A {@link RelOptTable} that delegates everything but the schema it claims to belong to. */
+  private static final class DelegatingRelOptTable implements RelOptTable {
+    private final RelOptTable delegate;
+    private final RelOptSchema relOptSchema;
+
+    DelegatingRelOptTable(RelOptTable delegate, RelOptSchema relOptSchema) {
+      this.delegate = delegate;
+      this.relOptSchema = relOptSchema;
+    }
+
+    @Override
+    public RelOptSchema getRelOptSchema() {
+      return relOptSchema;
+    }
+
+    @Override
+    public List<String> getQualifiedName() {
+      return delegate.getQualifiedName();
+    }
+
+    @Override
+    public double getRowCount() {
+      return delegate.getRowCount();
+    }
+
+    @Override
+    public RelDataType getRowType() {
+      return delegate.getRowType();
+    }
+
+    @Override
+    public RelNode toRel(ToRelContext context) {
+      return delegate.toRel(context);
+    }
+
+    @Override
+    public List<RelCollation> getCollationList() {
+      return delegate.getCollationList();
+    }
+
+    @Override
+    public RelDistribution getDistribution() {
+      return delegate.getDistribution();
+    }
+
+    @Override
+    public boolean isKey(ImmutableBitSet columns) {
+      return delegate.isKey(columns);
+    }
+
+    @Override
+    public List<ImmutableBitSet> getKeys() {
+      return delegate.getKeys();
+    }
+
+    @Override
+    public List<RelReferentialConstraint> getReferentialConstraints() {
+      return delegate.getReferentialConstraints();
+    }
+
+    @Override
+    public org.apache.calcite.linq4j.tree.Expression getExpression(Class clazz) {
+      return delegate.getExpression(clazz);
+    }
+
+    @Override
+    public RelOptTable extend(List<RelDataTypeField> extendedFields) {
+      return delegate.extend(extendedFields);
+    }
+
+    @Override
+    public List<ColumnStrategy> getColumnStrategies() {
+      return delegate.getColumnStrategies();
+    }
+
+    @Override
+    public <C> C unwrap(Class<C> aClass) {
+      return delegate.unwrap(aClass);
+    }
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
@@ -52,6 +52,13 @@ class ExpressionConvertabilityTest extends PlanTestBase {
   }
 
   @Test
+  void listLiteralWithMixedNullability() throws IOException, SqlParseException {
+    // The values of an ARRAY constructor are not cast to a common type, so mixing a NOT NULL column
+    // with a nullable one yields list values that differ only in nullability.
+    assertFullRoundTrip("select ARRAY[O_ORDERKEY, CAST(O_SHIPPRIORITY AS BIGINT)] from ORDERS");
+  }
+
+  @Test
   void mapLiteral() throws IOException, SqlParseException {
     assertFullRoundTrip("select MAP[1, 'hello'] from ORDERS");
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubtraitRelVisitorExtensionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubtraitRelVisitorExtensionTest.java
@@ -75,7 +75,10 @@ class SubtraitRelVisitorExtensionTest {
 
     @Override
     public RelNode copy(final RelTraitSet traitSet, final List<RelNode> inputs) {
-      assert inputs.size() == 1;
+      if (inputs.size() != 1) {
+        throw new IllegalArgumentException(
+            "RepeatRel requires exactly one input, but got " + inputs.size());
+      }
       return new RepeatRel(getCluster(), traitSet, inputs.get(0), this.repeatCount);
     }
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -79,7 +79,8 @@ class VirtualTableScanTest extends PlanTestBase {
   void emptySchemaNonEmptyTable() {
     NamedStruct schema = NamedStruct.of(List.of(), R.struct());
     assertThrows(
-        AssertionError.class, () -> createVirtualTableScan(schema, List.of(sb.i32(3), sb.fp64(8))));
+        IllegalArgumentException.class,
+        () -> createVirtualTableScan(schema, List.of(sb.i32(3), sb.fp64(8))));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
@@ -1,0 +1,40 @@
+package io.substrait.isthmus.calcite.rel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.substrait.isthmus.PlanTestBase;
+import java.util.List;
+import org.apache.calcite.rel.RelNode;
+import org.junit.jupiter.api.Test;
+
+/** The DDL relations are single-input, and their {@code copy()} rejects any other input count. */
+class DdlRelCopyTest extends PlanTestBase {
+
+  private final RelNode input = builder.values(new String[] {"a"}, 1).build();
+
+  @Test
+  void createTableCopiesItsSingleInput() {
+    CreateTable createTable = new CreateTable(List.of("FOO"), input);
+
+    assertEquals(input, createTable.copy(createTable.getTraitSet(), List.of(input)).getInput(0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createTable.copy(createTable.getTraitSet(), List.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createTable.copy(createTable.getTraitSet(), List.of(input, input)));
+  }
+
+  @Test
+  void createViewCopiesItsSingleInput() {
+    CreateView createView = new CreateView(List.of("FOO"), input);
+
+    assertEquals(input, createView.copy(createView.getTraitSet(), List.of(input)).getInput(0));
+    assertThrows(
+        IllegalArgumentException.class, () -> createView.copy(createView.getTraitSet(), List.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> createView.copy(createView.getTraitSet(), List.of(input, input)));
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/expression/CallConverterOperandCountTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/expression/CallConverterOperandCountTest.java
@@ -1,0 +1,72 @@
+package io.substrait.isthmus.expression;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.isthmus.PlanTestBase;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The converters for operators whose operands come in fixed groups reject a malformed {@link
+ * RexCall} up front, instead of failing while reading the operands.
+ */
+class CallConverterOperandCountTest extends PlanTestBase {
+
+  /** Never called: the converters reject these calls before converting any operand. */
+  private static final Function<RexNode, Expression> OPERAND_CONVERTER =
+      rex -> ExpressionCreator.i32(false, 0);
+
+  private final RexBuilder rexBuilder = new RexBuilder(typeFactory);
+  private final RelDataType intType = typeFactory.createSqlType(SqlTypeName.INTEGER);
+
+  @Test
+  void caseRejectsEvenOperandCount() {
+    // A well-formed CASE has WHEN/THEN pairs plus an ELSE, so an odd number of operands.
+    RexCall call = call(intType, SqlStdOperatorTable.CASE, rexBuilder.makeLiteral(true), one());
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> CallConverters.CASE.apply(call, OPERAND_CONVERTER));
+    assertTrue(e.getMessage().contains("but got 2"), () -> "unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  void mapValueConstructorRejectsOddOperandCount() {
+    RexCall call =
+        call(
+            typeFactory.createMapType(intType, intType),
+            SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR,
+            one());
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new SqlMapValueConstructorCallConverter().convert(call, OPERAND_CONVERTER));
+    assertTrue(e.getMessage().contains("but got 1"), () -> "unexpected message: " + e.getMessage());
+  }
+
+  /**
+   * Builds a call with the given return type, bypassing the return type inference that would reject
+   * these operand counts before the converter sees them.
+   */
+  private RexCall call(
+      RelDataType returnType, org.apache.calcite.sql.SqlOperator operator, RexNode... operands) {
+    return (RexCall) rexBuilder.makeCall(returnType, operator, List.of(operands));
+  }
+
+  private RexNode one() {
+    return rexBuilder.makeExactLiteral(BigDecimal.ONE, intType);
+  }
+}


### PR DESCRIPTION
`assert` compiles behind `$assertionsDisabled`, so the invariant checks in `:core` and `:isthmus` fired in Gradle's test JVMs (which enable `-ea` by default) and nowhere else. The invariants were documented by the code and enforced in CI, but not in the place where a malformed plan actually causes damage. And when they *do* run, `AssertionError` is an `Error`, not an `Exception`, so a host that wraps plan conversion in `catch (Exception e)` to report a bad plan does not catch it — it propagates as a hard failure.

Two of these checks cost a consumer something today:

- `Expression.NestedList` — `getType()` reads `values().get(0)`, so an empty nested list throws `IndexOutOfBoundsException` from an unrelated place instead of the assert's "use `ExpressionCreator.emptyList()`" hint.
- `SubstraitRelNodeConverter` `targetTable` — a missing catalog entry passes `null` into `LogicalTableModify.create`, which NPEs inside Calcite, rather than producing the clear `"Table not found in Calcite catalog"` message the same file already produces 150 lines earlier.

The rest are invariants that today's call sites cannot violate. They stay as explicit guards — an assert that genuinely cannot fail costs nothing to write as a throw — but they are not fixes for anything.

## The rule applied

- **caller-facing invariant** (builder input, a proto message, a Calcite `RelNode`) → `IllegalArgumentException`
- **internal invariant / configuration** ("cannot happen unless the converter is misconfigured") → `IllegalStateException`
- **no bare `assert` left**, anywhere.

## `:core`

| Site | Now throws |
| --- | --- |
| `VirtualTableScan.check()` — name count vs depth-first named-field count, row shape, rows not nullable, row field types match schema | `IllegalArgumentException` |
| `Expression.NestedList.check()` — non-empty, all values the same type | `IllegalArgumentException` |
| `ExpressionProtoConverter.toLiteral()` — guard; all call sites are statically `Expression.Literal` | `IllegalArgumentException` |
| `VariadicParameterConsistencyValidator` (already threw `AssertionError` unconditionally) | `IllegalArgumentException` |

`VirtualTableScan.check()`'s compound assert is split into one check per invariant so the message names the mismatched counts, and the schema's field types are now derived once per relation instead of once per row.

`NestedList`'s homogeneity check compares element types **modulo nullability**. The `assert` it replaces compared types exactly, which under `-ea` rejected `SELECT ARRAY[not_null_col, nullable_col]`: SQL list constructors do not cast their values to a common type, so such a list legitimately holds values that differ only in nullability. Enforcing the old comparison in production would have broken queries that convert today.

## `:isthmus`

| Site | Now throws |
| --- | --- |
| `SubstraitRelNodeConverter` ×2 — `relBuilder.getRelOptSchema()` | `IllegalStateException` |
| `SubstraitRelNodeConverter` — `targetTable` | `IllegalStateException`, reusing the existing message |
| `SubstraitRelNodeConverter` — `catalogReader`, asserted on a value just assigned from a cast | dropped as dead |
| `SqlMapValueConstructorCallConverter` — operand count even | `IllegalArgumentException` |
| `CallConverters.CASE` — operand count odd | `IllegalArgumentException` |
| `CreateTable.copy()`, `CreateView.copy()` — `inputs.size() == 1` | `IllegalArgumentException` |
| `SubstraitRelVisitor` ×2 (INSERT/DELETE, UPDATE) — guard; Calcite's `TableModify` constructor already dereferences the table | `IllegalArgumentException` |
| `FunctionConverter.matchKeys()` — guard; both lists come from the same operand stream | `IllegalStateException` |

Two small refactors fall out of this: a `requireTable(TableModify)` helper in `SubstraitRelVisitor` (which also collapses the repeated `modify.getTable()` calls) and `requireRelOptSchema()` / `requireCatalogReader()` helpers in `SubstraitRelNodeConverter`, shared by the write and update paths and `protected` so subclasses overriding those `visit` methods can reuse them. The `targetTable` null check deliberately stays *after* the `switch` — the CTAS branch returns earlier and legitimately has no pre-existing table, so hoisting it to the lookup would break `handleCreateTableAs`.

`SqlMapValueConstructorCallConverter` also grows two fixes the operand-count check exposed: it ran *after* the cast that would already have thrown `ClassCastException`, and the map it builds is now insertion-ordered so a map literal keeps the key order written in the query.

The stale `@throws AssertionError` Javadoc tags are updated.

## Guarding against regressions

A custom PMD rule `AvoidAssertStatement` (`//AssertStatement`) in `substrait-pmd.xml` fails the build on any new `assert`, and its violation message states the `IllegalArgumentException` / `IllegalStateException` rule above at the offending line. PMD scans test source sets too, so the one assert in isthmus test code (`RepeatRel.copy()`) is converted as well.

## Two calls worth a second opinion

- **No grace period.** `Plan.Root.check()` is the precedent — hard `IllegalArgumentException` for the invariant, `LOGGER.warn` only for its one legacy allowance.
- **`VirtualTableScan` row/schema types still compare with exact `Type.equals`**, so nullability must match precisely there. That is the strictest reading of the spec and the most likely thing to reject another producer's plan, but relaxing it would be a semantic change rather than part of this one.

`:spark` needed no changes: its Scala sources use `require(...)`, not the Java `assert` keyword.

BREAKING CHANGE: validation that previously used `assert` now throws unconditionally. Callers catching `AssertionError` must catch `IllegalArgumentException` or `IllegalStateException` instead, and code running without `-ea` — i.e. most deployments — will now see these checks fire: `VirtualTableScan` and `Expression.NestedList` reject malformed input both from their builders and from `ProtoRelConverter` / `ProtoExpressionConverter`, and `VariadicParameterConsistencyValidator` throws `IllegalArgumentException` rather than `AssertionError`.

Closes #1047

🤖 Generated with AI
