### PR TITLE
fix(isthmus)!: preserve interval_day precision in both conversion directions

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -28,9 +28,30 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   public static final SqlIntervalQualifier YEAR_MONTH_INTERVAL =
       new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO);
 
-  /** Interval qualifier from day to fractional second at microsecond precision. */
-  public static final SqlIntervalQualifier DAY_SECOND_INTERVAL =
-      new SqlIntervalQualifier(TimeUnit.DAY, -1, TimeUnit.SECOND, 6, SqlParserPos.ZERO);
+  /**
+   * Interval qualifier from day to fractional second at microsecond precision.
+   *
+   * <p>Conversion of a Substrait {@code interval_day<P>} builds its qualifier from {@code P} via
+   * {@link #daySecondInterval(int)} instead; sharing one constant is what used to drop the
+   * precision.
+   */
+  public static final SqlIntervalQualifier DAY_SECOND_INTERVAL = daySecondInterval(6);
+
+  /**
+   * Returns an interval qualifier from day to fractional second at the given precision.
+   *
+   * <p>Substrait's {@code interval_day<P>} carries its own fractional-second precision, and Calcite
+   * keeps it: the qualifier's precision becomes the scale of the resulting {@code INTERVAL DAY TO
+   * SECOND} type. Building the qualifier per value rather than sharing one constant is what lets
+   * {@code P} survive the conversion.
+   *
+   * @param precision the fractional-second precision
+   * @return the interval qualifier
+   */
+  public static SqlIntervalQualifier daySecondInterval(final int precision) {
+    return new SqlIntervalQualifier(
+        TimeUnit.DAY, -1, TimeUnit.SECOND, precision, SqlParserPos.ZERO);
+  }
 
   /**
    * Public no-argument constructor.

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -29,21 +29,10 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
       new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO);
 
   /**
-   * Interval qualifier from day to fractional second at microsecond precision.
-   *
-   * <p>Conversion of a Substrait {@code interval_day<P>} builds its qualifier from {@code P} via
-   * {@link #daySecondInterval(int)} instead; sharing one constant is what used to drop the
-   * precision.
-   */
-  public static final SqlIntervalQualifier DAY_SECOND_INTERVAL = daySecondInterval(6);
-
-  /**
    * Returns an interval qualifier from day to fractional second at the given precision.
    *
-   * <p>Substrait's {@code interval_day<P>} carries its own fractional-second precision, and Calcite
-   * keeps it: the qualifier's precision becomes the scale of the resulting {@code INTERVAL DAY TO
-   * SECOND} type. Building the qualifier per value rather than sharing one constant is what lets
-   * {@code P} survive the conversion.
+   * <p>The qualifier's precision becomes the scale of the resulting {@code INTERVAL DAY TO SECOND}
+   * type, which is how a Substrait {@code interval_day<P>} carries {@code P} into Calcite.
    *
    * @param precision the fractional-second precision
    * @return the interval qualifier

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -1,6 +1,5 @@
 package io.substrait.isthmus;
 
-import static io.substrait.isthmus.SubstraitTypeSystem.DAY_SECOND_INTERVAL;
 import static io.substrait.isthmus.SubstraitTypeSystem.YEAR_MONTH_INTERVAL;
 
 import io.substrait.function.NullableType;
@@ -342,8 +341,17 @@ public class TypeConverter {
 
     @Override
     public RelDataType visit(Type.IntervalDay expr) {
+      int maxPrecision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.INTERVAL_DAY);
+      if (expr.precision() > maxPrecision) {
+        throw new IllegalArgumentException(
+            String.format(
+                "unsupported interval_day precision %s, max precision in Calcite type system is set to %s",
+                expr.precision(), maxPrecision));
+      }
       return typeFactory.createTypeWithNullability(
-          typeFactory.createSqlIntervalType(DAY_SECOND_INTERVAL), n(expr));
+          typeFactory.createSqlIntervalType(
+              SubstraitTypeSystem.daySecondInterval(expr.precision())),
+          n(expr));
     }
 
     @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -341,11 +341,15 @@ public class TypeConverter {
 
     @Override
     public RelDataType visit(Type.IntervalDay expr) {
-      int maxPrecision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.INTERVAL_DAY);
-      if (expr.precision() > maxPrecision) {
+      // getMaxScale, not getMaxPrecision: for an interval the latter bounds the leading field,
+      // while the fractional-second bound is the scale of the INTERVAL_DAY_SECOND type produced
+      // here. That is also the knob SqlValidatorImpl checks an interval qualifier against, so this
+      // accepts exactly what SQL written as DAY TO SECOND(P) parses to.
+      int maxPrecision = typeFactory.getTypeSystem().getMaxScale(SqlTypeName.INTERVAL_DAY_SECOND);
+      if (expr.precision() < 0 || expr.precision() > maxPrecision) {
         throw new IllegalArgumentException(
             String.format(
-                "unsupported interval_day precision %s, max precision in Calcite type system is set to %s",
+                "unsupported interval_day precision %s, Calcite type system allows 0 to %s",
                 expr.precision(), maxPrecision));
       }
       return typeFactory.createTypeWithNullability(

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -19,7 +19,6 @@ import io.substrait.expression.WindowBound;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.SubstraitRelNodeConverter;
 import io.substrait.isthmus.SubstraitRelNodeConverter.Context;
-import io.substrait.isthmus.SubstraitTypeSystem;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.StringTypeVisitor;
 import io.substrait.type.Type;
@@ -408,11 +407,14 @@ public class ExpressionRexConverter
             ? (expr.subseconds() / (int) Math.pow(10, expr.precision() - 3))
             : (expr.subseconds() * (int) Math.pow(10, 3 - expr.precision()));
     // The value is in milliseconds, which is what Calcite's own interval literals carry, while the
-    // qualifier keeps the declared interval_day<P> so the precision survives the round trip. A
+    // type keeps the declared interval_day<P> so the precision survives the round trip. A
     // sub-millisecond component therefore does not: it is truncated by the conversion above.
-    return rexBuilder.makeIntervalLiteral(
+    // Taking the type from the converter rather than building a qualifier here is what applies the
+    // precision bound and the literal's nullability, as every other literal visit does.
+    return rexBuilder.makeLiteral(
         new BigDecimal((expr.days() * MILLIS_IN_DAY + expr.seconds() * 1_000L + milliseconds)),
-        SubstraitTypeSystem.daySecondInterval(expr.precision()));
+        typeConverter.toCalcite(typeFactory, expr.getType()),
+        true);
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -19,6 +19,7 @@ import io.substrait.expression.WindowBound;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.SubstraitRelNodeConverter;
 import io.substrait.isthmus.SubstraitRelNodeConverter.Context;
+import io.substrait.isthmus.SubstraitTypeSystem;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.StringTypeVisitor;
 import io.substrait.type.Type;
@@ -72,14 +73,6 @@ public class ExpressionRexConverter
           -1,
           org.apache.calcite.avatica.util.TimeUnit.MONTH,
           -1,
-          SqlParserPos.QUOTED_ZERO);
-
-  private static final SqlIntervalQualifier DAY_SECOND_INTERVAL =
-      new SqlIntervalQualifier(
-          org.apache.calcite.avatica.util.TimeUnit.DAY,
-          -1,
-          org.apache.calcite.avatica.util.TimeUnit.SECOND,
-          3, // Calcite only supports millisecond at the moment
           SqlParserPos.QUOTED_ZERO);
 
   private static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);
@@ -414,10 +407,12 @@ public class ExpressionRexConverter
         expr.precision() > 3
             ? (expr.subseconds() / (int) Math.pow(10, expr.precision() - 3))
             : (expr.subseconds() * (int) Math.pow(10, 3 - expr.precision()));
+    // The value is in milliseconds, which is what Calcite's own interval literals carry, while the
+    // qualifier keeps the declared interval_day<P> so the precision survives the round trip. A
+    // sub-millisecond component therefore does not: it is truncated by the conversion above.
     return rexBuilder.makeIntervalLiteral(
-        // Current Calcite behavior is to store milliseconds since Epoch
         new BigDecimal((expr.days() * MILLIS_IN_DAY + expr.seconds() * 1_000L + milliseconds)),
-        DAY_SECOND_INTERVAL);
+        SubstraitTypeSystem.daySecondInterval(expr.precision()));
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -249,11 +249,10 @@ public class FunctionMappings {
     if (datetimeType.getSqlTypeName() == SqlTypeName.DATE
         && intervalType.getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
       // The spec declares subtract(date, interval_day<P>) -> precision_timestamp<P> (spec
-      // v0.101.0), and the interval operand carries P as its fractional-second scale. The result is
-      // capped at the timestamp maximum, which is lower than the interval one, so an
-      // interval_day<9>
-      // still yields precision_timestamp<6> until the datetime ceiling itself moves (see #995's
-      // subject: TypeConverter rejects precision_timestamp above 6).
+      // v0.101.0), and the interval operand carries P as its fractional-second scale. The result
+      // is capped at the timestamp maximum, which is lower than the interval one, so an
+      // interval_day<9> still yields precision_timestamp<6> until the Substrait->Calcite
+      // conversion accepts a precision_timestamp above 6.
       int precision =
           Math.max(
               0,

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -248,13 +248,18 @@ public class FunctionMappings {
     RelDataType resultType = datetimeType;
     if (datetimeType.getSqlTypeName() == SqlTypeName.DATE
         && intervalType.getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
-      // The spec declares subtract(date, interval_day<P>) -> precision_timestamp<P>, and the
-      // interval operand carries P as its fractional-second scale, so the result precision follows
-      // from the argument. Clamped because the two type-system maxima are configured separately.
+      // The spec declares subtract(date, interval_day<P>) -> precision_timestamp<P> (spec
+      // v0.101.0), and the interval operand carries P as its fractional-second scale. The result is
+      // capped at the timestamp maximum, which is lower than the interval one, so an
+      // interval_day<9>
+      // still yields precision_timestamp<6> until the datetime ceiling itself moves (see #995's
+      // subject: TypeConverter rejects precision_timestamp above 6).
       int precision =
-          Math.min(
-              intervalType.getScale(),
-              typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP));
+          Math.max(
+              0,
+              Math.min(
+                  intervalType.getScale(),
+                  typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP)));
       resultType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP, precision);
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -248,11 +248,13 @@ public class FunctionMappings {
     RelDataType resultType = datetimeType;
     if (datetimeType.getSqlTypeName() == SqlTypeName.DATE
         && intervalType.getFamily() == SqlTypeFamily.INTERVAL_DAY_TIME) {
-      // Isthmus builds every interval_day with SubstraitTypeSystem.DAY_SECOND_INTERVAL, which
-      // pins the fractional-second precision at 6, so the operand no longer carries Substrait's
-      // interval_day<P>. Use the type system maximum as a best-effort inference;
-      // ExpressionRexConverter keeps the declared Substrait output type authoritative.
-      int precision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP);
+      // The spec declares subtract(date, interval_day<P>) -> precision_timestamp<P>, and the
+      // interval operand carries P as its fractional-second scale, so the result precision follows
+      // from the argument. Clamped because the two type-system maxima are configured separately.
+      int precision =
+          Math.min(
+              intervalType.getScale(),
+              typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP));
       resultType = typeFactory.createSqlType(SqlTypeName.TIMESTAMP, precision);
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus.expression;
 
+import com.google.common.math.LongMath;
 import com.google.protobuf.ByteString;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
@@ -8,7 +9,6 @@ import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -234,21 +234,27 @@ public class LiteralConverter {
       case INTERVAL_MINUTE_SECOND:
       case INTERVAL_SECOND:
         {
-          // Calcite represents day/time intervals in milliseconds, whatever the type's scale says.
-          Long totalMillis = Objects.requireNonNull(literal.getValueAs(Long.class));
-          Duration interval = Duration.ofMillis(totalMillis);
-
-          long days = interval.toDays();
-          long seconds = interval.minusDays(days).toSeconds();
-          // Report the interval at its declared precision rather than at a fixed 6, so that a
-          // Substrait interval_day<P> keeps its P across a round trip. The value itself carries no
-          // more than milliseconds, so a precision above 3 only widens the unit, never the detail.
+          // Report the interval at the precision the Calcite type declares, so a Substrait
+          // interval_day<P> keeps its P across a round trip. The value is narrowed to whole
+          // milliseconds here — Calcite day-time interval values may carry fractional ones, and
+          // getValueAs(Long.class) is what discards them — and P only sets the unit the subseconds
+          // component is expressed in.
+          long totalMillis = Objects.requireNonNull(literal.getValueAs(Long.class));
           int precision = resultType.getScale();
-          long millisPart = interval.toMillisPart();
-          int subseconds =
+
+          // Scale the whole value first: taking the components apart before narrowing would round a
+          // negative interval away from zero, since Duration keeps its sub-second part positive.
+          long total =
               precision > 3
-                  ? (int) (millisPart * (long) Math.pow(10, precision - 3))
-                  : (int) (millisPart / (long) Math.pow(10, 3 - precision));
+                  ? totalMillis * LongMath.pow(10, precision - 3)
+                  : totalMillis / LongMath.pow(10, 3 - precision);
+          long unitsPerSecond = LongMath.pow(10, precision);
+          long unitsPerDay = TimeUnit.DAYS.toSeconds(1) * unitsPerSecond;
+
+          long days = total / unitsPerDay;
+          long remainder = total - days * unitsPerDay;
+          long seconds = remainder / unitsPerSecond;
+          long subseconds = remainder - seconds * unitsPerSecond;
 
           return ExpressionCreator.intervalDay(
               nullable, (int) days, (int) seconds, subseconds, precision);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -234,15 +234,24 @@ public class LiteralConverter {
       case INTERVAL_MINUTE_SECOND:
       case INTERVAL_SECOND:
         {
-          // Calcite represents day/time intervals in milliseconds, despite a default scale of 6
+          // Calcite represents day/time intervals in milliseconds, whatever the type's scale says.
           Long totalMillis = Objects.requireNonNull(literal.getValueAs(Long.class));
           Duration interval = Duration.ofMillis(totalMillis);
 
           long days = interval.toDays();
           long seconds = interval.minusDays(days).toSeconds();
-          int micros = interval.toMillisPart() * 1000;
+          // Report the interval at its declared precision rather than at a fixed 6, so that a
+          // Substrait interval_day<P> keeps its P across a round trip. The value itself carries no
+          // more than milliseconds, so a precision above 3 only widens the unit, never the detail.
+          int precision = resultType.getScale();
+          long millisPart = interval.toMillisPart();
+          int subseconds =
+              precision > 3
+                  ? (int) (millisPart * (long) Math.pow(10, precision - 3))
+                  : (int) (millisPart / (long) Math.pow(10, 3 - precision));
 
-          return ExpressionCreator.intervalDay(nullable, (int) days, (int) seconds, micros, 6);
+          return ExpressionCreator.intervalDay(
+              nullable, (int) days, (int) seconds, subseconds, precision);
         }
 
       case ROW:

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -242,19 +242,19 @@ public class LiteralConverter {
           long totalMillis = Objects.requireNonNull(literal.getValueAs(Long.class));
           int precision = resultType.getScale();
 
-          // Scale the whole value first: taking the components apart before narrowing would round a
-          // negative interval away from zero, since Duration keeps its sub-second part positive.
-          long total =
+          // Decompose in milliseconds and scale only the sub-second remainder. Scaling the whole
+          // value first overflows a long past ~292 years at P=9, well inside the spec's
+          // [-3,650,000..3,650,000] day range. Integer division truncates towards zero and the
+          // remainder keeps the dividend's sign, so a negative interval still narrows towards zero.
+          long millisPerDay = TimeUnit.DAYS.toMillis(1);
+          long days = totalMillis / millisPerDay;
+          long remainder = totalMillis - days * millisPerDay;
+          long seconds = remainder / 1_000L;
+          long millisPart = remainder - seconds * 1_000L;
+          long subseconds =
               precision > 3
-                  ? totalMillis * LongMath.pow(10, precision - 3)
-                  : totalMillis / LongMath.pow(10, 3 - precision);
-          long unitsPerSecond = LongMath.pow(10, precision);
-          long unitsPerDay = TimeUnit.DAYS.toSeconds(1) * unitsPerSecond;
-
-          long days = total / unitsPerDay;
-          long remainder = total - days * unitsPerDay;
-          long seconds = remainder / unitsPerSecond;
-          long subseconds = remainder - seconds * unitsPerSecond;
+                  ? millisPart * LongMath.pow(10, precision - 3)
+                  : millisPart / LongMath.pow(10, 3 - precision);
 
           return ExpressionCreator.intervalDay(
               nullable, (int) days, (int) seconds, subseconds, precision);

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -39,6 +39,8 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class CalciteLiteralTest extends CalciteObjs {
   protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION =
@@ -213,28 +215,40 @@ class CalciteLiteralTest extends CalciteObjs {
         convertedRex.getValueAs(BigDecimal.class).longValue());
   }
 
-  @Test
-  void tIntervalMillisecond() {
-    // Calcite stores milliseconds since Epoch, so test only millisecond precision
-    BigDecimal bd =
-        new BigDecimal(
-            TimeUnit.DAYS.toMillis(3)
-                + TimeUnit.HOURS.toMillis(5)
-                + TimeUnit.MINUTES.toMillis(7)
-                + TimeUnit.SECONDS.toMillis(9)
-                + 500); // '3-5:7:9.500' day to second (6)
+  @ParameterizedTest
+  @ValueSource(ints = {0, 3, 6})
+  void tIntervalDaySecondKeepsItsPrecision(int precision) {
+    // Calcite carries an interval literal's value in milliseconds whatever the type says, so a
+    // half-second is all the detail every precision under test can hold. What varies is the unit
+    // the subseconds component is expressed in, which is what interval_day<P> declares.
+    long millis =
+        TimeUnit.DAYS.toMillis(3)
+            + TimeUnit.HOURS.toMillis(5)
+            + TimeUnit.MINUTES.toMillis(7)
+            + TimeUnit.SECONDS.toMillis(9)
+            + (precision == 0 ? 0 : 500);
+    int subseconds = precision == 0 ? 0 : (int) (500 * Math.pow(10, precision - 3));
+
     RexLiteral intervalDaySecond =
         rex.makeIntervalLiteral(
-            bd,
-            new SqlIntervalQualifier(
-                org.apache.calcite.avatica.util.TimeUnit.DAY,
-                -1,
-                org.apache.calcite.avatica.util.TimeUnit.SECOND,
-                3,
-                SqlParserPos.ZERO));
+            new BigDecimal(millis), SubstraitTypeSystem.daySecondInterval(precision));
+    assertEquals(precision, intervalDaySecond.getType().getScale());
+
     IntervalDayLiteral intervalDaySecondExpr =
-        ExpressionCreator.intervalDay(false, 3, 5 * 3600 + 7 * 60 + 9, 500_000, 6);
+        ExpressionCreator.intervalDay(false, 3, 5 * 3600 + 7 * 60 + 9, subseconds, precision);
     bitest(intervalDaySecondExpr, intervalDaySecond);
+  }
+
+  @Test
+  void tIntervalDaySecondTruncatesBelowMillisecond() {
+    // Calcite's interval literals carry milliseconds, so the sub-millisecond part of an
+    // interval_day<6> does not survive the conversion. The precision does.
+    IntervalDayLiteral withMicros = ExpressionCreator.intervalDay(false, 0, 0, 500_123, 6);
+    RexNode convertedRex = withMicros.accept(expressionRexConverter, Context.newContext());
+    assertEquals(6, convertedRex.getType().getScale());
+    assertEquals(
+        ExpressionCreator.intervalDay(false, 0, 0, 500_000, 6),
+        convertedRex.accept(rexExpressionConverter));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static io.substrait.isthmus.SubstraitTypeSystem.YEAR_MONTH_INTERVAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import io.substrait.expression.Expression;
@@ -40,7 +41,7 @@ import org.apache.calcite.util.TimestampString;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class CalciteLiteralTest extends CalciteObjs {
   protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION =
@@ -215,28 +216,50 @@ class CalciteLiteralTest extends CalciteObjs {
         convertedRex.getValueAs(BigDecimal.class).longValue());
   }
 
-  @ParameterizedTest
-  @ValueSource(ints = {0, 3, 6})
-  void tIntervalDaySecondKeepsItsPrecision(int precision) {
-    // Calcite carries an interval literal's value in milliseconds whatever the type says, so a
-    // half-second is all the detail every precision under test can hold. What varies is the unit
-    // the subseconds component is expressed in, which is what interval_day<P> declares.
-    long millis =
-        TimeUnit.DAYS.toMillis(3)
-            + TimeUnit.HOURS.toMillis(5)
-            + TimeUnit.MINUTES.toMillis(7)
-            + TimeUnit.SECONDS.toMillis(9)
-            + (precision == 0 ? 0 : 500);
-    int subseconds = precision == 0 ? 0 : (int) (500 * Math.pow(10, precision - 3));
-
-    RexLiteral intervalDaySecond =
+  @ParameterizedTest(name = "P={0} {1}ms")
+  @CsvSource({
+    // precision, calcite millis, expected days, seconds, subseconds, millis back
+    "6,      1500,  0,      1,     500000,      1500",
+    "6,     -1500,  0,     -1,    -500000,     -1500",
+    "5,      1500,  0,      1,      50000,      1500",
+    "4,      1500,  0,      1,       5000,      1500",
+    "3,      1500,  0,      1,        500,      1500",
+    "3,     -1500,  0,     -1,       -500,     -1500",
+    "2,      1500,  0,      1,         50,      1500",
+    "1,      1500,  0,      1,          5,      1500",
+    // Below millisecond precision the remainder cannot be represented and is dropped. It is
+    // dropped towards zero, which is why the whole value is scaled before it is taken apart:
+    // Duration would report -1500ms as -2 seconds plus a positive 500ms part.
+    "0,      1500,  0,      1,          0,      1000",
+    "0,     -1500,  0,     -1,          0,     -1000",
+    // A value spanning days, so the decomposition is exercised rather than just the seconds field.
+    "3, 277629500,  3,  18429,        500, 277629500",
+    "3,-277629500, -3, -18429,       -500,-277629500",
+  })
+  void tIntervalDaySecondKeepsItsPrecision(
+      int precision, long calciteMillis, int days, int seconds, long subseconds, long millisBack) {
+    RexLiteral calciteInterval =
         rex.makeIntervalLiteral(
-            new BigDecimal(millis), SubstraitTypeSystem.daySecondInterval(precision));
-    assertEquals(precision, intervalDaySecond.getType().getScale());
+            new BigDecimal(calciteMillis), SubstraitTypeSystem.daySecondInterval(precision));
+    assertEquals(precision, calciteInterval.getType().getScale());
 
-    IntervalDayLiteral intervalDaySecondExpr =
-        ExpressionCreator.intervalDay(false, 3, 5 * 3600 + 7 * 60 + 9, subseconds, precision);
-    bitest(intervalDaySecondExpr, intervalDaySecond);
+    IntervalDayLiteral expected =
+        ExpressionCreator.intervalDay(false, days, seconds, subseconds, precision);
+    assertEquals(expected, calciteInterval.accept(rexExpressionConverter));
+
+    RexNode back = expected.accept(expressionRexConverter, Context.newContext());
+    assertEquals(precision, back.getType().getScale());
+    assertEquals(new BigDecimal(millisBack), ((RexLiteral) back).getValueAs(BigDecimal.class));
+  }
+
+  @Test
+  void tIntervalDayLiteralIsNullableWhenTheSubstraitLiteralIs() {
+    // The interval literal is the one visit that used to build its Calcite type from a qualifier
+    // rather than from the type converter, which lost both the precision bound and this.
+    RexNode nullableInterval =
+        ExpressionCreator.intervalDay(true, 0, 1, 0, 3)
+            .accept(expressionRexConverter, Context.newContext());
+    assertTrue(nullableInterval.getType().isNullable());
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -227,14 +227,18 @@ class CalciteLiteralTest extends CalciteObjs {
     "3,     -1500,  0,     -1,       -500,     -1500",
     "2,      1500,  0,      1,         50,      1500",
     "1,      1500,  0,      1,          5,      1500",
-    // Below millisecond precision the remainder cannot be represented and is dropped. It is
-    // dropped towards zero, which is why the whole value is scaled before it is taken apart:
-    // Duration would report -1500ms as -2 seconds plus a positive 500ms part.
+    // Below millisecond precision the remainder cannot be represented and is dropped, towards
+    // zero: the millisecond remainder keeps the dividend's sign, where Duration would report
+    // -1500ms as -2 seconds plus a positive 500ms part.
     "0,      1500,  0,      1,          0,      1000",
     "0,     -1500,  0,     -1,          0,     -1000",
     // A value spanning days, so the decomposition is exercised rather than just the seconds field.
     "3, 277629500,  3,  18429,        500, 277629500",
     "3,-277629500, -3, -18429,       -500,-277629500",
+    // The spec's maximum day count at the highest precision the type system allows. Scaling the
+    // whole value into those units would overflow a long; scaling only the remainder does not.
+    "9, 315360000000500, 3650000, 0,  500000000, 315360000000500",
+    "9,-315360000000500,-3650000, 0, -500000000,-315360000000500",
   })
   void tIntervalDaySecondKeepsItsPrecision(
       int precision, long calciteMillis, int days, int seconds, long subseconds, long millisBack) {

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -145,7 +145,9 @@ class CalciteTypeTest extends CalciteObjs {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void intervalDay(boolean nullable) {
-    for (int precision : new int[] {0, 3, 6}) {
+    // Up to 9: for intervals the fractional-second ceiling is getMaxScale, which neither
+    // SubstraitTypeSystem nor Calcite lowers, unlike the datetime types capped at 6.
+    for (int precision : new int[] {0, 3, 6, 9}) {
       testType(
           Type.withNullability(nullable).intervalDay(precision),
           type.createSqlIntervalType(SubstraitTypeSystem.daySecondInterval(precision)),
@@ -153,15 +155,21 @@ class CalciteTypeTest extends CalciteObjs {
     }
   }
 
-  @Test
-  void intervalDayRejectsPrecisionAboveTheTypeSystemMaximum() {
-    // Same ceiling as the precision_* types: the conversion reports it instead of silently
-    // narrowing to the maximum the Calcite type system is configured for.
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 10, 12})
+  void intervalDayRejectsPrecisionOutsideTheTypeSystemRange(int precision) {
+    // Reported rather than silently narrowed to the maximum, as the precision_* conversions
+    // already do. -1 is Calcite's PRECISION_NOT_SPECIFIED, which a qualifier would otherwise
+    // turn back into the default of 6.
     IllegalArgumentException e =
         assertThrows(
             IllegalArgumentException.class,
-            () -> TypeConverter.DEFAULT.toCalcite(type, TypeCreator.REQUIRED.intervalDay(9)));
-    assertTrue(e.getMessage().contains("unsupported interval_day precision 9"));
+            () ->
+                TypeConverter.DEFAULT.toCalcite(type, TypeCreator.REQUIRED.intervalDay(precision)));
+    assertTrue(
+        e.getMessage()
+            .contains("unsupported interval_day precision " + precision + ", Calcite type system"),
+        e.getMessage());
   }
 
   @ParameterizedTest

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -1,6 +1,8 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.function.TypeExpression;
 import io.substrait.isthmus.utils.UserTypeFactory;
@@ -143,10 +145,23 @@ class CalciteTypeTest extends CalciteObjs {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void intervalDay(boolean nullable) {
-    testType(
-        Type.withNullability(nullable).intervalDay(6),
-        type.createSqlIntervalType(SubstraitTypeSystem.DAY_SECOND_INTERVAL),
-        nullable);
+    for (int precision : new int[] {0, 3, 6}) {
+      testType(
+          Type.withNullability(nullable).intervalDay(precision),
+          type.createSqlIntervalType(SubstraitTypeSystem.daySecondInterval(precision)),
+          nullable);
+    }
+  }
+
+  @Test
+  void intervalDayRejectsPrecisionAboveTheTypeSystemMaximum() {
+    // Same ceiling as the precision_* types: the conversion reports it instead of silently
+    // narrowing to the maximum the Calcite type system is configured for.
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> TypeConverter.DEFAULT.toCalcite(type, TypeCreator.REQUIRED.intervalDay(9)));
+    assertTrue(e.getMessage().contains("unsupported interval_day precision 9"));
   }
 
   @ParameterizedTest

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -65,7 +65,7 @@ class FunctionConversionTest extends PlanTestBase {
 
   @ParameterizedTest
   @MethodSource("subtractDateIDayTypes")
-  void subtractDateIDay(Type outputType, Type expectedInferredType) {
+  void subtractDateIDay(Type outputType, int intervalPrecision, Type expectedInferredType) {
     AtomicReference<TypeObservation> observed = new AtomicReference<>();
     ExpressionRexConverter observingConverter =
         new ExpressionRexConverter(
@@ -80,7 +80,7 @@ class FunctionConversionTest extends PlanTestBase {
             "subtract:date_iday",
             outputType,
             ExpressionCreator.date(false, 10561),
-            ExpressionCreator.intervalDay(false, 120, 0, 0, 6));
+            ExpressionCreator.intervalDay(false, 120, 0, 0, intervalPrecision));
 
     RexNode calciteExpr = expr.accept(observingConverter, Context.newContext());
     assertEquals(TypeConverter.DEFAULT.toCalcite(typeFactory, outputType), calciteExpr.getType());
@@ -103,12 +103,15 @@ class FunctionConversionTest extends PlanTestBase {
     Type maxPrecisionTimestamp = TypeCreator.REQUIRED.precisionTimestamp(6);
     return Stream.of(
         Arguments.of(
-            Named.of("legacy DATE output", TypeCreator.REQUIRED.DATE), maxPrecisionTimestamp),
+            Named.of("legacy DATE output", TypeCreator.REQUIRED.DATE), 6, maxPrecisionTimestamp),
         Arguments.of(
-            Named.of("spec max-precision output", maxPrecisionTimestamp), maxPrecisionTimestamp),
+            Named.of("spec max-precision output", maxPrecisionTimestamp), 6, maxPrecisionTimestamp),
+        // subtract(date, interval_day<P>) -> precision_timestamp<P>: the inferred precision follows
+        // the argument, so this case varies both rather than only the declared output.
         Arguments.of(
-            Named.of("non-max declared output", TypeCreator.REQUIRED.precisionTimestamp(3)),
-            maxPrecisionTimestamp));
+            Named.of("spec non-max precision", TypeCreator.REQUIRED.precisionTimestamp(3)),
+            3,
+            TypeCreator.REQUIRED.precisionTimestamp(3)));
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/FunctionConversionTest.java
@@ -111,7 +111,15 @@ class FunctionConversionTest extends PlanTestBase {
         Arguments.of(
             Named.of("spec non-max precision", TypeCreator.REQUIRED.precisionTimestamp(3)),
             3,
-            TypeCreator.REQUIRED.precisionTimestamp(3)));
+            TypeCreator.REQUIRED.precisionTimestamp(3)),
+        // Declared and inferred deliberately disagree, so the supplied Substrait type is still
+        // asserted to win over Calcite's inference.
+        Arguments.of(
+            Named.of(
+                "declared output narrower than the argument",
+                TypeCreator.REQUIRED.precisionTimestamp(3)),
+            6,
+            maxPrecisionTimestamp));
   }
 
   @Test


### PR DESCRIPTION
Substrait's `interval_day<P>` carries a fractional-second precision, and every path across the Calcite boundary discarded it. `TypeConverter` built every interval from the shared `SubstraitTypeSystem.DAY_SECOND_INTERVAL` qualifier at precision 6, `ExpressionRexConverter` had a second private qualifier pinned at 3 — so the two directions of the same conversion disagreed about the type of the same value — and coming back, `LiteralConverter` reported a fixed 6 whatever the Calcite literal's type said:

```
interval_day<0> -> INTERVAL DAY TO SECOND(6)  scale=6
interval_day<3> -> INTERVAL DAY TO SECOND(6)  scale=6
```

Build the qualifier from `P` instead, in both places, and read the declared precision back off the type when converting a Calcite interval literal. Calcite keeps a qualifier's precision as the type's scale, and `TypeConverter.toSubstrait` already read that scale, so the round trip becomes identity:

```
IntervalDayLiteral{days=1, seconds=2, subseconds=3, precision=3}
  -> 86402003:INTERVAL DAY TO SECOND(3)
  -> IntervalDayLiteral{days=1, seconds=2, subseconds=3, precision=3}
```

An interval written without an explicit precision is unaffected — Calcite gives it scale 6, which is exactly what was hardcoded. One written as `DAY TO SECOND(P)` parses to that `P` and now keeps it.

The value stays in milliseconds, which is what Calcite's own interval literals carry. A sub-millisecond component is therefore still truncated; what this changes is that the declared precision is no longer overwritten with a fixed 6.

With `P` available on the operand, `DATETIME_SUBTRACT` now infers `precision_timestamp<P>` exactly, as `functions_datetime.yaml` declares, instead of falling back to the type system maximum — the gap #1099 had to leave as a best-effort comment. The parameterized test it left behind, which could only vary the declared output, now varies the argument precision too.

Closes #1118, which reports the type-conversion half of this and was filed just before this PR went up.

It also removes the hardcoded 6 on the literal side — `LiteralConverter` reported `intervalDay(..., 6)` whatever scale the Calcite literal carried — so the interval third of #1114 goes with it. The `TIME` / `TIMESTAMP` halves of #1114 are a separate value rescale, in #1121.

BREAKING CHANGE: an `interval_day` precision outside 0 to 9 is now rejected instead of silently narrowed to 6. The bound is `getMaxScale(INTERVAL_DAY_SECOND)`, the same one Calcite validates an interval qualifier against, so nothing that parses from SQL is refused. Converted Calcite types and generated SQL now carry the interval's declared precision, so `INTERVAL ... DAY TO SECOND(P)` replaces the previous fixed `DAY TO SECOND(3)`. A Calcite interval literal whose declared scale is below 3 now converts to a Substrait `interval_day` at that scale, dropping the millisecond remainder towards zero, where it previously reported `interval_day<6>` and kept it.



