### PR TITLE
fix(core): report the missing path when an extension resource is absent

### DIFF
--- a/core/src/main/java/io/substrait/extension/SimpleExtension.java
+++ b/core/src/main/java/io/substrait/extension/SimpleExtension.java
@@ -1421,6 +1421,8 @@ public class SimpleExtension {
    *
    * @param resourcePaths the resource Paths
    * @return the load
+   * @throws IllegalArgumentException if {@code resourcePaths} is empty, or if any of the paths is
+   *     not present on the classpath
    */
   public static ExtensionCollection load(List<String> resourcePaths) {
     if (resourcePaths.isEmpty()) {
@@ -1432,6 +1434,10 @@ public class SimpleExtension {
             .map(
                 path -> {
                   try (InputStream stream = ExtensionCollection.class.getResourceAsStream(path)) {
+                    if (stream == null) {
+                      throw new IllegalArgumentException(
+                          "Extension resource not found on classpath: " + path);
+                    }
                     return load(stream);
                   } catch (IOException e) {
                     throw new UncheckedIOException(e);
@@ -1476,8 +1482,16 @@ public class SimpleExtension {
    *
    * @param stream the stream
    * @return the load
+   * @throws IllegalArgumentException if {@code stream} is null, which is what {@code
+   *     Class#getResourceAsStream} returns for a resource that is not on the classpath
    */
   public static ExtensionCollection load(InputStream stream) {
+    if (stream == null) {
+      throw new IllegalArgumentException(
+          "Extension stream must not be null;"
+              + " Class.getResourceAsStream returns null for a resource that is not on the"
+              + " classpath.");
+    }
     try (Scanner scanner = new Scanner(stream)) {
       scanner.useDelimiter(READ_WHOLE_FILE);
       String content = scanner.next();

--- a/core/src/test/java/io/substrait/extension/SimpleExtensionLoadTest.java
+++ b/core/src/test/java/io/substrait/extension/SimpleExtensionLoadTest.java
@@ -1,0 +1,57 @@
+package io.substrait.extension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Verifies the failure modes of the {@link SimpleExtension} {@code load} overloads. */
+class SimpleExtensionLoadTest {
+
+  private static final String MISSING_RESOURCE = "/substrait/extensions/does_not_exist.yaml";
+  private static final String PRESENT_RESOURCE = "/substrait/extensions/functions_boolean.yaml";
+
+  @Test
+  void loadEmptyResourcePathsThrows() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> SimpleExtension.load(Collections.emptyList()));
+    assertTrue(e.getMessage().contains("Require at least one resource path"), e.getMessage());
+  }
+
+  @Test
+  void loadMissingResourceNamesThePath() {
+    List<String> paths = Collections.singletonList(MISSING_RESOURCE);
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> SimpleExtension.load(paths));
+    assertTrue(e.getMessage().contains(MISSING_RESOURCE), e.getMessage());
+  }
+
+  @Test
+  void loadMissingResourceAmongPresentOnesNamesTheMissingPath() {
+    List<String> paths = Arrays.asList(PRESENT_RESOURCE, MISSING_RESOURCE);
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> SimpleExtension.load(paths));
+    assertTrue(e.getMessage().contains(MISSING_RESOURCE), e.getMessage());
+  }
+
+  @Test
+  void loadNullStreamThrowsWithAMessage() {
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> SimpleExtension.load((InputStream) null));
+    assertNotNull(e.getMessage());
+  }
+
+  @Test
+  void loadPresentResourceSucceeds() {
+    SimpleExtension.ExtensionCollection collection =
+        SimpleExtension.load(Collections.singletonList(PRESENT_RESOURCE));
+    assertTrue(collection.scalarFunctions().size() > 0);
+  }
+}


### PR DESCRIPTION
Closes #1109

`SimpleExtension.load(List<String>)` passed the result of `getResourceAsStream(path)` straight into the `load(InputStream)` overload, which immediately constructs a `Scanner` over it. `getResourceAsStream` returns `null` for a resource that is not on the classpath, and `new Scanner((InputStream) null)` throws an unmessaged `NullPointerException` — so a missing or relocated extension YAML failed without naming the path or even the operation. The `catch (IOException e)` never fired, and `path` was in scope at the failure point but never reported.

Because `DefaultExtensionCatalog.DEFAULT_COLLECTION` is a `static final` populated by `loadDefaultCollection()`, that NPE surfaced as `ExceptionInInitializerError` during class initialization and then as a cause-less `NoClassDefFoundError: Could not initialize class io.substrait.extension.DefaultExtensionCatalog` on every subsequent touch — the pattern where the real cause appears only in the very first stack trace.

Both `load` overloads now reject a null stream with an `IllegalArgumentException`; the `List<String>` overload names the resource path, mirroring the guard `Dialect.loadResource` already has. The `load(InputStream)` guard covers callers that resolve the resource themselves, such as `SparkExtension`.

This stopped being theoretical with spec v0.101.0, the first release where the set of shipped extension YAMLs shrank rather than grew: `extension_types.yaml` and `type_variations.yaml` both moved out of `substrait/extensions/` into `substrait/examples/extensions/`. `libs.substrait.extensions` is an `implementation` dependency, so a consumer’s dependency management can pin the extensions artifact independently of `:core`, which makes the version skew that triggers this reachable without any change in this repo.