### PR TITLE
feat(core)!: update to Substrait v0.101.0

### DIFF
--- a/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
+++ b/core/src/main/java/io/substrait/extension/DefaultExtensionCatalog.java
@@ -60,9 +60,6 @@ public class DefaultExtensionCatalog {
   /** Extension identifier for string functions. */
   public static final String FUNCTIONS_STRING = "extension:io.substrait:functions_string";
 
-  /** Identifier for extension types. */
-  public static final String EXTENSION_TYPES = "extension:io.substrait:extension_types";
-
   /** Extension identifier for unsigned integer types and functions. */
   public static final String UNSIGNED_INTEGERS = "extension:io.substrait:unsigned_integers";
 
@@ -95,7 +92,6 @@ public class DefaultExtensionCatalog {
             .map(c -> String.format("/substrait/extensions/functions_%s.yaml", c))
             .collect(Collectors.toList());
 
-    defaultFiles.add("/substrait/extensions/extension_types.yaml");
     defaultFiles.add("/substrait/extensions/unsigned_integers.yaml");
 
     return SimpleExtension.load(defaultFiles);

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -536,6 +536,8 @@ public class ProtoRelConverter {
     NamedStruct tableSchema = newNamedStruct(rel.getTableSchema());
     ProtoExpressionConverter converter =
         new ProtoExpressionConverter(lookup, extensions, tableSchema.struct(), this);
+    optionalRelAnchor(rel.getCommon())
+        .ifPresent(anchor -> anchorScopes.put(anchor, tableSchema.struct()));
     List<NamedUpdate.TransformExpression> transformations =
         new ArrayList<>(rel.getTransformationsCount());
     for (UpdateRel.TransformExpression transformation : rel.getTransformationsList()) {

--- a/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
+++ b/core/src/main/java/io/substrait/relation/ProtoRelConverter.java
@@ -551,6 +551,11 @@ public class ProtoRelConverter {
             .tableSchema(tableSchema)
             .addAllTransformations(transformations)
             .condition(converter.from(rel.getCondition()));
+    builder
+        .commonExtension(optionalAdvancedExtension(rel.getCommon()))
+        .remap(optionalRelmap(rel.getCommon()))
+        .hint(optionalHint(rel.getCommon()))
+        .relAnchor(optionalRelAnchor(rel.getCommon()));
     if (rel.hasAdvancedExtension()) {
       builder.extension(protoExtensionConverter.fromProto(rel.getAdvancedExtension()));
     }

--- a/core/src/main/java/io/substrait/relation/RelProtoConverter.java
+++ b/core/src/main/java/io/substrait/relation/RelProtoConverter.java
@@ -615,6 +615,7 @@ public class RelProtoConverter
   public Rel visit(NamedUpdate update, EmptyVisitationContext context) throws RuntimeException {
     UpdateRel.Builder builder =
         UpdateRel.newBuilder()
+            .setCommon(common(update))
             .setNamedTable(NamedTable.newBuilder().addAllNames(update.getNames()))
             .setTableSchema(update.getTableSchema().toProto(typeProtoConverter))
             .addAllTransformations(

--- a/core/src/test/java/io/substrait/extension/DefaultExtensionCatalogTest.java
+++ b/core/src/test/java/io/substrait/extension/DefaultExtensionCatalogTest.java
@@ -36,10 +36,7 @@ class DefaultExtensionCatalogTest {
           "functions_aggregate_decimal_output.yaml",
           // functions_geometry.yaml defines user-defined types (u!geometry) that are not
           // supported by Calcite's type conversion in isthmus.
-          "functions_geometry.yaml",
-          // type_variations.yaml only defines type variations, which are not tracked by
-          // ExtensionCollection (no functions or types), so containsUrn cannot verify it.
-          "type_variations.yaml");
+          "functions_geometry.yaml");
 
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -79,7 +79,11 @@ class LiteralRoundtripTest extends TestBase {
 
     Expression.UserDefinedLiteral val =
         ExpressionCreator.userDefinedLiteralAny(
-            false, NESTED_TYPES_URN, "point", java.util.Collections.emptyList(), anyValue);
+            false,
+            DefaultExtensionCatalog.UNSIGNED_INTEGERS,
+            "u8",
+            Collections.emptyList(),
+            anyValue);
 
     verifyRoundTrip(val);
   }

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -96,7 +96,7 @@ class LiteralRoundtripTest extends TestBase {
             ExpressionCreator.i32(false, 42), ExpressionCreator.i32(false, 100));
     Expression.UserDefinedLiteral val =
         ExpressionCreator.userDefinedLiteralStruct(
-            false, NESTED_TYPES_URN, "point", java.util.Collections.emptyList(), fields);
+            false, NESTED_TYPES_URN, "point", Collections.emptyList(), fields);
 
     verifyRoundTrip(val);
   }

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -79,11 +79,7 @@ class LiteralRoundtripTest extends TestBase {
 
     Expression.UserDefinedLiteral val =
         ExpressionCreator.userDefinedLiteralAny(
-            false,
-            DefaultExtensionCatalog.EXTENSION_TYPES,
-            "point",
-            java.util.Collections.emptyList(),
-            anyValue);
+            false, NESTED_TYPES_URN, "point", java.util.Collections.emptyList(), anyValue);
 
     verifyRoundTrip(val);
   }
@@ -96,11 +92,7 @@ class LiteralRoundtripTest extends TestBase {
             ExpressionCreator.i32(false, 42), ExpressionCreator.i32(false, 100));
     Expression.UserDefinedLiteral val =
         ExpressionCreator.userDefinedLiteralStruct(
-            false,
-            DefaultExtensionCatalog.EXTENSION_TYPES,
-            "point",
-            java.util.Collections.emptyList(),
-            fields);
+            false, NESTED_TYPES_URN, "point", java.util.Collections.emptyList(), fields);
 
     verifyRoundTrip(val);
   }

--- a/core/src/test/java/io/substrait/type/proto/NestedOuterReferenceRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/NestedOuterReferenceRoundtripTest.java
@@ -4,9 +4,12 @@ import io.substrait.TestBase;
 import io.substrait.expression.FieldReference;
 import io.substrait.relation.Join;
 import io.substrait.relation.LateralJoin;
+import io.substrait.relation.NamedUpdate;
 import io.substrait.relation.Rel;
 import io.substrait.relation.Rel.Remap;
+import io.substrait.type.NamedStruct;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -153,6 +156,32 @@ class NestedOuterReferenceRoundtripTest extends TestBase {
             anchoredOrders);
 
     verifyRoundTrip(plan);
+  }
+
+  @Test
+  void idBasedOuterReferenceIntoEnclosingNamedUpdate() {
+    // The same correlation shape as idBasedOuterReferenceIntoEnclosingSubquery, but the enclosing
+    // relation is a NamedUpdate: its own anchor must be registered before its condition (which
+    // hosts the correlated subquery) is converted, or the reference falls back to the subquery's
+    // own root type instead of the update's table schema.
+    int anchor = 1;
+    NamedStruct tableSchema =
+        NamedStruct.of(Arrays.asList("id", "name"), R.struct(R.I64, R.STRING));
+
+    FieldReference outerRef =
+        FieldReference.newRootStructOuterReferenceByRelReference(0, tableSchema.struct(), anchor);
+
+    Rel subquery = sb.filter(input -> sb.equal(sb.fieldReference(input, 0), outerRef), customer);
+
+    Rel update =
+        NamedUpdate.builder()
+            .tableSchema(tableSchema)
+            .names(Collections.singletonList("test_table"))
+            .relAnchor(anchor)
+            .condition(sb.exists(subquery))
+            .build();
+
+    verifyRoundTrip(update);
   }
 
   @Test

--- a/core/src/test/java/io/substrait/type/proto/RelAnchorRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/RelAnchorRoundtripTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.substrait.TestBase;
 import io.substrait.expression.Expression;
 import io.substrait.relation.Filter;
+import io.substrait.relation.NamedUpdate;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
 import io.substrait.relation.physical.TopN;
+import io.substrait.type.NamedStruct;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -65,6 +67,19 @@ class RelAnchorRoundtripTest extends TestBase {
             .build();
 
     verifyRoundTrip(topN);
+  }
+
+  @Test
+  void relAnchorOnNamedUpdate() {
+    Rel update =
+        NamedUpdate.builder()
+            .tableSchema(NamedStruct.of(Arrays.asList("id", "name"), R.struct(R.I64, R.STRING)))
+            .names(Collections.singletonList("test_table"))
+            .relAnchor(9)
+            .condition(sb.bool(true))
+            .build();
+
+    verifyRoundTrip(update);
   }
 
   @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ spark-3-5 = "3.5.4"
 spark-4-0 = "4.0.2"
 spotless = "8.9.0"
 # substrait-packaging artifacts, versioned by the Substrait spec release they are generated from.
-substrait-packaging = "0.100.0"
+substrait-packaging = "0.101.0"
 testcontainers = "2.0.5"
 validator = "3.0.6"
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -696,8 +696,13 @@ public class SubstraitRelNodeConverter
 
   @Override
   public RelNode visit(NamedUpdate update, Context context) {
+    if (update.getRemap().isPresent()) {
+      throw new UnsupportedOperationException(
+          "Emit mapping on a NamedUpdate is not supported: TableModify's row type is a single "
+              + "ROWCOUNT column, not the updated table's columns");
+    }
     relBuilder.scan(update.getNames());
-    context.enterScope(AnchoredInput.of(Optional.empty(), relBuilder.peek().getRowType()));
+    context.enterScope(AnchoredInput.of(update.getRelAnchor(), relBuilder.peek().getRowType()));
     RexNode condition = update.getCondition().accept(expressionRexConverter, context);
 
     NamedStruct tableSchema = update.getTableSchema();
@@ -713,10 +718,7 @@ public class SubstraitRelNodeConverter
           transform.getTransformation().accept(expressionRexConverter, context));
     }
 
-    // Keep the scope open through the condition and transformations so field-reference
-    // observations use the table row type. With no rel_anchor, its correlation set is always empty.
-    context.exitScope();
-    relBuilder.filter(condition);
+    relBuilder.filter(context.exitScope(), condition);
     RelNode inputForModify = relBuilder.build();
 
     final RelOptTable table = requireRelOptSchema().getTableForMember(update.getNames());

--- a/isthmus/src/test/java/io/substrait/isthmus/CatalogReaderValidationTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CatalogReaderValidationTest.java
@@ -1,9 +1,12 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.expression.ExpressionCreator;
+import io.substrait.expression.FieldReference;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
 import io.substrait.relation.AbstractWriteRel;
 import io.substrait.relation.NamedUpdate;
@@ -22,6 +25,9 @@ import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.prepare.RelOptTableImpl;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableModify;
+import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.FrameworkConfig;
@@ -39,9 +45,11 @@ import org.junit.jupiter.api.Test;
 class CatalogReaderValidationTest extends PlanTestBase {
 
   private static final List<String> TABLE = List.of("FOO");
+  private static final List<String> CORRELATED_TABLE = List.of("BAR");
 
   private final CalciteCatalogReader catalogReader =
-      SubstraitCreateStatementParser.processCreateStatementsToCatalog("CREATE TABLE FOO (A INT)");
+      SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+          "CREATE TABLE FOO (A INT)", "CREATE TABLE BAR (B INT)");
 
   CatalogReaderValidationTest() throws SqlParseException {}
 
@@ -92,6 +100,79 @@ class CatalogReaderValidationTest extends PlanTestBase {
   @Test
   void namedUpdateRejectsTableSchemaThatIsNotACatalogReader() {
     assertRejects(update(), schema -> new DelegatingRelOptSchema(schema, TableSchema.SELF));
+  }
+
+  @Test
+  void namedUpdateRejectsRemap() {
+    SubstraitRelNodeConverter converter =
+        new SubstraitRelNodeConverter(relBuilderWith(UnaryOperator.identity()), converterProvider);
+    NamedUpdate updateWithRemap =
+        sb.namedUpdate(
+            TABLE,
+            List.of("A"),
+            List.of(
+                NamedUpdate.TransformExpression.builder()
+                    .columnTarget(0)
+                    .transformation(ExpressionCreator.i32(false, 1))
+                    .build()),
+            ExpressionCreator.bool(false, true),
+            false,
+            sb.remap(0));
+
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                updateWithRemap.accept(converter, SubstraitRelNodeConverter.Context.newContext()));
+    assertTrue(
+        e.getMessage().contains("Emit mapping on a NamedUpdate is not supported"),
+        () -> "unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  void namedUpdateResolvesCorrelatedCondition() {
+    // The update's own condition contains a correlated subquery over BAR that references FOO's
+    // row via an id-based outer reference to the update's own rel_anchor. This exercises the
+    // anchor-scope registration (must be in place before the condition converts) and correlation
+    // id threading (must survive from the nested Filter's scope to the update's own) added to
+    // SubstraitRelNodeConverter.visit(NamedUpdate) alongside the core wiring of UpdateRel.common.
+    SubstraitRelNodeConverter converter =
+        new SubstraitRelNodeConverter(relBuilderWith(UnaryOperator.identity()), converterProvider);
+
+    int anchor = 1;
+    // Plain SQL INT columns are nullable by default in the catalog's DDL, so the POJO's declared
+    // field types must be nullable too, or Calcite's RexChecker rejects the built Filter as
+    // inconsistent with the real (nullable) scanned row type.
+    NamedStruct tableSchema = NamedStruct.of(List.of("A"), N.struct(N.I32));
+    FieldReference outerRef =
+        FieldReference.newRootStructOuterReferenceByRelReference(0, tableSchema.struct(), anchor);
+
+    Rel correlatedScan = sb.namedScan(CORRELATED_TABLE, List.of("B"), List.of(N.I32));
+    Rel subquery =
+        sb.filter(input -> sb.equal(sb.fieldReference(input, 0), outerRef), correlatedScan);
+
+    NamedUpdate update =
+        NamedUpdate.builder()
+            .tableSchema(tableSchema)
+            .names(TABLE)
+            .relAnchor(anchor)
+            .transformations(
+                List.of(
+                    NamedUpdate.TransformExpression.builder()
+                        .columnTarget(0)
+                        .transformation(ExpressionCreator.i32(false, 1))
+                        .build()))
+            .condition(sb.exists(subquery))
+            .build();
+
+    RelNode relNode = update.accept(converter, SubstraitRelNodeConverter.Context.newContext());
+
+    RelNode inputForModify = ((TableModify) relNode).getInput();
+    LogicalFilter filter = assertInstanceOf(LogicalFilter.class, inputForModify);
+    assertFalse(
+        filter.getVariablesSet().isEmpty(),
+        "the correlation resolved against the update's own anchor must be declared on the "
+            + "filter that owns it");
   }
 
   private void assertRejects(Rel rel, UnaryOperator<RelOptSchema> schemaWrapper) {


### PR DESCRIPTION
- Closes #1102
- Bump substrait-packaging to spec v0.101.0                                                                                                                                                                     
- Remove `DefaultExtensionCatalog.EXTENSION_TYPES`: spec v0.101.0 relocates extension_types.yaml out of the default extension set into `substrait/examples/extensions/` under a new URN (`extension:org.example:extension_types`), demoting it to a documentation example
- Update the two affected literal round-trip tests: one moves to the existing local nested-types fixture, the other to `DefaultExtensionCatalog.UNSIGNED_INTEGERS/u8` to keep `DEFAULT_COLLECTION` UDT coverage
- Wire UpdateRel's new common field (rel_anchor/hint/remap/advanced_extension) into NamedUpdate conversion, matching every other rel type; add a round-trip test.
- Drop the now-dead type_variations.yaml entry from `DefaultExtensionCatalogTest.UNSUPPORTED_FILES` — also relocated out of `substrait/extensions/` in this release, so the entry was unreachable
- Update isthmus's NamedUpdate conversion to match: thread the update's rel_anchor and correlation scope through instead of discarding them, and reject an emit mapping on a `NamedUpdate` rather than silently dropping it, since TableModify's row type is a single ROWCOUNT column and has no columns to remap against
- Considered the spec's companion v0.101.0 change deprecating `OuterReference.steps_out` in favor of `rel_reference`; no code change is needed since `FieldReference` already models both forms.

BREAKING CHANGE: `DefaultExtensionCatalog.EXTENSION_TYPES` is removed and `extension:io.substrait:extension_types` is no longer loaded into `DEFAULT_COLLECTION`, so code referencing the constant no longer compiles and plans referencing that URN — including previously serialized ones — no longer import. To keep reading existing plans, declare the point and line types in your own YAML under the original URN.