### PR TITLE
fix(isthmus)!: use a distinct datetime subtraction operator

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/expression/DatetimeSubtractionFunctionMapper.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/DatetimeSubtractionFunctionMapper.java
@@ -1,0 +1,43 @@
+package io.substrait.isthmus.expression;
+
+import io.substrait.expression.Expression;
+import io.substrait.expression.FunctionArg;
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.SimpleExtension.ScalarFunctionVariant;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+/** Maps Calcite datetime subtraction calls to Substrait's {@code subtract} function. */
+final class DatetimeSubtractionFunctionMapper implements ScalarFunctionMapper {
+  private static final String SUBTRACT_FUNCTION_NAME = "subtract";
+  private final List<ScalarFunctionVariant> subtractFunctions;
+
+  DatetimeSubtractionFunctionMapper(List<ScalarFunctionVariant> functions) {
+    this.subtractFunctions =
+        functions.stream()
+            .filter(
+                function ->
+                    SUBTRACT_FUNCTION_NAME.equals(function.name())
+                        && DefaultExtensionCatalog.FUNCTIONS_DATETIME.equals(function.urn()))
+            .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Override
+  public Optional<SubstraitFunctionMapping> toSubstrait(RexCall call) {
+    if (subtractFunctions.isEmpty() || !SqlStdOperatorTable.MINUS_DATE.equals(call.getOperator())) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new SubstraitFunctionMapping(
+            SUBTRACT_FUNCTION_NAME, call.getOperands(), subtractFunctions));
+  }
+
+  @Override
+  public Optional<List<FunctionArg>> getExpressionArguments(
+      Expression.ScalarFunctionInvocation expression) {
+    return Optional.empty();
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -8,9 +8,13 @@ import java.util.Set;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlBasicFunction;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
@@ -74,17 +78,7 @@ public class FunctionMappings {
    * two-operand {@code date - interval_day}, whose result is a precision timestamp. This distinct
    * operator keeps Calcite from treating those incompatible operators as equal.
    */
-  public static final SqlFunction DATETIME_SUBTRACT =
-      SqlBasicFunction.create(
-          "DATETIME_SUBTRACT",
-          FunctionMappings::inferDatetimeSubtractType,
-          OperandTypes.or(
-              OperandTypes.DATETIME_INTERVAL,
-              OperandTypes.sequence(
-                  "DATETIME_SUBTRACT(<DATETIME>, <INTERVAL>, <CHARACTER>)",
-                  OperandTypes.DATETIME,
-                  OperandTypes.INTERVAL,
-                  OperandTypes.CHARACTER)));
+  public static final SqlFunction DATETIME_SUBTRACT = new DatetimeSubtractionFunction();
 
   /** Scalar function mappings. */
   public static final ImmutableList<Sig> SCALAR_SIGS =
@@ -262,6 +256,31 @@ public class FunctionMappings {
       nullable |= binding.getOperandType(i).isNullable();
     }
     return typeFactory.createTypeWithNullability(resultType, nullable);
+  }
+
+  private static final class DatetimeSubtractionFunction extends SqlFunction {
+    private DatetimeSubtractionFunction() {
+      super(
+          "DATETIME_SUBTRACT",
+          SqlKind.OTHER_FUNCTION,
+          FunctionMappings::inferDatetimeSubtractType,
+          null,
+          OperandTypes.or(
+              OperandTypes.DATETIME_INTERVAL,
+              OperandTypes.sequence(
+                  "DATETIME_SUBTRACT(<DATETIME>, <INTERVAL>, <CHARACTER>)",
+                  OperandTypes.DATETIME,
+                  OperandTypes.INTERVAL,
+                  OperandTypes.CHARACTER)),
+          SqlFunctionCategory.NUMERIC);
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+      writer
+          .getDialect()
+          .unparseSqlDatetimeArithmetic(writer, call, SqlKind.MINUS, leftPrec, rightPrec);
+    }
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -248,10 +248,10 @@ public class FunctionMappings {
     RelDataType resultType = datetimeType;
     if (datetimeType.getSqlTypeName() == SqlTypeName.DATE
         && intervalType.getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
-      // Calcite's interval type does not retain Substrait's interval_day<P> precision, so the
-      // exact timestamp precision cannot be inferred here. Use the type system maximum as a
-      // best-effort inference; ExpressionRexConverter keeps the declared Substrait output type
-      // authoritative.
+      // Isthmus builds every interval_day with SubstraitTypeSystem.DAY_SECOND_INTERVAL, which
+      // pins the fractional-second precision at 6, so the operand no longer carries Substrait's
+      // interval_day<P>. Use the type system maximum as a best-effort inference;
+      // ExpressionRexConverter keeps the declared Substrait output type authoritative.
       int precision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP);
       resultType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP, precision);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -77,6 +77,10 @@ public class FunctionMappings {
    * interval qualifier operand or return the first operand type. Neither matches Substrait's
    * two-operand {@code date - interval_day}, whose result is a precision timestamp. This distinct
    * operator keeps Calcite from treating those incompatible operators as equal.
+   *
+   * <p>Calcite's Enumerable convention cannot execute this custom operator because it has no {@code
+   * RexImpTable} implementor. It is currently used to preserve conversion semantics and operator
+   * identity.
    */
   public static final SqlFunction DATETIME_SUBTRACT = new DatetimeSubtractionFunction();
 
@@ -244,9 +248,10 @@ public class FunctionMappings {
     RelDataType resultType = datetimeType;
     if (datetimeType.getSqlTypeName() == SqlTypeName.DATE
         && intervalType.getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
-      // Calcite interval literals report their millisecond storage scale rather than the
-      // configured Substrait interval precision. Use the type system constraint so inference does
-      // not silently narrow a precision_timestamp result.
+      // Calcite's interval type does not retain Substrait's interval_day<P> precision, so the
+      // exact timestamp precision cannot be inferred here. Use the type system maximum as a
+      // best-effort inference; ExpressionRexConverter keeps the declared Substrait output type
+      // authoritative.
       int precision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP);
       resultType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP, precision);
     }
@@ -272,11 +277,17 @@ public class FunctionMappings {
                   OperandTypes.DATETIME,
                   OperandTypes.INTERVAL,
                   OperandTypes.CHARACTER)),
-          SqlFunctionCategory.NUMERIC);
+          SqlFunctionCategory.TIMEDATE);
     }
 
     @Override
     public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+      if (call.operandCount() > 2) {
+        // unparseSqlDatetimeArithmetic treats the third operand as an interval qualifier and
+        // writes it after the closing parenthesis. Substrait uses it as a timezone argument.
+        super.unparse(writer, call, leftPrec, rightPrec);
+        return;
+      }
       writer
           .getDialect()
           .unparseSqlDatetimeArithmetic(writer, call, SqlKind.MINUS, leftPrec, rightPrec);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -5,9 +5,12 @@ import io.substrait.isthmus.AggregateFunctions;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlBasicFunction;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
@@ -63,6 +66,26 @@ public class FunctionMappings {
           ReturnTypes.ARG0_NULLABLE,
           OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER));
 
+  /**
+   * The Substrait datetime subtraction function.
+   *
+   * <p>Calcite's datetime subtraction operators either infer their return type from a third
+   * interval qualifier operand or return the first operand type. Neither matches Substrait's
+   * two-operand {@code date - interval_day}, whose result is a precision timestamp. This distinct
+   * operator keeps Calcite from treating those incompatible operators as equal.
+   */
+  public static final SqlFunction DATETIME_SUBTRACT =
+      SqlBasicFunction.create(
+          "DATETIME_SUBTRACT",
+          FunctionMappings::inferDatetimeSubtractType,
+          OperandTypes.or(
+              OperandTypes.DATETIME_INTERVAL,
+              OperandTypes.sequence(
+                  "DATETIME_SUBTRACT(<DATETIME>, <INTERVAL>, <CHARACTER>)",
+                  OperandTypes.DATETIME,
+                  OperandTypes.INTERVAL,
+                  OperandTypes.CHARACTER)));
+
   /** Scalar function mappings. */
   public static final ImmutableList<Sig> SCALAR_SIGS =
       ImmutableList.<Sig>builder()
@@ -98,7 +121,7 @@ public class FunctionMappings {
               s(SqlStdOperatorTable.IS_NULL, "is_null"),
               s(SqlStdOperatorTable.IS_NOT_NULL, "is_not_null"),
               s(SqlStdOperatorTable.NOT_EQUALS, "not_equal"),
-              s(SqlStdOperatorTable.MINUS_DATE, "subtract"),
+              s(DATETIME_SUBTRACT, "subtract"),
               s(SqlStdOperatorTable.DATETIME_PLUS, "add"),
               s(SqlStdOperatorTable.EXTRACT, "extract"),
               s(SqlStdOperatorTable.CEIL, "ceil"),
@@ -214,10 +237,32 @@ public class FunctionMappings {
           SqlStdOperatorTable.MINUS,
           resolver(
               SqlStdOperatorTable.MINUS, Set.of("i8", "i16", "i32", "i64", "fp32", "fp64", "dec")),
-          SqlStdOperatorTable.MINUS_DATE,
-          resolver(SqlStdOperatorTable.MINUS_DATE, Set.of("date", "ts", "tstz", "pts", "ptstz")),
+          DATETIME_SUBTRACT,
+          resolver(DATETIME_SUBTRACT, Set.of("date", "ts", "tstz", "pts", "ptstz")),
           SqlStdOperatorTable.BIT_LEFT_SHIFT,
           resolver(SqlStdOperatorTable.BIT_LEFT_SHIFT, Set.of("i8", "i16", "i32", "i64")));
+
+  private static RelDataType inferDatetimeSubtractType(SqlOperatorBinding binding) {
+    RelDataType datetimeType = binding.getOperandType(0);
+    RelDataType intervalType = binding.getOperandType(1);
+    RelDataTypeFactory typeFactory = binding.getTypeFactory();
+
+    RelDataType resultType = datetimeType;
+    if (datetimeType.getSqlTypeName() == SqlTypeName.DATE
+        && intervalType.getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
+      // Calcite interval literals report their millisecond storage scale rather than the
+      // configured Substrait interval precision. Use the type system constraint so inference does
+      // not silently narrow a precision_timestamp result.
+      int precision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP);
+      resultType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP, precision);
+    }
+
+    boolean nullable = false;
+    for (int i = 0; i < binding.getOperandCount(); i++) {
+      nullable |= binding.getOperandType(i).isNullable();
+    }
+    return typeFactory.createTypeWithNullability(resultType, nullable);
+  }
 
   /**
    * Creates a signature mapping entry.

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -17,9 +17,6 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.fun.SqlInternalOperators;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 
 /**
  * Converts Calcite {@link RexCall} scalar functions to Substrait {@link Expression} using known
@@ -68,6 +65,7 @@ public class ScalarFunctionConverter
 
     mappers =
         List.of(
+            new DatetimeSubtractionFunctionMapper(functions),
             new ConcatFunctionMapper(functions),
             new TrimFunctionMapper(functions),
             new SqrtFunctionMapper(functions),
@@ -88,20 +86,6 @@ public class ScalarFunctionConverter
     return FunctionMappings.SCALAR_SIGS;
   }
 
-  @Override
-  public Optional<SqlOperator> getSqlOperatorFromSubstraitFunc(
-      String key, Type outputType, List<FunctionArg> arguments) {
-    return super.getSqlOperatorFromSubstraitFunc(key, outputType, arguments)
-        .map(
-            operator ->
-                // MINUS_DATE models datetime - datetime and derives its interval result from a
-                // third qualifier operand. Substrait datetime subtraction takes an interval as
-                // its second operand, which is the two-operand MINUS_DATE2 form in Calcite.
-                operator == SqlStdOperatorTable.MINUS_DATE
-                    ? SqlInternalOperators.MINUS_DATE2
-                    : operator);
-  }
-
   /**
    * Converts a {@link RexCall} into a Substrait {@link Expression}, applying any registered custom
    * mapping first, then default matching if needed.
@@ -113,16 +97,10 @@ public class ScalarFunctionConverter
   @Override
   public Optional<Expression> convert(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
-    RexCall mappedCall =
-        call.op == SqlInternalOperators.MINUS_DATE2
-            ? (RexCall)
-                rexBuilder.makeCall(
-                    call.getType(), SqlStdOperatorTable.MINUS_DATE, call.getOperands())
-            : call;
     // If a mapping applies to this call, use it; otherwise default behavior.
-    return getMappingForCall(mappedCall)
-        .map(mapping -> mappedConvert(mapping, mappedCall, topLevelConverter))
-        .orElseGet(() -> defaultConvert(mappedCall, topLevelConverter));
+    return getMappingForCall(call)
+        .map(mapping -> mappedConvert(mapping, call, topLevelConverter))
+        .orElseGet(() -> defaultConvert(call, topLevelConverter));
   }
 
   private Optional<SubstraitFunctionMapping> getMappingForCall(final RexCall call) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ScalarFunctionConverter.java
@@ -17,6 +17,9 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlInternalOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 
 /**
  * Converts Calcite {@link RexCall} scalar functions to Substrait {@link Expression} using known
@@ -85,6 +88,20 @@ public class ScalarFunctionConverter
     return FunctionMappings.SCALAR_SIGS;
   }
 
+  @Override
+  public Optional<SqlOperator> getSqlOperatorFromSubstraitFunc(
+      String key, Type outputType, List<FunctionArg> arguments) {
+    return super.getSqlOperatorFromSubstraitFunc(key, outputType, arguments)
+        .map(
+            operator ->
+                // MINUS_DATE models datetime - datetime and derives its interval result from a
+                // third qualifier operand. Substrait datetime subtraction takes an interval as
+                // its second operand, which is the two-operand MINUS_DATE2 form in Calcite.
+                operator == SqlStdOperatorTable.MINUS_DATE
+                    ? SqlInternalOperators.MINUS_DATE2
+                    : operator);
+  }
+
   /**
    * Converts a {@link RexCall} into a Substrait {@link Expression}, applying any registered custom
    * mapping first, then default matching if needed.
@@ -96,10 +113,16 @@ public class ScalarFunctionConverter
   @Override
   public Optional<Expression> convert(
       RexCall call, Function<RexNode, Expression> topLevelConverter) {
+    RexCall mappedCall =
+        call.op == SqlInternalOperators.MINUS_DATE2
+            ? (RexCall)
+                rexBuilder.makeCall(
+                    call.getType(), SqlStdOperatorTable.MINUS_DATE, call.getOperands())
+            : call;
     // If a mapping applies to this call, use it; otherwise default behavior.
-    return getMappingForCall(call)
-        .map(mapping -> mappedConvert(mapping, call, topLevelConverter))
-        .orElseGet(() -> defaultConvert(call, topLevelConverter));
+    return getMappingForCall(mappedCall)
+        .map(mapping -> mappedConvert(mapping, mappedCall, topLevelConverter))
+        .orElseGet(() -> defaultConvert(mappedCall, topLevelConverter));
   }
 
   private Optional<SubstraitFunctionMapping> getMappingForCall(final RexCall call) {

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -2,7 +2,9 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
@@ -14,12 +16,15 @@ import io.substrait.isthmus.expression.CallConverters;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
+import io.substrait.isthmus.expression.TypeObservation;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
 import io.substrait.type.TypeCreator;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlInternalOperators;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.junit.jupiter.api.Test;
 
@@ -50,10 +55,14 @@ class FunctionConversionTest extends PlanTestBase {
 
   @Test
   void subtractDateIDay() {
-    // When this function is converted to Calcite, if the Calcite type derivation is used an
-    // java.lang.ArrayIndexOutOfBoundsException is thrown. It is quite likely that
-    // this is being mapped to the wrong Calcite function.
-    // TODO: https://github.com/substrait-io/substrait-java/issues/377
+    AtomicReference<TypeObservation> observed = new AtomicReference<>();
+    ExpressionRexConverter observingConverter =
+        new ExpressionRexConverter(
+            typeFactory,
+            scalarFnConverter,
+            windowFnConverter,
+            TypeConverter.DEFAULT,
+            observed::set);
     Expression.ScalarFunctionInvocation expr =
         sb.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -62,10 +71,15 @@ class FunctionConversionTest extends PlanTestBase {
             ExpressionCreator.date(false, 10561),
             ExpressionCreator.intervalDay(false, 120, 0, 0, 6));
 
-    RexNode calciteExpr = expr.accept(expressionRexConverter, Context.newContext());
+    RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
     assertEquals(
         TypeConverter.DEFAULT.toCalcite(typeFactory, TypeCreator.REQUIRED.DATE),
         calciteExpr.getType());
+    assertSame(
+        SqlInternalOperators.MINUS_DATE2,
+        assertInstanceOf(RexCall.class, calciteExpr).getOperator());
+    assertTrue(observed.get().inferenceFailure().isEmpty());
+    assertEquals(calciteExpr.getType(), observed.get().inferredType().orElseThrow());
 
     Expression reverse = calciteExpr.accept(rexExpressionConverter);
     assertEquals(expr, reverse);

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -1,6 +1,5 @@
 package io.substrait.isthmus;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -101,33 +100,21 @@ class FunctionConversionTest extends PlanTestBase {
   }
 
   static Stream<Arguments> subtractDateIDayTypes() {
-    Type timestamp = TypeCreator.REQUIRED.precisionTimestamp(6);
+    Type maxPrecisionTimestamp = TypeCreator.REQUIRED.precisionTimestamp(6);
     return Stream.of(
-        Arguments.of(Named.of("legacy DATE output", TypeCreator.REQUIRED.DATE), timestamp),
-        Arguments.of(Named.of("spec timestamp output", timestamp), timestamp));
+        Arguments.of(
+            Named.of("legacy DATE output", TypeCreator.REQUIRED.DATE), maxPrecisionTimestamp),
+        Arguments.of(
+            Named.of("spec max-precision output", maxPrecisionTimestamp), maxPrecisionTimestamp),
+        Arguments.of(
+            Named.of("spec non-max-precision output", TypeCreator.REQUIRED.precisionTimestamp(3)),
+            maxPrecisionTimestamp));
   }
 
   @Test
   void datetimeSubtractOperatorHasIndependentIdentity() {
     assertNotEquals(SqlStdOperatorTable.MINUS_DATE, FunctionMappings.DATETIME_SUBTRACT);
     assertNotEquals(SqlInternalOperators.MINUS_DATE2, FunctionMappings.DATETIME_SUBTRACT);
-  }
-
-  @Test
-  void timezoneDatetimeSubtractHasStableDigest() {
-    Expression.ScalarFunctionInvocation expr =
-        sb.scalarFn(
-            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
-            "subtract:ptstz_iyear_str",
-            TypeCreator.REQUIRED.precisionTimestampTZ(3),
-            ExpressionCreator.precisionTimestampTZ(false, 0, 3),
-            ExpressionCreator.intervalYear(false, 1, 0),
-            ExpressionCreator.string(false, "UTC"));
-
-    RexCall calciteExpr =
-        assertInstanceOf(RexCall.class, expr.accept(expressionRexConverter, Context.newContext()));
-    assertSame(FunctionMappings.DATETIME_SUBTRACT, calciteExpr.getOperator());
-    assertDoesNotThrow(calciteExpr::toString);
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,9 +19,11 @@ import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.TypeObservation;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
+import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
@@ -63,23 +66,25 @@ class FunctionConversionTest extends PlanTestBase {
             windowFnConverter,
             TypeConverter.DEFAULT,
             observed::set);
+    Type outputType = TypeCreator.REQUIRED.precisionTimestamp(6);
     Expression.ScalarFunctionInvocation expr =
         sb.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
             "subtract:date_iday",
-            TypeCreator.REQUIRED.DATE,
+            outputType,
             ExpressionCreator.date(false, 10561),
             ExpressionCreator.intervalDay(false, 120, 0, 0, 6));
 
     RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
-    assertEquals(
-        TypeConverter.DEFAULT.toCalcite(typeFactory, TypeCreator.REQUIRED.DATE),
-        calciteExpr.getType());
+    assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, outputType), calciteExpr.getType());
     assertSame(
         SqlInternalOperators.MINUS_DATE2,
         assertInstanceOf(RexCall.class, calciteExpr).getOperator());
     assertTrue(observed.get().inferenceFailure().isEmpty());
-    assertEquals(calciteExpr.getType(), observed.get().inferredType().orElseThrow());
+    RelDataType inferredType = observed.get().inferredType().orElseThrow();
+    assertEquals(
+        TypeConverter.DEFAULT.toCalcite(typeFactory, TypeCreator.REQUIRED.DATE), inferredType);
+    assertNotEquals(calciteExpr.getType(), inferredType);
 
     Expression reverse = calciteExpr.accept(rexExpressionConverter);
     assertEquals(expr, reverse);

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -1,11 +1,13 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
@@ -15,6 +17,7 @@ import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.isthmus.SubstraitRelNodeConverter.Context;
 import io.substrait.isthmus.expression.CallConverters;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
+import io.substrait.isthmus.expression.FunctionMappings;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.TypeObservation;
@@ -29,7 +32,12 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlInternalOperators;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Verify that "problematic" Substrait functions can be converted to Calcite and back successfully
@@ -56,8 +64,9 @@ class FunctionConversionTest extends PlanTestBase {
           windowFnConverter,
           TypeConverter.DEFAULT);
 
-  @Test
-  void subtractDateIDay() {
+  @ParameterizedTest
+  @MethodSource("subtractDateIDayTypes")
+  void subtractDateIDay(Type outputType, Type expectedInferredType) {
     AtomicReference<TypeObservation> observed = new AtomicReference<>();
     ExpressionRexConverter observingConverter =
         new ExpressionRexConverter(
@@ -66,7 +75,6 @@ class FunctionConversionTest extends PlanTestBase {
             windowFnConverter,
             TypeConverter.DEFAULT,
             observed::set);
-    Type outputType = TypeCreator.REQUIRED.precisionTimestamp(6);
     Expression.ScalarFunctionInvocation expr =
         sb.scalarFn(
             DefaultExtensionCatalog.FUNCTIONS_DATETIME,
@@ -78,16 +86,48 @@ class FunctionConversionTest extends PlanTestBase {
     RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
     assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, outputType), calciteExpr.getType());
     assertSame(
-        SqlInternalOperators.MINUS_DATE2,
+        FunctionMappings.DATETIME_SUBTRACT,
         assertInstanceOf(RexCall.class, calciteExpr).getOperator());
-    assertTrue(observed.get().inferenceFailure().isEmpty());
-    RelDataType inferredType = observed.get().inferredType().orElseThrow();
-    assertEquals(
-        TypeConverter.DEFAULT.toCalcite(typeFactory, TypeCreator.REQUIRED.DATE), inferredType);
-    assertNotEquals(calciteExpr.getType(), inferredType);
+    TypeObservation observation = observed.get();
+    assertNotNull(observation, "no type observation was recorded");
+    observation
+        .inferenceFailure()
+        .ifPresent(failure -> fail("Calcite return-type inference failed", failure));
+    RelDataType inferredType = observation.inferredType().orElseThrow();
+    assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, expectedInferredType), inferredType);
 
     Expression reverse = calciteExpr.accept(rexExpressionConverter);
     assertEquals(expr, reverse);
+  }
+
+  static Stream<Arguments> subtractDateIDayTypes() {
+    Type timestamp = TypeCreator.REQUIRED.precisionTimestamp(6);
+    return Stream.of(
+        Arguments.of(Named.of("legacy DATE output", TypeCreator.REQUIRED.DATE), timestamp),
+        Arguments.of(Named.of("spec timestamp output", timestamp), timestamp));
+  }
+
+  @Test
+  void datetimeSubtractOperatorHasIndependentIdentity() {
+    assertNotEquals(SqlStdOperatorTable.MINUS_DATE, FunctionMappings.DATETIME_SUBTRACT);
+    assertNotEquals(SqlInternalOperators.MINUS_DATE2, FunctionMappings.DATETIME_SUBTRACT);
+  }
+
+  @Test
+  void timezoneDatetimeSubtractHasStableDigest() {
+    Expression.ScalarFunctionInvocation expr =
+        sb.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "subtract:ptstz_iyear_str",
+            TypeCreator.REQUIRED.precisionTimestampTZ(3),
+            ExpressionCreator.precisionTimestampTZ(false, 0, 3),
+            ExpressionCreator.intervalYear(false, 1, 0),
+            ExpressionCreator.string(false, "UTC"));
+
+    RexCall calciteExpr =
+        assertInstanceOf(RexCall.class, expr.accept(expressionRexConverter, Context.newContext()));
+    assertSame(FunctionMappings.DATETIME_SUBTRACT, calciteExpr.getOperator());
+    assertDoesNotThrow(calciteExpr::toString);
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -107,7 +107,7 @@ class FunctionConversionTest extends PlanTestBase {
         Arguments.of(
             Named.of("spec max-precision output", maxPrecisionTimestamp), maxPrecisionTimestamp),
         Arguments.of(
-            Named.of("spec non-max-precision output", TypeCreator.REQUIRED.precisionTimestamp(3)),
+            Named.of("non-max declared output", TypeCreator.REQUIRED.precisionTimestamp(3)),
             maxPrecisionTimestamp));
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/PrecisionTimestampDatetimeSubtractionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PrecisionTimestampDatetimeSubtractionTest.java
@@ -3,8 +3,8 @@ package io.substrait.isthmus;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test class for precision timestamp datetime subtraction operations. Tests the mapping of
- * Calcite's MINUS_DATE operator to Substrait's subtract function for precision_timestamp and
+ * Test class for precision timestamp datetime subtraction operations. Tests the mapping between
+ * Calcite datetime subtraction and Substrait's subtract function for precision_timestamp and
  * precision_timestamp_tz types.
  */
 class PrecisionTimestampDatetimeSubtractionTest extends PlanTestBase {

--- a/isthmus/src/test/java/io/substrait/isthmus/PrecisionTimestampDatetimeSubtractionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PrecisionTimestampDatetimeSubtractionTest.java
@@ -1,5 +1,10 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.plan.Plan;
+import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,6 +44,16 @@ class PrecisionTimestampDatetimeSubtractionTest extends PlanTestBase {
   void dateSubtractIntervalDay() throws Exception {
     String query = "SELECT event_date - INTERVAL '5' DAY FROM events";
     assertFullRoundTrip(query, CREATES);
+  }
+
+  @Test
+  void dateSubtractIntervalUnparsesAsSqlArithmetic() throws Exception {
+    String query = "SELECT event_date - INTERVAL '5' DAY FROM events";
+    Plan plan = assertProtoPlanRoundrip(query, new SqlToSubstrait(), CREATES);
+
+    String generatedSql = new SubstraitToSql().convert(plan, PostgresqlSqlDialect.DEFAULT).get(0);
+    assertFalse(generatedSql.contains("DATETIME_SUBTRACT"));
+    assertTrue(generatedSql.contains("- INTERVAL"));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/PrecisionTimestampDatetimeSubtractionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PrecisionTimestampDatetimeSubtractionTest.java
@@ -3,7 +3,12 @@ package io.substrait.isthmus;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.plan.Plan;
+import io.substrait.relation.Project;
+import java.util.List;
 import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +59,25 @@ class PrecisionTimestampDatetimeSubtractionTest extends PlanTestBase {
     String generatedSql = new SubstraitToSql().convert(plan, PostgresqlSqlDialect.DEFAULT).get(0);
     assertFalse(generatedSql.contains("DATETIME_SUBTRACT"));
     assertTrue(generatedSql.contains("- INTERVAL"));
+  }
+
+  @Test
+  void timezoneDatetimeSubtractUnparsesAsFunctionCall() {
+    Expression.ScalarFunctionInvocation subtraction =
+        sb.scalarFn(
+            DefaultExtensionCatalog.FUNCTIONS_DATETIME,
+            "subtract:ptstz_iyear_str",
+            R.precisionTimestampTZ(3),
+            ExpressionCreator.precisionTimestampTZ(false, 0, 3),
+            ExpressionCreator.intervalYear(false, 1, 0),
+            ExpressionCreator.string(false, "UTC"));
+    Project project = sb.project(input -> List.of(subtraction), sb.emptyVirtualTableScan());
+    Plan plan = sb.plan(sb.root(project, List.of("result")));
+
+    String generatedSql = new SubstraitToSql().convert(plan, PostgresqlSqlDialect.DEFAULT).get(0);
+    assertTrue(generatedSql.contains("DATETIME_SUBTRACT("));
+    assertTrue(generatedSql.contains(", 'UTC')"));
+    assertFalse(generatedSql.contains(") 'UTC'"));
   }
 
   @Test


### PR DESCRIPTION
`subtract:date_iday` was resolved to Calcite `MINUS_DATE`, whose return type inference expects a third operand. The earlier `MINUS_DATE2` approach removed the exception, but it still compared equal to `MINUS_DATE` and inferred `DATE`.

Use an Isthmus-owned `DATETIME_SUBTRACT` operator. It has a distinct Calcite identity, handles both two-operand datetime/interval and three-operand timezone forms, and infers `TIMESTAMP` at the configured maximum precision for `DATE - interval_day`. A dedicated reverse mapper keeps existing Calcite-to-Substrait conversion of the stock datetime subtraction operators working.

Regression coverage includes both the legacy `DATE` output shape and the spec `precision_timestamp<P>` shape, independent operator identity, TypeObserver inference, round-trip conversion, and the three-operand timezone digest path.

BREAKING CHANGE: Converted Substrait datetime subtraction expressions now use an Isthmus-owned operator without a Calcite Enumerable implementation. Consumers executing these plans through the Enumerable convention must provide an implementation or handle this operator before execution.

Closes #377