### PR TITLE
build(isthmus): update HttpClient for GHSA-hjcp-jmpx-g3qm

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ graal = "25.0.2"
 graal-plugin = "1.1.7"
 gradle-extensions = "4.0.0"
 guava = "33.6.0-jre"
+httpclient = "5.6.3"
 httpcore = "5.4.3"
 immutables = "2.12.2"
 jackson = "2.22.1"
@@ -44,6 +45,7 @@ calcite-server = { module = "org.apache.calcite:calcite-server", version.ref = "
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graal" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+httpclient = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpclient" }
 httpcore = { module = "org.apache.httpcomponents.core5:httpcore5", version.ref = "httpcore" }
 httpcore-h2 = { module = "org.apache.httpcomponents.core5:httpcore5-h2", version.ref = "httpcore" }
 immutables-value = { module = "org.immutables:value", version.ref = "immutables" }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -89,7 +89,9 @@ dependencies {
   constraints {
     // calcite-core:1.42.0 has dependencies that contain vulnerabilities:
     // - CVE-2024-57699 (net.minidev:json-smart < 2.5.2)
+    // - GHSA-hjcp-jmpx-g3qm (org.apache.httpcomponents.client5:httpclient5 < 5.6.3)
     // - CVE-2026-54399 (org.apache.httpcomponents.core5:httpcore5 < 5.4.3)
+    implementation(libs.httpclient)
     implementation(libs.httpcore)
     implementation(libs.httpcore.h2)
     implementation(libs.json.smart)


### PR DESCRIPTION
Calcite 1.42.0 pulls Avatica 1.28.0, which resolves httpclient5 5.5. OSV now reports GHSA-hjcp-jmpx-g3qm for that version; the first fixed version is 5.6.3.

Add a dependency constraint so Isthmus and its CLI consumers select httpclient5 5.6.3.