### PR TITLE
feat(core)!: enforce Fetch offset/count expressions are integer-typed

### DIFF
--- a/core/src/main/java/io/substrait/relation/Fetch.java
+++ b/core/src/main/java/io/substrait/relation/Fetch.java
@@ -29,6 +29,32 @@ public abstract class Fetch extends SingleInputRel implements HasExtension {
    */
   public abstract Optional<Expression> getCount();
 
+  @Value.Check
+  protected void check() {
+    getOffset()
+        .ifPresent(
+            offset -> {
+              Type type = offset.getType();
+              if (!type.isInteger()) {
+                throw new IllegalArgumentException(
+                    "Fetch offset expression must have an integer type "
+                        + "(I8, I16, I32 or I64), but got: "
+                        + type);
+              }
+            });
+    getCount()
+        .ifPresent(
+            count -> {
+              Type type = count.getType();
+              if (!type.isInteger()) {
+                throw new IllegalArgumentException(
+                    "Fetch count expression must have an integer type "
+                        + "(I8, I16, I32 or I64), but got: "
+                        + type);
+              }
+            });
+  }
+
   @Override
   protected Type.Struct deriveRecordType() {
     return getInput().getRecordType();

--- a/core/src/main/java/io/substrait/relation/Fetch.java
+++ b/core/src/main/java/io/substrait/relation/Fetch.java
@@ -1,6 +1,7 @@
 package io.substrait.relation;
 
 import io.substrait.expression.Expression;
+import io.substrait.type.StringTypeVisitor;
 import io.substrait.type.Type;
 import io.substrait.util.VisitationContext;
 import java.util.Optional;
@@ -29,30 +30,31 @@ public abstract class Fetch extends SingleInputRel implements HasExtension {
    */
   public abstract Optional<Expression> getCount();
 
+  /**
+   * Validates that the offset and count expressions are integer-typed. Both must evaluate to a
+   * non-negative integer; {@code i64} is recommended but not required, so any integer width is
+   * accepted (spec v0.99.0).
+   *
+   * @throws IllegalArgumentException if the offset or count expression is not integer-typed
+   */
   @Value.Check
   protected void check() {
-    getOffset()
-        .ifPresent(
-            offset -> {
-              Type type = offset.getType();
-              if (!type.isInteger()) {
-                throw new IllegalArgumentException(
-                    "Fetch offset expression must have an integer type "
-                        + "(I8, I16, I32 or I64), but got: "
-                        + type);
-              }
-            });
-    getCount()
-        .ifPresent(
-            count -> {
-              Type type = count.getType();
-              if (!type.isInteger()) {
-                throw new IllegalArgumentException(
-                    "Fetch count expression must have an integer type "
-                        + "(I8, I16, I32 or I64), but got: "
-                        + type);
-              }
-            });
+    requireIntegerType(getOffset(), "offset");
+    requireIntegerType(getCount(), "count");
+  }
+
+  private static void requireIntegerType(Optional<Expression> expression, String field) {
+    expression.ifPresent(
+        e -> {
+          Type type = e.getType();
+          if (!type.isInteger()) {
+            throw new IllegalArgumentException(
+                "Fetch "
+                    + field
+                    + " expression must have an integer type (i8, i16, i32 or i64), but got: "
+                    + type.accept(new StringTypeVisitor()));
+          }
+        });
   }
 
   @Override

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -53,6 +53,18 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
     return TypeCreator.asNullable(this).equals(TypeCreator.asNullable(other));
   }
 
+  /**
+   * Returns whether this is one of the integer types {@link I8}, {@link I16}, {@link I32} or {@link
+   * I64}. The Substrait spec only "recommends" {@code i64} for contexts such as {@code FetchRel}'s
+   * {@code offset_expr}/{@code count_expr}, so callers that accept any integer width can use this
+   * to reject non-integer types.
+   *
+   * @return {@code true} if this is an integer type
+   */
+  default boolean isInteger() {
+    return this instanceof I8 || this instanceof I16 || this instanceof I32 || this instanceof I64;
+  }
+
   /** The boolean type. */
   @Value.Immutable
   abstract class Bool implements Type {

--- a/core/src/main/java/io/substrait/type/Type.java
+++ b/core/src/main/java/io/substrait/type/Type.java
@@ -54,10 +54,8 @@ public interface Type extends TypeExpression, ParameterizedType, NullableType, F
   }
 
   /**
-   * Returns whether this is one of the integer types {@link I8}, {@link I16}, {@link I32} or {@link
-   * I64}. The Substrait spec only "recommends" {@code i64} for contexts such as {@code FetchRel}'s
-   * {@code offset_expr}/{@code count_expr}, so callers that accept any integer width can use this
-   * to reject non-integer types.
+   * Returns whether this is one of the fixed-width signed integer types: {@link I8}, {@link I16},
+   * {@link I32} or {@link I64}.
    *
    * @return {@code true} if this is an integer type
    */

--- a/core/src/test/java/io/substrait/relation/FetchTest.java
+++ b/core/src/test/java/io/substrait/relation/FetchTest.java
@@ -1,0 +1,64 @@
+package io.substrait.relation;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.substrait.TestBase;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validation tests for {@link Fetch}, whose offset/count expressions must have an integer type.
+ * Round-trip coverage lives in the {@code io.substrait.type.proto} package.
+ */
+class FetchTest extends TestBase {
+
+  // Reuse the same schema shape as FetchRoundtripTest so the two files stay in sync.
+  final Rel table =
+      sb.namedScan(Arrays.asList("T"), Arrays.asList("a", "b"), Arrays.asList(R.I64, R.STRING));
+
+  /** Every integer width is an acceptable offset/count expression type. */
+  @Test
+  void integerWidthsAccepted() {
+    fetch().offset(sb.i8(1)).count(sb.i8(2)).build();
+    fetch().offset(sb.i16(1)).count(sb.i16(2)).build();
+    fetch().offset(sb.i32(1)).count(sb.i32(2)).build();
+    fetch().offset(sb.i64(1)).count(sb.i64(2)).build();
+  }
+
+  /** A non-integer offset expression is rejected at construction time. */
+  @Test
+  void nonIntegerOffsetRejected() {
+    assertThrows(IllegalArgumentException.class, () -> fetch().offset(sb.fp64(1.0)).build());
+  }
+
+  /** A non-integer count expression is rejected at construction time. */
+  @Test
+  void nonIntegerCountRejected() {
+    assertThrows(IllegalArgumentException.class, () -> fetch().count(sb.fp64(1.0)).build());
+  }
+
+  /** A non-integer type reaches the check via the proto conversion path too. */
+  @Test
+  void nonIntegerOffsetRejectedViaProto() {
+    // Build a FetchRel proto directly with a non-integer offset_expr so the Fetch POJO check is
+    // exercised by ProtoRelConverter rather than by direct construction.
+    io.substrait.proto.Rel inputProto = relProtoConverter.toProto(table);
+    io.substrait.proto.Expression fp64Expr =
+        io.substrait.proto.Expression.newBuilder()
+            .setLiteral(io.substrait.proto.Expression.Literal.newBuilder().setFp64(1.0).build())
+            .build();
+    io.substrait.proto.FetchRel fetchRel =
+        io.substrait.proto.FetchRel.newBuilder()
+            .setCommon(io.substrait.proto.RelCommon.newBuilder().build())
+            .setInput(inputProto)
+            .setOffsetExpr(fp64Expr)
+            .build();
+    io.substrait.proto.Rel protoRel =
+        io.substrait.proto.Rel.newBuilder().setFetch(fetchRel).build();
+    assertThrows(IllegalArgumentException.class, () -> protoRelConverter.from(protoRel));
+  }
+
+  private ImmutableFetch.Builder fetch() {
+    return Fetch.builder().input(table);
+  }
+}

--- a/core/src/test/java/io/substrait/type/TypeTest.java
+++ b/core/src/test/java/io/substrait/type/TypeTest.java
@@ -1,0 +1,61 @@
+package io.substrait.type;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for the default methods on {@link Type}. */
+class TypeTest {
+  private static final TypeCreator R = TypeCreator.REQUIRED;
+  private static final TypeCreator N = TypeCreator.NULLABLE;
+
+  @Test
+  void integerWidthsAreIntegers() {
+    assertTrue(R.I8.isInteger());
+    assertTrue(R.I16.isInteger());
+    assertTrue(R.I32.isInteger());
+    assertTrue(R.I64.isInteger());
+  }
+
+  @Test
+  void nullabilityIsIrrelevantForIsInteger() {
+    assertTrue(N.I8.isInteger());
+    assertTrue(N.I16.isInteger());
+    assertTrue(N.I32.isInteger());
+    assertTrue(N.I64.isInteger());
+  }
+
+  @Test
+  void nonIntegerPrimitivesAreNotIntegers() {
+    assertFalse(R.BOOLEAN.isInteger());
+    assertFalse(R.FP32.isInteger());
+    assertFalse(R.FP64.isInteger());
+    assertFalse(R.STRING.isInteger());
+    assertFalse(R.BINARY.isInteger());
+    assertFalse(R.DATE.isInteger());
+    assertFalse(R.UUID.isInteger());
+  }
+
+  @Test
+  void compoundAndSpecialTypesAreNotIntegers() {
+    assertFalse(R.decimal(10, 2).isInteger());
+    assertFalse(R.struct(R.I64).isInteger());
+    assertFalse(R.list(R.I64).isInteger());
+    assertFalse(R.map(R.I64, R.I64).isInteger());
+  }
+
+  @Test
+  void equalsIgnoringNullabilityMatchesAcrossNullability() {
+    assertTrue(R.I64.equalsIgnoringNullability(N.I64));
+    assertTrue(N.I64.equalsIgnoringNullability(R.I64));
+    assertTrue(R.I64.equalsIgnoringNullability(R.I64));
+  }
+
+  @Test
+  void equalsIgnoringNullabilityDistinguishesKinds() {
+    assertFalse(R.I64.equalsIgnoringNullability(R.I32));
+    assertFalse(R.I64.equalsIgnoringNullability(N.FP64));
+    assertFalse(R.struct(R.I64).equalsIgnoringNullability(R.I64));
+  }
+}

--- a/core/src/test/java/io/substrait/type/TypeTest.java
+++ b/core/src/test/java/io/substrait/type/TypeTest.java
@@ -46,16 +46,7 @@ class TypeTest {
   }
 
   @Test
-  void equalsIgnoringNullabilityMatchesAcrossNullability() {
-    assertTrue(R.I64.equalsIgnoringNullability(N.I64));
-    assertTrue(N.I64.equalsIgnoringNullability(R.I64));
-    assertTrue(R.I64.equalsIgnoringNullability(R.I64));
-  }
-
-  @Test
-  void equalsIgnoringNullabilityDistinguishesKinds() {
-    assertFalse(R.I64.equalsIgnoringNullability(R.I32));
-    assertFalse(R.I64.equalsIgnoringNullability(N.FP64));
-    assertFalse(R.struct(R.I64).equalsIgnoringNullability(R.I64));
+  void userDefinedIsNotAnInteger() {
+    assertFalse(R.userDefined("urn:test", "t").isInteger());
   }
 }


### PR DESCRIPTION
Adds enforcement that FetchRel's offset_expr/count_expr resolve to an integer type (I8/I16/I32/I64), rejecting non-integer expressions at construction. The spec only recommends i64 for these fields:

https://github.com/substrait-io/substrait/blob/v0.99.0/proto/substrait/algebra.proto#L345-L366

BREAKING CHANGE: `Fetch` relation now enforces that `offset` and `count` are integer types (or `unbound`). Otherwise, an exception is thrown. 

---
Note: This PR was developed with AI assistance. All changes have been reviewed, and I take full responsibility for this contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fetch operations now validate offset and count expressions and reject non-integer values.
  * Integer values of all supported widths and unbound expressions remain accepted.
  * Invalid Fetch expressions are also rejected during protocol conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->