### PR TITLE
fix(spark): accept Substrait precisions coarser than microseconds

### DIFF
--- a/core/src/test/java/io/substrait/dialect/SparkDialectParseTest.java
+++ b/core/src/test/java/io/substrait/dialect/SparkDialectParseTest.java
@@ -46,7 +46,7 @@ class SparkDialectParseTest {
             .filter(t -> t.type() == TypeKind.PRECISION_TIMESTAMP)
             .findFirst()
             .orElseThrow();
-    assertEquals(9, precisionTimestamp.maxPrecision().orElse(-1));
+    assertEquals(6, precisionTimestamp.maxPrecision().orElse(-1));
   }
 
   @Test

--- a/spark/spark_dialect.yaml
+++ b/spark/spark_dialect.yaml
@@ -57,17 +57,17 @@ supported_types:
   system_metadata:
     name: "TimestampNTZType"
     supported_as_column: true
-  max_precision: 9
+  max_precision: 6
 - type: "PRECISION_TIMESTAMP_TZ"
   system_metadata:
     name: "TimestampType"
     supported_as_column: true
-  max_precision: 9
+  max_precision: 6
 - type: "INTERVAL_DAY"
   system_metadata:
     name: "DayTimeIntervalType"
     supported_as_column: true
-  max_precision: 9
+  max_precision: 6
 - type: "INTERVAL_YEAR"
   system_metadata:
     name: "YearMonthIntervalType"

--- a/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
+++ b/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
@@ -60,16 +60,18 @@ private class ToSparkType(dfsNames: Seq[String])
   override def visit(expr: Type.Bool): BooleanType = BooleanType
 
   override def visit(expr: Type.PrecisionTimestamp): TimestampNTZType = {
-    Util.assertMicroseconds(expr.precision())
+    // Spark has one timestamp type, stored as microseconds. A coarser Substrait precision maps
+    // onto it without loss; the literal converter scales the value.
+    Util.assertRepresentableAsMicroseconds(expr.precision())
     TimestampNTZType
   }
   override def visit(expr: Type.PrecisionTimestampTZ): TimestampType = {
-    Util.assertMicroseconds(expr.precision())
+    Util.assertRepresentableAsMicroseconds(expr.precision())
     TimestampType
   }
 
   override def visit(expr: Type.IntervalDay): DayTimeIntervalType = {
-    Util.assertMicroseconds(expr.precision())
+    Util.assertRepresentableAsMicroseconds(expr.precision())
     DayTimeIntervalType.DEFAULT
   }
 

--- a/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
+++ b/spark/src/main/scala/io/substrait/spark/ToSubstraitType.scala
@@ -59,19 +59,21 @@ private class ToSparkType(dfsNames: Seq[String])
 
   override def visit(expr: Type.Bool): BooleanType = BooleanType
 
+  // These three keep rejecting anything but microsecond precision. Spark's types carry no
+  // precision of their own, so mapping a coarser one onto them would silently reinterpret the
+  // values it describes — a column of millisecond counts read as microsecond counts. The literal
+  // conversions rescale instead, which they can do because they hold the value.
   override def visit(expr: Type.PrecisionTimestamp): TimestampNTZType = {
-    // Spark has one timestamp type, stored as microseconds. A coarser Substrait precision maps
-    // onto it without loss; the literal converter scales the value.
-    Util.assertRepresentableAsMicroseconds(expr.precision())
+    Util.assertMicroseconds(expr.precision())
     TimestampNTZType
   }
   override def visit(expr: Type.PrecisionTimestampTZ): TimestampType = {
-    Util.assertRepresentableAsMicroseconds(expr.precision())
+    Util.assertMicroseconds(expr.precision())
     TimestampType
   }
 
   override def visit(expr: Type.IntervalDay): DayTimeIntervalType = {
-    Util.assertRepresentableAsMicroseconds(expr.precision())
+    Util.assertMicroseconds(expr.precision())
     DayTimeIntervalType.DEFAULT
   }
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -111,26 +111,23 @@ class ToSparkExpression(
       expr: SExpression.PrecisionTimestampLiteral,
       context: EmptyVisitationContext): Literal = {
     // Spark timestamps are stored as a microseconds Long
-    Util.assertMicroseconds(expr.precision())
-    Literal(expr.value(), ToSparkType.convert(expr.getType))
+    Literal(Util.toMicroseconds(expr.value(), expr.precision()), ToSparkType.convert(expr.getType))
   }
 
   override def visit(
       expr: SExpression.PrecisionTimestampTZLiteral,
       context: EmptyVisitationContext): Literal = {
     // Spark timestamps are stored as a microseconds Long
-    Util.assertMicroseconds(expr.precision())
-    Literal(expr.value(), ToSparkType.convert(expr.getType))
+    Literal(Util.toMicroseconds(expr.value(), expr.precision()), ToSparkType.convert(expr.getType))
   }
 
   override def visit(
       expr: SExpression.IntervalDayLiteral,
       context: EmptyVisitationContext): Literal = {
-    Util.assertMicroseconds(expr.precision())
     // Spark uses a single microseconds Long as the "physical" type for DayTimeInterval
     val micros =
       (expr.days() * Util.SECONDS_PER_DAY + expr.seconds()) * Util.MICROS_PER_SECOND +
-        expr.subseconds()
+        Util.toMicroseconds(expr.subseconds(), expr.precision())
     Literal(micros, ToSparkType.convert(expr.getType))
   }
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -107,28 +107,42 @@ class ToSparkExpression(
     Literal(expr.value(), ToSparkType.convert(expr.getType))
   }
 
+  // The three temporal literals below rescale their value into microseconds and land in the
+  // microsecond type, rather than converting the type they declare. ToSparkType rejects any other
+  // precision, because a Spark type carries none of its own and a type conversion has no value to
+  // rescale; here the value is in hand, so a coarser precision converts without loss.
   override def visit(
       expr: SExpression.PrecisionTimestampLiteral,
       context: EmptyVisitationContext): Literal = {
-    // Spark timestamps are stored as a microseconds Long
-    Literal(Util.toMicroseconds(expr.value(), expr.precision()), ToSparkType.convert(expr.getType))
+    val creator = Type.withNullability(expr.nullable())
+    Literal(
+      Util.toMicroseconds(expr.value(), expr.precision()),
+      ToSparkType.convert(creator.precisionTimestamp(Util.MICROSECOND_PRECISION)))
   }
 
   override def visit(
       expr: SExpression.PrecisionTimestampTZLiteral,
       context: EmptyVisitationContext): Literal = {
-    // Spark timestamps are stored as a microseconds Long
-    Literal(Util.toMicroseconds(expr.value(), expr.precision()), ToSparkType.convert(expr.getType))
+    val creator = Type.withNullability(expr.nullable())
+    Literal(
+      Util.toMicroseconds(expr.value(), expr.precision()),
+      ToSparkType.convert(creator.precisionTimestampTZ(Util.MICROSECOND_PRECISION)))
   }
 
   override def visit(
       expr: SExpression.IntervalDayLiteral,
       context: EmptyVisitationContext): Literal = {
     // Spark uses a single microseconds Long as the "physical" type for DayTimeInterval
+    val seconds =
+      Math.addExact(
+        Math.multiplyExact(expr.days().toLong, Util.SECONDS_PER_DAY),
+        expr.seconds().toLong)
     val micros =
-      (expr.days() * Util.SECONDS_PER_DAY + expr.seconds()) * Util.MICROS_PER_SECOND +
-        Util.toMicroseconds(expr.subseconds(), expr.precision())
-    Literal(micros, ToSparkType.convert(expr.getType))
+      Math.addExact(
+        Math.multiplyExact(seconds, Util.MICROS_PER_SECOND),
+        Util.toMicroseconds(expr.subseconds(), expr.precision()))
+    val creator = Type.withNullability(expr.nullable())
+    Literal(micros, ToSparkType.convert(creator.intervalDay(Util.MICROSECOND_PRECISION)))
   }
 
   override def visit(

--- a/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
@@ -129,18 +129,21 @@ class DialectGenerator {
       SupportedType("FIXED_CHAR", TypeMetadata("StringType", true)),
       SupportedType("BINARY", TypeMetadata("BinaryType", true)),
       SupportedType("BOOL", TypeMetadata("BooleanType", true)),
+      // Spark stores these as microseconds and carries no precision on the type itself, so the
+      // maximum it supports is the microsecond one. Reading this from Util keeps the declaration
+      // and the conversion guard from drifting apart.
       SupportedType(
         "PRECISION_TIMESTAMP",
         TypeMetadata("TimestampNTZType", true),
-        max_precision = Some(9)),
+        max_precision = Some(Util.MICROSECOND_PRECISION)),
       SupportedType(
         "PRECISION_TIMESTAMP_TZ",
         TypeMetadata("TimestampType", true),
-        max_precision = Some(9)),
+        max_precision = Some(Util.MICROSECOND_PRECISION)),
       SupportedType(
         "INTERVAL_DAY",
         TypeMetadata("DayTimeIntervalType", true),
-        max_precision = Some(9)),
+        max_precision = Some(Util.MICROSECOND_PRECISION)),
       SupportedType("INTERVAL_YEAR", TypeMetadata("YearMonthIntervalType", true)),
       SupportedType("LIST", TypeMetadata("ArrayType", true)),
       SupportedType("MAP", TypeMetadata("MapType", true)),

--- a/spark/src/main/scala/io/substrait/spark/utils/Util.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/Util.scala
@@ -25,12 +25,38 @@ object Util {
   val MICROS_PER_SECOND: Long = 1000 * 1000
   val MICROSECOND_PRECISION = 6 // for PrecisionTimestamp(TZ) and IntervalDay types
 
-  def assertMicroseconds(precision: Int): Unit = {
-    // Spark uses microseconds as a Long value as the "physical" type for most time things
-    if (precision != MICROSECOND_PRECISION) {
+  /**
+   * Checks that a Substrait fractional-second precision is one Spark's microsecond representation
+   * can hold. Coarser precisions carry fewer digits, not different ones, so they fit.
+   */
+  def assertRepresentableAsMicroseconds(precision: Int): Unit = {
+    if (precision < 0 || precision > MICROSECOND_PRECISION) {
       throw new UnsupportedOperationException(
-        s"Unsupported precision: $precision. Only microsecond precision ($MICROSECOND_PRECISION) is supported")
+        s"Unsupported precision: $precision. Spark stores time values as microseconds " +
+          s"($MICROSECOND_PRECISION), which cannot represent a finer precision")
     }
+  }
+
+  /**
+   * Rescales a sub-second value from the given Substrait precision to the microseconds Spark uses
+   * as its physical representation.
+   *
+   * A precision coarser than microseconds carries fewer digits, not different ones, so the value
+   * is exact after scaling. A finer one does not fit and is rejected rather than rounded.
+   */
+  def toMicroseconds(value: Long, precision: Int): Long = {
+    assertRepresentableAsMicroseconds(precision)
+    value * powerOfTen(MICROSECOND_PRECISION - precision)
+  }
+
+  private def powerOfTen(exponent: Int): Long = {
+    var result = 1L
+    var i = 0
+    while (i < exponent) {
+      result *= 10
+      i += 1
+    }
+    result
   }
 
   /**

--- a/spark/src/main/scala/io/substrait/spark/utils/Util.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/Util.scala
@@ -25,15 +25,24 @@ object Util {
   val MICROS_PER_SECOND: Long = 1000 * 1000
   val MICROSECOND_PRECISION = 6 // for PrecisionTimestamp(TZ) and IntervalDay types
 
+  /** Indexed by exponent, which [[toMicroseconds]] bounds to 0..MICROSECOND_PRECISION. */
+  private val POWERS_OF_TEN: Array[Long] =
+    Array(1L, 10L, 100L, 1000L, 10000L, 100000L, 1000000L)
+
   /**
-   * Checks that a Substrait fractional-second precision is one Spark's microsecond representation
-   * can hold. Coarser precisions carry fewer digits, not different ones, so they fit.
+   * Checks that a Substrait fractional-second precision is one a Spark type can carry.
+   *
+   * Spark has a single microsecond-based representation for each of these types, so the precision
+   * has to be exactly microseconds. A coarser one describes values in different units, and a type
+   * conversion has no values in hand to rescale — see [[toMicroseconds]], which is what the literal
+   * conversions use where a value is available.
    */
-  def assertRepresentableAsMicroseconds(precision: Int): Unit = {
-    if (precision < 0 || precision > MICROSECOND_PRECISION) {
+  def assertMicroseconds(precision: Int): Unit = {
+    if (precision != MICROSECOND_PRECISION) {
       throw new UnsupportedOperationException(
-        s"Unsupported precision: $precision. Spark stores time values as microseconds " +
-          s"($MICROSECOND_PRECISION), which cannot represent a finer precision")
+        s"Unsupported precision: $precision. Spark stores time values as microseconds, so a type " +
+          s"must declare a precision of exactly $MICROSECOND_PRECISION; a value at a coarser " +
+          s"precision is converted by rescaling it")
     }
   }
 
@@ -41,22 +50,16 @@ object Util {
    * Rescales a sub-second value from the given Substrait precision to the microseconds Spark uses
    * as its physical representation.
    *
-   * A precision coarser than microseconds carries fewer digits, not different ones, so the value
-   * is exact after scaling. A finer one does not fit and is rejected rather than rounded.
+   * A precision coarser than microseconds carries fewer digits, not different ones, so the value is
+   * exact after scaling. A finer one does not fit and is rejected rather than rounded.
    */
   def toMicroseconds(value: Long, precision: Int): Long = {
-    assertRepresentableAsMicroseconds(precision)
-    value * powerOfTen(MICROSECOND_PRECISION - precision)
-  }
-
-  private def powerOfTen(exponent: Int): Long = {
-    var result = 1L
-    var i = 0
-    while (i < exponent) {
-      result *= 10
-      i += 1
+    if (precision < 0 || precision > MICROSECOND_PRECISION) {
+      throw new UnsupportedOperationException(
+        s"Unsupported precision: $precision. Spark stores time values as microseconds, " +
+          s"so the precision must be between 0 and $MICROSECOND_PRECISION")
     }
-    result
+    Math.multiplyExact(value, POWERS_OF_TEN(MICROSECOND_PRECISION - precision))
   }
 
   /**

--- a/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
@@ -1,6 +1,7 @@
 package io.substrait.spark
 
 import io.substrait.spark.expression.{ToSparkExpression, ToSubstraitLiteral}
+import io.substrait.spark.utils.Util
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
@@ -10,9 +11,8 @@ import org.apache.spark.sql.types._
 import org.apache.spark.substrait.SparkTypeUtil
 import org.apache.spark.unsafe.types.UTF8String
 
-import io.substrait.expression.ExpressionCreator
-import io.substrait.spark.utils.Util
 import io.substrait.`type`.TypeCreator
+import io.substrait.expression.{Expression => SExpression, ExpressionCreator}
 import io.substrait.util.EmptyVisitationContext
 
 import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period}
@@ -241,50 +241,88 @@ class TypesAndLiteralsSuite extends SparkFunSuite {
         .sameElements(originalValues))
   }
 
-  test("coarser Substrait precisions convert to Spark microseconds") {
-    // Spark has one microsecond-based representation, so a coarser precision fits it without loss.
-    // The value has to be scaled to microseconds: taken verbatim it would be wrong by that factor.
-    val cases = Seq(
-      (0, 1L, 1000000L),
-      (3, 1500L, 1500000L),
-      (6, 1500000L, 1500000L)
-    )
-    cases.foreach {
-      case (precision, value, expectedMicros) =>
-        val timestamp = ExpressionCreator.precisionTimestamp(false, value, precision)
-        assert(
-          timestamp
-            .accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
-            .asInstanceOf[Literal]
-            .value === expectedMicros)
+  private def sparkLiteral(literal: SExpression.Literal): Literal =
+    literal.accept(toSparkExpression, EmptyVisitationContext.INSTANCE).asInstanceOf[Literal]
 
-        val timestampTz = ExpressionCreator.precisionTimestampTZ(false, value, precision)
-        assert(
-          timestampTz
-            .accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
-            .asInstanceOf[Literal]
-            .value === expectedMicros)
-    }
-
-    // The interval carries its sub-second part separately, so only that part is scaled.
-    val interval = ExpressionCreator.intervalDay(false, 1, 2, 500, 3)
+  private def rejects(precision: Int)(convert: => Any): Unit =
     assert(
-      interval
-        .accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
-        .asInstanceOf[Literal]
-        .value === (Util.SECONDS_PER_DAY + 2) * Util.MICROS_PER_SECOND + 500000L)
+      intercept[UnsupportedOperationException](convert).getMessage
+        .contains(s"Unsupported precision: $precision"))
+
+  test("a temporal literal coarser than microseconds is rescaled") {
+    // Spark has one microsecond-based representation per type, so a coarser precision fits without
+    // loss — but only once the value is scaled. Taken verbatim it is wrong by exactly that factor.
+    Seq((0, 1L, 1000000L), (1, 15L, 1500000L), (3, 1500L, 1500000L), (6, 1500000L, 1500000L))
+      .foreach {
+        case (precision, value, micros) =>
+          val ntz = sparkLiteral(ExpressionCreator.precisionTimestamp(false, value, precision))
+          assert(ntz.value === micros)
+          assert(ntz.dataType === TimestampNTZType)
+
+          val tz = sparkLiteral(ExpressionCreator.precisionTimestampTZ(false, value, precision))
+          assert(tz.value === micros)
+          assert(tz.dataType === TimestampType)
+      }
   }
 
-  test("a precision finer than microseconds is still rejected") {
-    val nanos = ExpressionCreator.precisionTimestamp(false, 1L, 9)
-    val e = intercept[UnsupportedOperationException] {
-      nanos.accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
+  test("an interval literal scales only its sub-second part") {
+    // days and seconds are whole units whatever the precision; only subseconds is expressed in
+    // 1e(-P) units, so it is the one field that moves.
+    Seq((0, 0L, 0L), (1, 5L, 500000L), (3, 500L, 500000L), (6, 500000L, 500000L)).foreach {
+      case (precision, subseconds, micros) =>
+        val interval =
+          sparkLiteral(ExpressionCreator.intervalDay(false, 1, 2, subseconds, precision))
+        assert(interval.value === (Util.SECONDS_PER_DAY + 2) * Util.MICROS_PER_SECOND + micros)
+        assert(interval.dataType === DayTimeIntervalType.DEFAULT)
     }
-    assert(e.getMessage.contains("Unsupported precision: 9"))
+  }
 
-    val nanoType = intercept[UnsupportedOperationException] {
-      ToSparkType.convert(TypeCreator.REQUIRED.precisionTimestamp(9))
-    }
-    assert(nanoType.getMessage.contains("Unsupported precision: 9"))
+  test("a precision finer than microseconds is rejected for every carrier") {
+    rejects(9)(sparkLiteral(ExpressionCreator.precisionTimestamp(false, 1L, 9)))
+    rejects(9)(sparkLiteral(ExpressionCreator.precisionTimestampTZ(false, 1L, 9)))
+    rejects(9)(sparkLiteral(ExpressionCreator.intervalDay(false, 0, 0, 1L, 9)))
+
+    rejects(9)(ToSparkType.convert(TypeCreator.REQUIRED.precisionTimestamp(9)))
+    rejects(9)(ToSparkType.convert(TypeCreator.REQUIRED.precisionTimestampTZ(9)))
+    rejects(9)(ToSparkType.convert(TypeCreator.REQUIRED.intervalDay(9)))
+  }
+
+  test("a negative precision is rejected, naming the range rather than one end of it") {
+    // Reachable from the wire: the literal's precision is a plain int32 in algebra.proto and core
+    // does not bound it, so the message has to cover both directions of the range.
+    val e = intercept[UnsupportedOperationException](Util.toMicroseconds(1L, -1))
+    assert(e.getMessage.contains("Unsupported precision: -1"))
+    assert(e.getMessage.contains("between 0 and 6"))
+  }
+
+  test("rescaling reports overflow instead of wrapping") {
+    // The scaling multiply is not reachable from any instant Spark can represent, but a sentinel
+    // value wraps into a plausible one: Long.MaxValue at precision 0 used to come out as
+    // -1000000, one second before the epoch.
+    intercept[ArithmeticException](Util.toMicroseconds(Long.MaxValue, 0))
+    intercept[ArithmeticException](Util.toMicroseconds(Long.MinValue, 0))
+
+    // The same for the interval, whose day count is a whole-unit multiply of its own.
+    intercept[ArithmeticException](
+      sparkLiteral(ExpressionCreator.intervalDay(false, Int.MaxValue, 0, 0L, 6)))
+  }
+
+  test("a coarser precision on a type is rejected, since a type has no value to rescale") {
+    // A Spark type carries no precision of its own, so mapping precision_timestamp<3> onto
+    // TimestampNTZType would reinterpret millisecond counts as microsecond ones. Only the literal
+    // conversions relax this, because only they hold a value.
+    rejects(3)(ToSparkType.convert(TypeCreator.REQUIRED.precisionTimestamp(3)))
+    rejects(3)(ToSparkType.convert(TypeCreator.REQUIRED.precisionTimestampTZ(3)))
+    rejects(3)(ToSparkType.convert(TypeCreator.REQUIRED.intervalDay(3)))
+
+    // The path that makes this matter: a cast to a coarser precision becomes a cast between two
+    // TimestampNTZTypes, which truncates nothing, so the value would keep its finer resolution.
+    val cast = SExpression.Cast
+      .builder()
+      .input(ExpressionCreator.precisionTimestamp(false, 1234567L, 6))
+      .`type`(TypeCreator.REQUIRED.precisionTimestamp(3))
+      .failureBehavior(SExpression.FailureBehavior.THROW_EXCEPTION)
+      .build()
+    rejects(3)(cast.accept(toSparkExpression, EmptyVisitationContext.INSTANCE))
   }
 }

--- a/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
@@ -10,6 +10,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.substrait.SparkTypeUtil
 import org.apache.spark.unsafe.types.UTF8String
 
+import io.substrait.expression.ExpressionCreator
+import io.substrait.spark.utils.Util
+import io.substrait.`type`.TypeCreator
 import io.substrait.util.EmptyVisitationContext
 
 import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period}
@@ -236,5 +239,52 @@ class TypesAndLiteralsSuite extends SparkFunSuite {
         .toArray[Integer](IntegerType)
         .sorted
         .sameElements(originalValues))
+  }
+
+  test("coarser Substrait precisions convert to Spark microseconds") {
+    // Spark has one microsecond-based representation, so a coarser precision fits it without loss.
+    // The value has to be scaled to microseconds: taken verbatim it would be wrong by that factor.
+    val cases = Seq(
+      (0, 1L, 1000000L),
+      (3, 1500L, 1500000L),
+      (6, 1500000L, 1500000L)
+    )
+    cases.foreach {
+      case (precision, value, expectedMicros) =>
+        val timestamp = ExpressionCreator.precisionTimestamp(false, value, precision)
+        assert(
+          timestamp
+            .accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
+            .asInstanceOf[Literal]
+            .value === expectedMicros)
+
+        val timestampTz = ExpressionCreator.precisionTimestampTZ(false, value, precision)
+        assert(
+          timestampTz
+            .accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
+            .asInstanceOf[Literal]
+            .value === expectedMicros)
+    }
+
+    // The interval carries its sub-second part separately, so only that part is scaled.
+    val interval = ExpressionCreator.intervalDay(false, 1, 2, 500, 3)
+    assert(
+      interval
+        .accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
+        .asInstanceOf[Literal]
+        .value === (Util.SECONDS_PER_DAY + 2) * Util.MICROS_PER_SECOND + 500000L)
+  }
+
+  test("a precision finer than microseconds is still rejected") {
+    val nanos = ExpressionCreator.precisionTimestamp(false, 1L, 9)
+    val e = intercept[UnsupportedOperationException] {
+      nanos.accept(toSparkExpression, EmptyVisitationContext.INSTANCE)
+    }
+    assert(e.getMessage.contains("Unsupported precision: 9"))
+
+    val nanoType = intercept[UnsupportedOperationException] {
+      ToSparkType.convert(TypeCreator.REQUIRED.precisionTimestamp(9))
+    }
+    assert(nanoType.getMessage.contains("Unsupported precision: 9"))
   }
 }


### PR DESCRIPTION
Spark stores timestamps and day-time intervals as a microseconds `Long`, and `Util.assertMicroseconds` refused any Substrait precision but 6. So a plan carrying `interval_day<3>` or `precision_timestamp<0>` did not convert to Spark at all, even though a coarser precision carries fewer digits than microseconds, not different ones, and fits that representation exactly.

The fix is a rescale rather than a relaxed guard, and it applies only where a value is in hand. `Util.toMicroseconds` scales a coarse value into microseconds and the three temporal literal conversions use it; the type conversions keep requiring exactly microseconds.

That split is the whole point. A Spark type carries no precision of its own, so mapping `precision_timestamp<3>` onto `TimestampNTZType` says nothing about the millisecond counts it describes, and a type conversion has no value at hand to rescale — a cast to a coarser precision becomes a cast between two `TimestampNTZType`s and truncates nothing, and a column declared at one has its data read as microseconds. Both previously failed loudly on the exact-6 check and still do. What changes is that a literal, which does carry its value, converts.

So this covers the literal half of #1125 and leaves the column half where it was: a plan whose *column* is `precision_timestamp<3>` is still rejected. Making that work means rescaling data rather than mapping a type — a normalization pass over the plan — which is worth deciding on deliberately rather than acquiring as a side effect here. The `Closes` keyword is off this description for that reason.

A precision finer than microseconds is still rejected everywhere: it does not fit, and rounding it would be the silent kind of loss this is avoiding.

The reverse direction needs nothing, and the asymmetry mostly closes on its own: a coarse precision now enters only on a literal, is rescaled there, and leaves as 6, which is lossless; a column type at a coarse precision does not enter at all, so nothing widens.

Two things came along that are not strictly the fix:

- The rescale multiplies, so it uses `Math.multiplyExact`, and the interval literal's `days * 86400 * 1e6` does too. Neither overflows within the spec's ranges, but `Long.MAX_VALUE` at precision 0 used to wrap to `-1000000` — one second before the epoch — rather than fail.
- `DialectGenerator` declared `max_precision = 9` for `PRECISION_TIMESTAMP`, `PRECISION_TIMESTAMP_TZ` and `INTERVAL_DAY`, which was already wrong before this PR, since the guard has always required 6. It reads `Util.MICROSECOND_PRECISION` now, and `spark_dialect.yaml` is regenerated. `core`'s `SparkDialectParseTest` pins that number off the copied file, so it moves with it.

Part of #1125. Found by @nielspardon while reviewing #1120.
