### PR TITLE
fix(core): write rel-level advanced extensions on exchange rels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,9 +118,10 @@ Proto conversion is split into two directions, and the class name tells you whic
   one helper per direction: `ProtoRelConverter.applyRelCommon(rel, relCommon)` on the way in and
   `RelProtoConverter.common(Rel)` on the way out. Both are still *called* per relation, so both
   halves are easy to forget: a new `newXxx` must route its result through `applyRelCommon`, and a
-  new `visit` must call `.setCommon(common(rel))`. `RelCommonRoundtripTest` covers every
-  `RelVisitor` type and fails when one has no sample — but it is keyed on POJO types, not on proto
-  `oneof` cases, so a new case mapping to an existing POJO type slips through. `applyRelCommon`
+  new `visit` must call `.setCommon(common(rel))`. `RelCommonRoundtripTest` round-trips every
+  relation in the shared `RelSamples` fixture (see Testing conventions), so a relation added without
+  a sample fails `RelSamplesTest` — but that fixture is keyed on POJO types, not on proto `oneof`
+  cases, so a new case mapping to an existing POJO type slips through. `applyRelCommon`
   runs *after* `build()`, so a relation with a `@Value.Check` on one of these fields must also set
   it on its builder (see `newLateralJoin`). Every modeled relation message has a `common` field;
   `ReferenceRel` does not, but no POJO models it.
@@ -167,6 +168,14 @@ CI runs, and a `:core` change can break the visitor implementors in the other mo
   `verifyRoundTrip(Expression)` / `verifyRoundTrip(Rel)` to assert POJO → proto → POJO
   fidelity. See `core/src/test/java/io/substrait/type/proto/DynamicParameterRoundtripTest.java`
   for the canonical pattern.
+- A test that has to cover *every* relation rather than a hand-picked few uses the shared
+  `core/src/test/java/io/substrait/utils/RelSamples.java` fixture — one sample per `RelVisitor`
+  type, plus a `relTypes()` reflecting over the visitor's `visit` overloads so `RelSamplesTest`
+  fails when a new relation has no sample. Its details are `StringHolder`s, so a consumer extends
+  `StringHolderRoundtripTestBase` rather than `TestBase` directly. Layer the per-relation data under
+  test onto the samples (`Rel.withXxx`, or the `AdvancedExtension` slots
+  `withAdvancedExtensions(...)` fills in) and assert that they carry it, so the round trip cannot
+  pass vacuously.
 
 ## Conventions & workflow
 

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -646,6 +646,9 @@ public class RelProtoConverter
                 exchange.getTargets().stream().map(this::toProto).collect(Collectors.toList()))
             .setCommon(common(exchange))
             .setInput(toProto(exchange.getInput()));
+    exchange
+        .getExtension()
+        .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
     return Rel.newBuilder().setExchange(builder).build();
   }
 
@@ -663,6 +666,9 @@ public class RelProtoConverter
                 exchange.getTargets().stream().map(this::toProto).collect(Collectors.toList()))
             .setCommon(common(exchange))
             .setInput(toProto(exchange.getInput()));
+    exchange
+        .getExtension()
+        .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
     return Rel.newBuilder().setExchange(builder).build();
   }
 
@@ -681,6 +687,9 @@ public class RelProtoConverter
                 exchange.getTargets().stream().map(this::toProto).collect(Collectors.toList()))
             .setCommon(common(exchange))
             .setInput(toProto(exchange.getInput()));
+    exchange
+        .getExtension()
+        .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
     return Rel.newBuilder().setExchange(builder).build();
   }
 
@@ -696,6 +705,9 @@ public class RelProtoConverter
                 exchange.getTargets().stream().map(this::toProto).collect(Collectors.toList()))
             .setCommon(common(exchange))
             .setInput(toProto(exchange.getInput()));
+    exchange
+        .getExtension()
+        .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
     return Rel.newBuilder().setExchange(builder).build();
   }
 
@@ -710,6 +722,9 @@ public class RelProtoConverter
                 exchange.getTargets().stream().map(this::toProto).collect(Collectors.toList()))
             .setCommon(common(exchange))
             .setInput(toProto(exchange.getInput()));
+    exchange
+        .getExtension()
+        .ifPresent(ae -> builder.setAdvancedExtension(extensionProtoConverter.toProto(ae)));
     return Rel.newBuilder().setExchange(builder).build();
   }
 

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -1,57 +1,104 @@
 package io.substrait.type.proto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import io.substrait.TestBase;
 import io.substrait.expression.Expression;
+import io.substrait.expression.FieldReference;
+import io.substrait.expression.FunctionOption;
+import io.substrait.expression.WindowBound;
 import io.substrait.extension.AdvancedExtension;
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.SimpleExtension;
+import io.substrait.relation.AbstractDdlRel;
+import io.substrait.relation.AbstractUpdate;
+import io.substrait.relation.AbstractWriteRel;
 import io.substrait.relation.Aggregate;
+import io.substrait.relation.ConsistentPartitionWindow;
 import io.substrait.relation.Cross;
 import io.substrait.relation.Expand;
+import io.substrait.relation.ExtensionDdl;
 import io.substrait.relation.ExtensionLeaf;
 import io.substrait.relation.ExtensionMulti;
 import io.substrait.relation.ExtensionSingle;
 import io.substrait.relation.ExtensionTable;
+import io.substrait.relation.ExtensionWrite;
 import io.substrait.relation.Fetch;
 import io.substrait.relation.Filter;
+import io.substrait.relation.HasExtension;
 import io.substrait.relation.Join;
 import io.substrait.relation.LateralJoin;
 import io.substrait.relation.LocalFiles;
+import io.substrait.relation.NamedDdl;
 import io.substrait.relation.NamedScan;
+import io.substrait.relation.NamedUpdate;
+import io.substrait.relation.NamedWrite;
 import io.substrait.relation.Project;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelProtoConverter;
+import io.substrait.relation.RelVisitor;
 import io.substrait.relation.Set;
 import io.substrait.relation.Sort;
 import io.substrait.relation.VirtualTableScan;
+import io.substrait.relation.physical.BroadcastExchange;
 import io.substrait.relation.physical.HashJoin;
 import io.substrait.relation.physical.MergeJoin;
+import io.substrait.relation.physical.MultiBucketExchange;
 import io.substrait.relation.physical.NestedLoopJoin;
+import io.substrait.relation.physical.RoundRobinExchange;
+import io.substrait.relation.physical.ScatterExchange;
+import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.relation.physical.TopN;
 import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import io.substrait.utils.StringHolder;
 import io.substrait.utils.StringHolderHandlingProtoRelConverter;
 import io.substrait.utils.StringHolderHandlingRelProtoConverter;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 /**
  * Verify that the various extension types in {@link io.substrait.relation.Extension} roundtrip
  * correctly.
+ *
+ * <p>Every relation type that {@link RelVisitor} knows about and that implements {@link
+ * HasExtension} must appear in {@link #relSamples()}; {@link
+ * #everyRelWithAnAdvancedExtensionIsCovered()} fails the build otherwise. A converter that reads a
+ * rel-level {@code advanced_extension} back but never writes it silently discards third-party
+ * extensions on a read-modify-write roundtrip, which is invisible without per-rel coverage.
  */
 class ExtensionRoundtripTest extends TestBase {
 
   final ProtoRelConverter protoRelConverter =
       new StringHolderHandlingProtoRelConverter(functionCollector, extensions);
 
-  final Rel commonTable =
+  final NamedScan commonTable =
       sb.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+  final Rel typedTable =
+      sb.namedScan(
+          Collections.singletonList("test_table"),
+          Arrays.asList("a", "b", "c"),
+          Arrays.asList(R.I64, R.I16, R.I32));
+
+  final NamedStruct boolSchema =
+      NamedStruct.builder()
+          .addNames("KEY")
+          .struct(TypeCreator.REQUIRED.struct(TypeCreator.REQUIRED.BOOLEAN))
+          .build();
 
   final AdvancedExtension commonExtension =
       AdvancedExtension.builder()
@@ -76,108 +123,83 @@ class ExtensionRoundtripTest extends TestBase {
     assertEquals(rel, relReturned);
   }
 
-  @Test
-  void virtualTable() {
-    Rel rel =
+  /**
+   * One sample per relation type, carrying a common-level {@link AdvancedExtension} and — for the
+   * {@link HasExtension} types — a rel-level one as well.
+   */
+  Map<Class<? extends Rel>, Rel> relSamples() {
+    Map<Class<? extends Rel>, Rel> samples = new LinkedHashMap<>();
+
+    // Read rels
+    samples.put(
+        VirtualTableScan.class,
         VirtualTableScan.builder()
             .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
             .addRows(Expression.NestedStruct.builder().fields(Collections.emptyList()).build())
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void localFiles() {
-    Rel rel =
+            .build());
+    samples.put(
+        LocalFiles.class,
         LocalFiles.builder()
             .initialSchema(
                 NamedStruct.of(
                     Collections.emptyList(), Type.Struct.builder().nullable(false).build()))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void namedScan() {
-    Rel rel =
+            .build());
+    samples.put(
+        NamedScan.class,
         NamedScan.builder()
-            .from(
-                sb.namedScan(
-                    Collections.emptyList(), Collections.emptyList(), Collections.emptyList()))
+            .from(commonTable)
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
+            .build());
+    samples.put(
+        ExtensionTable.class,
+        ExtensionTable.from(detail)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
 
-  @Test
-  void extensionTable() {
-    Rel rel = ExtensionTable.from(detail).build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void filter() {
-    Rel rel =
+    // Logical rels
+    samples.put(
+        Filter.class,
         Filter.builder()
             .from(sb.filter(__ -> sb.bool(true), commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void fetch() {
-    Rel rel =
+            .build());
+    samples.put(
+        Fetch.class,
         Fetch.builder()
             .from(sb.fetch(1, 2, commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void aggregate() {
-    Rel rel =
+            .build());
+    samples.put(
+        Aggregate.class,
         Aggregate.builder()
             .from(sb.aggregate(sb::grouping, __ -> Collections.emptyList(), commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void sort() {
-    Rel rel =
+            .build());
+    samples.put(
+        Sort.class,
         Sort.builder()
             .from(sb.sort(__ -> Collections.emptyList(), commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void join() {
-    Rel rel =
+            .build());
+    samples.put(
+        Join.class,
         Join.builder()
             .from(sb.innerJoin(__ -> sb.bool(true), commonTable, commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void lateralJoin() {
-    Rel rel =
+            .build());
+    samples.put(
+        LateralJoin.class,
         LateralJoin.builder()
             .left(commonTable)
             .right(commonTable)
@@ -186,126 +208,293 @@ class ExtensionRoundtripTest extends TestBase {
             .relAnchor(1)
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
+            .build());
+    samples.put(
+        Project.class,
+        Project.builder()
+            .from(sb.project(__ -> Collections.emptyList(), commonTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Expand.class,
+        Expand.builder()
+            .from(sb.expand(__ -> Collections.emptyList(), commonTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Set.class,
+        Set.builder()
+            .from(sb.set(Set.SetOp.UNION_ALL, commonTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Cross.class,
+        Cross.builder()
+            .from(sb.cross(commonTable, commonTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ConsistentPartitionWindow.class,
+        ConsistentPartitionWindow.builder()
+            .input(typedTable)
+            // lead(a) OVER (PARTITION BY b ORDER BY c)
+            .addWindowFunctions(
+                ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
+                    .declaration(
+                        extensions.getWindowFunction(
+                            SimpleExtension.FunctionAnchor.of(
+                                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any")))
+                    .addArguments(sb.fieldReference(typedTable, 0))
+                    .addOptions(FunctionOption.builder().name("option").addValues("VALUE1").build())
+                    .outputType(R.I64)
+                    .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                    .invocation(Expression.AggregationInvocation.ALL)
+                    .lowerBound(WindowBound.Unbounded.UNBOUNDED)
+                    .upperBound(WindowBound.Following.CURRENT_ROW)
+                    .boundsType(Expression.WindowBoundsType.RANGE)
+                    .build())
+            .addPartitionExpressions(sb.fieldReference(typedTable, 1))
+            .addSorts(
+                Expression.SortField.builder()
+                    .expr(sb.fieldReference(typedTable, 2))
+                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                    .build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
 
-  @Test
-  void hashJoin() {
-    // with empty keys
-    List<Integer> leftEmptyKeys = Collections.emptyList();
-    List<Integer> rightEmptyKeys = Collections.emptyList();
-    Rel relWithoutKeys =
+    // Extension rels, which carry only a common-level extension
+    samples.put(
+        ExtensionLeaf.class, ExtensionLeaf.from(detail).commonExtension(commonExtension).build());
+    samples.put(
+        ExtensionSingle.class,
+        ExtensionSingle.from(detail, commonTable).commonExtension(commonExtension).build());
+    samples.put(
+        ExtensionMulti.class,
+        ExtensionMulti.from(detail, commonTable, commonTable)
+            .commonExtension(commonExtension)
+            .build());
+
+    // Write, DDL and update rels
+    samples.put(
+        NamedWrite.class,
+        NamedWrite.builder()
+            .addNames("CUSTOMER")
+            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
+            .operation(AbstractWriteRel.WriteOp.INSERT)
+            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
+            .tableSchema(boolSchema)
+            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ExtensionWrite.class,
+        ExtensionWrite.builder()
+            .detail(detail)
+            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
+            .operation(AbstractWriteRel.WriteOp.INSERT)
+            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
+            .tableSchema(boolSchema)
+            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        NamedDdl.class,
+        NamedDdl.builder()
+            .addNames("CUSTOMER")
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .tableSchema(boolSchema)
+            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .tableDefaults(
+                Expression.StructLiteral.builder()
+                    .nullable(false)
+                    .addFields(sb.bool(false))
+                    .build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ExtensionDdl.class,
+        ExtensionDdl.builder()
+            .detail(detail)
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .tableSchema(boolSchema)
+            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .tableDefaults(
+                Expression.StructLiteral.builder()
+                    .nullable(false)
+                    .addFields(sb.bool(false))
+                    .build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    // UpdateRel is the one rel message with no RelCommon, so a NamedUpdate can only carry the
+    // rel-level extension — a common-level one has nowhere to be written.
+    samples.put(
+        NamedUpdate.class,
+        NamedUpdate.builder()
+            .addNames("CUSTOMER")
+            .tableSchema(boolSchema)
+            .condition(
+                sb.equal(
+                    FieldReference.builder()
+                        .addSegments(FieldReference.StructField.of(0))
+                        .type(TypeCreator.REQUIRED.BOOLEAN)
+                        .build(),
+                    sb.bool(true)))
+            .addTransformations(
+                AbstractUpdate.TransformExpression.builder()
+                    .columnTarget(0)
+                    .transformation(sb.bool(false))
+                    .build())
+            .extension(relExtension)
+            .build());
+
+    // Physical rels
+    samples.put(
+        HashJoin.class,
         HashJoin.builder()
             .from(
                 sb.hashJoin(
-                    leftEmptyKeys,
-                    rightEmptyKeys,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
                     HashJoin.JoinType.INNER,
                     commonTable,
                     commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(relWithoutKeys);
-  }
-
-  @Test
-  void mergeJoin() {
-    // with empty keys
-    List<Integer> leftEmptyKeys = Collections.emptyList();
-    List<Integer> rightEmptyKeys = Collections.emptyList();
-    Rel relWithoutKeys =
+            .build());
+    samples.put(
+        MergeJoin.class,
         MergeJoin.builder()
             .from(
                 sb.mergeJoin(
-                    leftEmptyKeys,
-                    rightEmptyKeys,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
                     MergeJoin.JoinType.INNER,
                     commonTable,
                     commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(relWithoutKeys);
-  }
-
-  @Test
-  void nestedLoopJoin() {
-    Rel rel =
+            .build());
+    samples.put(
+        NestedLoopJoin.class,
         NestedLoopJoin.builder()
             .from(
                 sb.nestedLoopJoin(
                     __ -> sb.bool(true), NestedLoopJoin.JoinType.INNER, commonTable, commonTable))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void project() {
-    Rel rel =
-        Project.builder()
-            .from(sb.project(__ -> Collections.emptyList(), commonTable))
+            .build());
+    samples.put(
+        TopN.class,
+        TopN.builder()
+            .input(typedTable)
+            .addSortFields(
+                Expression.SortField.builder()
+                    .expr(sb.fieldReference(typedTable, 0))
+                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                    .build())
+            .count(sb.i64(10))
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
+            .build());
 
-  @Test
-  void expand() {
-    Rel rel =
-        Expand.builder()
-            .from(sb.expand(__ -> Collections.emptyList(), commonTable))
+    // Exchange rels
+    samples.put(
+        ScatterExchange.class,
+        ScatterExchange.builder()
+            .input(typedTable)
+            .addFields(sb.fieldReference(typedTable, 0))
+            .partitionCount(1)
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void set() {
-    Rel rel =
-        Set.builder()
-            .from(sb.set(Set.SetOp.UNION_ALL, commonTable))
+            .build());
+    samples.put(
+        SingleBucketExchange.class,
+        SingleBucketExchange.builder()
+            .input(typedTable)
+            .expression(sb.fieldReference(typedTable, 0))
+            .partitionCount(1)
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void extensionSingleRel() {
-    Rel rel = ExtensionSingle.from(detail, commonTable).commonExtension(commonExtension).build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void extensionMultiRel() {
-    Rel rel =
-        ExtensionMulti.from(detail, commonTable, commonTable)
-            .commonExtension(commonExtension)
-            .build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void extensionLeafRel() {
-    Rel rel = ExtensionLeaf.from(detail).commonExtension(commonExtension).build();
-    verifyRoundTrip(rel);
-  }
-
-  @Test
-  void cross() {
-    Rel rel =
-        Cross.builder()
-            .from(sb.cross(commonTable, commonTable))
+            .build());
+    samples.put(
+        MultiBucketExchange.class,
+        MultiBucketExchange.builder()
+            .input(typedTable)
+            .expression(sb.fieldReference(typedTable, 0))
+            .constrainedToCount(true)
+            .partitionCount(1)
             .commonExtension(commonExtension)
             .extension(relExtension)
-            .build();
-    verifyRoundTrip(rel);
+            .build());
+    samples.put(
+        RoundRobinExchange.class,
+        RoundRobinExchange.builder()
+            .input(typedTable)
+            .exact(true)
+            .partitionCount(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        BroadcastExchange.class,
+        BroadcastExchange.builder()
+            .input(typedTable)
+            .partitionCount(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+
+    return samples;
+  }
+
+  @TestFactory
+  Stream<DynamicTest> relExtensions() {
+    return relSamples().entrySet().stream()
+        .map(
+            sample ->
+                DynamicTest.dynamicTest(
+                    sample.getKey().getSimpleName(), () -> verifyRoundTrip(sample.getValue())));
+  }
+
+  /**
+   * Guards {@link #relSamples()} against drift: a relation type that can hold a rel-level {@link
+   * AdvancedExtension} but has no sample here would let a missing converter side go unnoticed.
+   */
+  @Test
+  void everyRelWithAnAdvancedExtensionIsCovered() {
+    List<Class<?>> relTypes =
+        Arrays.stream(RelVisitor.class.getMethods())
+            .filter(method -> "visit".equals(method.getName()))
+            .map(Method::getParameterTypes)
+            .map(parameterTypes -> parameterTypes[0])
+            .filter(HasExtension.class::isAssignableFrom)
+            .collect(Collectors.toList());
+    // Without this the check below passes vacuously if the reflection above stops finding rels.
+    assertFalse(relTypes.isEmpty(), "No HasExtension relation types found on RelVisitor");
+
+    Map<Class<? extends Rel>, Rel> samples = relSamples();
+    List<String> uncovered =
+        relTypes.stream()
+            .filter(relType -> !samples.containsKey(relType))
+            .map(Class::getSimpleName)
+            .sorted()
+            .collect(Collectors.toList());
+
+    assertEquals(
+        Collections.emptyList(),
+        uncovered,
+        "Relation types implementing HasExtension without an advanced extension roundtrip sample");
   }
 
   @Nested

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -1,24 +1,19 @@
 package io.substrait.type.proto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.substrait.TestBase;
 import io.substrait.expression.Expression;
 import io.substrait.extension.AdvancedExtension;
 import io.substrait.relation.HasExtension;
 import io.substrait.relation.Project;
-import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
-import io.substrait.relation.RelProtoConverter;
 import io.substrait.type.TypeCreator;
 import io.substrait.utils.RelSamples;
 import io.substrait.utils.StringHolder;
-import io.substrait.utils.StringHolderHandlingProtoRelConverter;
-import io.substrait.utils.StringHolderHandlingRelProtoConverter;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -30,16 +25,12 @@ import org.junit.jupiter.api.TestFactory;
  * Verify that the various extension types in {@link io.substrait.relation.Extension} roundtrip
  * correctly.
  *
- * <p>{@link #everyRelWithAnAdvancedExtensionIsCovered()} keeps the coverage exhaustive: every
- * relation type implementing {@link HasExtension} needs a sample, so a converter that reads a
- * rel-level {@code advanced_extension} back but never writes it cannot go unnoticed. Such a
- * converter discards third-party extensions on a read-modify-write roundtrip without raising
- * anything.
+ * <p>The relations come from the shared {@link RelSamples}, whose own test keeps them exhaustive,
+ * so a converter that reads a rel-level {@code advanced_extension} back but never writes it cannot
+ * go unnoticed for want of a sample. Such a converter discards third-party extensions on a
+ * read-modify-write roundtrip without raising anything.
  */
-class ExtensionRoundtripTest extends TestBase {
-
-  final ProtoRelConverter protoRelConverter =
-      new StringHolderHandlingProtoRelConverter(functionCollector, extensions);
+class ExtensionRoundtripTest extends StringHolderRoundtripTestBase {
 
   final Rel commonTable =
       sb.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
@@ -59,15 +50,6 @@ class ExtensionRoundtripTest extends TestBase {
   final Map<Class<? extends Rel>, Rel> relSamples =
       new RelSamples(sb, extensions).withAdvancedExtensions(commonExtension, relExtension);
 
-  @Override
-  protected void verifyRoundTrip(Rel rel) {
-    RelProtoConverter relProtoConverter =
-        new StringHolderHandlingRelProtoConverter(functionCollector);
-    io.substrait.proto.Rel protoRel = relProtoConverter.toProto(rel);
-    Rel relReturned = protoRelConverter.from(protoRel);
-    assertEquals(rel, relReturned);
-  }
-
   @TestFactory
   Stream<DynamicTest> relExtensions() {
     return relSamples.entrySet().stream()
@@ -78,25 +60,26 @@ class ExtensionRoundtripTest extends TestBase {
   }
 
   @Test
-  void everyRelWithAnAdvancedExtensionIsCovered() {
-    List<Class<?>> relTypes =
-        RelSamples.relTypes().stream()
-            .filter(HasExtension.class::isAssignableFrom)
-            .collect(Collectors.toList());
-    // Without this the check below passes vacuously if the reflection above stops finding rels.
-    assertFalse(relTypes.isEmpty(), "No HasExtension relation types found on RelVisitor");
+  void samplesCarryTheExtensionsUnderTest() {
+    // Guards the roundtrips above against passing vacuously: a converter that reads an
+    // advanced_extension back but never writes it still roundtrips a sample that carries none.
+    assertTrue(
+        relSamples.values().stream().anyMatch(HasExtension.class::isInstance),
+        "No HasExtension relation samples found");
 
-    List<String> uncovered =
-        relTypes.stream()
-            .filter(relType -> !relSamples.containsKey(relType))
-            .map(Class::getSimpleName)
-            .sorted()
-            .collect(Collectors.toList());
-
-    assertEquals(
-        Collections.emptyList(),
-        uncovered,
-        "Relation types implementing HasExtension without an advanced extension roundtrip sample");
+    for (Map.Entry<Class<? extends Rel>, Rel> sample : relSamples.entrySet()) {
+      String relType = sample.getKey().getSimpleName();
+      assertEquals(
+          Optional.of(commonExtension),
+          sample.getValue().getCommonExtension(),
+          relType + " carries no common-level advanced extension");
+      if (sample.getValue() instanceof HasExtension) {
+        assertEquals(
+            Optional.of(relExtension),
+            ((HasExtension) sample.getValue()).getExtension(),
+            relType + " carries no rel-level advanced extension");
+      }
+    }
   }
 
   @Nested

--- a/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ExtensionRoundtripTest.java
@@ -5,62 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import io.substrait.TestBase;
 import io.substrait.expression.Expression;
-import io.substrait.expression.FieldReference;
-import io.substrait.expression.FunctionOption;
-import io.substrait.expression.WindowBound;
 import io.substrait.extension.AdvancedExtension;
-import io.substrait.extension.DefaultExtensionCatalog;
-import io.substrait.extension.SimpleExtension;
-import io.substrait.relation.AbstractDdlRel;
-import io.substrait.relation.AbstractUpdate;
-import io.substrait.relation.AbstractWriteRel;
-import io.substrait.relation.Aggregate;
-import io.substrait.relation.ConsistentPartitionWindow;
-import io.substrait.relation.Cross;
-import io.substrait.relation.Expand;
-import io.substrait.relation.ExtensionDdl;
-import io.substrait.relation.ExtensionLeaf;
-import io.substrait.relation.ExtensionMulti;
-import io.substrait.relation.ExtensionSingle;
-import io.substrait.relation.ExtensionTable;
-import io.substrait.relation.ExtensionWrite;
-import io.substrait.relation.Fetch;
-import io.substrait.relation.Filter;
 import io.substrait.relation.HasExtension;
-import io.substrait.relation.Join;
-import io.substrait.relation.LateralJoin;
-import io.substrait.relation.LocalFiles;
-import io.substrait.relation.NamedDdl;
-import io.substrait.relation.NamedScan;
-import io.substrait.relation.NamedUpdate;
-import io.substrait.relation.NamedWrite;
 import io.substrait.relation.Project;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelProtoConverter;
-import io.substrait.relation.RelVisitor;
-import io.substrait.relation.Set;
-import io.substrait.relation.Sort;
-import io.substrait.relation.VirtualTableScan;
-import io.substrait.relation.physical.BroadcastExchange;
-import io.substrait.relation.physical.HashJoin;
-import io.substrait.relation.physical.MergeJoin;
-import io.substrait.relation.physical.MultiBucketExchange;
-import io.substrait.relation.physical.NestedLoopJoin;
-import io.substrait.relation.physical.RoundRobinExchange;
-import io.substrait.relation.physical.ScatterExchange;
-import io.substrait.relation.physical.SingleBucketExchange;
-import io.substrait.relation.physical.TopN;
-import io.substrait.type.NamedStruct;
-import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
+import io.substrait.utils.RelSamples;
 import io.substrait.utils.StringHolder;
 import io.substrait.utils.StringHolderHandlingProtoRelConverter;
 import io.substrait.utils.StringHolderHandlingRelProtoConverter;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -74,31 +30,19 @@ import org.junit.jupiter.api.TestFactory;
  * Verify that the various extension types in {@link io.substrait.relation.Extension} roundtrip
  * correctly.
  *
- * <p>Every relation type that {@link RelVisitor} knows about and that implements {@link
- * HasExtension} must appear in {@link #relSamples()}; {@link
- * #everyRelWithAnAdvancedExtensionIsCovered()} fails the build otherwise. A converter that reads a
- * rel-level {@code advanced_extension} back but never writes it silently discards third-party
- * extensions on a read-modify-write roundtrip, which is invisible without per-rel coverage.
+ * <p>{@link #everyRelWithAnAdvancedExtensionIsCovered()} keeps the coverage exhaustive: every
+ * relation type implementing {@link HasExtension} needs a sample, so a converter that reads a
+ * rel-level {@code advanced_extension} back but never writes it cannot go unnoticed. Such a
+ * converter discards third-party extensions on a read-modify-write roundtrip without raising
+ * anything.
  */
 class ExtensionRoundtripTest extends TestBase {
 
   final ProtoRelConverter protoRelConverter =
       new StringHolderHandlingProtoRelConverter(functionCollector, extensions);
 
-  final NamedScan commonTable =
+  final Rel commonTable =
       sb.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-
-  final Rel typedTable =
-      sb.namedScan(
-          Collections.singletonList("test_table"),
-          Arrays.asList("a", "b", "c"),
-          Arrays.asList(R.I64, R.I16, R.I32));
-
-  final NamedStruct boolSchema =
-      NamedStruct.builder()
-          .addNames("KEY")
-          .struct(TypeCreator.REQUIRED.struct(TypeCreator.REQUIRED.BOOLEAN))
-          .build();
 
   final AdvancedExtension commonExtension =
       AdvancedExtension.builder()
@@ -106,13 +50,14 @@ class ExtensionRoundtripTest extends TestBase {
           .addOptimizations(new StringHolder("COMMON OPTIMIZATION"))
           .build();
 
-  final StringHolder detail = new StringHolder("DETAIL");
-
   final AdvancedExtension relExtension =
       AdvancedExtension.builder()
           .enhancement(new StringHolder("REL ENHANCEMENT"))
           .addOptimizations(new StringHolder("REL OPTIMIZATION"))
           .build();
+
+  final Map<Class<? extends Rel>, Rel> relSamples =
+      new RelSamples(sb, extensions).withAdvancedExtensions(commonExtension, relExtension);
 
   @Override
   protected void verifyRoundTrip(Rel rel) {
@@ -123,370 +68,27 @@ class ExtensionRoundtripTest extends TestBase {
     assertEquals(rel, relReturned);
   }
 
-  /**
-   * One sample per relation type, carrying a common-level {@link AdvancedExtension} and — for the
-   * {@link HasExtension} types — a rel-level one as well.
-   */
-  Map<Class<? extends Rel>, Rel> relSamples() {
-    Map<Class<? extends Rel>, Rel> samples = new LinkedHashMap<>();
-
-    // Read rels
-    samples.put(
-        VirtualTableScan.class,
-        VirtualTableScan.builder()
-            .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
-            .addRows(Expression.NestedStruct.builder().fields(Collections.emptyList()).build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        LocalFiles.class,
-        LocalFiles.builder()
-            .initialSchema(
-                NamedStruct.of(
-                    Collections.emptyList(), Type.Struct.builder().nullable(false).build()))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        NamedScan.class,
-        NamedScan.builder()
-            .from(commonTable)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        ExtensionTable.class,
-        ExtensionTable.from(detail)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-
-    // Logical rels
-    samples.put(
-        Filter.class,
-        Filter.builder()
-            .from(sb.filter(__ -> sb.bool(true), commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Fetch.class,
-        Fetch.builder()
-            .from(sb.fetch(1, 2, commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Aggregate.class,
-        Aggregate.builder()
-            .from(sb.aggregate(sb::grouping, __ -> Collections.emptyList(), commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Sort.class,
-        Sort.builder()
-            .from(sb.sort(__ -> Collections.emptyList(), commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Join.class,
-        Join.builder()
-            .from(sb.innerJoin(__ -> sb.bool(true), commonTable, commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        LateralJoin.class,
-        LateralJoin.builder()
-            .left(commonTable)
-            .right(commonTable)
-            .condition(sb.bool(true))
-            .joinType(Join.JoinType.INNER)
-            .relAnchor(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Project.class,
-        Project.builder()
-            .from(sb.project(__ -> Collections.emptyList(), commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Expand.class,
-        Expand.builder()
-            .from(sb.expand(__ -> Collections.emptyList(), commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Set.class,
-        Set.builder()
-            .from(sb.set(Set.SetOp.UNION_ALL, commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        Cross.class,
-        Cross.builder()
-            .from(sb.cross(commonTable, commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        ConsistentPartitionWindow.class,
-        ConsistentPartitionWindow.builder()
-            .input(typedTable)
-            // lead(a) OVER (PARTITION BY b ORDER BY c)
-            .addWindowFunctions(
-                ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
-                    .declaration(
-                        extensions.getWindowFunction(
-                            SimpleExtension.FunctionAnchor.of(
-                                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any")))
-                    .addArguments(sb.fieldReference(typedTable, 0))
-                    .addOptions(FunctionOption.builder().name("option").addValues("VALUE1").build())
-                    .outputType(R.I64)
-                    .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
-                    .invocation(Expression.AggregationInvocation.ALL)
-                    .lowerBound(WindowBound.Unbounded.UNBOUNDED)
-                    .upperBound(WindowBound.Following.CURRENT_ROW)
-                    .boundsType(Expression.WindowBoundsType.RANGE)
-                    .build())
-            .addPartitionExpressions(sb.fieldReference(typedTable, 1))
-            .addSorts(
-                Expression.SortField.builder()
-                    .expr(sb.fieldReference(typedTable, 2))
-                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
-                    .build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-
-    // Extension rels, which carry only a common-level extension
-    samples.put(
-        ExtensionLeaf.class, ExtensionLeaf.from(detail).commonExtension(commonExtension).build());
-    samples.put(
-        ExtensionSingle.class,
-        ExtensionSingle.from(detail, commonTable).commonExtension(commonExtension).build());
-    samples.put(
-        ExtensionMulti.class,
-        ExtensionMulti.from(detail, commonTable, commonTable)
-            .commonExtension(commonExtension)
-            .build());
-
-    // Write, DDL and update rels
-    samples.put(
-        NamedWrite.class,
-        NamedWrite.builder()
-            .addNames("CUSTOMER")
-            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
-            .operation(AbstractWriteRel.WriteOp.INSERT)
-            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
-            .tableSchema(boolSchema)
-            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        ExtensionWrite.class,
-        ExtensionWrite.builder()
-            .detail(detail)
-            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
-            .operation(AbstractWriteRel.WriteOp.INSERT)
-            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
-            .tableSchema(boolSchema)
-            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        NamedDdl.class,
-        NamedDdl.builder()
-            .addNames("CUSTOMER")
-            .operation(AbstractDdlRel.DdlOp.CREATE)
-            .object(AbstractDdlRel.DdlObject.VIEW)
-            .tableSchema(boolSchema)
-            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .tableDefaults(
-                Expression.StructLiteral.builder()
-                    .nullable(false)
-                    .addFields(sb.bool(false))
-                    .build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        ExtensionDdl.class,
-        ExtensionDdl.builder()
-            .detail(detail)
-            .operation(AbstractDdlRel.DdlOp.CREATE)
-            .object(AbstractDdlRel.DdlObject.VIEW)
-            .tableSchema(boolSchema)
-            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .tableDefaults(
-                Expression.StructLiteral.builder()
-                    .nullable(false)
-                    .addFields(sb.bool(false))
-                    .build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    // UpdateRel is the one rel message with no RelCommon, so a NamedUpdate can only carry the
-    // rel-level extension — a common-level one has nowhere to be written.
-    samples.put(
-        NamedUpdate.class,
-        NamedUpdate.builder()
-            .addNames("CUSTOMER")
-            .tableSchema(boolSchema)
-            .condition(
-                sb.equal(
-                    FieldReference.builder()
-                        .addSegments(FieldReference.StructField.of(0))
-                        .type(TypeCreator.REQUIRED.BOOLEAN)
-                        .build(),
-                    sb.bool(true)))
-            .addTransformations(
-                AbstractUpdate.TransformExpression.builder()
-                    .columnTarget(0)
-                    .transformation(sb.bool(false))
-                    .build())
-            .extension(relExtension)
-            .build());
-
-    // Physical rels
-    samples.put(
-        HashJoin.class,
-        HashJoin.builder()
-            .from(
-                sb.hashJoin(
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    HashJoin.JoinType.INNER,
-                    commonTable,
-                    commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        MergeJoin.class,
-        MergeJoin.builder()
-            .from(
-                sb.mergeJoin(
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    MergeJoin.JoinType.INNER,
-                    commonTable,
-                    commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        NestedLoopJoin.class,
-        NestedLoopJoin.builder()
-            .from(
-                sb.nestedLoopJoin(
-                    __ -> sb.bool(true), NestedLoopJoin.JoinType.INNER, commonTable, commonTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        TopN.class,
-        TopN.builder()
-            .input(typedTable)
-            .addSortFields(
-                Expression.SortField.builder()
-                    .expr(sb.fieldReference(typedTable, 0))
-                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
-                    .build())
-            .count(sb.i64(10))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-
-    // Exchange rels
-    samples.put(
-        ScatterExchange.class,
-        ScatterExchange.builder()
-            .input(typedTable)
-            .addFields(sb.fieldReference(typedTable, 0))
-            .partitionCount(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        SingleBucketExchange.class,
-        SingleBucketExchange.builder()
-            .input(typedTable)
-            .expression(sb.fieldReference(typedTable, 0))
-            .partitionCount(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        MultiBucketExchange.class,
-        MultiBucketExchange.builder()
-            .input(typedTable)
-            .expression(sb.fieldReference(typedTable, 0))
-            .constrainedToCount(true)
-            .partitionCount(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        RoundRobinExchange.class,
-        RoundRobinExchange.builder()
-            .input(typedTable)
-            .exact(true)
-            .partitionCount(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        BroadcastExchange.class,
-        BroadcastExchange.builder()
-            .input(typedTable)
-            .partitionCount(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-
-    return samples;
-  }
-
   @TestFactory
   Stream<DynamicTest> relExtensions() {
-    return relSamples().entrySet().stream()
+    return relSamples.entrySet().stream()
         .map(
             sample ->
                 DynamicTest.dynamicTest(
                     sample.getKey().getSimpleName(), () -> verifyRoundTrip(sample.getValue())));
   }
 
-  /**
-   * Guards {@link #relSamples()} against drift: a relation type that can hold a rel-level {@link
-   * AdvancedExtension} but has no sample here would let a missing converter side go unnoticed.
-   */
   @Test
   void everyRelWithAnAdvancedExtensionIsCovered() {
     List<Class<?>> relTypes =
-        Arrays.stream(RelVisitor.class.getMethods())
-            .filter(method -> "visit".equals(method.getName()))
-            .map(Method::getParameterTypes)
-            .map(parameterTypes -> parameterTypes[0])
+        RelSamples.relTypes().stream()
             .filter(HasExtension.class::isAssignableFrom)
             .collect(Collectors.toList());
     // Without this the check below passes vacuously if the reflection above stops finding rels.
     assertFalse(relTypes.isEmpty(), "No HasExtension relation types found on RelVisitor");
 
-    Map<Class<? extends Rel>, Rel> samples = relSamples();
     List<String> uncovered =
         relTypes.stream()
-            .filter(relType -> !samples.containsKey(relType))
+            .filter(relType -> !relSamples.containsKey(relType))
             .map(Class::getSimpleName)
             .sorted()
             .collect(Collectors.toList());

--- a/core/src/test/java/io/substrait/type/proto/RelCommonRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/RelCommonRoundtripTest.java
@@ -4,54 +4,25 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.substrait.TestBase;
-import io.substrait.expression.Expression;
-import io.substrait.expression.ExpressionCreator;
-import io.substrait.expression.WindowBound;
 import io.substrait.extension.AdvancedExtension;
-import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.ExtensionLookup;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.hint.Hint;
 import io.substrait.proto.RelCommon;
-import io.substrait.relation.AbstractWriteRel;
-import io.substrait.relation.ConsistentPartitionWindow;
-import io.substrait.relation.Expand;
-import io.substrait.relation.ExtensionDdl;
-import io.substrait.relation.ExtensionLeaf;
-import io.substrait.relation.ExtensionMulti;
-import io.substrait.relation.ExtensionSingle;
-import io.substrait.relation.ExtensionTable;
-import io.substrait.relation.ExtensionWrite;
-import io.substrait.relation.Join;
 import io.substrait.relation.LateralJoin;
-import io.substrait.relation.LocalFiles;
-import io.substrait.relation.NamedDdl;
-import io.substrait.relation.NamedUpdate;
+import io.substrait.relation.NamedScan;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelVisitor;
-import io.substrait.relation.Set;
 import io.substrait.relation.SingleInputRel;
-import io.substrait.relation.VirtualTableScan;
-import io.substrait.relation.extensions.EmptyDetail;
-import io.substrait.relation.physical.BroadcastExchange;
-import io.substrait.relation.physical.HashJoin;
-import io.substrait.relation.physical.MergeJoin;
-import io.substrait.relation.physical.MultiBucketExchange;
-import io.substrait.relation.physical.NestedLoopJoin;
-import io.substrait.relation.physical.RoundRobinExchange;
-import io.substrait.relation.physical.ScatterExchange;
-import io.substrait.relation.physical.SingleBucketExchange;
-import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.util.VisitationContext;
+import io.substrait.utils.RelSamples;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -65,12 +36,12 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Rel#getCommonExtension() common extension} and {@link Rel#getRelAnchor() rel anchor} — through a
  * POJO → proto → POJO round trip.
  *
- * <p>{@link #everyRelationTypeIsCovered()} keeps the sample set exhaustive: it fails when a
- * relation is added to {@link RelVisitor} without a sample here, so a new relation cannot silently
- * miss its {@code RelCommon} wiring.
+ * <p>The samples are the shared {@link RelSamples}, kept exhaustive by their own test: a relation
+ * added to {@link RelVisitor} without a sample fails there, so it cannot silently miss its {@code
+ * RelCommon} wiring here.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class RelCommonRoundtripTest extends TestBase {
+class RelCommonRoundtripTest extends StringHolderRoundtripTestBase {
 
   static final Hint HINT =
       Hint.builder()
@@ -95,15 +66,10 @@ class RelCommonRoundtripTest extends TestBase {
 
   static final int REL_ANCHOR = 11;
 
-  final Rel left =
-      sb.namedScan(
-          Arrays.asList("left_table"), Arrays.asList("a", "b"), Arrays.asList(R.I64, R.STRING));
+  final Map<Class<? extends Rel>, Rel> relSamples = new RelSamples(sb, extensions).samples();
 
-  final Rel right =
-      sb.namedScan(
-          Arrays.asList("right_table"), Arrays.asList("c", "d"), Arrays.asList(R.I64, R.STRING));
-
-  final NamedStruct schema = NamedStruct.of(Arrays.asList("a", "b"), R.struct(R.I64, R.STRING));
+  /** A plain relation for the hand-written {@link Rel}s below to wrap. */
+  final Rel scan = relSamples.get(NamedScan.class);
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("samples")
@@ -112,25 +78,9 @@ class RelCommonRoundtripTest extends TestBase {
   }
 
   @Test
-  void everyRelationTypeIsCovered() {
-    java.util.Set<Class<?>> visitable =
-        Arrays.stream(RelVisitor.class.getDeclaredMethods())
-            .filter(method -> "visit".equals(method.getName()))
-            .map(method -> method.getParameterTypes()[0])
-            .collect(Collectors.toCollection(HashSet::new));
-
-    java.util.Set<Class<?>> sampled =
-        allRelationTypes().stream()
-            .map(RelCommonRoundtripTest::relationType)
-            .collect(Collectors.toCollection(HashSet::new));
-
-    assertEquals(visitable, sampled, "every relation type needs a RelCommon round-trip sample");
-  }
-
-  @Test
   void samplesCarryTheDataUnderTest() {
     // Guards the round-trip assertions above against silently asserting on empty optionals.
-    for (Rel rel : allRelationTypes()) {
+    for (Rel rel : relSamples.values()) {
       Rel sample = withRelCommon(rel);
       assertEquals(Optional.of(HINT), sample.getHint());
       assertEquals(Optional.of(COMMON_EXTENSION), sample.getCommonExtension());
@@ -145,7 +95,7 @@ class RelCommonRoundtripTest extends TestBase {
     // documented extension point that every newXxx must route through, so it must not fail on a
     // relation whose common message carries no data.
     ApplyRelCommonConverter converter = new ApplyRelCommonConverter(functionCollector, extensions);
-    Rel custom = new PassThroughRel(left);
+    Rel custom = new PassThroughRel(scan);
 
     assertEquals(custom, converter.applyRelCommon(custom, RelCommon.getDefaultInstance()));
     assertEquals(
@@ -163,8 +113,8 @@ class RelCommonRoundtripTest extends TestBase {
     // carry. applyRelCommon must leave that alone rather than try to clear it, which would destroy
     // the input's own common data (and here hits Rel's throwing withXxx defaults).
     ApplyRelCommonConverter converter = new ApplyRelCommonConverter(functionCollector, extensions);
-    Rel inner = withRelCommon(left);
-    Rel custom = new DelegatingRel(inner, left.getRecordType());
+    Rel inner = withRelCommon(scan);
+    Rel custom = new DelegatingRel(inner, scan.getRecordType());
 
     assertTrue(custom.getHint().isPresent());
     assertTrue(custom.getCommonExtension().isPresent());
@@ -185,7 +135,7 @@ class RelCommonRoundtripTest extends TestBase {
     // A custom Rel whose withXxx returns its delegate rather than a re-wrapped copy would otherwise
     // surface as a ClassCastException at the caller's assignment, naming neither culprit.
     ApplyRelCommonConverter converter = new ApplyRelCommonConverter(functionCollector, extensions);
-    Rel custom = new ForwardingRel(left);
+    Rel custom = new ForwardingRel(scan);
 
     IllegalStateException failure =
         assertThrows(
@@ -199,7 +149,7 @@ class RelCommonRoundtripTest extends TestBase {
                         .build()));
 
     assertTrue(failure.getMessage().contains(ForwardingRel.class.getName()));
-    assertTrue(failure.getMessage().contains(left.getClass().getName()));
+    assertTrue(failure.getMessage().contains(scan.getClass().getName()));
   }
 
   /** Exposes {@link ProtoRelConverter#applyRelCommon} so the test can call it directly. */
@@ -370,8 +320,8 @@ class RelCommonRoundtripTest extends TestBase {
   }
 
   Stream<Arguments> samples() {
-    return allRelationTypes().stream()
-        .map(rel -> Arguments.of(relationType(rel).getSimpleName(), rel));
+    return relSamples.entrySet().stream()
+        .map(sample -> Arguments.of(sample.getKey().getSimpleName(), sample.getValue()));
   }
 
   /**
@@ -399,177 +349,5 @@ class RelCommonRoundtripTest extends TestBase {
       indices.add(i);
     }
     return Rel.Remap.of(indices);
-  }
-
-  /** The declared relation type of {@code rel}, i.e. the type its generated Immutable extends. */
-  static Class<?> relationType(Rel rel) {
-    return rel.getClass().getSuperclass();
-  }
-
-  /** One sample of every relation type reachable through {@link RelVisitor}. */
-  List<Rel> allRelationTypes() {
-    List<Rel> rels = new ArrayList<>();
-
-    // Read relations
-    rels.add(left);
-    rels.add(
-        VirtualTableScan.builder()
-            .initialSchema(schema)
-            .addRows(
-                Expression.NestedStruct.builder()
-                    .addFields(ExpressionCreator.i64(false, 1))
-                    .addFields(ExpressionCreator.string(false, "one"))
-                    .build())
-            .build());
-    rels.add(LocalFiles.builder().initialSchema(schema).build());
-    // A real schema rather than EmptyDetail's empty one, so the reversed emit mapping is non-empty
-    // and the assertions cover the order of RelCommon.Emit.output_mapping for this relation too.
-    rels.add(ExtensionTable.from(new EmptyDetail()).initialSchema(schema).build());
-
-    // Logical relations
-    rels.add(sb.filter(input -> sb.equal(sb.fieldReference(input, 0), sb.i64(1)), left));
-    rels.add(sb.limit(10, left));
-    rels.add(sb.project(input -> Arrays.asList(sb.fieldReference(input, 0)), left));
-    rels.add(
-        sb.aggregate(
-            input -> sb.grouping(input, 0), input -> Arrays.asList(sb.count(input, 0)), left));
-    rels.add(sb.sort(input -> sb.sortFields(input, 0), left));
-    rels.add(
-        sb.innerJoin(
-            inputs -> sb.equal(sb.fieldReference(inputs, 0), sb.fieldReference(inputs, 2)),
-            left,
-            right));
-    rels.add(sb.cross(left, right));
-    rels.add(sb.set(Set.SetOp.UNION_ALL, left, right));
-    rels.add(
-        sb.expand(
-            input ->
-                Arrays.asList(
-                    Expand.ConsistentField.builder()
-                        .expression(sb.fieldReference(input, 0))
-                        .build()),
-            left));
-    rels.add(
-        LateralJoin.builder()
-            .left(left)
-            .right(right)
-            .joinType(Join.JoinType.INNER)
-            .relAnchor(7)
-            .build());
-    rels.add(consistentPartitionWindow());
-
-    // Physical relations
-    rels.add(sb.topN(input -> sb.sortFields(input, 0), 0, 10, left));
-    rels.add(sb.hashJoin(Arrays.asList(0), Arrays.asList(0), HashJoin.JoinType.INNER, left, right));
-    rels.add(
-        sb.mergeJoin(Arrays.asList(0), Arrays.asList(0), MergeJoin.JoinType.INNER, left, right));
-    rels.add(
-        sb.nestedLoopJoin(
-            inputs -> sb.equal(sb.fieldReference(inputs, 0), sb.fieldReference(inputs, 2)),
-            NestedLoopJoin.JoinType.INNER,
-            left,
-            right));
-    rels.add(BroadcastExchange.builder().input(left).partitionCount(1).build());
-    rels.add(RoundRobinExchange.builder().input(left).exact(true).partitionCount(1).build());
-    rels.add(
-        ScatterExchange.builder()
-            .input(left)
-            .addFields(sb.fieldReference(left, 0))
-            .partitionCount(1)
-            .build());
-    rels.add(
-        SingleBucketExchange.builder()
-            .input(left)
-            .expression(sb.fieldReference(left, 0))
-            .partitionCount(1)
-            .build());
-    rels.add(
-        MultiBucketExchange.builder()
-            .input(left)
-            .expression(sb.fieldReference(left, 0))
-            .constrainedToCount(true)
-            .partitionCount(1)
-            .build());
-
-    // Write, DDL and update relations
-    rels.add(
-        sb.namedWrite(
-            Arrays.asList("target_table"),
-            Arrays.asList("a", "b"),
-            AbstractWriteRel.WriteOp.INSERT,
-            AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS,
-            AbstractWriteRel.OutputMode.NO_OUTPUT,
-            left));
-    rels.add(
-        ExtensionWrite.builder()
-            .input(left)
-            .detail(new EmptyDetail())
-            .tableSchema(schema)
-            .operation(ExtensionWrite.WriteOp.INSERT)
-            .createMode(ExtensionWrite.CreateMode.APPEND_IF_EXISTS)
-            .outputMode(ExtensionWrite.OutputMode.NO_OUTPUT)
-            .build());
-    rels.add(
-        NamedDdl.builder()
-            .names(Arrays.asList("target_table"))
-            .tableSchema(schema)
-            .tableDefaults(tableDefaults())
-            .operation(NamedDdl.DdlOp.CREATE)
-            .object(NamedDdl.DdlObject.TABLE)
-            .build());
-    rels.add(
-        ExtensionDdl.builder()
-            .detail(new EmptyDetail())
-            .tableSchema(schema)
-            .tableDefaults(tableDefaults())
-            .operation(ExtensionDdl.DdlOp.ALTER)
-            .object(ExtensionDdl.DdlObject.TABLE)
-            .build());
-    rels.add(
-        sb.namedUpdate(
-            Arrays.asList("target_table"),
-            Arrays.asList("a"),
-            Arrays.asList(
-                NamedUpdate.TransformExpression.builder()
-                    .columnTarget(0)
-                    .transformation(sb.i64(1))
-                    .build()),
-            sb.bool(true),
-            false));
-
-    // Extension relations
-    rels.add(ExtensionLeaf.from(new EmptyDetail()).build());
-    rels.add(ExtensionSingle.from(new EmptyDetail(), left).build());
-    rels.add(ExtensionMulti.from(new EmptyDetail(), Arrays.asList(left, right)).build());
-
-    return rels;
-  }
-
-  private Expression.StructLiteral tableDefaults() {
-    return ExpressionCreator.struct(
-        false, ExpressionCreator.i64(false, 1), ExpressionCreator.string(false, "one"));
-  }
-
-  private Rel consistentPartitionWindow() {
-    SimpleExtension.WindowFunctionVariant lead =
-        extensions.getWindowFunction(
-            SimpleExtension.FunctionAnchor.of(
-                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
-    return ConsistentPartitionWindow.builder()
-        .input(left)
-        .addWindowFunctions(
-            ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
-                .declaration(lead)
-                .arguments(Arrays.asList(sb.fieldReference(left, 0)))
-                .outputType(R.I64)
-                .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
-                .invocation(Expression.AggregationInvocation.ALL)
-                .lowerBound(WindowBound.Unbounded.UNBOUNDED)
-                .upperBound(WindowBound.Following.CURRENT_ROW)
-                .boundsType(Expression.WindowBoundsType.RANGE)
-                .build())
-        .addPartitionExpressions(sb.fieldReference(left, 1))
-        .sorts(sb.sortFields(left, 0))
-        .build();
   }
 }

--- a/core/src/test/java/io/substrait/type/proto/StringHolderRoundtripTestBase.java
+++ b/core/src/test/java/io/substrait/type/proto/StringHolderRoundtripTestBase.java
@@ -1,0 +1,37 @@
+package io.substrait.type.proto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.TestBase;
+import io.substrait.relation.Rel;
+import io.substrait.relation.RelProtoConverter;
+import io.substrait.utils.RelSamples;
+import io.substrait.utils.StringHolder;
+import io.substrait.utils.StringHolderHandlingProtoRelConverter;
+import io.substrait.utils.StringHolderHandlingRelProtoConverter;
+
+/**
+ * A {@link TestBase} that round-trips {@link StringHolder} extension details, as the shared {@link
+ * RelSamples} carry.
+ *
+ * <p>The handling reader routes <em>every</em> detail through {@link StringHolder#fromProto}, which
+ * throws on an {@code Any} holding anything else, so a consumer of those samples cannot mix the
+ * plain converters back in. Advanced extensions are unaffected either way: the extension converters
+ * only reach for a detail handler when an enhancement or optimization is actually present.
+ */
+abstract class StringHolderRoundtripTestBase extends TestBase {
+
+  /** Shares {@code TestBase}'s collector, which allocates the function anchors the reader needs. */
+  private final RelProtoConverter stringHolderRelProtoConverter =
+      new StringHolderHandlingRelProtoConverter(functionCollector);
+
+  @Override
+  protected void verifyRoundTrip(Rel rel) {
+    io.substrait.proto.Rel protoRel = stringHolderRelProtoConverter.toProto(rel);
+    // A fresh reader per round trip: a ProtoRelConverter accumulates the outer-reference and anchor
+    // scopes it descends through, and the test instance is shared across every sample.
+    Rel relReturned =
+        new StringHolderHandlingProtoRelConverter(functionCollector, extensions).from(protoRel);
+    assertEquals(rel, relReturned);
+  }
+}

--- a/core/src/test/java/io/substrait/utils/RelSamples.java
+++ b/core/src/test/java/io/substrait/utils/RelSamples.java
@@ -2,14 +2,11 @@ package io.substrait.utils;
 
 import io.substrait.dsl.SubstraitBuilder;
 import io.substrait.expression.Expression;
-import io.substrait.expression.FieldReference;
-import io.substrait.expression.FunctionOption;
+import io.substrait.expression.ExpressionCreator;
 import io.substrait.expression.WindowBound;
 import io.substrait.extension.AdvancedExtension;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
-import io.substrait.relation.AbstractDdlRel;
-import io.substrait.relation.AbstractUpdate;
 import io.substrait.relation.AbstractWriteRel;
 import io.substrait.relation.Aggregate;
 import io.substrait.relation.ConsistentPartitionWindow;
@@ -47,14 +44,13 @@ import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
 import io.substrait.relation.physical.TopN;
 import io.substrait.type.NamedStruct;
-import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -69,6 +65,10 @@ import java.util.stream.Collectors;
  *
  * <p>Samples use {@link StringHolder} for their extension detail objects, so a consumer needs the
  * {@code StringHolderHandling} converters to round-trip them.
+ *
+ * <p>Their record types are deliberately non-empty: a consumer derives per-relation data from a
+ * sample's fields — an emit mapping most of all — so a sample over an empty schema quietly weakens
+ * the assertion it feeds.
  */
 public class RelSamples {
 
@@ -80,23 +80,22 @@ public class RelSamples {
 
   private final StringHolder detail = new StringHolder("DETAIL");
 
-  private final NamedScan emptyTable;
+  private final NamedScan left;
 
-  private final Rel typedTable;
+  private final NamedScan right;
 
-  private final NamedStruct boolSchema =
-      NamedStruct.builder().addNames("KEY").struct(R.struct(R.BOOLEAN)).build();
+  private final NamedStruct schema =
+      NamedStruct.of(Arrays.asList("a", "b"), R.struct(R.I64, R.STRING));
 
   public RelSamples(SubstraitBuilder sb, SimpleExtension.ExtensionCollection extensions) {
     this.sb = sb;
     this.extensions = extensions;
-    this.emptyTable =
-        sb.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-    this.typedTable =
+    this.left =
         sb.namedScan(
-            Collections.singletonList("test_table"),
-            Arrays.asList("a", "b", "c"),
-            Arrays.asList(R.I64, R.I16, R.I32));
+            Arrays.asList("left_table"), Arrays.asList("a", "b"), Arrays.asList(R.I64, R.STRING));
+    this.right =
+        sb.namedScan(
+            Arrays.asList("right_table"), Arrays.asList("c", "d"), Arrays.asList(R.I64, R.STRING));
   }
 
   /**
@@ -114,260 +113,154 @@ public class RelSamples {
   }
 
   /**
-   * One sample per relation type, each carrying the {@link AdvancedExtension} slots its type
-   * supports: the common-level one on every {@link Rel}, and the rel-level one on {@link
-   * HasExtension} implementors.
+   * One sample per relation type, carrying no {@link AdvancedExtension}s.
    *
-   * <p>Layer further per-relation data on top with the type-agnostic {@code Rel} copy methods
-   * rather than re-listing the samples here.
+   * @return the samples, keyed by relation type
+   */
+  public Map<Class<? extends Rel>, Rel> samples() {
+    return samples(Optional.empty());
+  }
+
+  /**
+   * The same samples, each carrying the {@link AdvancedExtension} slots its type supports: the
+   * common-level one on every {@link Rel}, and the rel-level one on {@link HasExtension}
+   * implementors.
    *
-   * @param commonExtension the common-level extension to set on every sample
-   * @param relExtension the rel-level extension to set on every {@link HasExtension} sample
+   * @param commonExtension the common-level extension every sample carries
+   * @param relExtension the rel-level extension every {@link HasExtension} sample carries
    * @return the samples, keyed by relation type
    */
   public Map<Class<? extends Rel>, Rel> withAdvancedExtensions(
       AdvancedExtension commonExtension, AdvancedExtension relExtension) {
+    Map<Class<? extends Rel>, Rel> stamped = new LinkedHashMap<>();
+    samples(Optional.of(relExtension))
+        .forEach(
+            (relType, rel) ->
+                stamped.put(relType, rel.withCommonExtension(Optional.of(commonExtension))));
+    return stamped;
+  }
+
+  /**
+   * The sample bodies. The common-level extension is layered on afterwards with {@code
+   * Rel.withCommonExtension}, but the rel-level one has to be set here: {@link HasExtension}
+   * declares no matching copy method.
+   */
+  private Map<Class<? extends Rel>, Rel> samples(Optional<AdvancedExtension> relExtension) {
     Map<Class<? extends Rel>, Rel> samples = new LinkedHashMap<>();
 
-    // Read rels
+    // Read relations. The NamedScan sample is a copy of left rather than left itself, which is the
+    // input of most other samples and has to stay free of the data under test.
+    samples.put(NamedScan.class, NamedScan.builder().from(left).extension(relExtension).build());
     samples.put(
         VirtualTableScan.class,
         VirtualTableScan.builder()
-            .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
-            .addRows(Expression.NestedStruct.builder().fields(Collections.emptyList()).build())
-            .commonExtension(commonExtension)
+            .initialSchema(schema)
+            .addRows(
+                Expression.NestedStruct.builder()
+                    .addFields(ExpressionCreator.i64(false, 1))
+                    .addFields(ExpressionCreator.string(false, "one"))
+                    .build())
             .extension(relExtension)
             .build());
     samples.put(
         LocalFiles.class,
-        LocalFiles.builder()
-            .initialSchema(
-                NamedStruct.of(
-                    Collections.emptyList(), Type.Struct.builder().nullable(false).build()))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        NamedScan.class,
-        NamedScan.builder()
-            .from(emptyTable)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
+        LocalFiles.builder().initialSchema(schema).extension(relExtension).build());
+    // A real schema rather than the detail's empty one, so data derived from this sample's fields
+    // is
+    // non-empty here too. from(detail) seeds the schema, so the override has to follow it.
     samples.put(
         ExtensionTable.class,
-        ExtensionTable.from(detail)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
+        ExtensionTable.from(detail).initialSchema(schema).extension(relExtension).build());
 
-    // Logical rels
+    // Logical relations
     samples.put(
         Filter.class,
         Filter.builder()
-            .from(sb.filter(__ -> sb.bool(true), emptyTable))
-            .commonExtension(commonExtension)
+            .from(sb.filter(input -> sb.equal(sb.fieldReference(input, 0), sb.i64(1)), left))
             .extension(relExtension)
             .build());
     samples.put(
-        Fetch.class,
-        Fetch.builder()
-            .from(sb.fetch(1, 2, emptyTable))
-            .commonExtension(commonExtension)
+        Fetch.class, Fetch.builder().from(sb.limit(10, left)).extension(relExtension).build());
+    samples.put(
+        Project.class,
+        Project.builder()
+            .from(sb.project(input -> Arrays.asList(sb.fieldReference(input, 0)), left))
             .extension(relExtension)
             .build());
     samples.put(
         Aggregate.class,
         Aggregate.builder()
-            .from(sb.aggregate(sb::grouping, __ -> Collections.emptyList(), emptyTable))
-            .commonExtension(commonExtension)
+            .from(
+                sb.aggregate(
+                    input -> sb.grouping(input, 0),
+                    input -> Arrays.asList(sb.count(input, 0)),
+                    left))
             .extension(relExtension)
             .build());
     samples.put(
         Sort.class,
         Sort.builder()
-            .from(sb.sort(__ -> Collections.emptyList(), emptyTable))
-            .commonExtension(commonExtension)
+            .from(sb.sort(input -> sb.sortFields(input, 0), left))
             .extension(relExtension)
             .build());
     samples.put(
         Join.class,
         Join.builder()
-            .from(sb.innerJoin(__ -> sb.bool(true), emptyTable, emptyTable))
-            .commonExtension(commonExtension)
+            .from(
+                sb.innerJoin(
+                    inputs -> sb.equal(sb.fieldReference(inputs, 0), sb.fieldReference(inputs, 2)),
+                    left,
+                    right))
             .extension(relExtension)
             .build());
     samples.put(
-        LateralJoin.class,
-        LateralJoin.builder()
-            .left(emptyTable)
-            .right(emptyTable)
-            .condition(sb.bool(true))
-            .joinType(Join.JoinType.INNER)
-            .relAnchor(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
+        Cross.class, Cross.builder().from(sb.cross(left, right)).extension(relExtension).build());
     samples.put(
-        Project.class,
-        Project.builder()
-            .from(sb.project(__ -> Collections.emptyList(), emptyTable))
-            .commonExtension(commonExtension)
+        Set.class,
+        Set.builder()
+            .from(sb.set(Set.SetOp.UNION_ALL, left, right))
             .extension(relExtension)
             .build());
     samples.put(
         Expand.class,
         Expand.builder()
-            .from(sb.expand(__ -> Collections.emptyList(), emptyTable))
-            .commonExtension(commonExtension)
+            .from(
+                sb.expand(
+                    input ->
+                        Arrays.asList(
+                            Expand.ConsistentField.builder()
+                                .expression(sb.fieldReference(input, 0))
+                                .build()),
+                    left))
             .extension(relExtension)
             .build());
+    // The anchor is set on the builder rather than layered on, because LateralJoin checks for it on
+    // every copy. A consumer stamping its own anchor has to leave this one alone: the right input
+    // resolves its outer references against it.
     samples.put(
-        Set.class,
-        Set.builder()
-            .from(sb.set(Set.SetOp.UNION_ALL, emptyTable))
-            .commonExtension(commonExtension)
+        LateralJoin.class,
+        LateralJoin.builder()
+            .left(left)
+            .right(right)
+            .joinType(Join.JoinType.INNER)
+            .relAnchor(7)
             .extension(relExtension)
             .build());
-    samples.put(
-        Cross.class,
-        Cross.builder()
-            .from(sb.cross(emptyTable, emptyTable))
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        ConsistentPartitionWindow.class,
-        ConsistentPartitionWindow.builder()
-            .input(typedTable)
-            // lead(a) OVER (PARTITION BY b ORDER BY c)
-            .addWindowFunctions(
-                ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
-                    .declaration(
-                        extensions.getWindowFunction(
-                            SimpleExtension.FunctionAnchor.of(
-                                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any")))
-                    .addArguments(sb.fieldReference(typedTable, 0))
-                    .addOptions(FunctionOption.builder().name("option").addValues("VALUE1").build())
-                    .outputType(R.I64)
-                    .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
-                    .invocation(Expression.AggregationInvocation.ALL)
-                    .lowerBound(WindowBound.Unbounded.UNBOUNDED)
-                    .upperBound(WindowBound.Following.CURRENT_ROW)
-                    .boundsType(Expression.WindowBoundsType.RANGE)
-                    .build())
-            .addPartitionExpressions(sb.fieldReference(typedTable, 1))
-            .addSorts(
-                Expression.SortField.builder()
-                    .expr(sb.fieldReference(typedTable, 2))
-                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
-                    .build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
+    samples.put(ConsistentPartitionWindow.class, consistentPartitionWindow(relExtension));
 
-    // Extension rels, which carry only a common-level extension
+    // Physical relations
     samples.put(
-        ExtensionLeaf.class, ExtensionLeaf.from(detail).commonExtension(commonExtension).build());
-    samples.put(
-        ExtensionSingle.class,
-        ExtensionSingle.from(detail, emptyTable).commonExtension(commonExtension).build());
-    samples.put(
-        ExtensionMulti.class,
-        ExtensionMulti.from(detail, emptyTable, emptyTable)
-            .commonExtension(commonExtension)
-            .build());
-
-    // Write, DDL and update rels
-    samples.put(
-        NamedWrite.class,
-        NamedWrite.builder()
-            .addNames("CUSTOMER")
-            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
-            .operation(AbstractWriteRel.WriteOp.INSERT)
-            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
-            .tableSchema(boolSchema)
-            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .commonExtension(commonExtension)
+        TopN.class,
+        TopN.builder()
+            .from(sb.topN(input -> sb.sortFields(input, 0), 0, 10, left))
             .extension(relExtension)
             .build());
-    samples.put(
-        ExtensionWrite.class,
-        ExtensionWrite.builder()
-            .detail(detail)
-            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
-            .operation(AbstractWriteRel.WriteOp.INSERT)
-            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
-            .tableSchema(boolSchema)
-            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        NamedDdl.class,
-        NamedDdl.builder()
-            .addNames("CUSTOMER")
-            .operation(AbstractDdlRel.DdlOp.CREATE)
-            .object(AbstractDdlRel.DdlObject.VIEW)
-            .tableSchema(boolSchema)
-            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .tableDefaults(
-                Expression.StructLiteral.builder()
-                    .nullable(false)
-                    .addFields(sb.bool(false))
-                    .build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        ExtensionDdl.class,
-        ExtensionDdl.builder()
-            .detail(detail)
-            .operation(AbstractDdlRel.DdlOp.CREATE)
-            .object(AbstractDdlRel.DdlObject.VIEW)
-            .tableSchema(boolSchema)
-            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
-            .tableDefaults(
-                Expression.StructLiteral.builder()
-                    .nullable(false)
-                    .addFields(sb.bool(false))
-                    .build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        NamedUpdate.class,
-        NamedUpdate.builder()
-            .addNames("CUSTOMER")
-            .tableSchema(boolSchema)
-            .condition(
-                sb.equal(
-                    FieldReference.builder()
-                        .addSegments(FieldReference.StructField.of(0))
-                        .type(R.BOOLEAN)
-                        .build(),
-                    sb.bool(true)))
-            .addTransformations(
-                AbstractUpdate.TransformExpression.builder()
-                    .columnTarget(0)
-                    .transformation(sb.bool(false))
-                    .build())
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-
-    // Physical rels
     samples.put(
         HashJoin.class,
         HashJoin.builder()
             .from(
                 sb.hashJoin(
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    HashJoin.JoinType.INNER,
-                    emptyTable,
-                    emptyTable))
-            .commonExtension(commonExtension)
+                    Arrays.asList(0), Arrays.asList(0), HashJoin.JoinType.INNER, left, right))
             .extension(relExtension)
             .build());
     samples.put(
@@ -375,12 +268,7 @@ public class RelSamples {
         MergeJoin.builder()
             .from(
                 sb.mergeJoin(
-                    Collections.emptyList(),
-                    Collections.emptyList(),
-                    MergeJoin.JoinType.INNER,
-                    emptyTable,
-                    emptyTable))
-            .commonExtension(commonExtension)
+                    Arrays.asList(0), Arrays.asList(0), MergeJoin.JoinType.INNER, left, right))
             .extension(relExtension)
             .build());
     samples.put(
@@ -388,71 +276,153 @@ public class RelSamples {
         NestedLoopJoin.builder()
             .from(
                 sb.nestedLoopJoin(
-                    __ -> sb.bool(true), NestedLoopJoin.JoinType.INNER, emptyTable, emptyTable))
-            .commonExtension(commonExtension)
+                    inputs -> sb.equal(sb.fieldReference(inputs, 0), sb.fieldReference(inputs, 2)),
+                    NestedLoopJoin.JoinType.INNER,
+                    left,
+                    right))
             .extension(relExtension)
             .build());
     samples.put(
-        TopN.class,
-        TopN.builder()
-            .input(typedTable)
-            .addSortFields(
-                Expression.SortField.builder()
-                    .expr(sb.fieldReference(typedTable, 0))
-                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
-                    .build())
-            .count(sb.i64(10))
-            .commonExtension(commonExtension)
+        BroadcastExchange.class,
+        BroadcastExchange.builder().input(left).partitionCount(1).extension(relExtension).build());
+    samples.put(
+        RoundRobinExchange.class,
+        RoundRobinExchange.builder()
+            .input(left)
+            .exact(true)
+            .partitionCount(1)
             .extension(relExtension)
             .build());
-
-    // Exchange rels
     samples.put(
         ScatterExchange.class,
         ScatterExchange.builder()
-            .input(typedTable)
-            .addFields(sb.fieldReference(typedTable, 0))
+            .input(left)
+            .addFields(sb.fieldReference(left, 0))
             .partitionCount(1)
-            .commonExtension(commonExtension)
             .extension(relExtension)
             .build());
     samples.put(
         SingleBucketExchange.class,
         SingleBucketExchange.builder()
-            .input(typedTable)
-            .expression(sb.fieldReference(typedTable, 0))
+            .input(left)
+            .expression(sb.fieldReference(left, 0))
             .partitionCount(1)
-            .commonExtension(commonExtension)
             .extension(relExtension)
             .build());
     samples.put(
         MultiBucketExchange.class,
         MultiBucketExchange.builder()
-            .input(typedTable)
-            .expression(sb.fieldReference(typedTable, 0))
+            .input(left)
+            .expression(sb.fieldReference(left, 0))
             .constrainedToCount(true)
             .partitionCount(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        RoundRobinExchange.class,
-        RoundRobinExchange.builder()
-            .input(typedTable)
-            .exact(true)
-            .partitionCount(1)
-            .commonExtension(commonExtension)
-            .extension(relExtension)
-            .build());
-    samples.put(
-        BroadcastExchange.class,
-        BroadcastExchange.builder()
-            .input(typedTable)
-            .partitionCount(1)
-            .commonExtension(commonExtension)
             .extension(relExtension)
             .build());
 
+    // Write, DDL and update relations
+    samples.put(
+        NamedWrite.class,
+        NamedWrite.builder()
+            .from(
+                sb.namedWrite(
+                    Arrays.asList("target_table"),
+                    Arrays.asList("a", "b"),
+                    AbstractWriteRel.WriteOp.INSERT,
+                    AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS,
+                    AbstractWriteRel.OutputMode.NO_OUTPUT,
+                    left))
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ExtensionWrite.class,
+        ExtensionWrite.builder()
+            .input(left)
+            .detail(detail)
+            .tableSchema(schema)
+            .operation(ExtensionWrite.WriteOp.INSERT)
+            .createMode(ExtensionWrite.CreateMode.APPEND_IF_EXISTS)
+            .outputMode(ExtensionWrite.OutputMode.NO_OUTPUT)
+            .extension(relExtension)
+            .build());
+    // CREATE VIEW rather than CREATE TABLE, so that this sample carries a view definition: writing
+    // one is per-relation code and the DDL round-trip test only covers the extension variant.
+    samples.put(
+        NamedDdl.class,
+        NamedDdl.builder()
+            .names(Arrays.asList("target_table"))
+            .tableSchema(schema)
+            .tableDefaults(tableDefaults())
+            .operation(NamedDdl.DdlOp.CREATE)
+            .object(NamedDdl.DdlObject.VIEW)
+            .viewDefinition(left)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ExtensionDdl.class,
+        ExtensionDdl.builder()
+            .detail(detail)
+            .tableSchema(schema)
+            .tableDefaults(tableDefaults())
+            .operation(ExtensionDdl.DdlOp.ALTER)
+            .object(ExtensionDdl.DdlObject.TABLE)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        NamedUpdate.class,
+        NamedUpdate.builder()
+            .from(
+                sb.namedUpdate(
+                    Arrays.asList("target_table"),
+                    Arrays.asList("a"),
+                    Arrays.asList(
+                        NamedUpdate.TransformExpression.builder()
+                            .columnTarget(0)
+                            .transformation(sb.i64(1))
+                            .build()),
+                    sb.bool(true),
+                    false))
+            .extension(relExtension)
+            .build());
+
+    // Extension relations. These do not implement HasExtension, so they carry no rel-level
+    // extension. Their record type is derived from the detail on both the write and the read side,
+    // and StringHolder derives an empty struct — so unlike every other sample, data a consumer
+    // derives from their fields is empty. That is a property of extension relations, not something
+    // to work around by giving StringHolder a record type.
+    samples.put(ExtensionLeaf.class, ExtensionLeaf.from(detail).build());
+    samples.put(ExtensionSingle.class, ExtensionSingle.from(detail, left).build());
+    samples.put(
+        ExtensionMulti.class, ExtensionMulti.from(detail, Arrays.asList(left, right)).build());
+
     return samples;
+  }
+
+  private Expression.StructLiteral tableDefaults() {
+    return ExpressionCreator.struct(
+        false, ExpressionCreator.i64(false, 1), ExpressionCreator.string(false, "one"));
+  }
+
+  private Rel consistentPartitionWindow(Optional<AdvancedExtension> relExtension) {
+    SimpleExtension.WindowFunctionVariant lead =
+        extensions.getWindowFunction(
+            SimpleExtension.FunctionAnchor.of(
+                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
+    return ConsistentPartitionWindow.builder()
+        .input(left)
+        .addWindowFunctions(
+            ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
+                .declaration(lead)
+                .arguments(Arrays.asList(sb.fieldReference(left, 0)))
+                .outputType(R.I64)
+                .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                .invocation(Expression.AggregationInvocation.ALL)
+                .lowerBound(WindowBound.Unbounded.UNBOUNDED)
+                .upperBound(WindowBound.Following.CURRENT_ROW)
+                .boundsType(Expression.WindowBoundsType.RANGE)
+                .build())
+        .addPartitionExpressions(sb.fieldReference(left, 1))
+        .sorts(sb.sortFields(left, 0))
+        .extension(relExtension)
+        .build();
   }
 }

--- a/core/src/test/java/io/substrait/utils/RelSamples.java
+++ b/core/src/test/java/io/substrait/utils/RelSamples.java
@@ -1,0 +1,458 @@
+package io.substrait.utils;
+
+import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.Expression;
+import io.substrait.expression.FieldReference;
+import io.substrait.expression.FunctionOption;
+import io.substrait.expression.WindowBound;
+import io.substrait.extension.AdvancedExtension;
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.SimpleExtension;
+import io.substrait.relation.AbstractDdlRel;
+import io.substrait.relation.AbstractUpdate;
+import io.substrait.relation.AbstractWriteRel;
+import io.substrait.relation.Aggregate;
+import io.substrait.relation.ConsistentPartitionWindow;
+import io.substrait.relation.Cross;
+import io.substrait.relation.Expand;
+import io.substrait.relation.ExtensionDdl;
+import io.substrait.relation.ExtensionLeaf;
+import io.substrait.relation.ExtensionMulti;
+import io.substrait.relation.ExtensionSingle;
+import io.substrait.relation.ExtensionTable;
+import io.substrait.relation.ExtensionWrite;
+import io.substrait.relation.Fetch;
+import io.substrait.relation.Filter;
+import io.substrait.relation.HasExtension;
+import io.substrait.relation.Join;
+import io.substrait.relation.LateralJoin;
+import io.substrait.relation.LocalFiles;
+import io.substrait.relation.NamedDdl;
+import io.substrait.relation.NamedScan;
+import io.substrait.relation.NamedUpdate;
+import io.substrait.relation.NamedWrite;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import io.substrait.relation.RelVisitor;
+import io.substrait.relation.Set;
+import io.substrait.relation.Sort;
+import io.substrait.relation.VirtualTableScan;
+import io.substrait.relation.physical.BroadcastExchange;
+import io.substrait.relation.physical.HashJoin;
+import io.substrait.relation.physical.MergeJoin;
+import io.substrait.relation.physical.MultiBucketExchange;
+import io.substrait.relation.physical.NestedLoopJoin;
+import io.substrait.relation.physical.RoundRobinExchange;
+import io.substrait.relation.physical.ScatterExchange;
+import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.relation.physical.TopN;
+import io.substrait.type.NamedStruct;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * One sample relation per type that {@link RelVisitor} dispatches on, for round-trip tests that
+ * have to cover every relation rather than a hand-picked few.
+ *
+ * <p>Coverage of per-relation data — an advanced extension, a hint, an emit mapping, a rel anchor —
+ * is easy to add for some relations and forget for others, and a converter that reads a field back
+ * but never writes it discards data silently on a read-modify-write round trip. Pairing these
+ * samples with {@link #relTypes()} lets a test assert its own exhaustiveness, so a relation type
+ * added without that coverage fails the build instead.
+ *
+ * <p>Samples use {@link StringHolder} for their extension detail objects, so a consumer needs the
+ * {@code StringHolderHandling} converters to round-trip them.
+ */
+public class RelSamples {
+
+  private static final TypeCreator R = TypeCreator.REQUIRED;
+
+  private final SubstraitBuilder sb;
+
+  private final SimpleExtension.ExtensionCollection extensions;
+
+  private final StringHolder detail = new StringHolder("DETAIL");
+
+  private final NamedScan emptyTable;
+
+  private final Rel typedTable;
+
+  private final NamedStruct boolSchema =
+      NamedStruct.builder().addNames("KEY").struct(R.struct(R.BOOLEAN)).build();
+
+  public RelSamples(SubstraitBuilder sb, SimpleExtension.ExtensionCollection extensions) {
+    this.sb = sb;
+    this.extensions = extensions;
+    this.emptyTable =
+        sb.namedScan(Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+    this.typedTable =
+        sb.namedScan(
+            Collections.singletonList("test_table"),
+            Arrays.asList("a", "b", "c"),
+            Arrays.asList(R.I64, R.I16, R.I32));
+  }
+
+  /**
+   * Every relation type {@link RelVisitor} dispatches on, derived from its {@code visit} overloads
+   * so that it cannot fall behind the model.
+   *
+   * @return the relation types a visitor has to handle
+   */
+  public static List<Class<?>> relTypes() {
+    return Arrays.stream(RelVisitor.class.getMethods())
+        .filter(method -> "visit".equals(method.getName()))
+        .map(Method::getParameterTypes)
+        .map(parameterTypes -> parameterTypes[0])
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * One sample per relation type, each carrying the {@link AdvancedExtension} slots its type
+   * supports: the common-level one on every {@link Rel}, and the rel-level one on {@link
+   * HasExtension} implementors.
+   *
+   * <p>Layer further per-relation data on top with the type-agnostic {@code Rel} copy methods
+   * rather than re-listing the samples here.
+   *
+   * @param commonExtension the common-level extension to set on every sample
+   * @param relExtension the rel-level extension to set on every {@link HasExtension} sample
+   * @return the samples, keyed by relation type
+   */
+  public Map<Class<? extends Rel>, Rel> withAdvancedExtensions(
+      AdvancedExtension commonExtension, AdvancedExtension relExtension) {
+    Map<Class<? extends Rel>, Rel> samples = new LinkedHashMap<>();
+
+    // Read rels
+    samples.put(
+        VirtualTableScan.class,
+        VirtualTableScan.builder()
+            .initialSchema(NamedStruct.of(Collections.emptyList(), R.struct()))
+            .addRows(Expression.NestedStruct.builder().fields(Collections.emptyList()).build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        LocalFiles.class,
+        LocalFiles.builder()
+            .initialSchema(
+                NamedStruct.of(
+                    Collections.emptyList(), Type.Struct.builder().nullable(false).build()))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        NamedScan.class,
+        NamedScan.builder()
+            .from(emptyTable)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ExtensionTable.class,
+        ExtensionTable.from(detail)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+
+    // Logical rels
+    samples.put(
+        Filter.class,
+        Filter.builder()
+            .from(sb.filter(__ -> sb.bool(true), emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Fetch.class,
+        Fetch.builder()
+            .from(sb.fetch(1, 2, emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Aggregate.class,
+        Aggregate.builder()
+            .from(sb.aggregate(sb::grouping, __ -> Collections.emptyList(), emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Sort.class,
+        Sort.builder()
+            .from(sb.sort(__ -> Collections.emptyList(), emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Join.class,
+        Join.builder()
+            .from(sb.innerJoin(__ -> sb.bool(true), emptyTable, emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        LateralJoin.class,
+        LateralJoin.builder()
+            .left(emptyTable)
+            .right(emptyTable)
+            .condition(sb.bool(true))
+            .joinType(Join.JoinType.INNER)
+            .relAnchor(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Project.class,
+        Project.builder()
+            .from(sb.project(__ -> Collections.emptyList(), emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Expand.class,
+        Expand.builder()
+            .from(sb.expand(__ -> Collections.emptyList(), emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Set.class,
+        Set.builder()
+            .from(sb.set(Set.SetOp.UNION_ALL, emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        Cross.class,
+        Cross.builder()
+            .from(sb.cross(emptyTable, emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ConsistentPartitionWindow.class,
+        ConsistentPartitionWindow.builder()
+            .input(typedTable)
+            // lead(a) OVER (PARTITION BY b ORDER BY c)
+            .addWindowFunctions(
+                ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
+                    .declaration(
+                        extensions.getWindowFunction(
+                            SimpleExtension.FunctionAnchor.of(
+                                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any")))
+                    .addArguments(sb.fieldReference(typedTable, 0))
+                    .addOptions(FunctionOption.builder().name("option").addValues("VALUE1").build())
+                    .outputType(R.I64)
+                    .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                    .invocation(Expression.AggregationInvocation.ALL)
+                    .lowerBound(WindowBound.Unbounded.UNBOUNDED)
+                    .upperBound(WindowBound.Following.CURRENT_ROW)
+                    .boundsType(Expression.WindowBoundsType.RANGE)
+                    .build())
+            .addPartitionExpressions(sb.fieldReference(typedTable, 1))
+            .addSorts(
+                Expression.SortField.builder()
+                    .expr(sb.fieldReference(typedTable, 2))
+                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                    .build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+
+    // Extension rels, which carry only a common-level extension
+    samples.put(
+        ExtensionLeaf.class, ExtensionLeaf.from(detail).commonExtension(commonExtension).build());
+    samples.put(
+        ExtensionSingle.class,
+        ExtensionSingle.from(detail, emptyTable).commonExtension(commonExtension).build());
+    samples.put(
+        ExtensionMulti.class,
+        ExtensionMulti.from(detail, emptyTable, emptyTable)
+            .commonExtension(commonExtension)
+            .build());
+
+    // Write, DDL and update rels
+    samples.put(
+        NamedWrite.class,
+        NamedWrite.builder()
+            .addNames("CUSTOMER")
+            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
+            .operation(AbstractWriteRel.WriteOp.INSERT)
+            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
+            .tableSchema(boolSchema)
+            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ExtensionWrite.class,
+        ExtensionWrite.builder()
+            .detail(detail)
+            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
+            .operation(AbstractWriteRel.WriteOp.INSERT)
+            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
+            .tableSchema(boolSchema)
+            .input(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        NamedDdl.class,
+        NamedDdl.builder()
+            .addNames("CUSTOMER")
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .tableSchema(boolSchema)
+            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .tableDefaults(
+                Expression.StructLiteral.builder()
+                    .nullable(false)
+                    .addFields(sb.bool(false))
+                    .build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        ExtensionDdl.class,
+        ExtensionDdl.builder()
+            .detail(detail)
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .tableSchema(boolSchema)
+            .viewDefinition(VirtualTableScan.builder().initialSchema(boolSchema).build())
+            .tableDefaults(
+                Expression.StructLiteral.builder()
+                    .nullable(false)
+                    .addFields(sb.bool(false))
+                    .build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        NamedUpdate.class,
+        NamedUpdate.builder()
+            .addNames("CUSTOMER")
+            .tableSchema(boolSchema)
+            .condition(
+                sb.equal(
+                    FieldReference.builder()
+                        .addSegments(FieldReference.StructField.of(0))
+                        .type(R.BOOLEAN)
+                        .build(),
+                    sb.bool(true)))
+            .addTransformations(
+                AbstractUpdate.TransformExpression.builder()
+                    .columnTarget(0)
+                    .transformation(sb.bool(false))
+                    .build())
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+
+    // Physical rels
+    samples.put(
+        HashJoin.class,
+        HashJoin.builder()
+            .from(
+                sb.hashJoin(
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    HashJoin.JoinType.INNER,
+                    emptyTable,
+                    emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        MergeJoin.class,
+        MergeJoin.builder()
+            .from(
+                sb.mergeJoin(
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    MergeJoin.JoinType.INNER,
+                    emptyTable,
+                    emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        NestedLoopJoin.class,
+        NestedLoopJoin.builder()
+            .from(
+                sb.nestedLoopJoin(
+                    __ -> sb.bool(true), NestedLoopJoin.JoinType.INNER, emptyTable, emptyTable))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        TopN.class,
+        TopN.builder()
+            .input(typedTable)
+            .addSortFields(
+                Expression.SortField.builder()
+                    .expr(sb.fieldReference(typedTable, 0))
+                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                    .build())
+            .count(sb.i64(10))
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+
+    // Exchange rels
+    samples.put(
+        ScatterExchange.class,
+        ScatterExchange.builder()
+            .input(typedTable)
+            .addFields(sb.fieldReference(typedTable, 0))
+            .partitionCount(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        SingleBucketExchange.class,
+        SingleBucketExchange.builder()
+            .input(typedTable)
+            .expression(sb.fieldReference(typedTable, 0))
+            .partitionCount(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        MultiBucketExchange.class,
+        MultiBucketExchange.builder()
+            .input(typedTable)
+            .expression(sb.fieldReference(typedTable, 0))
+            .constrainedToCount(true)
+            .partitionCount(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        RoundRobinExchange.class,
+        RoundRobinExchange.builder()
+            .input(typedTable)
+            .exact(true)
+            .partitionCount(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+    samples.put(
+        BroadcastExchange.class,
+        BroadcastExchange.builder()
+            .input(typedTable)
+            .partitionCount(1)
+            .commonExtension(commonExtension)
+            .extension(relExtension)
+            .build());
+
+    return samples;
+  }
+}

--- a/core/src/test/java/io/substrait/utils/RelSamplesTest.java
+++ b/core/src/test/java/io/substrait/utils/RelSamplesTest.java
@@ -1,0 +1,30 @@
+package io.substrait.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.substrait.TestBase;
+import io.substrait.relation.Rel;
+import io.substrait.relation.RelVisitor;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the exhaustiveness the round trips built on {@link RelSamples} rely on. It lives here
+ * rather than in one of them because both depend on it, so it must not disappear with either.
+ */
+class RelSamplesTest extends TestBase {
+
+  @Test
+  void everyRelationTypeHasASample() {
+    Set<Class<?>> relTypes = new HashSet<>(RelSamples.relTypes());
+    // Without this the comparison below passes vacuously if the reflection stops finding relations.
+    assertFalse(relTypes.isEmpty(), "no relation types found on " + RelVisitor.class.getName());
+
+    Set<Class<? extends Rel>> sampled =
+        new HashSet<>(new RelSamples(sb, extensions).samples().keySet());
+
+    assertEquals(relTypes, sampled, "every relation type needs a sample, and every sample a type");
+  }
+}


### PR DESCRIPTION
All five `ExchangeRel` readers in `ProtoRelConverter` restore `advanced_extension` into `.extension(...)`, but none of the five writers in `RelProtoConverter` emitted it. A third-party extension on an exchange rel therefore survived proto → POJO and was silently destroyed on re-emit — no exception, no warning. The common-extension slot was unaffected; `common()` has always mapped it.

Advanced-extension coverage was opt-in per rel and nothing opted in for exchanges, which is why this stayed hidden. `ExtensionRoundtripTest` now round-trips one sample of every relation type `RelVisitor` dispatches on, and asserts that each sample carries the extension slots its type supports, so the next relation added without extension coverage turns the build red instead of quietly losing extensions. That also closes the same gap for `TopN` and `ConsistentPartitionWindow`.

Those samples live in a shared `RelSamples` fixture that `RelCommonRoundtripTest` consumes as well: two hand-maintained registries of "one sample per relation type" would be exactly the drift this is meant to catch. The fixture keeps the sample bodies from #1069, whose relations scan real schemas, so data a consumer derives from a sample's fields — a reversed emit mapping most of all — stays sensitive to order and count. Each round trip layers the data it is about to assert onto the samples (the `AdvancedExtension` slots here, hint / emit mapping / rel anchor there) and checks that they carry it, since a sample carrying none of it round-trips whether or not the converters write the field.

`NamedUpdate` now carries a common-level extension too, on top of v0.101.0 giving `UpdateRel` a `RelCommon` field.

Follow-ups: #1122 for a `withExtension` copy method on `HasExtension`, so the rel-level slot can be layered on the way the common one is, and #1123 for `AdvancedExtensionRelProtoConversionTest`, a third per-relation sample set the fixture subsumes.

Closes #1084