### PR TITLE
docs: mention CLA requirement for all contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,14 @@
 
 This page provides some orientation and recommendations on how to get the best results when engaging with the community.
 
-1. [Commit conventions](#commit-conventions)
-2. [Style Guide](#style-guide)
-3. [Building and testing](#building-and-testing)
+1. [Contributor License Agreement](#contributor-license-agreement)
+2. [Commit conventions](#commit-conventions)
+3. [Style Guide](#style-guide)
+4. [Building and testing](#building-and-testing)
+
+## Contributor License Agreement
+
+Substrait requires all contributors to sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait) before their contributions can be merged. A GitHub app checks this on every pull request and guides new contributors through signing it.
 
 ## Commit Conventions
 


### PR DESCRIPTION
Substrait requires every contributor to sign the [Contributor License Agreement (CLA)](https://cla-assistant.io/substrait-io/substrait), and CLA Assistant enforces this as a `license/cla` status check on every pull request in this repository. Nothing in `CONTRIBUTING.md` mentioned it, so contributors only learned about the requirement from the check appearing on their PR — the confusing first contact described in substrait-io/substrait#630.

Add a *Contributor License Agreement* section as the first item, using the wording already carried by [`substrait-rs`](https://github.com/substrait-io/substrait-rs/blob/main/CONTRIBUTING.md), the one repository in the organization that documented this.

Companion to substrait-io/substrait#1170, which covers the specification repository's website and `CONTRIBUTING.md`.

See substrait-io/substrait#630

🤖 Generated with AI
