### PR TITLE
fix(core): make ProtoRelConverter.newTopN keep relAnchor on the way back from proto

### DIFF
--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -1082,7 +1082,8 @@ public class ProtoRelConverter {
     builder
         .commonExtension(optionalAdvancedExtension(rel.getCommon()))
         .remap(optionalRelmap(rel.getCommon()))
-        .hint(optionalHint(rel.getCommon()));
+        .hint(optionalHint(rel.getCommon()))
+        .relAnchor(optionalRelAnchor(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(protoExtensionConverter.fromProto(rel.getAdvancedExtension()));
     }

--- a/core/src/test/java/io/substrait/type/proto/RelAnchorRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/RelAnchorRoundtripTest.java
@@ -3,9 +3,11 @@ package io.substrait.type.proto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.substrait.TestBase;
+import io.substrait.expression.Expression;
 import io.substrait.relation.Filter;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
+import io.substrait.relation.physical.TopN;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -46,6 +48,23 @@ class RelAnchorRoundtripTest extends TestBase {
             .build();
 
     verifyRoundTrip(filter);
+  }
+
+  @Test
+  void relAnchorOnTopN() {
+    Rel topN =
+        TopN.builder()
+            .input(baseTable)
+            .relAnchor(3)
+            .addSortFields(
+                Expression.SortField.builder()
+                    .expr(sb.fieldReference(baseTable, 0))
+                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                    .build())
+            .count(sb.i64(10))
+            .build();
+
+    verifyRoundTrip(topN);
   }
 
   @Test


### PR DESCRIPTION
- Closes #1085
- newTopN dropped relAnchor converting proto to POJO while the writer emitted it, breaking round-trip fidelity and losing the anchor's outer-reference binding for any TopN with an anchor set
- Added relAnchorOnTopN as a regression test