### PR TITLE
feat(isthmus): observe window function return types

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -88,6 +88,9 @@ public class ConverterProvider {
   /** The Calcite SQL parser configuration, controlling parsing behaviour like identifier casing. */
   protected final SqlParser.Config sqlParserConfig;
 
+  /** Observer for supplied and independently inferred expression types. */
+  protected final TypeObserver typeObserver;
+
   /** Converter for Substrait scalar functions. */
   protected ScalarFunctionConverter scalarFunctionConverter;
 
@@ -215,6 +218,7 @@ public class ConverterProvider {
     this.typeConverter = builder.typeConverter;
     this.executionBehavior = builder.executionBehavior;
     this.sqlParserConfig = builder.sqlParserConfig;
+    this.typeObserver = builder.typeObserver;
 
     this.scalarFunctionConverter =
         builder.scalarFunctionConverter.orElseGet(
@@ -421,12 +425,13 @@ public class ConverterProvider {
   /**
    * Returns the observer for supplied and independently inferred expression types.
    *
-   * <p>Override to collect type observations during Substrait-to-Calcite conversion.
+   * <p>Configure via {@link Builder#typeObserver(TypeObserver)} or override this method to collect
+   * type observations during Substrait-to-Calcite conversion.
    *
    * @return a no-op observer by default
    */
   public TypeObserver getTypeObserver() {
-    return TypeObserver.NOOP;
+    return typeObserver;
   }
 
   /**
@@ -558,6 +563,7 @@ public class ConverterProvider {
     private TypeConverter typeConverter = TypeConverter.DEFAULT;
     private Plan.ExecutionBehavior executionBehavior = createDefaultExecutionBehavior();
     private SqlParser.Config sqlParserConfig = DEFAULT_SQL_PARSER_CONFIG;
+    private TypeObserver typeObserver = TypeObserver.NOOP;
 
     // Derived from the extensions and type factory at build time when left unset.
     private Optional<ScalarFunctionConverter> scalarFunctionConverter = Optional.empty();
@@ -619,6 +625,17 @@ public class ConverterProvider {
      */
     public Builder sqlParserConfig(SqlParser.Config sqlParserConfig) {
       this.sqlParserConfig = sqlParserConfig;
+      return this;
+    }
+
+    /**
+     * Sets the observer for supplied and independently inferred expression types.
+     *
+     * @param typeObserver the type observer
+     * @return this builder
+     */
+    public Builder typeObserver(TypeObserver typeObserver) {
+      this.typeObserver = typeObserver;
       return this;
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -39,6 +39,7 @@ import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCallBinding;
 import org.apache.calcite.rex.RexFieldCollation;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLambdaRef;
@@ -51,6 +52,7 @@ import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -652,8 +654,37 @@ public class ExpressionRexConverter
     observeType(
         expr,
         TypeObservation.Source.WINDOW_FUNCTION,
-        () -> rexBuilder.deriveReturnType(operator, args));
+        () -> operator.inferReturnType(windowBinding(operator, args, lowerBound, upperBound)));
     return rexOver;
+  }
+
+  /**
+   * Builds the operand binding Calcite itself uses when inferring the return type of a windowed
+   * aggregate.
+   *
+   * <p>{@link RexBuilder#deriveReturnType(SqlOperator, java.util.List)} binds the operands with a
+   * plain {@link RexCallBinding}, whose {@link
+   * org.apache.calcite.sql.SqlOperatorBinding#hasEmptyGroup()} is always {@code false}. Calcite's
+   * validator instead derives that flag from the window bounds, and an operator whose return type
+   * strategy consults it widens its result to nullable over a frame that may be empty. Among the
+   * operators reachable here that is {@code FIRST_VALUE}, {@code LAST_VALUE} and {@code NTH_VALUE},
+   * which use {@code ARG0_NULLABLE_IF_EMPTY}; the aggregates usable in a window are unaffected
+   * because {@link io.substrait.isthmus.AggregateFunctions} already forces their results nullable.
+   * Binding without the flag would report a non-nullable inferred type for the former, so a genuine
+   * nullability deviation would be observed as a match.
+   */
+  private RexCallBinding windowBinding(
+      SqlOperator operator,
+      List<RexNode> operands,
+      RexWindowBound lowerBound,
+      RexWindowBound upperBound) {
+    boolean emptyGroup = !SqlWindow.isAlwaysNonEmpty(lowerBound, upperBound);
+    return new RexCallBinding(typeFactory, operator, operands, ImmutableList.of()) {
+      @Override
+      public boolean hasEmptyGroup() {
+        return emptyGroup;
+      }
+    };
   }
 
   private Set<SqlKind> asSqlKind(Expression.SortDirection direction) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -662,13 +662,11 @@ public class ExpressionRexConverter
    * <p>{@link RexBuilder#deriveReturnType(SqlOperator, java.util.List)} binds the operands with a
    * plain {@link RexCallBinding}, whose {@link
    * org.apache.calcite.sql.SqlOperatorBinding#hasEmptyGroup()} is always {@code false}. Calcite's
-   * validator instead derives that flag from the window bounds, and an operator whose return type
-   * strategy consults it widens its result to nullable over a frame that may be empty. Among the
-   * operators reachable here that is {@code FIRST_VALUE}, {@code LAST_VALUE} and {@code NTH_VALUE},
-   * which use {@code ARG0_NULLABLE_IF_EMPTY}; the aggregates usable in a window are unaffected
-   * because {@link io.substrait.isthmus.AggregateFunctions} already forces their results nullable.
-   * Binding without the flag would report a non-nullable inferred type for the former, so a genuine
-   * nullability deviation would be observed as a match.
+   * validator instead derives that flag from the window bounds, so any return type strategy that
+   * consults it (for example {@code ARG0_NULLABLE_IF_EMPTY} or {@code AGG_SUM}) widens its result
+   * to nullable over a frame that may be empty. Binding without the flag would report a
+   * non-nullable inferred type for such an operator, so a genuine nullability deviation would be
+   * observed as a match.
    */
   private RexCallBinding windowBinding(
       SqlOperator operator,

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -551,15 +551,10 @@ public class ExpressionRexConverter
 
     RelDataType returnType = typeConverter.toCalcite(typeFactory, expr.outputType());
     RexNode rexCall = rexBuilder.makeCall(returnType, operator, args);
-    // If type observations are not needed, avoid recomputing the RexCall with Calcite's
-    // independently inferred return type.
-    if (typeObserver == TypeObserver.NOOP) {
-      return rexCall;
-    }
     observeType(
         expr,
         TypeObservation.Source.SCALAR_FUNCTION,
-        () -> rexBuilder.makeCall(operator, args).getType());
+        () -> rexBuilder.deriveReturnType(operator, args));
     return rexCall;
   }
 
@@ -567,6 +562,11 @@ public class ExpressionRexConverter
       Expression expression,
       TypeObservation.Source source,
       Supplier<RelDataType> inferredTypeSupplier) {
+    // The conversion result never depends on the independently inferred type, so when no observer
+    // is installed skip Calcite's inference entirely.
+    if (typeObserver == TypeObserver.NOOP) {
+      return;
+    }
     TypeObservation observation;
     RelDataType inferredType;
     try {
@@ -648,9 +648,6 @@ public class ExpressionRexConverter
             nullWhenCountZero,
             distinct,
             ignoreNulls);
-    if (typeObserver == TypeObserver.NOOP) {
-      return rexOver;
-    }
     observeType(
         expr,
         TypeObservation.Source.WINDOW_FUNCTION,

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -554,26 +554,27 @@ public class ExpressionRexConverter
     if (typeObserver == TypeObserver.NOOP) {
       return rexCall;
     }
-    observeScalarType(expr, () -> rexBuilder.makeCall(operator, args));
+    observeType(
+        expr,
+        TypeObservation.Source.SCALAR_FUNCTION,
+        () -> rexBuilder.makeCall(operator, args).getType());
     return rexCall;
   }
 
-  private void observeScalarType(
-      Expression.ScalarFunctionInvocation expression, Supplier<RexNode> inferredCallSupplier) {
+  private void observeType(
+      Expression expression,
+      TypeObservation.Source source,
+      Supplier<RelDataType> inferredTypeSupplier) {
     TypeObservation observation;
-    RexNode inferredCall;
+    RelDataType inferredType;
     try {
-      inferredCall = inferredCallSupplier.get();
+      inferredType = inferredTypeSupplier.get();
     } catch (RuntimeException inferenceFailure) {
-      observation =
-          TypeObservation.failure(
-              TypeObservation.Source.SCALAR_FUNCTION, expression, inferenceFailure);
+      observation = TypeObservation.failure(source, expression, inferenceFailure);
       typeObserver.observe(observation);
       return;
     }
-    observation =
-        TypeObservation.success(
-            TypeObservation.Source.SCALAR_FUNCTION, expression, inferredCall.getType());
+    observation = TypeObservation.success(source, expression, inferredType);
     typeObserver.observe(observation);
   }
 
@@ -631,19 +632,28 @@ public class ExpressionRexConverter
     boolean nullWhenCountZero = false;
     boolean allowPartial = true;
 
-    return rexBuilder.makeOver(
-        outputType,
-        (SqlAggFunction) operator,
-        args,
-        partitionKeys,
-        orderKeys,
-        lowerBound,
-        upperBound,
-        rowMode,
-        allowPartial,
-        nullWhenCountZero,
-        distinct,
-        ignoreNulls);
+    RexNode rexOver =
+        rexBuilder.makeOver(
+            outputType,
+            (SqlAggFunction) operator,
+            args,
+            partitionKeys,
+            orderKeys,
+            lowerBound,
+            upperBound,
+            rowMode,
+            allowPartial,
+            nullWhenCountZero,
+            distinct,
+            ignoreNulls);
+    if (typeObserver == TypeObserver.NOOP) {
+      return rexOver;
+    }
+    observeType(
+        expr,
+        TypeObservation.Source.WINDOW_FUNCTION,
+        () -> rexBuilder.deriveReturnType(operator, args));
+    return rexOver;
   }
 
   private Set<SqlKind> asSqlKind(Expression.SortDirection direction) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/TypeObservation.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/TypeObservation.java
@@ -15,7 +15,10 @@ public final class TypeObservation {
   /** The expression category that produced an observation. */
   public enum Source {
     /** A scalar function invocation. */
-    SCALAR_FUNCTION
+    SCALAR_FUNCTION,
+
+    /** A window function invocation. */
+    WINDOW_FUNCTION
   }
 
   private final Source source;

--- a/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
@@ -11,6 +11,7 @@ import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.expression.AggregateFunctionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
+import io.substrait.isthmus.expression.TypeObserver;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ class ConverterProviderBuilderTest {
     assertNotNull(provider.getAggregateFunctionConverter());
     assertNotNull(provider.getWindowFunctionConverter());
     assertEquals(ConverterProvider.DEFAULT_SQL_PARSER_CONFIG, provider.getSqlParserConfig());
+    assertSame(TypeObserver.NOOP, provider.getTypeObserver());
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -280,12 +280,7 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
   void injectTypeObserverThroughConverterProvider() {
     AtomicReference<TypeObservation> observed = new AtomicReference<>();
     ConverterProvider observingProvider =
-        new ConverterProvider() {
-          @Override
-          public TypeObserver getTypeObserver() {
-            return observed::set;
-          }
-        };
+        ConverterProvider.builder().typeObserver(observed::set).build();
     Expression.ScalarFunctionInvocation expr =
         sb.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -419,6 +420,34 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
+  void observeNullableWindowTypeOverPossiblyEmptyWindow() {
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ExpressionRexConverter observingConverter = observingConverter(observed::set);
+    // first_value infers ARG0 widened to nullable whenever the frame may be empty, and a frame
+    // bounded by a row offset carries no compile-time guarantee that it is not.
+    Expression.WindowFunctionInvocation expr =
+        firstValueOver(WindowBound.Preceding.of(1), WindowBound.Preceding.of(1));
+
+    expr.accept(observingConverter, Context.newContext());
+
+    assertTrue(observed.get().inferredType().orElseThrow().isNullable());
+  }
+
+  @Test
+  void observeNonNullableWindowTypeOverAlwaysNonEmptyWindow() {
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ExpressionRexConverter observingConverter = observingConverter(observed::set);
+    // A frame running from the start of the partition to the current row always holds that row,
+    // so first_value keeps the non-nullable argument type.
+    Expression.WindowFunctionInvocation expr =
+        firstValueOver(WindowBound.UNBOUNDED, WindowBound.CURRENT_ROW);
+
+    expr.accept(observingConverter, Context.newContext());
+
+    assertFalse(observed.get().inferredType().orElseThrow().isNullable());
+  }
+
+  @Test
   void skipWindowTypeInferenceForNoopObserver() {
     AtomicInteger inferenceCalls = new AtomicInteger();
     ExpressionRexConverter nonObservingConverter =
@@ -496,6 +525,20 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
         Expression.WindowBoundsType.RANGE,
         WindowBound.UNBOUNDED,
         WindowBound.UNBOUNDED);
+  }
+
+  private Expression.WindowFunctionInvocation firstValueOver(
+      WindowBound lowerBound, WindowBound upperBound) {
+    return sb.windowFn(
+        DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
+        "first_value:any",
+        R.I32,
+        Expression.AggregationPhase.INITIAL_TO_RESULT,
+        Expression.AggregationInvocation.ALL,
+        Expression.WindowBoundsType.ROWS,
+        lowerBound,
+        upperBound,
+        sb.i32(42));
   }
 
   private ExpressionRexConverter observingConverter(TypeObserver observer) {

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -30,6 +30,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
@@ -357,12 +358,57 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
 
   @Test
   void useSubstraitReturnTypeDuringWindowFunctionConversion() {
+    // THIS IS (INTENTIONALLY) THE WRONG OUTPUT TYPE
+    // SHOULD BE R.I64
+    Expression.WindowFunctionInvocation expr = rowNumberWithReturnType(R.STRING);
+
+    RexNode calciteExpr = expr.accept(expressionRexConverter, Context.newContext());
+    assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, R.STRING), calciteExpr.getType());
+  }
+
+  @Test
+  void observeSuppliedAndInferredWindowFunctionTypes() {
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ExpressionRexConverter observingConverter = observingConverter(observed::set);
+    Expression.WindowFunctionInvocation expr = rowNumberWithReturnType(R.STRING);
+
+    RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
+
+    TypeObservation observation = observed.get();
+    assertEquals(TypeObservation.Source.WINDOW_FUNCTION, observation.source());
+    assertSame(expr, observation.expression());
+    assertEquals(R.STRING, observation.suppliedType());
+    assertTrue(observation.inferenceFailure().isEmpty());
+    assertNotEquals(calciteExpr.getType(), observation.inferredType().orElseThrow());
+    assertEquals(
+        TypeConverter.DEFAULT.toCalcite(typeFactory, R.I64),
+        observation.inferredType().orElseThrow());
+    assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, R.STRING), calciteExpr.getType());
+  }
+
+  @Test
+  void observeMatchingWindowFunctionTypes() {
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ExpressionRexConverter observingConverter = observingConverter(observed::set);
+    Expression.WindowFunctionInvocation expr = rowNumberWithReturnType(R.I64);
+
+    expr.accept(observingConverter, Context.newContext());
+
+    assertSame(expr, observed.get().expression());
+    assertEquals(R.I64, observed.get().suppliedType());
+    assertEquals(
+        TypeConverter.DEFAULT.toCalcite(typeFactory, R.I64),
+        observed.get().inferredType().orElseThrow());
+  }
+
+  @Test
+  void observeArgumentDependentWindowFunctionType() {
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ExpressionRexConverter observingConverter = observingConverter(observed::set);
     Expression.WindowFunctionInvocation expr =
         sb.windowFn(
             DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
-            "row_number:",
-            // THIS IS (INTENTIONALLY) THE WRONG OUTPUT TYPE
-            // SHOULD BE R.I64
+            "lag:any",
             R.STRING,
             Expression.AggregationPhase.INITIAL_TO_RESULT,
             Expression.AggregationInvocation.ALL,
@@ -371,8 +417,64 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
             WindowBound.UNBOUNDED,
             sb.i32(42));
 
-    RexNode calciteExpr = expr.accept(expressionRexConverter, Context.newContext());
+    RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
+
+    assertEquals(SqlTypeName.INTEGER, observed.get().inferredType().orElseThrow().getSqlTypeName());
     assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, R.STRING), calciteExpr.getType());
+  }
+
+  @Test
+  void skipWindowTypeInferenceForNoopObserver() {
+    AtomicInteger inferenceCalls = new AtomicInteger();
+    ExpressionRexConverter nonObservingConverter =
+        new ExpressionRexConverter(
+            typeFactory,
+            new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory),
+            countingInferenceWindowFunctionConverter(inferenceCalls),
+            TypeConverter.DEFAULT);
+    Expression.WindowFunctionInvocation expr = rowNumberWithReturnType(R.STRING);
+
+    RexNode calciteExpr = expr.accept(nonObservingConverter, Context.newContext());
+
+    assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, R.STRING), calciteExpr.getType());
+    assertEquals(0, inferenceCalls.get());
+  }
+
+  @Test
+  void reportWindowInferenceFailureWithoutFailingConversion() {
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ExpressionRexConverter observingConverter =
+        observingConverter(failingInferenceWindowFunctionConverter(), observed::set);
+    Expression.WindowFunctionInvocation expr = rowNumberWithReturnType(R.STRING);
+
+    RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
+
+    assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, R.STRING), calciteExpr.getType());
+    assertSame(expr, observed.get().expression());
+    assertEquals(R.STRING, observed.get().suppliedType());
+    assertTrue(observed.get().inferredType().isEmpty());
+    IllegalStateException failure =
+        assertInstanceOf(
+            IllegalStateException.class, observed.get().inferenceFailure().orElseThrow());
+    assertEquals("controlled window inference failure", failure.getMessage());
+  }
+
+  @Test
+  void propagateWindowObserverException() {
+    ExpressionRexConverter observingConverter =
+        observingConverter(
+            new WindowFunctionConverter(extensions.windowFunctions(), typeFactory),
+            observation -> {
+              throw new IllegalStateException("window observer failure");
+            });
+    Expression.WindowFunctionInvocation expr = rowNumberWithReturnType(R.I64);
+
+    IllegalStateException failure =
+        assertThrows(
+            IllegalStateException.class,
+            () -> expr.accept(observingConverter, Context.newContext()));
+
+    assertEquals("window observer failure", failure.getMessage());
   }
 
   void assertTypeMatch(RelDataType actual, Type expected) {
@@ -389,6 +491,18 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
         sb.i32(42));
   }
 
+  private Expression.WindowFunctionInvocation rowNumberWithReturnType(Type outputType) {
+    return sb.windowFn(
+        DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
+        "row_number:",
+        outputType,
+        Expression.AggregationPhase.INITIAL_TO_RESULT,
+        Expression.AggregationInvocation.ALL,
+        Expression.WindowBoundsType.RANGE,
+        WindowBound.UNBOUNDED,
+        WindowBound.UNBOUNDED);
+  }
+
   private ExpressionRexConverter observingConverter(TypeObserver observer) {
     return observingConverter(
         new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory), observer);
@@ -400,6 +514,16 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
         typeFactory,
         scalarFunctionConverter,
         new WindowFunctionConverter(extensions.windowFunctions(), typeFactory),
+        TypeConverter.DEFAULT,
+        observer);
+  }
+
+  private ExpressionRexConverter observingConverter(
+      WindowFunctionConverter windowFunctionConverter, TypeObserver observer) {
+    return new ExpressionRexConverter(
+        typeFactory,
+        new ScalarFunctionConverter(extensions.scalarFunctions(), typeFactory),
+        windowFunctionConverter,
         TypeConverter.DEFAULT,
         observer);
   }
@@ -440,6 +564,45 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
       @Override
       public Optional<SqlOperator> getSqlOperatorFromSubstraitFunc(String key, Type outputType) {
         return Optional.of(countingOperator);
+      }
+    };
+  }
+
+  private WindowFunctionConverter failingInferenceWindowFunctionConverter() {
+    SqlAggFunction failingOperator =
+        new SqlAggFunction(
+            "controlled_window_inference_failure",
+            SqlKind.OTHER_FUNCTION,
+            binding -> {
+              throw new IllegalStateException("controlled window inference failure");
+            },
+            null,
+            null,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+    return windowFunctionConverter(failingOperator);
+  }
+
+  private WindowFunctionConverter countingInferenceWindowFunctionConverter(
+      AtomicInteger inferenceCalls) {
+    SqlAggFunction countingOperator =
+        new SqlAggFunction(
+            "counting_window_inference",
+            SqlKind.OTHER_FUNCTION,
+            binding -> {
+              inferenceCalls.incrementAndGet();
+              return TypeConverter.DEFAULT.toCalcite(typeFactory, R.I64);
+            },
+            null,
+            null,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION) {};
+    return windowFunctionConverter(countingOperator);
+  }
+
+  private WindowFunctionConverter windowFunctionConverter(SqlAggFunction operator) {
+    return new WindowFunctionConverter(extensions.windowFunctions(), typeFactory) {
+      @Override
+      public Optional<SqlOperator> getSqlOperatorFromSubstraitFunc(String key, Type outputType) {
+        return Optional.of(operator);
       }
     };
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitExpressionConverterTest.java
@@ -300,6 +300,30 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
   }
 
   @Test
+  void injectTypeObserverByOverridingConverterProvider() {
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ConverterProvider observingProvider =
+        new ConverterProvider() {
+          @Override
+          public TypeObserver getTypeObserver() {
+            return observed::set;
+          }
+        };
+    Expression.ScalarFunctionInvocation expr =
+        sb.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
+            "add:i32_i32",
+            R.I32,
+            sb.i32(7),
+            sb.i32(42));
+    Project query = sb.project(input -> List.of(expr), sb.emptyVirtualTableScan());
+
+    new SubstraitToCalcite(observingProvider).convert(query);
+
+    assertEquals(R.I32, observed.get().suppliedType());
+  }
+
+  @Test
   void observeEachNestedScalarFunction() {
     List<TypeObservation> observations = new ArrayList<>();
     ExpressionRexConverter observingConverter = observingConverter(observations::add);
@@ -415,7 +439,10 @@ class SubstraitExpressionConverterTest extends PlanTestBase {
 
     RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
 
-    assertEquals(SqlTypeName.INTEGER, observed.get().inferredType().orElseThrow().getSqlTypeName());
+    // LAG with no default operand forces a nullable return type.
+    assertEquals(
+        TypeConverter.DEFAULT.toCalcite(typeFactory, N.I32),
+        observed.get().inferredType().orElseThrow());
     assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, R.STRING), calciteExpr.getType());
   }
 


### PR DESCRIPTION
## Summary

- report Calcite-inferred return types through `TypeObserver` during window-function conversion
- preserve the Substrait-supplied return type and skip extra inference for `TypeObserver.NOOP`
- allow callers to configure the observer through `ConverterProvider.Builder`

## Motivation

Scalar-function type observation was introduced in #1015. Issue #379 also identifies window functions as a conversion point where Substrait-supplied and Calcite-inferred types can diverge. This change extends the same observation side channel to window functions and makes it available without subclassing `ConverterProvider`.

## Validation

- `./gradlew :isthmus:spotlessCheck :isthmus:test --tests 'io.substrait.isthmus.ConverterProviderBuilderTest' --tests 'io.substrait.isthmus.SubstraitExpressionConverterTest' :isthmus:javadoc`
- `./gradlew build --rerun-tasks`

Related to #379.
