### PR TITLE
fix(isthmus): preserve field types in sort and aggregate references

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -507,12 +507,9 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   /**
    * Converts a Calcite {@link AggregateCall} to a Substrait {@link Aggregate.Measure}.
    *
-   * <p>This method handles the conversion of aggregate function calls from Calcite's representation
-   * to Substrait's format. For statistical aggregate functions (STDDEV_POP, STDDEV_SAMP, VAR_POP,
-   * VAR_SAMP), it automatically transforms the input relation by inserting a projection that casts
-   * the aggregate function's argument fields to DOUBLE (FP64) type, ensuring type compatibility
-   * with Substrait's statistical function requirements. Fields not referenced by the aggregate
-   * function are passed through unchanged.
+   * <p>Statistical aggregate arguments have already been rewritten by {@link
+   * #castStatisticalAggregatesToFloatingPoint(org.apache.calcite.rel.core.Aggregate)} before this
+   * method runs. That rewrite appends fp64 input columns and re-points the affected calls.
    *
    * <p>The method also processes optional filter arguments (FILTER clauses) by converting them to
    * Substrait's preMeasureFilter representation.
@@ -535,7 +532,8 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     }
     Builder builder = Aggregate.Measure.builder().function(invocation.get());
     if (call.filterArg != -1) {
-      builder.preMeasureFilter(FieldReference.newRootStructReference(call.filterArg, inputType));
+      builder.preMeasureFilter(
+          FieldReference.StructField.of(call.filterArg).constructOnRoot(inputType));
     }
     return builder.build();
   }
@@ -737,9 +735,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     Expression.SortDirection direction = asSortDirection(collation);
 
     return Expression.SortField.builder()
-        .expr(
-            FieldReference.newRootStructReference(
-                collation.getFieldIndex(), inputType.fields().get(collation.getFieldIndex())))
+        .expr(FieldReference.StructField.of(collation.getFieldIndex()).constructOnRoot(inputType))
         .direction(direction)
         .build();
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -536,8 +536,6 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     if (call.filterArg != -1) {
       builder.preMeasureFilter(FieldReference.newRootStructReference(call.filterArg, inputType));
     }
-    // TODO: handle the collation on the AggregateCall
-    //   https://github.com/substrait-io/substrait-java/issues/215
     return builder.build();
   }
 
@@ -738,7 +736,9 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
     Expression.SortDirection direction = asSortDirection(collation);
 
     return Expression.SortField.builder()
-        .expr(FieldReference.newRootStructReference(collation.getFieldIndex(), inputType))
+        .expr(
+            FieldReference.newRootStructReference(
+                collation.getFieldIndex(), inputType.fields().get(collation.getFieldIndex())))
         .direction(direction)
         .build();
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -138,8 +138,8 @@ class AggregationFunctionsTest extends PlanTestBase {
   void aggregateCallCollation() {
     builder.values(new String[] {"value", "first_sort", "second_sort"}, 1, 2, 3);
     RexNode value = builder.field("value");
-    RexNode firstSort = builder.nullsLast(builder.field("first_sort"));
-    RexNode secondSort = builder.nullsFirst(builder.desc(builder.field("second_sort")));
+    RexNode firstSort = builder.nullsFirst(builder.field("first_sort"));
+    RexNode secondSort = builder.nullsLast(builder.desc(builder.field("second_sort")));
 
     RelNode calcite =
         builder
@@ -148,17 +148,14 @@ class AggregationFunctionsTest extends PlanTestBase {
 
     Aggregate converted =
         assertInstanceOf(Aggregate.class, SubstraitRelVisitor.convert(calcite, converterProvider));
-    Type.Struct inputType = converted.getInput().getRecordType();
     assertEquals(
         List.of(
-            Expression.SortField.builder()
-                .expr(FieldReference.newRootStructReference(1, inputType.fields().get(1)))
-                .direction(Expression.SortDirection.ASC_NULLS_LAST)
-                .build(),
-            Expression.SortField.builder()
-                .expr(FieldReference.newRootStructReference(2, inputType.fields().get(2)))
-                .direction(Expression.SortDirection.DESC_NULLS_FIRST)
-                .build()),
+            sb.sortField(
+                FieldReference.newRootStructReference(1, R.I32),
+                Expression.SortDirection.ASC_NULLS_FIRST),
+            sb.sortField(
+                FieldReference.newRootStructReference(2, R.I32),
+                Expression.SortDirection.DESC_NULLS_LAST)),
         converted.getMeasures().get(0).getFunction().sort());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/AggregationFunctionsTest.java
@@ -1,6 +1,11 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
 import com.google.common.collect.Streams;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FieldReference;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.NamedScan;
 import io.substrait.relation.Rel;
@@ -9,6 +14,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexNode;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -124,5 +132,33 @@ class AggregationFunctionsTest extends PlanTestBase {
             input -> functions(input, aggFunction),
             numericTypesTable);
     assertFullRoundTrip(rel);
+  }
+
+  @Test
+  void aggregateCallCollation() {
+    builder.values(new String[] {"value", "first_sort", "second_sort"}, 1, 2, 3);
+    RexNode value = builder.field("value");
+    RexNode firstSort = builder.nullsLast(builder.field("first_sort"));
+    RexNode secondSort = builder.nullsFirst(builder.desc(builder.field("second_sort")));
+
+    RelNode calcite =
+        builder
+            .aggregate(builder.groupKey(), builder.sum(value).sort(firstSort, secondSort))
+            .build();
+
+    Aggregate converted =
+        assertInstanceOf(Aggregate.class, SubstraitRelVisitor.convert(calcite, converterProvider));
+    Type.Struct inputType = converted.getInput().getRecordType();
+    assertEquals(
+        List.of(
+            Expression.SortField.builder()
+                .expr(FieldReference.newRootStructReference(1, inputType.fields().get(1)))
+                .direction(Expression.SortDirection.ASC_NULLS_LAST)
+                .build(),
+            Expression.SortField.builder()
+                .expr(FieldReference.newRootStructReference(2, inputType.fields().get(2)))
+                .direction(Expression.SortDirection.DESC_NULLS_FIRST)
+                .build()),
+        converted.getMeasures().get(0).getFunction().sort());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
@@ -132,6 +132,27 @@ class ComplexAggregateTest extends PlanTestBase {
   }
 
   @Test
+  void roundTripSortingArguments() {
+    Aggregate rel =
+        sb.aggregate(
+            input -> emptyGrouping,
+            input ->
+                List.of(
+                    withSort(
+                        sb.sum(input, 3),
+                        List.of(
+                            sb.sortField(
+                                sb.fieldReference(input, 1),
+                                Expression.SortDirection.ASC_NULLS_LAST),
+                            sb.sortField(
+                                sb.fieldReference(input, 2),
+                                Expression.SortDirection.DESC_NULLS_FIRST)))),
+            table);
+
+    assertFullRoundTrip(rel);
+  }
+
+  @Test
   void handleComplexGroupingArgument() {
     Aggregate rel =
         sb.aggregate(

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexAggregateTest.java
@@ -132,6 +132,22 @@ class ComplexAggregateTest extends PlanTestBase {
   }
 
   @Test
+  void roundTripPreMeasureFilter() {
+    NamedScan input =
+        sb.namedScan(List.of("example"), List.of("value", "filter"), List.of(R.I32, R.BOOLEAN));
+    Aggregate rel =
+        sb.aggregate(
+            aggregateInput -> emptyGrouping,
+            aggregateInput ->
+                List.of(
+                    withPreMeasureFilter(
+                        sb.sum(aggregateInput, 0), sb.fieldReference(aggregateInput, 1))),
+            input);
+
+    assertFullRoundTrip(rel);
+  }
+
+  @Test
   void roundTripSortingArguments() {
     Aggregate rel =
         sb.aggregate(
@@ -143,10 +159,10 @@ class ComplexAggregateTest extends PlanTestBase {
                         List.of(
                             sb.sortField(
                                 sb.fieldReference(input, 1),
-                                Expression.SortDirection.ASC_NULLS_LAST),
+                                Expression.SortDirection.ASC_NULLS_FIRST),
                             sb.sortField(
                                 sb.fieldReference(input, 2),
-                                Expression.SortDirection.DESC_NULLS_FIRST)))),
+                                Expression.SortDirection.DESC_NULLS_LAST)))),
             table);
 
     assertFullRoundTrip(rel);

--- a/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ComplexSortTest.java
@@ -11,6 +11,7 @@ import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.externalize.RelWriterImpl;
 import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.util.Pair;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,11 @@ class ComplexSortTest extends PlanTestBase {
       }
       super.explain_(rel, values);
     }
+  }
+
+  @Test
+  void roundTripInputReferenceSort() throws SqlParseException {
+    assertFullRoundTrip("SELECT L_ORDERKEY FROM LINEITEM ORDER BY L_ORDERKEY");
   }
 
   @Test


### PR DESCRIPTION
Calcite collations were already propagated to Substrait sort fields, but those field references used the whole input struct as their type. The shared conversion is used by both aggregate sort arguments and Sort relations, so those plans were not round-trip stable. Aggregate pre-measure filters had the same problem.

Build each reference from the selected input field, preserving its exact type in Sort relations, aggregate sort arguments, and pre-measure filters.

Closes #215
