### PR TITLE
feat(isthmus): convert nested struct and map expressions to and from Calcite

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -127,14 +127,18 @@ public class CallConverters {
           };
 
   /**
-   * Converts Calcite ROW constructors into Substrait {@link Expression.StructLiteral}s.
+   * Converts Calcite ROW constructors into Substrait {@link Expression.StructLiteral}s, or into
+   * {@link Expression.NestedStruct}s when the fields are not all literals.
    *
-   * <p>ROW values are always concrete (never null themselves) - if a value is actually null, use
-   * NullLiteral instead of StructLiteral. Therefore, the resulting StructLiteral always has
-   * nullable=false. The ROW's type may be nullable (for regular structs) or non-nullable (for UDT
-   * struct encoding), but the value itself is always concrete.
+   * <p>Either way the struct takes its nullability from the ROW's type, which is where Calcite
+   * keeps it. On a Substrait literal, {@code nullable} marks the literal's type as nullable rather
+   * than the value as null - a value that is actually null is a NullLiteral - so a nullable ROW of
+   * literals does not have to give up being a StructLiteral. The UDT struct encoding depends on
+   * that: it builds a deliberately non-nullable ROW, keeping the user-defined type's own
+   * nullability in the REINTERPRET target type, and so still arrives here as a StructLiteral.
    *
-   * <p>Each literal's nullability is set to match its field type's nullability.
+   * <p>Each literal's nullability is set to match its field type's nullability. Note that Calcite
+   * makes every field of a nullable record type nullable, so a nullable ROW widens its fields.
    */
   public static final SimpleCallConverter ROW =
       (call, visitor) -> {
@@ -145,10 +149,12 @@ public class CallConverters {
         List<Expression> operands =
             call.getOperands().stream().map(visitor).collect(Collectors.toList());
         if (!operands.stream().allMatch(expr -> expr instanceof Expression.Literal)) {
-          throw new IllegalArgumentException("ROW operands must be literals.");
+          return Expression.NestedStruct.builder()
+              .nullable(call.getType().isNullable())
+              .fields(operands)
+              .build();
         }
 
-        // ROW types are never nullable (struct literals are always concrete values).
         // Field nullability comes from individual field types, so match literal nullability
         // to field type nullability.
         List<RelDataTypeField> fieldTypes = call.getType().getFieldList();
@@ -162,9 +168,7 @@ public class CallConverters {
                     })
                 .collect(Collectors.toList());
 
-        // Struct literals are always concrete values (never null).
-        // For UDT struct literals, struct-level nullability is in the REINTERPRET target type.
-        return ExpressionCreator.struct(false, literals);
+        return ExpressionCreator.struct(call.getType().isNullable(), literals);
       };
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -439,7 +439,19 @@ public class ExpressionRexConverter
   public RexNode visit(Expression.ListLiteral expr, Context context) throws RuntimeException {
     List<RexNode> args =
         expr.values().stream().map(l -> l.accept(this, context)).collect(Collectors.toList());
-    return rexBuilder.makeCall(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, args);
+    // expr.getType() carries the nullability of the list itself, which Calcite would otherwise
+    // infer as non-nullable from the elements
+    RelDataType listType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(listType, SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, args);
+  }
+
+  @Override
+  public RexNode visit(Expression.NestedStruct expr, Context context) {
+    List<RexNode> fieldNodes =
+        expr.fields().stream().map(f -> f.accept(this, context)).collect(Collectors.toList());
+    // expr.getType() carries the nullability of the NestedStruct itself
+    RelDataType structType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(structType, SqlStdOperatorTable.ROW, fieldNodes);
   }
 
   @Override
@@ -477,7 +489,25 @@ public class ExpressionRexConverter
                         entry.getKey().accept(this, context),
                         entry.getValue().accept(this, context)))
             .collect(Collectors.toList());
-    return rexBuilder.makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, args);
+    // expr.getType() carries the nullability of the map itself, which Calcite would otherwise
+    // infer as non-nullable from the keys and values
+    RelDataType mapType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(mapType, SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, args);
+  }
+
+  @Override
+  public RexNode visit(Expression.NestedMap expr, Context context) {
+    List<RexNode> args =
+        expr.keyValues().stream()
+            .flatMap(
+                keyValue ->
+                    Stream.of(
+                        keyValue.key().accept(this, context),
+                        keyValue.value().accept(this, context)))
+            .collect(Collectors.toList());
+    // expr.getType() carries the nullability of the NestedMap itself
+    RelDataType mapType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(mapType, SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, args);
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -437,7 +437,19 @@ public class ExpressionRexConverter
   public RexNode visit(Expression.ListLiteral expr, Context context) throws RuntimeException {
     List<RexNode> args =
         expr.values().stream().map(l -> l.accept(this, context)).collect(Collectors.toList());
-    return rexBuilder.makeCall(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, args);
+    // expr.getType() carries the nullability of the list itself, which Calcite would otherwise
+    // infer as non-nullable from the elements
+    RelDataType listType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(listType, SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, args);
+  }
+
+  @Override
+  public RexNode visit(Expression.NestedStruct expr, Context context) {
+    List<RexNode> fieldNodes =
+        expr.fields().stream().map(f -> f.accept(this, context)).collect(Collectors.toList());
+    // expr.getType() carries the nullability of the NestedStruct itself
+    RelDataType structType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(structType, SqlStdOperatorTable.ROW, fieldNodes);
   }
 
   @Override
@@ -475,7 +487,25 @@ public class ExpressionRexConverter
                         entry.getKey().accept(this, context),
                         entry.getValue().accept(this, context)))
             .collect(Collectors.toList());
-    return rexBuilder.makeCall(SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, args);
+    // expr.getType() carries the nullability of the map itself, which Calcite would otherwise
+    // infer as non-nullable from the keys and values
+    RelDataType mapType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(mapType, SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, args);
+  }
+
+  @Override
+  public RexNode visit(Expression.NestedMap expr, Context context) {
+    List<RexNode> args =
+        expr.values().entrySet().stream()
+            .flatMap(
+                entry ->
+                    Stream.of(
+                        entry.getKey().accept(this, context),
+                        entry.getValue().accept(this, context)))
+            .collect(Collectors.toList());
+    // expr.getType() carries the nullability of the NestedMap itself
+    RelDataType mapType = typeConverter.toCalcite(typeFactory, expr.getType());
+    return rexBuilder.makeCall(mapType, SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, args);
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
@@ -3,21 +3,29 @@ package io.substrait.isthmus.expression;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.CallConverter;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlMapValueConstructor;
 
 /**
- * Converts Calcite {@link SqlMapValueConstructor} calls into Substrait map literals.
+ * Converts Calcite {@link SqlMapValueConstructor} calls into Substrait map expressions.
  *
- * <p>Expects an even-numbered operand list (key/value pairs) and produces an {@link Expression} map
- * literal via {@link ExpressionCreator}.
+ * <p>Expects an even-numbered operand list (key/value pairs) and produces an {@link
+ * Expression.MapLiteral} when every key and value is a literal and no key is repeated, and an
+ * {@link Expression.NestedMap} otherwise. A MapLiteral holds its pairs in a {@code Map}, so a
+ * repeated key would cost a pair; a NestedMap keeps them in a list and can represent it.
+ *
+ * <p>Either way the map takes its nullability from the call's type, which is where Calcite keeps
+ * it: on a Substrait literal, {@code nullable} marks the literal's type as nullable rather than the
+ * value as null, so a nullable map of literals is still a MapLiteral.
  */
 public class SqlMapValueConstructorCallConverter implements CallConverter {
 
@@ -26,15 +34,13 @@ public class SqlMapValueConstructorCallConverter implements CallConverter {
 
   /**
    * Attempts to convert a Calcite {@link RexCall} representing a {@link SqlMapValueConstructor}
-   * into a Substrait map literal.
+   * into a Substrait map expression.
    *
    * @param call The Calcite call to convert.
    * @param topLevelConverter Function for converting {@link RexNode} operands to Substrait {@link
    *     Expression}s.
    * @return An {@link Optional} containing the converted {@link Expression} if the operator is a
    *     {@link SqlMapValueConstructor}; otherwise {@link Optional#empty()}.
-   * @throws ClassCastException if operands converted by {@code topLevelConverter} are not {@link
-   *     Expression.Literal} instances.
    * @throws IllegalArgumentException if the number of operands is not even (expecting key/value
    *     pairs).
    */
@@ -43,28 +49,44 @@ public class SqlMapValueConstructorCallConverter implements CallConverter {
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
     SqlOperator operator = call.getOperator();
     if (operator instanceof SqlMapValueConstructor) {
-      return toMapLiteral(call, topLevelConverter);
+      return toMap(call, topLevelConverter);
     }
     return Optional.empty();
   }
 
-  private Optional<Expression> toMapLiteral(
+  private Optional<Expression> toMap(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
     if (call.operands.size() % 2 != 0) {
       throw new IllegalArgumentException(
           String.format(
-              "SqlMapValueConstructor requires an even number of operands (key/value pairs), but got %d",
+              "SqlMapValueConstructor requires an even number of operands (key/value pairs), but got"
+                  + " %d",
               call.operands.size()));
     }
-    List<Expression.Literal> literals =
-        call.operands.stream()
-            .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
-            .collect(java.util.stream.Collectors.toList());
-    // Insertion-ordered so that the map literal keeps the key order written in the query.
-    Map<Expression.Literal, Expression.Literal> items = new LinkedHashMap<>();
-    for (int i = 0; i < literals.size(); i += 2) {
-      items.put(literals.get(i), literals.get(i + 1));
+
+    List<Expression> expressions =
+        call.operands.stream().map(topLevelConverter).collect(Collectors.toList());
+
+    List<Expression.NestedMap.KeyValue> keyValues = new ArrayList<>();
+    for (int i = 0; i < expressions.size(); i += 2) {
+      keyValues.add(Expression.NestedMap.KeyValue.of(expressions.get(i), expressions.get(i + 1)));
     }
-    return Optional.of(ExpressionCreator.map(false, items));
+
+    // A MapLiteral holds its pairs in a Map, so it can only stand in for this call when every key
+    // and value is a literal and no key is repeated - a repeated key would lose a pair.
+    boolean allLiterals = expressions.stream().allMatch(e -> e instanceof Expression.Literal);
+    boolean keysAreDistinct =
+        keyValues.stream().map(Expression.NestedMap.KeyValue::key).distinct().count()
+            == keyValues.size();
+    if (allLiterals && keysAreDistinct) {
+      // A LinkedHashMap so that the pairs keep the order they were written in.
+      Map<Expression.Literal, Expression.Literal> literals = new LinkedHashMap<>();
+      for (Expression.NestedMap.KeyValue keyValue : keyValues) {
+        literals.put((Expression.Literal) keyValue.key(), (Expression.Literal) keyValue.value());
+      }
+      return Optional.of(ExpressionCreator.map(call.getType().isNullable(), literals));
+    }
+
+    return Optional.of(ExpressionCreator.nestedMap(call.getType().isNullable(), keyValues));
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/SqlMapValueConstructorCallConverter.java
@@ -3,21 +3,25 @@ package io.substrait.isthmus.expression;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.CallConverter;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlMapValueConstructor;
 
 /**
- * Converts Calcite {@link SqlMapValueConstructor} calls into Substrait map literals.
+ * Converts Calcite {@link SqlMapValueConstructor} calls into Substrait map expressions.
  *
- * <p>Expects an even-numbered operand list (key/value pairs) and produces an {@link Expression} map
- * literal via {@link ExpressionCreator}.
+ * <p>Expects an even-numbered operand list (key/value pairs) and produces an {@link
+ * Expression.MapLiteral} when every key and value is a literal, and an {@link Expression.NestedMap}
+ * otherwise. Either way the map takes its nullability from the call's type, which is where Calcite
+ * keeps it: on a Substrait literal, {@code nullable} marks the literal's type as nullable rather
+ * than the value as null, so a nullable map of literals is still a MapLiteral.
  */
 public class SqlMapValueConstructorCallConverter implements CallConverter {
 
@@ -26,38 +30,53 @@ public class SqlMapValueConstructorCallConverter implements CallConverter {
 
   /**
    * Attempts to convert a Calcite {@link RexCall} representing a {@link SqlMapValueConstructor}
-   * into a Substrait map literal.
+   * into a Substrait map expression.
    *
    * @param call The Calcite call to convert.
    * @param topLevelConverter Function for converting {@link RexNode} operands to Substrait {@link
    *     Expression}s.
    * @return An {@link Optional} containing the converted {@link Expression} if the operator is a
    *     {@link SqlMapValueConstructor}; otherwise {@link Optional#empty()}.
-   * @throws ClassCastException if operands converted by {@code topLevelConverter} are not {@link
-   *     Expression.Literal} instances.
-   * @throws AssertionError if the number of operands is not even (expecting key/value pairs).
+   * @throws IllegalArgumentException if the number of operands is not even (expecting key/value
+   *     pairs).
    */
   @Override
   public Optional<Expression> convert(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
     SqlOperator operator = call.getOperator();
     if (operator instanceof SqlMapValueConstructor) {
-      return toMapLiteral(call, topLevelConverter);
+      return toMap(call, topLevelConverter);
     }
     return Optional.empty();
   }
 
-  private Optional<Expression> toMapLiteral(
+  private Optional<Expression> toMap(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
-    List<Expression.Literal> literals =
-        call.operands.stream()
-            .map(t -> ((Expression.Literal) topLevelConverter.apply(t)))
-            .collect(java.util.stream.Collectors.toList());
-    Map<Expression.Literal, Expression.Literal> items = new HashMap<>();
-    assert literals.size() % 2 == 0;
-    for (int i = 0; i < literals.size(); i += 2) {
-      items.put(literals.get(i), literals.get(i + 1));
+    if (call.operands.size() % 2 != 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "A map value constructor takes key/value pairs, so it must have an even number of"
+                  + " operands, but it has %d.",
+              call.operands.size()));
     }
-    return Optional.of(ExpressionCreator.map(false, items));
+
+    List<Expression> expressions =
+        call.operands.stream().map(topLevelConverter).collect(Collectors.toList());
+
+    // The maps below are LinkedHashMaps so that the pairs keep the order they were written in.
+    if (expressions.stream().allMatch(e -> e instanceof Expression.Literal)) {
+      Map<Expression.Literal, Expression.Literal> literals = new LinkedHashMap<>();
+      for (int i = 0; i < expressions.size(); i += 2) {
+        literals.put(
+            (Expression.Literal) expressions.get(i), (Expression.Literal) expressions.get(i + 1));
+      }
+      return Optional.of(ExpressionCreator.map(call.getType().isNullable(), literals));
+    }
+
+    Map<Expression, Expression> values = new LinkedHashMap<>();
+    for (int i = 0; i < expressions.size(); i += 2) {
+      values.put(expressions.get(i), expressions.get(i + 1));
+    }
+    return Optional.of(ExpressionCreator.nestedMap(call.getType().isNullable(), values));
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
@@ -1,9 +1,11 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
 import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.ImmutableExpression;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
@@ -11,7 +13,9 @@ import io.substrait.type.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
 class NestedExpressionsTest extends PlanTestBase {
@@ -154,5 +158,257 @@ class NestedExpressionsTest extends PlanTestBase {
     Project project = Project.builder().expressions(expressionList).input(emptyTable).build();
 
     assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedStructWithLiteralsTest() {
+    Expression.NestedStruct literalNestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(literalExpression)
+            .addFields(sb.i32(12))
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedStruct)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.StructLiteral.class, roundTripped.getClass());
+    Expression.StructLiteral structLiteral = (Expression.StructLiteral) roundTripped;
+    assertEquals(literalNestedStruct.fields(), structLiteral.fields());
+  }
+
+  @Test
+  void nullableNestedStructWithLiteralsTest() {
+    // An all-literal struct collapses to a StructLiteral, but its nullability has to survive the
+    // collapse: on a Substrait literal, nullable describes the type, not a null value.
+    Expression.NestedStruct literalNestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(literalExpression)
+            .addFields(sb.i32(12))
+            .nullable(true)
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedStruct)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.StructLiteral.class, roundTripped.getClass());
+    assertTrue(((Expression.StructLiteral) roundTripped).nullable());
+  }
+
+  @Test
+  void nullableStructLiteralTest() {
+    // The same nullability, on a value that is a StructLiteral to begin with. Its fields are
+    // nullable because Calcite makes every field of a nullable record type nullable.
+    Expression.StructLiteral structLiteral =
+        ExpressionCreator.struct(true, ExpressionCreator.i32(true, 7));
+
+    Project project =
+        Project.builder().expressions(List.of(structLiteral)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedStructWithNonLiteralsTest() {
+    Expression.NestedStruct nonLiteralNestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(nonLiteralExpression)
+            .addFields(nonLiteralExpression2)
+            .build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nonLiteralNestedStruct))
+            .input(commonTable)
+            // project only the nestedStruct expression and exclude the 5 input columns
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void heterogeneouslyTypedNestedStructTest() {
+    Expression.NestedStruct nestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(nonLiteralExpression)
+            .addFields(fieldRef1)
+            .addFields(literalExpression)
+            .build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nestedStruct))
+            .input(commonTable)
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nullableNestedStructTest() {
+    Expression.NestedStruct nestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(nonLiteralExpression)
+            .addFields(nonLiteralExpression2)
+            .nullable(true)
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(nestedStruct)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedMapWithLiteralsTest() {
+    // keys deliberately out of natural order, so that the assertion on key order below would catch
+    // a map that no longer preserves the order the pairs were written in
+    Expression.NestedMap literalNestedMap =
+        Expression.NestedMap.builder()
+            .putValues(sb.str("zzz"), literalExpression)
+            .putValues(sb.str("aaa"), literalExpression)
+            .putValues(sb.str("mmm"), literalExpression)
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedMap)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.MapLiteral.class, roundTripped.getClass());
+    Expression.MapLiteral mapLiteral = (Expression.MapLiteral) roundTripped;
+    assertEquals(literalNestedMap.values(), mapLiteral.values());
+    // Map.equals ignores order, so compare the key sequences directly
+    assertEquals(
+        new ArrayList<>(literalNestedMap.values().keySet()),
+        new ArrayList<>(mapLiteral.values().keySet()));
+  }
+
+  @Test
+  void nullableNestedMapWithLiteralsTest() {
+    // An all-literal map collapses to a MapLiteral, but its nullability has to survive the
+    // collapse: on a Substrait literal, nullable describes the type, not a null value.
+    Expression.NestedMap literalNestedMap =
+        Expression.NestedMap.builder()
+            .putValues(sb.str("a"), literalExpression)
+            .putValues(sb.str("b"), literalExpression)
+            .nullable(true)
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedMap)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.MapLiteral.class, roundTripped.getClass());
+    assertTrue(((Expression.MapLiteral) roundTripped).nullable());
+  }
+
+  @Test
+  void nullableMapLiteralTest() {
+    // The same nullability, on a value that is a MapLiteral to begin with.
+    Expression.MapLiteral mapLiteral =
+        ExpressionCreator.map(
+            true, Map.of(ExpressionCreator.string(false, "a"), ExpressionCreator.i32(false, 1)));
+
+    Project project = Project.builder().expressions(List.of(mapLiteral)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nullableListLiteralTest() {
+    // And on a ListLiteral, the third of the three literal containers.
+    Expression.ListLiteral listLiteral =
+        ExpressionCreator.list(true, ExpressionCreator.i32(false, 1));
+
+    Project project = Project.builder().expressions(List.of(listLiteral)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedMapWithNonLiteralsTest() {
+    Expression.NestedMap nonLiteralNestedMap =
+        Expression.NestedMap.builder()
+            .putValues(sb.str("a"), nonLiteralExpression)
+            .putValues(sb.str("b"), nonLiteralExpression2)
+            .build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nonLiteralNestedMap))
+            .input(commonTable)
+            // project only the nestedMap expression and exclude the 5 input columns
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedMapWithFieldReferenceTest() {
+    Expression.NestedMap nestedMapWithField =
+        Expression.NestedMap.builder().putValues(fieldRef1, fieldRef2).build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nestedMapWithField))
+            .input(commonTable)
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nullableNestedMapTest() {
+    Expression.NestedMap nestedMap =
+        Expression.NestedMap.builder()
+            .putValues(sb.str("a"), nonLiteralExpression)
+            .nullable(true)
+            .build();
+
+    Project project = Project.builder().expressions(List.of(nestedMap)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedStructOfNestedTypesTest() {
+    Expression.NestedList list =
+        Expression.NestedList.builder()
+            .addValues(nonLiteralExpression)
+            .addValues(nonLiteralExpression2)
+            .build();
+    Expression.NestedMap map =
+        Expression.NestedMap.builder().putValues(sb.str("a"), nonLiteralExpression).build();
+
+    Expression.NestedStruct nestedStruct =
+        Expression.NestedStruct.builder().addFields(list).addFields(map).build();
+
+    Project project =
+        Project.builder().expressions(List.of(nestedStruct)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void rowConstructorFromSqlTest() throws SqlParseException {
+    assertFullRoundTrip("SELECT ROW(a + 1, b) FROM t", "CREATE TABLE t (a INT, b INT)");
+  }
+
+  @Test
+  void mapConstructorFromSqlTest() throws SqlParseException {
+    assertFullRoundTrip("SELECT MAP['key', a + 1] FROM t", "CREATE TABLE t (a INT)");
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
@@ -39,6 +39,10 @@ class NestedExpressionsTest extends PlanTestBase {
   Expression fieldRef1 = sb.fieldReference(commonTable, 2);
   Expression fieldRef2 = sb.fieldReference(commonTable, 4);
 
+  final Rel nullableIntTable =
+      sb.namedScan(List.of("nullableInts"), List.of("a", "b"), List.of(N.I32, N.I32));
+  Expression nullableIntFieldRef = sb.fieldReference(nullableIntTable, 0);
+
   @Test
   void nestedListWithLiteralsTest() {
     List<Expression> expressionList = new ArrayList<>();
@@ -97,6 +101,65 @@ class NestedExpressionsTest extends PlanTestBase {
             .build();
 
     assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedListMixingNullableLiteralAndFieldReferenceTest() {
+    // Both values are i32?, so this list is homogeneous on the way in. Calcite types every
+    // non-null literal NOT NULL, so the literal comes back non-nullable while the field reference
+    // keeps its nullability. The list still converts, because a nested list compares its element
+    // types disregarding nullability, and it still reports list<i32?>, because the element type is
+    // the nullable union of the values.
+    Expression.NestedList nestedList =
+        Expression.NestedList.builder()
+            .addValues(ExpressionCreator.i32(true, 5))
+            .addValues(nullableIntFieldRef)
+            .build();
+    assertEquals(R.list(N.I32), nestedList.getType());
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nestedList))
+            .input(nullableIntTable)
+            .remap(Rel.Remap.of(Collections.singleton(2)))
+            .build();
+
+    Expression roundTripped = roundTripExpression(project);
+    Expression.NestedList result = assertInstanceOf(Expression.NestedList.class, roundTripped);
+    assertEquals(nestedList.getType(), result.getType());
+    // The literal itself does not come back nullable, so the round trip is not identity.
+    assertEquals(ExpressionCreator.i32(false, 5), result.values().get(0));
+  }
+
+  @Test
+  void nestedMapMixingNullableLiteralAndFieldReferenceTest() {
+    // As above, for the value side of a map.
+    Expression.NestedMap nestedMap =
+        Expression.NestedMap.builder()
+            .addKeyValues(
+                Expression.NestedMap.KeyValue.of(sb.str("a"), ExpressionCreator.i32(true, 5)))
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("b"), nullableIntFieldRef))
+            .build();
+    assertEquals(R.map(R.STRING, N.I32), nestedMap.getType());
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nestedMap))
+            .input(nullableIntTable)
+            .remap(Rel.Remap.of(Collections.singleton(2)))
+            .build();
+
+    Expression roundTripped = roundTripExpression(project);
+    Expression.NestedMap result = assertInstanceOf(Expression.NestedMap.class, roundTripped);
+    assertEquals(nestedMap.getType(), result.getType());
+    assertEquals(ExpressionCreator.i32(false, 5), result.keyValues().get(0).value());
+  }
+
+  /** Converts the given single-expression project to Calcite and back, returning the expression. */
+  private Expression roundTripExpression(Project project) {
+    RelNode relNode = substraitToCalcite.convert(project);
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, converterProvider);
+    return ((Project) substraitRel).getExpressions().get(0);
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
@@ -1,17 +1,28 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
 import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.ImmutableExpression;
+import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import io.substrait.isthmus.sql.SubstraitSqlToCalcite;
+import io.substrait.plan.Plan;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
 import io.substrait.type.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
 class NestedExpressionsTest extends PlanTestBase {
@@ -154,5 +165,304 @@ class NestedExpressionsTest extends PlanTestBase {
     Project project = Project.builder().expressions(expressionList).input(emptyTable).build();
 
     assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedStructWithLiteralsTest() {
+    Expression.NestedStruct literalNestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(literalExpression)
+            .addFields(sb.i32(12))
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedStruct)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.StructLiteral.class, roundTripped.getClass());
+    Expression.StructLiteral structLiteral = (Expression.StructLiteral) roundTripped;
+    assertEquals(literalNestedStruct.fields(), structLiteral.fields());
+  }
+
+  @Test
+  void nullableNestedStructWithLiteralsTest() {
+    // An all-literal struct collapses to a StructLiteral, but its nullability has to survive the
+    // collapse: on a Substrait literal, nullable describes the type, not a null value.
+    Expression.NestedStruct literalNestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(literalExpression)
+            .addFields(sb.i32(12))
+            .nullable(true)
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedStruct)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.StructLiteral.class, roundTripped.getClass());
+    assertTrue(((Expression.StructLiteral) roundTripped).nullable());
+  }
+
+  @Test
+  void nullableStructLiteralTest() {
+    // The same nullability, on a value that is a StructLiteral to begin with. Its fields are
+    // nullable because Calcite makes every field of a nullable record type nullable.
+    Expression.StructLiteral structLiteral =
+        ExpressionCreator.struct(true, ExpressionCreator.i32(true, 7));
+
+    Project project =
+        Project.builder().expressions(List.of(structLiteral)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedStructWithNonLiteralsTest() {
+    Expression.NestedStruct nonLiteralNestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(nonLiteralExpression)
+            .addFields(nonLiteralExpression2)
+            .build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nonLiteralNestedStruct))
+            .input(commonTable)
+            // project only the nestedStruct expression and exclude the 5 input columns
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void heterogeneouslyTypedNestedStructTest() {
+    Expression.NestedStruct nestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(nonLiteralExpression)
+            .addFields(fieldRef1)
+            .addFields(literalExpression)
+            .build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nestedStruct))
+            .input(commonTable)
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nullableNestedStructTest() {
+    Expression.NestedStruct nestedStruct =
+        Expression.NestedStruct.builder()
+            .addFields(nonLiteralExpression)
+            .addFields(nonLiteralExpression2)
+            .nullable(true)
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(nestedStruct)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedMapWithLiteralsTest() {
+    // keys deliberately out of natural order, so that the assertion on key order below would catch
+    // a map that no longer preserves the order the pairs were written in
+    Expression.NestedMap literalNestedMap =
+        Expression.NestedMap.builder()
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("zzz"), literalExpression))
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("aaa"), literalExpression))
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("mmm"), literalExpression))
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedMap)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.MapLiteral.class, roundTripped.getClass());
+    Expression.MapLiteral mapLiteral = (Expression.MapLiteral) roundTripped;
+
+    List<Expression> keys =
+        literalNestedMap.keyValues().stream()
+            .map(Expression.NestedMap.KeyValue::key)
+            .collect(Collectors.toList());
+    // Map.equals ignores order, so compare the key sequences directly
+    assertEquals(keys, new ArrayList<>(mapLiteral.values().keySet()));
+    List<Expression> values =
+        literalNestedMap.keyValues().stream()
+            .map(Expression.NestedMap.KeyValue::value)
+            .collect(Collectors.toList());
+    assertEquals(values, new ArrayList<>(mapLiteral.values().values()));
+  }
+
+  @Test
+  void nestedMapWithRepeatedLiteralKeysTest() {
+    // A map expression may repeat a key, which a MapLiteral cannot represent, so this one has to
+    // stay a NestedMap even though every key and value is a literal.
+    Expression.NestedMap repeatedKeys =
+        Expression.NestedMap.builder()
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("a"), sb.i32(1)))
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("a"), sb.i32(2)))
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(repeatedKeys)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.NestedMap.class, roundTripped.getClass());
+    assertEquals(repeatedKeys.keyValues(), ((Expression.NestedMap) roundTripped).keyValues());
+  }
+
+  @Test
+  void nullableNestedMapWithLiteralsTest() {
+    // An all-literal map collapses to a MapLiteral, but its nullability has to survive the
+    // collapse: on a Substrait literal, nullable describes the type, not a null value.
+    Expression.NestedMap literalNestedMap =
+        Expression.NestedMap.builder()
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("a"), literalExpression))
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("b"), literalExpression))
+            .nullable(true)
+            .build();
+
+    Project project =
+        Project.builder().expressions(List.of(literalNestedMap)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project); // substrait rel to calcite
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions); // calcite to substrait
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.MapLiteral.class, roundTripped.getClass());
+    assertTrue(((Expression.MapLiteral) roundTripped).nullable());
+  }
+
+  @Test
+  void nullableMapLiteralTest() {
+    // The same nullability, on a value that is a MapLiteral to begin with.
+    Expression.MapLiteral mapLiteral =
+        ExpressionCreator.map(
+            true, Map.of(ExpressionCreator.string(false, "a"), ExpressionCreator.i32(false, 1)));
+
+    Project project = Project.builder().expressions(List.of(mapLiteral)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nullableListLiteralTest() {
+    // And on a ListLiteral, the third of the three literal containers.
+    Expression.ListLiteral listLiteral =
+        ExpressionCreator.list(true, ExpressionCreator.i32(false, 1));
+
+    Project project = Project.builder().expressions(List.of(listLiteral)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedMapWithNonLiteralsTest() {
+    Expression.NestedMap nonLiteralNestedMap =
+        Expression.NestedMap.builder()
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("a"), nonLiteralExpression))
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("b"), nonLiteralExpression2))
+            .build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nonLiteralNestedMap))
+            .input(commonTable)
+            // project only the nestedMap expression and exclude the 5 input columns
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedMapWithFieldReferenceTest() {
+    Expression.NestedMap nestedMapWithField =
+        Expression.NestedMap.builder()
+            .addKeyValues(Expression.NestedMap.KeyValue.of(fieldRef1, fieldRef2))
+            .build();
+
+    Project project =
+        Project.builder()
+            .expressions(List.of(nestedMapWithField))
+            .input(commonTable)
+            .remap(Rel.Remap.of(Collections.singleton(5)))
+            .build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nullableNestedMapTest() {
+    Expression.NestedMap nestedMap =
+        Expression.NestedMap.builder()
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("a"), nonLiteralExpression))
+            .nullable(true)
+            .build();
+
+    Project project = Project.builder().expressions(List.of(nestedMap)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void nestedStructOfNestedTypesTest() {
+    Expression.NestedList list =
+        Expression.NestedList.builder()
+            .addValues(nonLiteralExpression)
+            .addValues(nonLiteralExpression2)
+            .build();
+    Expression.NestedMap map =
+        Expression.NestedMap.builder()
+            .addKeyValues(Expression.NestedMap.KeyValue.of(sb.str("a"), nonLiteralExpression))
+            .build();
+
+    Expression.NestedStruct nestedStruct =
+        Expression.NestedStruct.builder().addFields(list).addFields(map).build();
+
+    Project project =
+        Project.builder().expressions(List.of(nestedStruct)).input(emptyTable).build();
+
+    assertFullRoundTrip(project);
+  }
+
+  @Test
+  void rowConstructorFromSqlTest() throws SqlParseException {
+    assertFullRoundTrip("SELECT ROW(a + 1, b) FROM t", "CREATE TABLE t (a INT, b INT)");
+  }
+
+  @Test
+  void mapConstructorFromSqlTest() throws SqlParseException {
+    assertFullRoundTrip("SELECT MAP['key', a + 1] FROM t", "CREATE TABLE t (a INT)");
+  }
+
+  @Test
+  void mapConstructorWithRepeatedKeyFromSqlTest() throws SqlParseException {
+    // A repeated key rules out a MapLiteral, so both pairs have to be carried by a NestedMap. The
+    // round trip starts at Calcite, so it alone would not catch a pair dropped on the way in.
+    String query = "SELECT MAP['key', 1, 'key', 2] FROM t";
+    CalciteCatalogReader catalog =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog("CREATE TABLE t (a INT)");
+
+    RelRoot calcite = SubstraitSqlToCalcite.convertQuery(query, catalog, converterProvider);
+    Plan.Root root = SubstraitRelVisitor.convert(calcite, converterProvider);
+    Expression expression = ((Project) root.getInput()).getExpressions().get(0);
+    assertEquals(2, assertInstanceOf(Expression.NestedMap.class, expression).keyValues().size());
+
+    assertFullRoundTrip(query, catalog);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/UserDefinedLiteralRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/UserDefinedLiteralRoundtripTest.java
@@ -228,6 +228,23 @@ class UserDefinedLiteralRoundtripTest extends PlanTestBase {
   }
 
   @Test
+  void structEncodedUdtWithNullableStructFieldRoundTrip() {
+    // A struct-encoded UDT is a Calcite ROW that CallConverters.REINTERPRET recognises by its
+    // operand being a StructLiteral. A nullable struct field produces a nullable inner ROW, so
+    // anything that stops a nullable ROW of literals from converting back to a StructLiteral also
+    // breaks the enclosing user-defined literal.
+    assertRoundTrip(
+        ExpressionCreator.userDefinedLiteralStruct(
+            false,
+            NESTED_TYPES_URN,
+            "point",
+            Collections.emptyList(),
+            Arrays.asList(
+                ExpressionCreator.struct(true, ExpressionCreator.i32(true, 1)),
+                ExpressionCreator.i32(false, 100))));
+  }
+
+  @Test
   void parameterizedUdtRoundTrip() {
     Type.Parameter typeParam =
         io.substrait.type.ImmutableType.ParameterDataType.builder()


### PR DESCRIPTION
Builds on #1062, now merged, which added the `NestedMap` POJO and the proto import this needs.

Of the three nested expression kinds, only nested lists survived a trip through Calcite. In the Substrait to Calcite direction `ExpressionRexConverter` had no case for `NestedStruct` or `NestedMap`, so both reached `visitFallback` and threw `UnsupportedOperationException`. Coming back the other way, `CallConverters.ROW` rejected any ROW whose fields were not all literals with "ROW operands must be literals.", and the map value constructor cast every operand to `Expression.Literal` — so `SELECT ROW(a + 1, b)` and `SELECT MAP['key', a + 1]` failed with an `IllegalArgumentException` and a `ClassCastException` respectively.

Nested structs now become Calcite ROW calls and nested maps become `MAP_VALUE_CONSTRUCTOR` calls, each carrying its own nullability in the call type. In reverse, a ROW or map constructor whose operands are not all literals falls back to a `NestedStruct` or `NestedMap` — the same treatment array value constructors already gave nested lists — while the all-literal cases still collapse to a `StructLiteral` or `MapLiteral`.

A map constructor has to clear one more bar than a ROW to collapse: its keys must also be distinct. A `MapLiteral` holds its pairs in a `Map`, so `MAP['key', 1, 'key', 2]` came back with one pair instead of two; it now stays a `NestedMap`, which keeps its pairs in a list. Same limitation as the one #1062 fixed, reached from the SQL side instead of from proto.

## Nullability has to survive that collapse

`nullable` on a Substrait literal marks the literal's *type* as nullable, not the value as null — a value that is actually null is a `NullLiteral`. The ROW and map converters were hardcoding `nullable=false`, so a nullable struct or map of literals silently came back non-nullable. They now take it from the call type, which is what the array value constructor already did for lists.

The same gap existed in the other direction: the list and map literal visitors let Calcite infer the container type from the elements, which discards the container's own nullability, so they now pass the converted type like their struct and nested counterparts.

Struct-level nullability is deliberately kept *inside* `StructLiteral` rather than routed out to `NestedStruct`. Routing looks tidier and gives an exact round trip, but it breaks the user-defined type struct encoding, which recognises its payload by it being a `StructLiteral`: a UDT literal with a nullable struct field produces a nullable inner ROW, that ROW becomes a `NestedStruct`, the enclosing UDT ROW then fails its all-literals test too, and `REINTERPRET` can no longer extract the literal — `IllegalArgumentException: Unable to convert call Reinterpret(struct<struct<i32>?, i32>)`. `structEncodedUdtWithNullableStructFieldRoundTrip` locks that shape down.

One consequence to be aware of: Calcite makes every field of a nullable record type nullable, so a nullable struct widens its field types on the way through. That is Calcite's representation of a nullable row, not something this change can avoid.

## Mixed literal and non-literal entries, and what remains of #1066

Calcite types every non-null literal NOT NULL while preserving nullability on everything else, so a nested value that mixes a nullable literal with a nullable non-literal of the same declared type came back with entry types that no longer matched. `NestedList` and `NestedMap` used to reject that outright. As of #1062 they compare their element types disregarding nullability and report the nullable union, so such a value converts, and the container's own type survives the round trip — `list<i32?>` in, `list<i32?>` out.

What is still lost is the nullability of the individual literal, which comes back non-nullable. So the round trip is not identity, and that part of #1066 stays open; fixing it needs literals to carry their nullability across the Calcite boundary, which is a change to every literal visitor rather than to the nested arms. `nestedListMixingNullableLiteralAndFieldReferenceTest` and its map counterpart pin down where the behaviour stands.

## Incidental fix in the map converter

The literal map is built in operand order rather than `HashMap` order, so the emitted `key_values` no longer depend on hash iteration order.

Closes #375
