### PR TITLE
fix(isthmus)!: convert temporal literals at their declared type

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -54,6 +54,31 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   public SubstraitTypeSystem() {}
 
   /**
+   * Checks that a Substrait fractional-second precision is one the Calcite type system in effect
+   * allows for the type it converts to, and reports the bound it exceeds if it is not.
+   *
+   * @param typeSystem the type system the converted type will live under, which need not be this
+   *     one
+   * @param typeName the Calcite type name the Substrait type converts to
+   * @param substraitTypeName the Substrait type name, for the failure message
+   * @param precision the fractional-second precision carried by the Substrait type or literal
+   * @throws IllegalArgumentException if the precision exceeds what the type system allows
+   */
+  public static void requireSupportedPrecision(
+      final RelDataTypeSystem typeSystem,
+      final SqlTypeName typeName,
+      final String substraitTypeName,
+      final int precision) {
+    int maxPrecision = typeSystem.getMaxPrecision(typeName);
+    if (precision > maxPrecision) {
+      throw new IllegalArgumentException(
+          String.format(
+              "unsupported %s precision %s, max precision in Calcite type system is set to %s",
+              substraitTypeName, precision, maxPrecision));
+    }
+  }
+
+  /**
    * Returns the maximum precision for the given SQL type.
    *
    * @param typeName The {@link SqlTypeName} for which precision is requested.

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -65,6 +65,24 @@ public class TypeConverter {
   }
 
   /**
+   * Returns the fractional-second precision of a Calcite temporal type, reading an unspecified
+   * precision as zero.
+   *
+   * <p>A temporal type built from a Java class rather than a SQL type name -- how a reflective
+   * schema exposes a {@code java.sql.Time} or {@code java.sql.Timestamp} column -- carries {@link
+   * RelDataType#PRECISION_NOT_SPECIFIED}. Calcite's own {@code RexBuilder.clean} reads that
+   * sentinel as precision 0; left as -1 it would travel into the Substrait type and the literals
+   * built at it.
+   *
+   * @param type the Calcite temporal type
+   * @return the fractional-second precision, never negative
+   */
+  public static int precisionOf(final RelDataType type) {
+    int precision = type.getPrecision();
+    return precision == RelDataType.PRECISION_NOT_SPECIFIED ? 0 : precision;
+  }
+
+  /**
    * Converts a Calcite {@link RelDataType} to a Substrait {@link Type}.
    *
    * @param type Calcite type to convert.
@@ -145,11 +163,11 @@ public class TypeConverter {
       case DATE:
         return creator.DATE;
       case TIME:
-        return creator.precisionTime(type.getPrecision());
+        return creator.precisionTime(precisionOf(type));
       case TIMESTAMP:
-        return creator.precisionTimestamp(type.getPrecision());
+        return creator.precisionTimestamp(precisionOf(type));
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-        return creator.precisionTimestampTZ(type.getPrecision());
+        return creator.precisionTimestampTZ(precisionOf(type));
       case INTERVAL_YEAR:
       case INTERVAL_YEAR_MONTH:
       case INTERVAL_MONTH:
@@ -298,38 +316,28 @@ public class TypeConverter {
 
     @Override
     public RelDataType visit(Type.PrecisionTime expr) {
-      int maxPrecision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIME);
-      if (expr.precision() > maxPrecision) {
-        throw new IllegalArgumentException(
-            String.format(
-                "unsupported precision_time precision %s, max precision in Calcite type system is set to %s",
-                expr.precision(), maxPrecision));
-      }
+      SubstraitTypeSystem.requireSupportedPrecision(
+          typeFactory.getTypeSystem(), SqlTypeName.TIME, "precision_time", expr.precision());
       return t(n(expr), SqlTypeName.TIME, expr.precision());
     }
 
     @Override
     public RelDataType visit(Type.PrecisionTimestamp expr) {
-      int maxPrecision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP);
-      if (expr.precision() > maxPrecision) {
-        throw new IllegalArgumentException(
-            String.format(
-                "unsupported precision_timestamp precision %s, max precision in Calcite type system is set to %s",
-                expr.precision(), maxPrecision));
-      }
+      SubstraitTypeSystem.requireSupportedPrecision(
+          typeFactory.getTypeSystem(),
+          SqlTypeName.TIMESTAMP,
+          "precision_timestamp",
+          expr.precision());
       return t(n(expr), SqlTypeName.TIMESTAMP, expr.precision());
     }
 
     @Override
     public RelDataType visit(Type.PrecisionTimestampTZ expr) throws RuntimeException {
-      int maxPrecision =
-          typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
-      if (expr.precision() > maxPrecision) {
-        throw new IllegalArgumentException(
-            String.format(
-                "unsupported precision_timestamp_tz precision %s, max precision in Calcite type system is set to %s",
-                expr.precision(), maxPrecision));
-      }
+      SubstraitTypeSystem.requireSupportedPrecision(
+          typeFactory.getTypeSystem(),
+          SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+          "precision_timestamp_tz",
+          expr.precision());
       return t(n(expr), SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, expr.precision());
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus.expression;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.math.LongMath;
 import io.substrait.expression.AbstractExpressionVisitor;
 import io.substrait.expression.EnumArg;
 import io.substrait.expression.Expression;
@@ -19,6 +20,7 @@ import io.substrait.expression.WindowBound;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.SubstraitRelNodeConverter;
 import io.substrait.isthmus.SubstraitRelNodeConverter.Context;
+import io.substrait.isthmus.SubstraitTypeSystem;
 import io.substrait.isthmus.TypeConverter;
 import io.substrait.type.StringTypeVisitor;
 import io.substrait.type.Type;
@@ -273,13 +275,8 @@ public class ExpressionRexConverter
 
   @Override
   public RexNode visit(PrecisionTimeLiteral expr, Context context) throws RuntimeException {
-    int maxPrecision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIME);
-    if (expr.precision() > maxPrecision) {
-      throw new IllegalArgumentException(
-          String.format(
-              "unsupported precision_time precision %s, max precision in Calcite type system is set to %s",
-              expr.precision(), maxPrecision));
-    }
+    SubstraitTypeSystem.requireSupportedPrecision(
+        typeFactory.getTypeSystem(), SqlTypeName.TIME, "precision_time", expr.precision());
 
     return preserveNullability(
         rexBuilder.makeTimeLiteral(
@@ -290,15 +287,9 @@ public class ExpressionRexConverter
   /**
    * Creates a TimeString from a time value with the specified precision.
    *
-   * <p>The time unit for the value is dictated by the supplied precision, with the following valid
-   * values:
-   *
-   * <ul>
-   *   <li>0 - seconds
-   *   <li>3 - milliseconds
-   *   <li>6 - microseconds
-   *   <li>9 - nanoseconds
-   * </ul>
+   * <p>The time unit for the value is dictated by the supplied precision: the value counts
+   * 10^-precision seconds, so precision 0 is seconds, 3 milliseconds, 6 microseconds and 9
+   * nanoseconds, and every precision in between is a unit of its own.
    *
    * @param value the time value in the appropriate unit based on precision
    * @param precision the precision level
@@ -333,13 +324,11 @@ public class ExpressionRexConverter
 
   @Override
   public RexNode visit(PrecisionTimestampLiteral expr, Context context) throws RuntimeException {
-    int maxPrecision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP);
-    if (expr.precision() > maxPrecision) {
-      throw new IllegalArgumentException(
-          String.format(
-              "unsupported precision_timestamp precision %s, max precision in Calcite type system is set to %s",
-              expr.precision(), maxPrecision));
-    }
+    SubstraitTypeSystem.requireSupportedPrecision(
+        typeFactory.getTypeSystem(),
+        SqlTypeName.TIMESTAMP,
+        "precision_timestamp",
+        expr.precision());
 
     return preserveNullability(
         rexBuilder.makeTimestampLiteral(
@@ -350,15 +339,13 @@ public class ExpressionRexConverter
   @Override
   public RexNode visit(PrecisionTimestampTZLiteral expr, Context context) throws RuntimeException {
     // TIMESTAMP_WITH_LOCAL_TIME_ZONE, not TIMESTAMP_TZ: that is the name TypeConverter maps
-    // precision_timestamp_tz to, and the only one SubstraitTypeSystem configures a maximum for.
-    int maxPrecision =
-        typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
-    if (expr.precision() > maxPrecision) {
-      throw new IllegalArgumentException(
-          String.format(
-              "unsupported precision_timestamp_tz precision %s, max precision in Calcite type system is set to %s",
-              expr.precision(), maxPrecision));
-    }
+    // precision_timestamp_tz to, so the bound checked here is the one the converted type is
+    // built against.
+    SubstraitTypeSystem.requireSupportedPrecision(
+        typeFactory.getTypeSystem(),
+        SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+        "precision_timestamp_tz",
+        expr.precision());
 
     return rexBuilder.makeLiteral(
         getTimestampString(expr.value(), expr.precision()),
@@ -376,25 +363,23 @@ public class ExpressionRexConverter
   /**
    * Returns how many units of a temporal value at the given precision make up one second.
    *
+   * <p>Every precision from 0 to 9 is a unit, not just the multiples of three: {@code
+   * algebra.proto} documents what 0, 3, 6, 9 and 12 mean and leaves the field an unbounded {@code
+   * int32}, and Calcite types a literal by the fractional digits actually written, so {@code
+   * TIMESTAMP '2024-01-01 00:00:00.12'} is precision 2.
+   *
    * @param precision the fractional-second precision
    * @param typeName the Substrait type being converted, for the failure message
    * @return the number of units per second
-   * @throws IllegalArgumentException if the precision is not one Calcite can be given
+   * @throws IllegalArgumentException if the precision is finer than nanoseconds or negative
    */
   private static long unitsPerSecond(int precision, String typeName) {
-    switch (precision) {
-      case 0:
-        return 1L;
-      case 3:
-        return 1_000L;
-      case 6:
-        return 1_000_000L;
-      case 9:
-        return 1_000_000_000L;
-      default:
-        throw new IllegalArgumentException(
-            String.format("Cannot handle %s with precision %d.", typeName, precision));
+    if (precision < 0 || precision > 9) {
+      // A nanosecond is the finest unit a TimeString or TimestampString carries.
+      throw new IllegalArgumentException(
+          String.format("Cannot handle %s with precision %d.", typeName, precision));
     }
+    return LongMath.pow(10, precision);
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -349,11 +349,14 @@ public class ExpressionRexConverter
 
   @Override
   public RexNode visit(PrecisionTimestampTZLiteral expr, Context context) throws RuntimeException {
-    int maxPrecision = typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP_TZ);
+    // TIMESTAMP_WITH_LOCAL_TIME_ZONE, not TIMESTAMP_TZ: that is the name TypeConverter maps
+    // precision_timestamp_tz to, and the only one SubstraitTypeSystem configures a maximum for.
+    int maxPrecision =
+        typeFactory.getTypeSystem().getMaxPrecision(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
     if (expr.precision() > maxPrecision) {
       throw new IllegalArgumentException(
           String.format(
-              "unsupported precision_timestamp precision %s, max precision in Calcite type system is set to %s",
+              "unsupported precision_timestamp_tz precision %s, max precision in Calcite type system is set to %s",
               expr.precision(), maxPrecision));
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -199,7 +199,7 @@ public class LiteralConverter {
           LocalTime localTime = LocalTime.parse(time.toString(), CALCITE_LOCAL_TIME_FORMATTER);
           int precision = TypeConverter.precisionOf(resultType);
           return ExpressionCreator.precisionTime(
-              nullable, subsecondsOf(localTime.toNanoOfDay(), precision), precision);
+              nullable, rescaleNanos(localTime.toNanoOfDay(), precision), precision);
         }
       case TIMESTAMP:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
@@ -210,7 +210,7 @@ public class LiteralConverter {
           int precision = TypeConverter.precisionOf(resultType);
           long value =
               localDateTime.toEpochSecond(ZoneOffset.UTC) * LongMath.pow(10, precision)
-                  + subsecondsOf(localDateTime.getNano(), precision);
+                  + rescaleNanos(localDateTime.getNano(), precision);
           // toEpochSecond floors, and the nanosecond part it leaves behind is always positive, so
           // a pre-epoch timestamp narrowed to a coarser precision moves back in time rather than
           // towards the epoch. That is what a timestamp wants — 1969-12-31 23:59:59.5 at second
@@ -317,12 +317,13 @@ public class LiteralConverter {
    * Rescales a nanosecond count to the fractional-second unit a Substrait temporal literal of the
    * given precision is expressed in.
    *
-   * @param nanos the sub-second component in nanoseconds, which {@code LocalTime} and {@code
-   *     LocalDateTime} both report as a non-negative value
+   * @param nanos a non-negative nanosecond count: a whole time of day for a {@code precision_time},
+   *     the sub-second remainder for a {@code precision_timestamp}. Non-negativity is the
+   *     precondition the division relies on, since it truncates towards zero rather than flooring.
    * @param precision the fractional-second precision of the target literal
-   * @return the sub-second component in units of 10^-precision seconds
+   * @return {@code nanos} in units of 10^-precision seconds
    */
-  private static long subsecondsOf(long nanos, int precision) {
+  private static long rescaleNanos(long nanos, int precision) {
     return precision >= 9
         ? nanos * LongMath.pow(10, precision - 9)
         : nanos / LongMath.pow(10, 9 - precision);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.TimeString;
@@ -196,10 +197,9 @@ public class LiteralConverter {
         {
           TimeString time = literal.getValueAs(TimeString.class);
           LocalTime localTime = LocalTime.parse(time.toString(), CALCITE_LOCAL_TIME_FORMATTER);
-          // Calcite supports up to microsecond precision (6), convert nanoseconds to microseconds
-          long nanos = localTime.toNanoOfDay();
-          long micros = TimeUnit.NANOSECONDS.toMicros(nanos);
-          return ExpressionCreator.precisionTime(nullable, micros, 6);
+          int precision = resultType.getPrecision();
+          return ExpressionCreator.precisionTime(
+              nullable, subsecondsOf(localTime.toNanoOfDay(), precision), precision);
         }
       case TIMESTAMP:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
@@ -207,12 +207,15 @@ public class LiteralConverter {
           TimestampString timestamp = literal.getValueAs(TimestampString.class);
           LocalDateTime localDateTime =
               LocalDateTime.parse(timestamp.toString(), CALCITE_LOCAL_DATETIME_FORMATTER);
-          // Calcite supports up to microsecond precision (6)
-          long epochSeconds = localDateTime.toEpochSecond(ZoneOffset.UTC);
-          long epochMicros =
-              TimeUnit.SECONDS.toMicros(epochSeconds)
-                  + TimeUnit.NANOSECONDS.toMicros(localDateTime.getNano());
-          return ExpressionCreator.precisionTimestamp(nullable, epochMicros, 6);
+          int precision = resultType.getPrecision();
+          long value =
+              localDateTime.toEpochSecond(ZoneOffset.UTC) * pow10(precision)
+                  + subsecondsOf(localDateTime.getNano(), precision);
+          // The same Calcite SqlTypeName that toSubstrait maps to precision_timestamp_tz above, so
+          // the literal has to agree with the type its own conversion produced.
+          return resultType.getSqlTypeName() == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+              ? ExpressionCreator.precisionTimestampTZ(nullable, value, precision)
+              : ExpressionCreator.precisionTimestamp(nullable, value, precision);
         }
       case INTERVAL_YEAR:
       case INTERVAL_YEAR_MONTH:
@@ -302,6 +305,26 @@ public class LiteralConverter {
   public static byte[] padRightIfNeeded(
       org.apache.calcite.avatica.util.ByteString bytes, int length) {
     return padRightIfNeeded(bytes.getBytes(), length);
+  }
+
+  /**
+   * Rescales a nanosecond count to the fractional-second unit a Substrait temporal literal of the
+   * given precision is expressed in.
+   *
+   * @param nanos the sub-second component in nanoseconds
+   * @param precision the fractional-second precision of the target literal
+   * @return the sub-second component in units of 10^-precision seconds
+   */
+  private static long subsecondsOf(long nanos, int precision) {
+    return precision >= 9 ? nanos * pow10(precision - 9) : nanos / pow10(9 - precision);
+  }
+
+  private static long pow10(int exponent) {
+    long result = 1;
+    for (int i = 0; i < exponent; i++) {
+      result *= 10;
+    }
+    return result;
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -197,7 +197,7 @@ public class LiteralConverter {
         {
           TimeString time = literal.getValueAs(TimeString.class);
           LocalTime localTime = LocalTime.parse(time.toString(), CALCITE_LOCAL_TIME_FORMATTER);
-          int precision = resultType.getPrecision();
+          int precision = TypeConverter.precisionOf(resultType);
           return ExpressionCreator.precisionTime(
               nullable, subsecondsOf(localTime.toNanoOfDay(), precision), precision);
         }
@@ -207,7 +207,7 @@ public class LiteralConverter {
           TimestampString timestamp = literal.getValueAs(TimestampString.class);
           LocalDateTime localDateTime =
               LocalDateTime.parse(timestamp.toString(), CALCITE_LOCAL_DATETIME_FORMATTER);
-          int precision = resultType.getPrecision();
+          int precision = TypeConverter.precisionOf(resultType);
           long value =
               localDateTime.toEpochSecond(ZoneOffset.UTC) * LongMath.pow(10, precision)
                   + subsecondsOf(localDateTime.getNano(), precision);

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/LiteralConverter.java
@@ -209,9 +209,15 @@ public class LiteralConverter {
               LocalDateTime.parse(timestamp.toString(), CALCITE_LOCAL_DATETIME_FORMATTER);
           int precision = resultType.getPrecision();
           long value =
-              localDateTime.toEpochSecond(ZoneOffset.UTC) * pow10(precision)
+              localDateTime.toEpochSecond(ZoneOffset.UTC) * LongMath.pow(10, precision)
                   + subsecondsOf(localDateTime.getNano(), precision);
-          // The same Calcite SqlTypeName that toSubstrait maps to precision_timestamp_tz above, so
+          // toEpochSecond floors, and the nanosecond part it leaves behind is always positive, so
+          // a pre-epoch timestamp narrowed to a coarser precision moves back in time rather than
+          // towards the epoch. That is what a timestamp wants — 1969-12-31 23:59:59.5 at second
+          // precision is 23:59:59 — and it is the opposite of the interval case, where the value
+          // is a duration and narrowing shortens it.
+          //
+          // The SqlTypeName below is the same one toSubstrait maps to precision_timestamp_tz, so
           // the literal has to agree with the type its own conversion produced.
           return resultType.getSqlTypeName() == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
               ? ExpressionCreator.precisionTimestampTZ(nullable, value, precision)
@@ -311,20 +317,15 @@ public class LiteralConverter {
    * Rescales a nanosecond count to the fractional-second unit a Substrait temporal literal of the
    * given precision is expressed in.
    *
-   * @param nanos the sub-second component in nanoseconds
+   * @param nanos the sub-second component in nanoseconds, which {@code LocalTime} and {@code
+   *     LocalDateTime} both report as a non-negative value
    * @param precision the fractional-second precision of the target literal
    * @return the sub-second component in units of 10^-precision seconds
    */
   private static long subsecondsOf(long nanos, int precision) {
-    return precision >= 9 ? nanos * pow10(precision - 9) : nanos / pow10(9 - precision);
-  }
-
-  private static long pow10(int exponent) {
-    long result = 1;
-    for (int i = 0; i < exponent; i++) {
-      result *= 10;
-    }
-    return result;
+    return precision >= 9
+        ? nanos * LongMath.pow(10, precision - 9)
+        : nanos / LongMath.pow(10, 9 - precision);
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -20,6 +20,8 @@ import io.substrait.isthmus.expression.ExpressionRexConverter;
 import io.substrait.isthmus.expression.LiteralConverter;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
+import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import io.substrait.isthmus.sql.SubstraitSqlToCalcite;
 import io.substrait.type.TypeCreator;
 import io.substrait.util.DecimalUtil;
 import java.math.BigDecimal;
@@ -31,6 +33,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -285,6 +289,33 @@ class CalciteLiteralTest extends CalciteObjs {
     assertEquals(
         ExpressionCreator.precisionTimestamp(false, -500, 3),
         atMilli.accept(rexExpressionConverter));
+  }
+
+  @Test
+  void tSqlTimestampLiteralKeepsTheWrittenPrecision() throws Exception {
+    // The behaviour the breaking-change note is about: a literal written without a fractional part
+    // is TIMESTAMP(0) on the Calcite side, so the plan Isthmus emits declares
+    // precision_timestamp<0>
+    // with a value in seconds rather than precision_timestamp<6> with a value in microseconds.
+    assertEquals(
+        ExpressionCreator.precisionTimestamp(false, 1704067200L, 0),
+        literalFromSql("TIMESTAMP '2024-01-01 00:00:00'"));
+    assertEquals(
+        ExpressionCreator.precisionTimestamp(false, 1704067200123L, 3),
+        literalFromSql("TIMESTAMP '2024-01-01 00:00:00.123'"));
+    assertEquals(
+        ExpressionCreator.precisionTime(false, 45045L, 0), literalFromSql("TIME '12:30:45'"));
+  }
+
+  private Expression.Literal literalFromSql(String expression) throws Exception {
+    RelRoot root =
+        SubstraitSqlToCalcite.convertQuery(
+            "SELECT " + expression + " FROM t",
+            SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+                "CREATE TABLE t (a INT)"),
+            ConverterProvider.DEFAULT);
+    RexNode projected = ((Project) root.project()).getProjects().get(0);
+    return new LiteralConverter(TypeConverter.DEFAULT).convert((RexLiteral) projected);
   }
 
   private static long timeValue(int precision) {

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -334,10 +334,9 @@ class CalciteLiteralTest extends CalciteObjs {
 
   @Test
   void tSqlTimestampLiteralKeepsTheWrittenPrecision() throws Exception {
-    // The behaviour the breaking-change note is about: a literal written without a fractional part
-    // is TIMESTAMP(0) on the Calcite side, so the plan Isthmus emits declares
-    // precision_timestamp<0>
-    // with a value in seconds rather than precision_timestamp<6> with a value in microseconds.
+    // A literal written without a fractional part is TIMESTAMP(0) on the Calcite side, so the
+    // plan Isthmus emits declares precision_timestamp<0> with a value in seconds rather than
+    // precision_timestamp<6> with a value in microseconds.
     assertEquals(
         ExpressionCreator.precisionTimestamp(false, 1704067200L, 0),
         literalFromSql("TIMESTAMP '2024-01-01 00:00:00'"));

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
@@ -238,7 +239,7 @@ class CalciteLiteralTest extends CalciteObjs {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {0, 3, 6})
+  @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
   void tPrecisionTimeKeepsItsPrecision(int precision) {
     Expression.PrecisionTimeLiteral time =
         ExpressionCreator.precisionTime(false, timeValue(precision), precision);
@@ -249,7 +250,7 @@ class CalciteLiteralTest extends CalciteObjs {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {0, 3, 6})
+  @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
   void tPrecisionTimestampKeepsItsPrecision(int precision) {
     PrecisionTimestampLiteral timestamp =
         ExpressionCreator.precisionTimestamp(false, timestampValue(precision), precision);
@@ -260,7 +261,7 @@ class CalciteLiteralTest extends CalciteObjs {
   }
 
   @ParameterizedTest
-  @ValueSource(ints = {0, 3, 6})
+  @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
   void tPrecisionTimestampTZStaysTimeZoned(int precision) {
     // Calcite has no dedicated timestamp-with-time-zone literal, but it does have the
     // TIMESTAMP_WITH_LOCAL_TIME_ZONE type that TypeConverter maps precision_timestamp_tz to, so a
@@ -273,6 +274,34 @@ class CalciteLiteralTest extends CalciteObjs {
     assertEquals(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, converted.getType().getSqlTypeName());
     assertEquals(precision, converted.getType().getPrecision());
     assertEquals(timestampTz, converted.accept(rexExpressionConverter));
+  }
+
+  @Test
+  void tTemporalLiteralAtASchemaTypeWithoutAPrecision() {
+    // visit(Values) converts each literal at the row type of the containing schema, and a type
+    // built from a Java class rather than a SQL type name -- how a reflective schema exposes a
+    // java.sql.Time column -- carries PRECISION_NOT_SPECIFIED. Read as a precision, that divides
+    // a TIME value by 10^10 and takes a TIMESTAMP into Guava's "exponent (-1) must be >= 0".
+    JavaTypeFactory javaTypeFactory = (JavaTypeFactory) type;
+    RelDataType javaTime = javaTypeFactory.createJavaType(java.sql.Time.class);
+    RelDataType javaTimestamp = javaTypeFactory.createJavaType(java.sql.Timestamp.class);
+    assertEquals(RelDataType.PRECISION_NOT_SPECIFIED, javaTime.getPrecision());
+
+    LiteralConverter literalConverter = new LiteralConverter(TypeConverter.DEFAULT);
+    assertEquals(
+        ExpressionCreator.precisionTime(true, 45045L, 0),
+        literalConverter.convert((RexLiteral) rex.makeLiteral(45_045_000, javaTime), javaTime));
+    assertEquals(
+        ExpressionCreator.precisionTimestamp(true, 1_704_067_200L, 0),
+        literalConverter.convert(
+            (RexLiteral) rex.makeLiteral(1_704_067_200_000L, javaTimestamp), javaTimestamp));
+
+    // The column type the literal sits in is read the same way, so the two agree.
+    assertEquals(
+        TypeCreator.NULLABLE.precisionTime(0), TypeConverter.DEFAULT.toSubstrait(javaTime));
+    assertEquals(
+        TypeCreator.NULLABLE.precisionTimestamp(0),
+        TypeConverter.DEFAULT.toSubstrait(javaTimestamp));
   }
 
   @Test
@@ -289,6 +318,18 @@ class CalciteLiteralTest extends CalciteObjs {
     assertEquals(
         ExpressionCreator.precisionTimestamp(false, -500, 3),
         atMilli.accept(rexExpressionConverter));
+
+    // Precision 1 is where the .5 survives RexBuilder's rounding and the two directions differ:
+    // truncating towards zero would give 0 here and read back as the epoch itself.
+    RexLiteral atTenth = rex.makeTimestampLiteral(new TimestampString("1969-12-31 23:59:59.5"), 1);
+    assertEquals(
+        ExpressionCreator.precisionTimestamp(false, -5, 1), atTenth.accept(rexExpressionConverter));
+    assertEquals(
+        new TimestampString("1969-12-31 23:59:59.5"),
+        ((RexLiteral)
+                ExpressionCreator.precisionTimestamp(false, -5, 1)
+                    .accept(expressionRexConverter, Context.newContext()))
+            .getValueAs(TimestampString.class));
   }
 
   @Test
@@ -305,6 +346,14 @@ class CalciteLiteralTest extends CalciteObjs {
         literalFromSql("TIMESTAMP '2024-01-01 00:00:00.123'"));
     assertEquals(
         ExpressionCreator.precisionTime(false, 45045L, 0), literalFromSql("TIME '12:30:45'"));
+
+    // The precision is not a multiple of three either: Calcite types the literal by the fractional
+    // digits written, and two of them is precision 2.
+    assertEquals(
+        ExpressionCreator.precisionTimestamp(false, 170406720012L, 2),
+        literalFromSql("TIMESTAMP '2024-01-01 00:00:00.12'"));
+    assertEquals(
+        ExpressionCreator.precisionTime(false, 450454L, 1), literalFromSql("TIME '12:30:45.4'"));
   }
 
   private Expression.Literal literalFromSql(String expression) throws Exception {
@@ -330,7 +379,8 @@ class CalciteLiteralTest extends CalciteObjs {
 
   /** 123 milliseconds expressed at the given precision, or none at all when there is no room. */
   private static long subseconds(int precision) {
-    return precision < 3 ? 0 : 123 * LongMath.pow(10, precision - 3);
+    // The first `precision` digits of .123456, so no precision is left with an empty fraction.
+    return 123_456L / LongMath.pow(10, 6 - precision);
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.math.LongMath;
 import io.substrait.expression.Expression;
 import io.substrait.expression.Expression.IntervalDayLiteral;
 import io.substrait.expression.Expression.IntervalYearLiteral;
@@ -270,27 +271,35 @@ class CalciteLiteralTest extends CalciteObjs {
     assertEquals(timestampTz, converted.accept(rexExpressionConverter));
   }
 
+  @Test
+  void tPrecisionTimestampBeforeTheEpochFloors() {
+    // Narrowing a pre-epoch timestamp moves it back in time, not towards the epoch: at second
+    // precision 1969-12-31 23:59:59.5 is 23:59:59, i.e. -1. The opposite of the interval case,
+    // where the value is a duration and narrowing shortens it.
+    RexLiteral atSecond = rex.makeTimestampLiteral(new TimestampString("1969-12-31 23:59:59.5"), 0);
+    assertEquals(
+        ExpressionCreator.precisionTimestamp(false, -1, 0),
+        atSecond.accept(rexExpressionConverter));
+
+    RexLiteral atMilli = rex.makeTimestampLiteral(new TimestampString("1969-12-31 23:59:59.5"), 3);
+    assertEquals(
+        ExpressionCreator.precisionTimestamp(false, -500, 3),
+        atMilli.accept(rexExpressionConverter));
+  }
+
   private static long timeValue(int precision) {
-    return (14L * 60 * 60 + 22 * 60 + 47) * pow10(precision) + subseconds(precision);
+    return (14L * 60 * 60 + 22 * 60 + 47) * LongMath.pow(10, precision) + subseconds(precision);
   }
 
   private static long timestampValue(int precision) {
     return LocalDateTime.of(2002, 2, 14, 16, 20, 47).toEpochSecond(ZoneOffset.UTC)
-            * pow10(precision)
+            * LongMath.pow(10, precision)
         + subseconds(precision);
   }
 
   /** 123 milliseconds expressed at the given precision, or none at all when there is no room. */
   private static long subseconds(int precision) {
-    return precision < 3 ? 0 : 123 * pow10(precision - 3);
-  }
-
-  private static long pow10(int exponent) {
-    long result = 1;
-    for (int i = 0; i < exponent; i++) {
-      result *= 10;
-    }
-    return result;
+    return precision < 3 ? 0 : 123 * LongMath.pow(10, precision - 3);
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteLiteralTest.java
@@ -39,10 +39,10 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class CalciteLiteralTest extends CalciteObjs {
   protected static final SimpleExtension.ExtensionCollection EXTENSION_COLLECTION =
@@ -232,12 +232,65 @@ class CalciteLiteralTest extends CalciteObjs {
     bitest(ts, rex.makeTimestampLiteral(tsx, 6));
   }
 
-  @Disabled("Not clear what the right literal mapping is.")
-  @Test
-  void tTimestampTZ() {
-    // Calcite has TimestampWithTimeZoneString but it doesn't appear to be available as a literal or
-    // data type.
-    // (Doesn't exist in SqlTypeName.)
+  @ParameterizedTest
+  @ValueSource(ints = {0, 3, 6})
+  void tPrecisionTimeKeepsItsPrecision(int precision) {
+    Expression.PrecisionTimeLiteral time =
+        ExpressionCreator.precisionTime(false, timeValue(precision), precision);
+
+    RexNode converted = time.accept(expressionRexConverter, Context.newContext());
+    assertEquals(precision, converted.getType().getPrecision());
+    assertEquals(time, converted.accept(rexExpressionConverter));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 3, 6})
+  void tPrecisionTimestampKeepsItsPrecision(int precision) {
+    PrecisionTimestampLiteral timestamp =
+        ExpressionCreator.precisionTimestamp(false, timestampValue(precision), precision);
+
+    RexNode converted = timestamp.accept(expressionRexConverter, Context.newContext());
+    assertEquals(precision, converted.getType().getPrecision());
+    assertEquals(timestamp, converted.accept(rexExpressionConverter));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 3, 6})
+  void tPrecisionTimestampTZStaysTimeZoned(int precision) {
+    // Calcite has no dedicated timestamp-with-time-zone literal, but it does have the
+    // TIMESTAMP_WITH_LOCAL_TIME_ZONE type that TypeConverter maps precision_timestamp_tz to, so a
+    // literal of that type is the mapping — and it must not come back as a plain
+    // precision_timestamp.
+    Expression.PrecisionTimestampTZLiteral timestampTz =
+        ExpressionCreator.precisionTimestampTZ(false, timestampValue(precision), precision);
+
+    RexNode converted = timestampTz.accept(expressionRexConverter, Context.newContext());
+    assertEquals(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, converted.getType().getSqlTypeName());
+    assertEquals(precision, converted.getType().getPrecision());
+    assertEquals(timestampTz, converted.accept(rexExpressionConverter));
+  }
+
+  private static long timeValue(int precision) {
+    return (14L * 60 * 60 + 22 * 60 + 47) * pow10(precision) + subseconds(precision);
+  }
+
+  private static long timestampValue(int precision) {
+    return LocalDateTime.of(2002, 2, 14, 16, 20, 47).toEpochSecond(ZoneOffset.UTC)
+            * pow10(precision)
+        + subseconds(precision);
+  }
+
+  /** 123 milliseconds expressed at the given precision, or none at all when there is no room. */
+  private static long subseconds(int precision) {
+    return precision < 3 ? 0 : 123 * pow10(precision - 3);
+  }
+
+  private static long pow10(int exponent) {
+    long result = 1;
+    for (int i = 0; i < exponent; i++) {
+      result *= 10;
+    }
+    return result;
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
@@ -142,8 +142,15 @@ class ExpressionConvertabilityTest extends PlanTestBase {
 
   @Test
   void supportedPrecisionForPrecisionTimestampLiteral() {
+    // Every precision up to the maximum SubstraitTypeSystem configures, not just the multiples of
+    // three: Calcite types a literal by the fractional digits written, so a two-digit one is
+    // precision 2.
     assertPrecisionTimestampLiteral(0);
+    assertPrecisionTimestampLiteral(1);
+    assertPrecisionTimestampLiteral(2);
     assertPrecisionTimestampLiteral(3);
+    assertPrecisionTimestampLiteral(4);
+    assertPrecisionTimestampLiteral(5);
     assertPrecisionTimestampLiteral(6);
   }
 
@@ -162,7 +169,11 @@ class ExpressionConvertabilityTest extends PlanTestBase {
     // The same set the non-TZ literal supports: SubstraitTypeSystem configures a maximum of 6 for
     // TIMESTAMP_WITH_LOCAL_TIME_ZONE, and the TZ literal is checked against that name too.
     assertPrecisionTimestampTZLiteral(0);
+    assertPrecisionTimestampTZLiteral(1);
+    assertPrecisionTimestampTZLiteral(2);
     assertPrecisionTimestampTZLiteral(3);
+    assertPrecisionTimestampTZLiteral(4);
+    assertPrecisionTimestampTZLiteral(5);
     assertPrecisionTimestampTZLiteral(6);
   }
 
@@ -180,11 +191,6 @@ class ExpressionConvertabilityTest extends PlanTestBase {
   void unsupportedPrecisionForPrecisionTimestampLiteral() {
     // test different edge case precision values
     assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(-1);
-    assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(1);
-    assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(2);
-
-    assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(4);
-    assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(5);
 
     assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(7);
     assertThrowsUnsupportedPrecisionPrecisionTimestampLiteral(8);
@@ -211,11 +217,6 @@ class ExpressionConvertabilityTest extends PlanTestBase {
   void unsupportedPrecisionPrecisionTimestampTZLiteral() {
     // test different edge case precision values
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(-1);
-    assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(1);
-    assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(2);
-
-    assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(4);
-    assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(5);
 
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(7);
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(8);

--- a/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ExpressionConvertabilityTest.java
@@ -159,8 +159,11 @@ class ExpressionConvertabilityTest extends PlanTestBase {
 
   @Test
   void supportedPrecisionForPrecisionTimestampTZLiteral() {
+    // The same set the non-TZ literal supports: SubstraitTypeSystem configures a maximum of 6 for
+    // TIMESTAMP_WITH_LOCAL_TIME_ZONE, and the TZ literal is checked against that name too.
     assertPrecisionTimestampTZLiteral(0);
     assertPrecisionTimestampTZLiteral(3);
+    assertPrecisionTimestampTZLiteral(6);
   }
 
   void assertPrecisionTimestampTZLiteral(int precision) {
@@ -213,7 +216,7 @@ class ExpressionConvertabilityTest extends PlanTestBase {
 
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(4);
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(5);
-    assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(6);
+
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(7);
     assertThrowsUnsupportedPrecisionPrecisionTimestampTZLiteral(8);
 


### PR DESCRIPTION
`LiteralConverter.convert` computes the Substrait type of the literal it is handed on its first line, then does not use it in the temporal cases. `TIME` and `TIMESTAMP` were reported at a fixed precision 6 with the value rescaled to microseconds, and `TIMESTAMP_WITH_LOCAL_TIME_ZONE` shared the `TIMESTAMP` branch and came back as a plain `precision_timestamp`. `TypeConverter.toSubstrait` maps those same Calcite types to `precision_time<P>`, `precision_timestamp<P>` and `precision_timestamp_tz<P>`, so the two halves of one conversion disagreed about the same literal.

That is not only a round trip losing the producer's choice — SQL literals carry their own precision, so it is what Isthmus emits:

```
TIMESTAMP '2024-01-01 00:00:00'      -> Calcite TIMESTAMP(0) -> precision_timestamp<6>
TIME '12:30:45'                      -> Calcite TIME(0)      -> precision_time<6>
```

Take the precision from the result type and express the value at it, and route `TIMESTAMP_WITH_LOCAL_TIME_ZONE` to `precisionTimestampTZ`. At precision 6 the arithmetic is unchanged; other precisions round-trip instead of being widened.

In the other direction, the maximum-precision check for a `precision_timestamp_tz` literal looked up `SqlTypeName.TIMESTAMP_TZ`. `SubstraitTypeSystem` does not configure that name — it overrides `TIMESTAMP_WITH_LOCAL_TIME_ZONE` — so the lookup fell through to Calcite's default of 3 and rejected a microsecond TZ literal, while the corresponding *type* conversion accepted it. It now checks the name everything else TZ-related uses.

Emitting the declared precision only works if the reverse direction takes it back, and it did not: `getTimestampString` and `createTimeString` handled 0, 3, 6 and 9 and threw for everything else, so `TIMESTAMP '2024-01-01 00:00:00.12'` — precision 2, from the fractional digits written — produced a plan Isthmus could not read. `algebra.proto` documents what 0, 3, 6, 9 and 12 mean and leaves the field an unbounded `int32`, so the unit is now 10^-precision at any precision a `TimeString` or `TimestampString` carries. Precisions 1, 2, 4 and 5 were listed in `ExpressionConvertabilityTest` as unsupported for both timestamp literals; they moved to the supported side.

Two smaller things. A temporal type built from a Java class rather than a SQL type name carries `PRECISION_NOT_SPECIFIED`, which nothing read: a `java.sql.Time` field of a reflective schema became `precision_time<-1>` with the value divided by 10^10, and the timestamp side failed inside Guava. Both the type and the literal now read the sentinel as precision 0, the way Calcite's own `RexBuilder.clean` does. And the precision check, written out six times and identical apart from a `SqlTypeName` and a hand-typed noun, is now `SubstraitTypeSystem.requireSupportedPrecision` — a static, since `TypeConverter` and `ExpressionRexConverter` have no common ancestor to hang an instance method on.

Closes #1113. Finishes #1114, whose interval third is in #1120.

BREAKING CHANGE: a Calcite `TIME` or `TIMESTAMP` literal now converts to a Substrait literal carrying its own precision rather than always precision 6, so a plan built from `TIMESTAMP '2024-01-01 00:00:00'` declares `precision_timestamp<0>` with a value in seconds where it previously declared `precision_timestamp<6>` with a value in microseconds. A `TIMESTAMP WITH LOCAL TIME ZONE` literal converts to `precision_timestamp_tz` instead of `precision_timestamp`.

