### PR TITLE
fix(isthmus)!: preserve literal nullability converting to Calcite

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -87,6 +87,7 @@ import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
 
@@ -815,10 +816,16 @@ public class SubstraitRelNodeConverter
           RexNode rexNode = literal.accept(expressionRexConverter, context);
           // A nullable literal converts as CAST(literal AS nullable type). LogicalValues tuples
           // hold bare literals, and the field's nullability is already declared in the row type,
-          // so unwrap the cast here.
-          if (rexNode.isA(SqlKind.CAST)
-              && ((RexCall) rexNode).getOperands().get(0) instanceof RexLiteral) {
-            rexNode = ((RexCall) rexNode).getOperands().get(0);
+          // so unwrap that cast here. Only that one: a cast that changes anything else is doing
+          // work, and dropping it would leave the literal under a row type that does not describe
+          // it. Such a tuple is malformed whatever happens to the cast, and the cast below is what
+          // reports it.
+          if (rexNode.isA(SqlKind.CAST)) {
+            RexNode castOperand = ((RexCall) rexNode).getOperands().get(0);
+            if (castOperand instanceof RexLiteral
+                && SqlTypeUtil.equalSansNullability(rexNode.getType(), castOperand.getType())) {
+              rexNode = castOperand;
+            }
           }
           tupleBuilder.add((RexLiteral) rexNode);
         }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -78,11 +78,13 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexSlot;
 import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.tools.Frameworks;
@@ -810,8 +812,15 @@ public class SubstraitRelNodeConverter
         ImmutableList.Builder<RexLiteral> tupleBuilder = ImmutableList.builder();
         for (Expression expr : rowExpr.fields()) {
           final Expression.Literal literal = (Expression.Literal) expr;
-          final RexLiteral rexNode = (RexLiteral) literal.accept(expressionRexConverter, context);
-          tupleBuilder.add(rexNode);
+          RexNode rexNode = literal.accept(expressionRexConverter, context);
+          // A nullable literal converts as CAST(literal AS nullable type). LogicalValues tuples
+          // hold bare literals, and the field's nullability is already declared in the row type,
+          // so unwrap the cast here.
+          if (rexNode.isA(SqlKind.CAST)
+              && ((RexCall) rexNode).getOperands().get(0) instanceof RexLiteral) {
+            rexNode = ((RexCall) rexNode).getOperands().get(0);
+          }
+          tupleBuilder.add((RexLiteral) rexNode);
         }
         tuplesBuilder.add(tupleBuilder.build());
       }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -66,7 +66,10 @@ public class CallConverters {
           RexNode operand = call.getOperands().get(0);
           if (operand instanceof RexLiteral && !((RexLiteral) operand).isNull()) {
             RexLiteral literal = (RexLiteral) operand;
-            if (type.equalsIgnoringNullability(typeConverter.toSubstrait(literal.getType()))) {
+            Type literalType = typeConverter.toSubstrait(literal.getType());
+            // Nullability only: an exact no-op cast is not this representation and stays an
+            // Expression.Cast, so a plan that carries one keeps carrying it.
+            if (!type.equals(literalType) && type.equalsIgnoringNullability(literalType)) {
               return literalConverter.convert(literal, call.getType());
             }
           }

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/CallConverters.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexUtil;
@@ -38,28 +39,41 @@ public class CallConverters {
    * <p>On SAFE_CAST, sets {@link Expression.FailureBehavior#RETURN_NULL}; otherwise
    * THROW_EXCEPTION.
    *
+   * <p>A cast that changes nothing but nullability over a non-null literal is how {@link
+   * ExpressionRexConverter} represents a nullable Substrait literal (Calcite types every non-null
+   * {@link RexLiteral} NOT NULL), so it converts back to a literal carrying the cast's nullability
+   * rather than to an {@link Expression.Cast}.
+   *
    * @see ExpressionCreator#cast(Type, Expression, Expression.FailureBehavior)
    */
   public static final Function<TypeConverter, SimpleCallConverter> CAST =
-      typeConverter ->
-          (call, visitor) -> {
-            Expression.FailureBehavior failureBehavior;
-            switch (call.getKind()) {
-              case CAST:
-                failureBehavior = Expression.FailureBehavior.THROW_EXCEPTION;
-                break;
-              case SAFE_CAST:
-                failureBehavior = Expression.FailureBehavior.RETURN_NULL;
-                break;
-              default:
-                return null;
-            }
+      typeConverter -> {
+        LiteralConverter literalConverter = new LiteralConverter(typeConverter);
+        return (call, visitor) -> {
+          Expression.FailureBehavior failureBehavior;
+          switch (call.getKind()) {
+            case CAST:
+              failureBehavior = Expression.FailureBehavior.THROW_EXCEPTION;
+              break;
+            case SAFE_CAST:
+              failureBehavior = Expression.FailureBehavior.RETURN_NULL;
+              break;
+            default:
+              return null;
+          }
 
-            return ExpressionCreator.cast(
-                typeConverter.toSubstrait(call.getType()),
-                visitor.apply(call.getOperands().get(0)),
-                failureBehavior);
-          };
+          Type type = typeConverter.toSubstrait(call.getType());
+          RexNode operand = call.getOperands().get(0);
+          if (operand instanceof RexLiteral && !((RexLiteral) operand).isNull()) {
+            RexLiteral literal = (RexLiteral) operand;
+            if (type.equalsIgnoringNullability(typeConverter.toSubstrait(literal.getType()))) {
+              return literalConverter.convert(literal, call.getType());
+            }
+          }
+
+          return ExpressionCreator.cast(type, visitor.apply(operand), failureBehavior);
+        };
+      };
 
   /**
    * {@link SqlKind#REINTERPRET} is utilized by Isthmus to represent and store {@link

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -152,6 +152,23 @@ public class ExpressionRexConverter
     this.relNodeConverter = substraitRelNodeConverter;
   }
 
+  /**
+   * Applies a nullable Substrait literal type to the {@link RexNode} built for its value.
+   *
+   * <p>Calcite gives every non-null {@link org.apache.calcite.rex.RexLiteral} a NOT NULL type, so a
+   * nullable literal is represented as {@code CAST(literal AS nullable type)} — the same shape
+   * {@link RexBuilder#makeLiteral(Object, RelDataType, boolean)} produces on a type mismatch.
+   * {@link CallConverters#CAST} recognizes the nullability-only cast over a literal and folds it
+   * back into a nullable literal on the way to Substrait.
+   */
+  private RexNode preserveNullability(RexNode node, Type type) {
+    RelDataType calciteType = typeConverter.toCalcite(typeFactory, type);
+    if (node.getType().isNullable() == calciteType.isNullable()) {
+      return node;
+    }
+    return rexBuilder.makeAbstractCast(calciteType, node, false);
+  }
+
   @Override
   public RexNode visit(Expression.NullLiteral expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(null, typeConverter.toCalcite(typeFactory, expr.getType()));
@@ -179,48 +196,50 @@ public class ExpressionRexConverter
 
   @Override
   public RexNode visit(Expression.BoolLiteral expr, Context context) throws RuntimeException {
-    return rexBuilder.makeLiteral(expr.value());
+    return rexBuilder.makeLiteral(
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
   public RexNode visit(Expression.I8Literal expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(
-        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()));
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
   public RexNode visit(Expression.I16Literal expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(
-        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()));
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
   public RexNode visit(Expression.I32Literal expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(
-        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()));
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
   public RexNode visit(Expression.I64Literal expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(
-        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()));
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
   public RexNode visit(Expression.FP32Literal expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(
-        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()));
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
   public RexNode visit(Expression.FP64Literal expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(
-        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()));
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
   public RexNode visit(Expression.FixedCharLiteral expr, Context context) throws RuntimeException {
-    return rexBuilder.makeLiteral(expr.value());
+    return rexBuilder.makeLiteral(
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
@@ -262,8 +281,10 @@ public class ExpressionRexConverter
               expr.precision(), maxPrecision));
     }
 
-    return rexBuilder.makeTimeLiteral(
-        createTimeString(expr.value(), expr.precision()), expr.precision());
+    return preserveNullability(
+        rexBuilder.makeTimeLiteral(
+            createTimeString(expr.value(), expr.precision()), expr.precision()),
+        expr.getType());
   }
 
   /**
@@ -327,7 +348,7 @@ public class ExpressionRexConverter
   @Override
   public RexNode visit(Expression.DateLiteral expr, Context context) throws RuntimeException {
     return rexBuilder.makeLiteral(
-        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()));
+        expr.value(), typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override
@@ -340,8 +361,10 @@ public class ExpressionRexConverter
               expr.precision(), maxPrecision));
     }
 
-    return rexBuilder.makeTimestampLiteral(
-        getTimestampString(expr.value(), expr.precision()), expr.precision());
+    return preserveNullability(
+        rexBuilder.makeTimestampLiteral(
+            getTimestampString(expr.value(), expr.precision()), expr.precision()),
+        expr.getType());
   }
 
   @Override
@@ -356,7 +379,8 @@ public class ExpressionRexConverter
 
     return rexBuilder.makeLiteral(
         getTimestampString(expr.value(), expr.precision()),
-        typeConverter.toCalcite(typeFactory, expr.getType()));
+        typeConverter.toCalcite(typeFactory, expr.getType()),
+        true);
   }
 
   private TimestampString getTimestampString(long value, int precision) {
@@ -395,8 +419,10 @@ public class ExpressionRexConverter
   @Override
   public RexNode visit(Expression.IntervalYearLiteral expr, Context context)
       throws RuntimeException {
-    return rexBuilder.makeIntervalLiteral(
-        new BigDecimal(expr.years() * 12 + expr.months()), YEAR_MONTH_INTERVAL);
+    return preserveNullability(
+        rexBuilder.makeIntervalLiteral(
+            new BigDecimal(expr.years() * 12 + expr.months()), YEAR_MONTH_INTERVAL),
+        expr.getType());
   }
 
   @Override
@@ -421,7 +447,8 @@ public class ExpressionRexConverter
   public RexNode visit(Expression.DecimalLiteral expr, Context context) throws RuntimeException {
     byte[] value = expr.value().toByteArray();
     BigDecimal decimal = DecimalUtil.getBigDecimalFromBytes(value, expr.scale(), 16);
-    return rexBuilder.makeLiteral(decimal, typeConverter.toCalcite(typeFactory, expr.getType()));
+    return rexBuilder.makeLiteral(
+        decimal, typeConverter.toCalcite(typeFactory, expr.getType()), true);
   }
 
   @Override

--- a/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
@@ -2,19 +2,29 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
+import io.substrait.isthmus.expression.CallConverters;
+import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
 import io.substrait.relation.Rel.Remap;
+import io.substrait.relation.VirtualTableScan;
+import io.substrait.type.NamedStruct;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.function.Function;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -86,6 +96,60 @@ class LiteralNullabilityRoundtripTest extends PlanTestBase {
   void typedNullRoundTrip() {
     Expression.Literal literal = ExpressionCreator.typedNull(N.I32);
     assertEquals(literal, roundtrip(literal));
+  }
+
+  /**
+   * The shape the fold in {@link io.substrait.isthmus.expression.CallConverters} and the unwrap in
+   * {@link SubstraitRelNodeConverter} both key on: a nullable literal is a cast of the literal to
+   * its nullable type. The round trip passes either way, so this pins it directly.
+   */
+  @Test
+  void nullableLiteralBecomesNullabilityCast() {
+    Project project =
+        sb.project(input -> List.of(ExpressionCreator.i32(true, 5)), Remap.of(List.of(1)), table);
+    RelNode calcite = substraitToCalcite.convert(project);
+    RexNode rex = ((LogicalProject) calcite).getProjects().get(0);
+    assertEquals(SqlKind.CAST, rex.getKind());
+    assertTrue(rex.getType().isNullable());
+    assertEquals(SqlKind.LITERAL, ((RexCall) rex).getOperands().get(0).getKind());
+  }
+
+  /**
+   * A cast doing more than nullability is not this representation, so the tuple unwrap leaves it
+   * alone. A varchar literal longer than its declared length is malformed input either way; the
+   * point is that it stays loud instead of landing in a row type that does not describe it.
+   */
+  @Test
+  void tupleUnwrapLeavesATruncatingCastAlone() {
+    VirtualTableScan overlong =
+        VirtualTableScan.builder()
+            .initialSchema(NamedStruct.of(List.of("A"), R.struct(R.varChar(3))))
+            .addRows(
+                ExpressionCreator.nestedStruct(
+                    false, ExpressionCreator.varChar(false, "abcdef", 3)))
+            .build();
+    assertThrows(ClassCastException.class, () -> substraitToCalcite.convert(overlong));
+  }
+
+  /**
+   * The fold is nullability-only: a cast whose type equals the literal's exactly is not this
+   * representation and stays an {@link Expression.Cast}. Built directly rather than round-tripped,
+   * because Calcite drops an exact cast over a literal on the way out, so no plan reaches this
+   * through the converter pair.
+   */
+  @Test
+  void exactCastOverALiteralStaysACast() {
+    RexBuilder rexBuilder = new RexBuilder(typeFactory);
+    RelDataType i32 = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    RexNode exactCast =
+        rexBuilder.makeAbstractCast(i32, rexBuilder.makeLiteral(5, i32, false), false);
+    assertEquals(SqlKind.CAST, exactCast.getKind());
+
+    Expression converted =
+        CallConverters.CAST
+            .apply(TypeConverter.DEFAULT)
+            .apply((RexCall) exactCast, rex -> rex.accept(new RexExpressionConverter()));
+    assertInstanceOf(Expression.Cast.class, converted, "converted to: " + converted);
   }
 
   /** A non-nullable literal keeps converting to a bare Calcite literal, with no cast wrapper. */

--- a/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
@@ -1,0 +1,114 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import io.substrait.relation.Rel.Remap;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Literal nullability must survive Substrait → Calcite → Substrait conversion. Calcite types every
+ * non-null literal NOT NULL, so a nullable Substrait literal travels as a nullability-only cast
+ * that folds back into a nullable literal on the return trip.
+ */
+class LiteralNullabilityRoundtripTest extends PlanTestBase {
+
+  final Rel table = sb.namedScan(List.of("example"), List.of("a"), List.of(N.I32));
+
+  /** Every scalar literal kind, parameterized by nullability. */
+  static List<Function<Boolean, Expression.Literal>> scalarLiterals() {
+    return List.of(
+        n -> ExpressionCreator.bool(n, true),
+        n -> ExpressionCreator.i8(n, 12),
+        n -> ExpressionCreator.i16(n, 1234),
+        n -> ExpressionCreator.i32(n, 5),
+        n -> ExpressionCreator.i64(n, 5L),
+        n -> ExpressionCreator.fp32(n, 1.5f),
+        n -> ExpressionCreator.fp64(n, 1.5),
+        n -> ExpressionCreator.string(n, "x"),
+        n -> ExpressionCreator.varChar(n, "x", 10),
+        n -> ExpressionCreator.fixedChar(n, "x"),
+        n -> ExpressionCreator.binary(n, new byte[] {1, 2}),
+        n -> ExpressionCreator.fixedBinary(n, new byte[] {1, 2}),
+        n -> ExpressionCreator.date(n, 19000),
+        // precision 6 matches the microsecond normalization LiteralConverter applies on the way
+        // back; precision_timestamp_tz is absent because it currently returns as a plain
+        // precision_timestamp regardless of nullability
+        n -> ExpressionCreator.precisionTime(n, 1_000_000L, 6),
+        n -> ExpressionCreator.precisionTimestamp(n, 1_000_000L, 6),
+        n -> ExpressionCreator.intervalYear(n, 1, 2),
+        n -> ExpressionCreator.intervalDay(n, 1, 2, 3000, 6),
+        n -> ExpressionCreator.decimal(n, BigDecimal.valueOf(123, 2), 10, 2));
+  }
+
+  private Expression roundtripExpression(Expression expression) {
+    Project project = sb.project(input -> List.of(expression), Remap.of(List.of(1)), table);
+    RelNode calcite = substraitToCalcite.convert(project);
+    Rel back = SubstraitRelVisitor.convert(calcite, extensions);
+    assertInstanceOf(Project.class, back);
+    return ((Project) back).getExpressions().get(0);
+  }
+
+  private Expression.Literal roundtrip(Expression.Literal literal) {
+    Expression expression = roundtripExpression(literal);
+    assertInstanceOf(Expression.Literal.class, expression, "came back as: " + expression);
+    return (Expression.Literal) expression;
+  }
+
+  @Test
+  void nullableScalarsRoundTrip() {
+    for (Function<Boolean, Expression.Literal> factory : scalarLiterals()) {
+      Expression.Literal literal = factory.apply(true);
+      assertEquals(literal, roundtrip(literal), () -> "for literal " + literal);
+    }
+  }
+
+  @Test
+  void nonNullableScalarsRoundTrip() {
+    for (Function<Boolean, Expression.Literal> factory : scalarLiterals()) {
+      Expression.Literal literal = factory.apply(false);
+      assertEquals(literal, roundtrip(literal), () -> "for literal " + literal);
+    }
+  }
+
+  @Test
+  void typedNullRoundTrip() {
+    Expression.Literal literal = ExpressionCreator.typedNull(N.I32);
+    assertEquals(literal, roundtrip(literal));
+  }
+
+  /** A non-nullable literal keeps converting to a bare Calcite literal, with no cast wrapper. */
+  @Test
+  void nonNullableLiteralStaysBare() {
+    Project project =
+        sb.project(input -> List.of(ExpressionCreator.i32(false, 5)), Remap.of(List.of(1)), table);
+    RelNode calcite = substraitToCalcite.convert(project);
+    RexNode rex = ((LogicalProject) calcite).getProjects().get(0);
+    assertEquals(SqlKind.LITERAL, rex.getKind());
+  }
+
+  /**
+   * A nested list that is homogeneous on input — a nullable literal next to a nullable field
+   * reference — must stay homogeneous through the round trip instead of failing the same-type
+   * check.
+   */
+  @Test
+  void nestedListWithNullableLiteralElement() {
+    Expression nestedList =
+        ExpressionCreator.nestedList(
+            false, List.of(ExpressionCreator.i32(true, 5), sb.fieldReference(table, 0)));
+    Expression back = roundtripExpression(nestedList);
+    assertEquals(nestedList.getType(), back.getType());
+  }
+}


### PR DESCRIPTION
Substrait literal nullability did not survive conversion to Calcite: `RexBuilder` gives every non-null literal a NOT NULL type, so nullable literals came back non-nullable, and a homogeneous `NestedList` holding a nullable literal next to a nullable field reference came back mixed-typed and was rejected. Only the character/binary paths kept the type, incidentally, by picking up a cast wrapper.

This makes that shape the contract. Scalar literal visitors request their exact Substrait type (`makeLiteral(value, type, allowCast = true)`); the `makeTimeLiteral` / `makeTimestampLiteral` / `makeIntervalLiteral` paths wrap through `preserveNullability`. Interval-day no longer needs it: #1120 moved that visit onto the type converter, which already carries nullability. On the way back, `CallConverters.CAST` folds a cast over a non-null literal that changes nothing but nullability into the literal itself, carrying the cast's nullability, instead of surfacing an `Expression.Cast`. `LogicalValues` tuples keep bare literals — the row type already declares field nullability there, so that one cast is unwrapped, and only that one: a cast doing anything else is doing work, and dropping it would leave the literal under a row type that does not describe it.

Found along the way and left as is, tracked separately: the Calcite→Substrait path normalizes time/timestamp literals to microsecond precision (#1114) and a `precision_timestamp_tz` literal returns as a plain `precision_timestamp` (#1113).

Closes #1066

BREAKING CHANGE: Substrait→Calcite conversion now represents a nullable literal as a cast of the literal to its nullable type where it previously produced a bare literal with a non-nullable type, and converted row types become nullable accordingly. Calcite→Substrait conversion folds nullability-only casts over literals into nullable literals instead of Expression.Cast.


