### PR TITLE
fix(isthmus)!: use schema types for virtual table literals

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -163,19 +163,19 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     NamedStruct type = typeConverter.toNamedStruct(values.getRowType());
 
     LiteralConverter literalConverter = new LiteralConverter(typeConverter);
-    List<Type> schemaFieldTypes = type.struct().fields();
     List<Expression.NestedStruct> structs =
         values.getTuples().stream()
             .map(
                 list -> {
-                  // Use schema nullability since Calcite infers non-nullable for all non-null
-                  // values
+                  // Calcite may infer a narrower type for a tuple literal than for its row field.
+                  // Virtual table rows must use the complete schema type.
                   List<Expression> fields =
                       IntStream.range(0, list.size())
                           .mapToObj(
                               i ->
                                   literalConverter.convert(
-                                      list.get(i), schemaFieldTypes.get(i).nullable()))
+                                      list.get(i),
+                                      values.getRowType().getFieldList().get(i).getType()))
                           .collect(Collectors.toUnmodifiableList());
                   return ExpressionCreator.nestedStruct(false, fields);
                 })

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -56,6 +56,7 @@ import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
@@ -161,6 +162,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   @Override
   public Rel visit(org.apache.calcite.rel.core.Values values) {
     NamedStruct type = typeConverter.toNamedStruct(values.getRowType());
+    List<RelDataTypeField> rowFields = values.getRowType().getFieldList();
 
     LiteralConverter literalConverter = new LiteralConverter(typeConverter);
     List<Expression.NestedStruct> structs =
@@ -168,14 +170,12 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
             .map(
                 list -> {
                   // Calcite may infer a narrower type for a tuple literal than for its row field.
-                  // Virtual table rows must use the complete schema type.
+                  // Virtual table rows must use the row field type.
                   List<Expression> fields =
                       IntStream.range(0, list.size())
                           .mapToObj(
                               i ->
-                                  literalConverter.convert(
-                                      list.get(i),
-                                      values.getRowType().getFieldList().get(i).getType()))
+                                  literalConverter.convert(list.get(i), rowFields.get(i).getType()))
                           .collect(Collectors.toUnmodifiableList());
                   return ExpressionCreator.nestedStruct(false, fields);
                 })

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -96,39 +96,23 @@ public class LiteralConverter {
   }
 
   /**
-   * Converts a RexLiteral to a Substrait Literal with the specified nullability.
-   *
-   * <p>This overload is useful when the target nullability should come from the schema rather than
-   * the literal's own type. For example, Calcite's LogicalValues may have literals with
-   * non-nullable types even when the schema field is nullable.
-   *
-   * @param literal the RexLiteral to convert
-   * @param nullable the nullability to use for the resulting Substrait literal
-   * @return the converted Substrait Literal
-   */
-  public Expression.Literal convert(RexLiteral literal, boolean nullable) {
-    return convert(literal, literal.getType(), nullable);
-  }
-
-  /**
-   * Converts a RexLiteral to a Substrait Literal using the specified result type.
+   * Converts a RexLiteral to a Substrait Literal carrying the given result type.
    *
    * <p>This overload is useful when the target type comes from a containing schema rather than the
    * literal itself. Calcite may infer a narrower type for a value in a LogicalValues tuple than for
-   * the corresponding row field.
+   * the corresponding row field. Nullability is taken from {@code resultType}, so callers that need
+   * a nullability other than the literal's own should widen the Calcite type with {@link
+   * org.apache.calcite.rel.type.RelDataTypeFactory#createTypeWithNullability} before calling.
    *
    * @param literal the RexLiteral to convert
    * @param resultType the Calcite type required by the containing schema
    * @return the converted Substrait Literal
    */
   public Expression.Literal convert(RexLiteral literal, RelDataType resultType) {
-    Type type = typeConverter.toSubstrait(resultType);
-    return convert(literal, resultType, type.nullable());
-  }
-
-  private Expression.Literal convert(RexLiteral literal, RelDataType resultType, boolean nullable) {
+    // convert type first to guarantee we can handle the value.
+    final Type type = typeConverter.toSubstrait(resultType);
+    final boolean nullable = type.nullable();
     if (literal.isNull()) {
-      final Type type = typeConverter.toSubstrait(resultType);
       final Type typeWithNullability =
           nullable ? TypeCreator.asNullable(type) : TypeCreator.asNotNullable(type);
       return ExpressionCreator.typedNull(typeWithNullability);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.util.DateString;
@@ -91,9 +92,7 @@ public class LiteralConverter {
    * @throws UnsupportedOperationException if the literal type/value cannot be handled
    */
   public Expression.Literal convert(RexLiteral literal) {
-    // convert type first to guarantee we can handle the value.
-    final Type type = typeConverter.toSubstrait(literal.getType());
-    return convert(literal, type.nullable());
+    return convert(literal, literal.getType());
   }
 
   /**
@@ -108,14 +107,34 @@ public class LiteralConverter {
    * @return the converted Substrait Literal
    */
   public Expression.Literal convert(RexLiteral literal, boolean nullable) {
+    return convert(literal, literal.getType(), nullable);
+  }
+
+  /**
+   * Converts a RexLiteral to a Substrait Literal using the specified result type.
+   *
+   * <p>This overload is useful when the target type comes from a containing schema rather than the
+   * literal itself. Calcite may infer a narrower type for a value in a LogicalValues tuple than for
+   * the corresponding row field.
+   *
+   * @param literal the RexLiteral to convert
+   * @param resultType the Calcite type required by the containing schema
+   * @return the converted Substrait Literal
+   */
+  public Expression.Literal convert(RexLiteral literal, RelDataType resultType) {
+    Type type = typeConverter.toSubstrait(resultType);
+    return convert(literal, resultType, type.nullable());
+  }
+
+  private Expression.Literal convert(RexLiteral literal, RelDataType resultType, boolean nullable) {
     if (literal.isNull()) {
-      final Type type = typeConverter.toSubstrait(literal.getType());
+      final Type type = typeConverter.toSubstrait(resultType);
       final Type typeWithNullability =
           nullable ? TypeCreator.asNullable(type) : TypeCreator.asNotNullable(type);
       return ExpressionCreator.typedNull(typeWithNullability);
     }
 
-    switch (literal.getType().getSqlTypeName()) {
+    switch (resultType.getSqlTypeName()) {
       case TINYINT:
         return ExpressionCreator.i8(nullable, i(literal).intValue());
       case SMALLINT:
@@ -145,15 +164,15 @@ public class LiteralConverter {
         {
           BigDecimal bd = bd(literal);
           return ExpressionCreator.decimal(
-              nullable, bd, literal.getType().getPrecision(), literal.getType().getScale());
+              nullable, bd, resultType.getPrecision(), resultType.getScale());
         }
       case VARCHAR:
         {
-          if (literal.getType().getPrecision() == RelDataType.PRECISION_NOT_SPECIFIED) {
+          if (resultType.getPrecision() == RelDataType.PRECISION_NOT_SPECIFIED) {
             return ExpressionCreator.string(nullable, s(literal));
           }
 
-          return ExpressionCreator.varChar(nullable, s(literal), literal.getType().getPrecision());
+          return ExpressionCreator.varChar(nullable, s(literal), resultType.getPrecision());
         }
       case BINARY:
         return ExpressionCreator.fixedBinary(
@@ -161,7 +180,7 @@ public class LiteralConverter {
             ByteString.copyFrom(
                 padRightIfNeeded(
                     literal.getValueAs(org.apache.calcite.avatica.util.ByteString.class),
-                    literal.getType().getPrecision())));
+                    resultType.getPrecision())));
       case VARBINARY:
         return ExpressionCreator.binary(
             nullable, ByteString.copyFrom(literal.getValueAs(byte[].class)));
@@ -246,21 +265,29 @@ public class LiteralConverter {
         {
           List<RexLiteral> literals = (List<RexLiteral>) literal.getValue();
           return ExpressionCreator.struct(
-              nullable, literals.stream().map(this::convert).collect(Collectors.toList()));
+              nullable,
+              IntStream.range(0, literals.size())
+                  .mapToObj(
+                      i -> convert(literals.get(i), resultType.getFieldList().get(i).getType()))
+                  .collect(Collectors.toList()));
         }
 
       case ARRAY:
         {
           List<RexLiteral> literals = (List<RexLiteral>) literal.getValue();
+          RelDataType componentType = Objects.requireNonNull(resultType.getComponentType());
           return ExpressionCreator.list(
-              nullable, literals.stream().map(this::convert).collect(Collectors.toList()));
+              nullable,
+              literals.stream()
+                  .map(nestedLiteral -> convert(nestedLiteral, componentType))
+                  .collect(Collectors.toList()));
         }
 
       default:
         throw new UnsupportedOperationException(
             String.format(
                 "Unable to convert the value of %s of type %s to a literal.",
-                literal, literal.getType().getSqlTypeName()));
+                literal, resultType.getSqlTypeName()));
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -14,6 +14,7 @@ import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.SubstraitRelNodeConverter.Context;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
+import io.substrait.isthmus.expression.LiteralConverter;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.type.TypeCreator;
@@ -27,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlIntervalQualifier;
@@ -398,6 +400,17 @@ class CalciteLiteralTest extends CalciteObjs {
                 Arrays.asList("c1", "c2")),
             false,
             false));
+  }
+
+  @Test
+  void tStructUsesResultFieldTypes() {
+    RelDataType literalType = type.createStructType(List.of(t(SqlTypeName.TINYINT)), List.of("c1"));
+    RexLiteral literal = (RexLiteral) rex.makeLiteral(List.of(4), literalType, false, false);
+    RelDataType resultType = type.createStructType(List.of(tN(SqlTypeName.INTEGER)), List.of("c1"));
+
+    assertEquals(
+        ExpressionCreator.struct(false, ExpressionCreator.i32(true, 4)),
+        new LiteralConverter(TypeConverter.DEFAULT).convert(literal, resultType));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -120,22 +120,33 @@ class VirtualTableScanTest extends PlanTestBase {
 
   @Test
   void valuesLiteralUsesSchemaType() {
-    RelDataType rowType = typeFactory.builder().add("col1", SqlTypeName.INTEGER).build();
-    RexLiteral literal =
+    RelDataType requiredI32 = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    RelDataType nullableI32 = typeFactory.createTypeWithNullability(requiredI32, true);
+    RelDataType rowType =
+        typeFactory.builder().add("required", requiredI32).add("nullable", nullableI32).build();
+    RelDataType narrowType = typeFactory.createSqlType(SqlTypeName.TINYINT);
+    RexLiteral one = builder.getRexBuilder().makeExactLiteral(BigDecimal.ONE, narrowType);
+    RexLiteral nullValue =
         builder
             .getRexBuilder()
-            .makeExactLiteral(BigDecimal.ONE, typeFactory.createSqlType(SqlTypeName.TINYINT));
+            .makeNullLiteral(typeFactory.createTypeWithNullability(narrowType, true));
+    RexLiteral five = builder.getRexBuilder().makeExactLiteral(BigDecimal.valueOf(5), narrowType);
     LogicalValues values =
         LogicalValues.create(
-            builder.getCluster(), rowType, ImmutableList.of(ImmutableList.of(literal)));
+            builder.getCluster(),
+            rowType,
+            ImmutableList.of(ImmutableList.of(one, nullValue), ImmutableList.of(one, five)));
 
     VirtualTableScan converted =
         assertInstanceOf(
             VirtualTableScan.class, SubstraitRelVisitor.convert(values, converterProvider));
-    assertEquals(R.I32, converted.getInitialSchema().struct().fields().get(0));
-    Expression.I32Literal convertedLiteral =
-        assertInstanceOf(Expression.I32Literal.class, converted.getRows().get(0).fields().get(0));
-    assertEquals(1, convertedLiteral.value());
+    assertEquals(List.of(R.I32, N.I32), converted.getInitialSchema().struct().fields());
+    assertEquals(
+        List.of(ExpressionCreator.i32(false, 1), ExpressionCreator.typedNull(N.I32)),
+        converted.getRows().get(0).fields());
+    assertEquals(
+        List.of(ExpressionCreator.i32(false, 1), ExpressionCreator.i32(true, 5)),
+        converted.getRows().get(1).fields());
   }
 
   @SafeVarargs

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -2,14 +2,17 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.NamedStruct;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +20,11 @@ import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.externalize.RelWriterImpl;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
 class VirtualTableScanTest extends PlanTestBase {
@@ -109,6 +116,26 @@ class VirtualTableScanTest extends PlanTestBase {
     VirtualTableScan virtualTableScan =
         createVirtualTableScan(schema, List.of(nullI32, sb.fp64(8), nullString));
     assertFullRoundTrip(virtualTableScan);
+  }
+
+  @Test
+  void valuesLiteralUsesSchemaType() {
+    RelDataType rowType = typeFactory.builder().add("col1", SqlTypeName.INTEGER).build();
+    RexLiteral literal =
+        builder
+            .getRexBuilder()
+            .makeExactLiteral(BigDecimal.ONE, typeFactory.createSqlType(SqlTypeName.TINYINT));
+    LogicalValues values =
+        LogicalValues.create(
+            builder.getCluster(), rowType, ImmutableList.of(ImmutableList.of(literal)));
+
+    VirtualTableScan converted =
+        assertInstanceOf(
+            VirtualTableScan.class, SubstraitRelVisitor.convert(values, converterProvider));
+    assertEquals(R.I32, converted.getInitialSchema().struct().fields().get(0));
+    Expression.I32Literal convertedLiteral =
+        assertInstanceOf(Expression.I32Literal.class, converted.getRows().get(0).fields().get(0));
+    assertEquals(1, convertedLiteral.value());
   }
 
   @SafeVarargs


### PR DESCRIPTION
## Summary

- convert `LogicalValues` tuple literals using the complete row-schema field type;
- preserve the existing literal-based behavior for other expression conversions;
- add a regression test for a `TINYINT` tuple literal in an `INTEGER` field.

`VirtualTableScan` requires row field types to exactly match its schema. Calcite
may infer a narrower type for a tuple literal than for the corresponding
`LogicalValues` row field — `Values.assertRowType()` only asserts that the field
type `canAssignFrom` the literal type, so a `TINYINT` literal is a legal member of
an `INTEGER` row. Previously Isthmus copied only schema nullability, so the
conversion could construct an `I8` row under an `I32` schema and fail its own
validation.

`LiteralConverter.convert` now takes the schema `RelDataType`, and derives
nullability from it rather than from a separate flag. Existing callers continue to
derive the result type from the literal itself.

Fixes #1064

BREAKING CHANGE: `io.substrait.isthmus.expression.LiteralConverter#convert(RexLiteral, boolean)` is removed. Use `convert(RexLiteral, RelDataType)`, which takes nullability from the supplied Calcite type; callers needing a nullability other than the literal's own should widen the type with `RelDataTypeFactory#createTypeWithNullability` first.
