### PR TITLE
test(core): fix TestBase's ProtoExpressionConverter construction

### DIFF
--- a/core/src/test/java/io/substrait/TestBase.java
+++ b/core/src/test/java/io/substrait/TestBase.java
@@ -34,12 +34,7 @@ public abstract class TestBase {
   protected ExpressionProtoConverter expressionProtoConverter =
       relProtoConverter.getExpressionProtoConverter();
 
-  protected ProtoExpressionConverter protoExpressionConverter =
-      new ProtoExpressionConverter(
-          functionCollector,
-          DefaultExtensionCatalog.DEFAULT_COLLECTION,
-          EMPTY_TYPE,
-          protoRelConverter);
+  protected ProtoExpressionConverter protoExpressionConverter;
 
   protected TestBase() {
     this(DefaultExtensionCatalog.DEFAULT_COLLECTION);
@@ -49,6 +44,11 @@ public abstract class TestBase {
     this.extensions = extensions;
     this.sb = new SubstraitBuilder(extensions);
     this.protoRelConverter = new ProtoRelConverter(functionCollector, extensions);
+    // Must be assigned here rather than in a field initializer: it needs the fully constructed
+    // protoRelConverter to convert subqueries, and the extension collection this instance was
+    // built with to resolve user-defined types.
+    this.protoExpressionConverter =
+        new ProtoExpressionConverter(functionCollector, extensions, EMPTY_TYPE, protoRelConverter);
   }
 
   protected void verifyRoundTrip(Rel rel) {

--- a/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/LiteralRoundtripTest.java
@@ -1,20 +1,13 @@
 package io.substrait.type.proto;
 
-import static io.substrait.expression.proto.ProtoExpressionConverter.EMPTY_TYPE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.protobuf.Any;
 import io.substrait.TestBase;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
-import io.substrait.expression.proto.ExpressionProtoConverter;
-import io.substrait.expression.proto.ProtoExpressionConverter;
 import io.substrait.extension.DefaultExtensionCatalog;
-import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.SimpleExtension;
-import io.substrait.relation.ProtoRelConverter;
-import io.substrait.relation.RelProtoConverter;
 import java.math.BigDecimal;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -66,27 +59,9 @@ class LiteralRoundtripTest extends TestBase {
   private static final SimpleExtension.ExtensionCollection NESTED_TYPES_EXTENSIONS =
       SimpleExtension.load(NESTED_TYPES_YAML);
 
-  private static final ExtensionCollector NESTED_TYPES_FUNCTION_COLLECTOR =
-      new ExtensionCollector();
-  private static final RelProtoConverter NESTED_TYPES_REL_PROTO_CONVERTER =
-      new RelProtoConverter(NESTED_TYPES_FUNCTION_COLLECTOR);
-  private static final ProtoRelConverter NESTED_TYPES_PROTO_REL_CONVERTER =
-      new ProtoRelConverter(NESTED_TYPES_FUNCTION_COLLECTOR, NESTED_TYPES_EXTENSIONS);
-  private static final ExpressionProtoConverter NESTED_TYPES_EXPRESSION_TO_PROTO =
-      new ExpressionProtoConverter(
-          NESTED_TYPES_FUNCTION_COLLECTOR, NESTED_TYPES_REL_PROTO_CONVERTER);
-  private static final ProtoExpressionConverter NESTED_TYPES_PROTO_TO_EXPRESSION =
-      new ProtoExpressionConverter(
-          NESTED_TYPES_FUNCTION_COLLECTOR,
-          NESTED_TYPES_EXTENSIONS,
-          EMPTY_TYPE,
-          NESTED_TYPES_PROTO_REL_CONVERTER);
-
-  private void verifyNestedTypesRoundTrip(Expression expression) {
-    io.substrait.proto.Expression protoExpression =
-        NESTED_TYPES_EXPRESSION_TO_PROTO.toProto(expression);
-    Expression result = NESTED_TYPES_PROTO_TO_EXPRESSION.from(protoExpression);
-    assertEquals(expression, result);
+  LiteralRoundtripTest() {
+    // The nested types are additional to the default catalog, which the tests below also draw on.
+    super(DefaultExtensionCatalog.DEFAULT_COLLECTION.merge(NESTED_TYPES_EXTENSIONS));
   }
 
   @Test
@@ -171,7 +146,7 @@ class LiteralRoundtripTest extends TestBase {
             Collections.emptyList(),
             java.util.Arrays.asList(p1, p2, p3));
 
-    verifyNestedTypesRoundTrip(triangle);
+    verifyRoundTrip(triangle);
   }
 
   /**
@@ -187,7 +162,7 @@ class LiteralRoundtripTest extends TestBase {
         ExpressionCreator.userDefinedLiteralAny(
             false, NESTED_TYPES_URN, "triangle", Collections.emptyList(), triangleAny);
 
-    verifyNestedTypesRoundTrip(triangle);
+    verifyRoundTrip(triangle);
   }
 
   /**
@@ -221,7 +196,7 @@ class LiteralRoundtripTest extends TestBase {
             Collections.emptyList(),
             java.util.Arrays.asList(p1, p2, p3));
 
-    verifyNestedTypesRoundTrip(triangle);
+    verifyRoundTrip(triangle);
   }
 
   /**
@@ -248,7 +223,7 @@ class LiteralRoundtripTest extends TestBase {
                 ExpressionCreator.i32(false, 2),
                 ExpressionCreator.i32(false, 3)));
 
-    verifyNestedTypesRoundTrip(vectorI32);
+    verifyRoundTrip(vectorI32);
   }
 
   /**
@@ -286,7 +261,7 @@ class LiteralRoundtripTest extends TestBase {
                 typeParam, intParam, boolParam, stringParam, nullParam, enumParam),
             java.util.Arrays.asList(ExpressionCreator.i32(false, 42)));
 
-    verifyNestedTypesRoundTrip(multiParam);
+    verifyRoundTrip(multiParam);
   }
 
   /** Verifies that NullLiteral rejects non nullable types. See issue #685. */

--- a/core/src/test/java/io/substrait/type/proto/SubqueryExpressionRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/SubqueryExpressionRoundtripTest.java
@@ -1,0 +1,43 @@
+package io.substrait.type.proto;
+
+import io.substrait.TestBase;
+import io.substrait.expression.Expression;
+import io.substrait.relation.Rel;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Round-trips the expression types that embed a relation, so that the ProtoRelConverter the
+ * ProtoExpressionConverter delegates subqueries to is exercised through the shared
+ * TestBase#verifyRoundTrip(Expression) helper.
+ */
+class SubqueryExpressionRoundtripTest extends TestBase {
+
+  final Rel subqueryInput =
+      sb.namedScan(
+          Arrays.asList("subquery_table"), Arrays.asList("subquery_column"), Arrays.asList(R.I64));
+
+  @Test
+  void scalarSubquery() {
+    verifyRoundTrip(Expression.ScalarSubquery.builder().input(subqueryInput).type(R.I64).build());
+  }
+
+  @Test
+  void setPredicate() {
+    verifyRoundTrip(
+        Expression.SetPredicate.builder()
+            .predicateOp(Expression.PredicateOp.PREDICATE_OP_EXISTS)
+            .tuples(subqueryInput)
+            .build());
+  }
+
+  @Test
+  void inPredicate() {
+    verifyRoundTrip(
+        Expression.InPredicate.builder()
+            .haystack(subqueryInput)
+            .needles(Collections.singletonList(sb.i64(42)))
+            .build());
+  }
+}


### PR DESCRIPTION
`TestBase.protoExpressionConverter` was a field initializer, so it ran before the constructor body and captured `protoRelConverter` while it was still `null`. `ProtoExpressionConverter` stores that reference unchecked (only `rootType` is `requireNonNull`'d), so construction succeeded and the failure surfaced later: `verifyRoundTrip(Expression)` threw a `NullPointerException` for any expression carrying a subquery, silently narrowing what the helper shared by ~44 test classes could cover.

The same initializer also hardcoded `DefaultExtensionCatalog.DEFAULT_COLLECTION` rather than the `extensions` constructor argument, so the collection a subclass passed to `TestBase(SimpleExtension.ExtensionCollection)` never reached the expression helper. `verifyRoundTrip(Rel)` honoured it and `verifyRoundTrip(Expression)` did not, so the two disagreed about which user-defined types exist.

Assigning `protoExpressionConverter` in the constructor body — after `protoRelConverter`, and with the instance's own collection — fixes both halves. That lets `LiteralRoundtripTest` drop the private `ExtensionCollector` / `RelProtoConverter` / `ProtoRelConverter` / `ExpressionProtoConverter` / `ProtoExpressionConverter` stack it carried purely to round-trip nested user-defined types against a non-default collection; it merges the nested types into the default catalog and calls `super(...)` instead.

Typed `test` rather than `fix` since nothing outside the test source set changes.

Closes #1072