### PR TITLE
build(isthmus): update HttpCore for CVE-2026-54399

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ graal = "25.0.2"
 graal-plugin = "1.1.7"
 gradle-extensions = "4.0.0"
 guava = "33.6.0-jre"
+httpcore = "5.4.3"
 immutables = "2.12.2"
 jackson = "2.22.1"
 json-smart = "[2.5.2,)"
@@ -43,6 +44,8 @@ calcite-server = { module = "org.apache.calcite:calcite-server", version.ref = "
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graal" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+httpcore = { module = "org.apache.httpcomponents.core5:httpcore5", version.ref = "httpcore" }
+httpcore-h2 = { module = "org.apache.httpcomponents.core5:httpcore5-h2", version.ref = "httpcore" }
 immutables-value = { module = "org.immutables:value", version.ref = "immutables" }
 immutables-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -87,8 +87,11 @@ dependencies {
       )
   }
   constraints {
-    // calcite-core:1.41.0 has dependencies that contain vulnerabilities:
+    // calcite-core:1.42.0 has dependencies that contain vulnerabilities:
     // - CVE-2024-57699 (net.minidev:json-smart < 2.5.2)
+    // - CVE-2026-54399 (org.apache.httpcomponents.core5:httpcore5 < 5.4.3)
+    implementation(libs.httpcore)
+    implementation(libs.httpcore.h2)
     implementation(libs.json.smart)
   }
   implementation(libs.calcite.server) {


### PR DESCRIPTION
Calcite 1.42.0 brings in HttpCore 5.3.x through Avatica and HttpClient. Those releases are affected by CVE-2026-54399.

Constrain both `httpcore5` and `httpcore5-h2` to 5.4.3 so the modules stay aligned on the patched release and the constraint is published to downstream `isthmus` consumers.
