### PR TITLE
build(spark): enforce scalafmt on the shared Scala source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,8 +165,11 @@ CI runs, and a `:core` change can break the visitor implementors in the other mo
   change that compiles on one variant can still break another. Compiling only
   `:spark:spark-3.5_2.12` misses 2.13 breaks — also run
   `./gradlew :spark:spark-4.0_2.13:compileScala`, or build all three with `:spark:build`.
-- Formatting is done by the **parent** `:spark` project (`./gradlew :spark:spotlessApply`);
-  spotless is disabled in the variant subprojects.
+- Formatting is done by the **parent** `:spark` project (`./gradlew :spark:spotlessApply`) —
+  scalafmt against `spark/.scalafmt.conf`, with an explicit `src/**/*.scala` target because that
+  project has no Scala source set of its own. Enforcement lives there too: `:spark:spotlessCheck`
+  fails the build on drift. The variant subprojects set `isEnforceCheck = false` precisely so the
+  shared source isn't formatted three times over — don't add a Scala step to them.
 
 ## Testing conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,14 +60,17 @@ Keep that footer **last, with nothing after it** — below the rationale and bel
 Changes must adhere to the style guide and this will be verified by the continuous integration build.
 
 * Java code style is [Google style](https://google.github.io/styleguide/javaguide.html).
+* Scala code style is defined by [`spark/.scalafmt.conf`](spark/.scalafmt.conf).
 
-Java code style is checked by [Spotless](https://github.com/diffplug/spotless)
-with [google-java-format](https://github.com/google/google-java-format) during the build.
+Both are checked by [Spotless](https://github.com/diffplug/spotless) during the build —
+Java with [google-java-format](https://github.com/google/google-java-format), Scala with
+[scalafmt](https://scalameta.org/scalafmt/). The Scala step is configured on the parent
+`:spark` project, because the Scala source is shared by the variant subprojects rather than
+owned by any one of them.
 
 ### Automatically fixing code style issues
 
-Java code style issues can be fixed from the command line using
-`./gradlew spotlessApply`.
+Code style issues can be fixed from the command line using `./gradlew spotlessApply`.
 
 ### Configuring the Code Formatter for Intellij IDEA and Eclipse
 
@@ -107,7 +110,8 @@ high-level build and the native-image executable. Useful narrower tasks while it
   (see [Gradle & JDK 17](#gradle--jdk-17)).
 * **Spark variants:** the Scala source is shared across `spark-3.4_2.12`, `spark-3.5_2.12`, and
   `spark-4.0_2.13`; `./gradlew :spark:build` builds all three, or compile one with
-  `./gradlew :spark:spark-3.5_2.12:compileScala`. Formatting runs from the parent `:spark`.
+  `./gradlew :spark:spark-3.5_2.12:compileScala`. Formatting runs from the parent `:spark`
+  (`./gradlew :spark:spotlessApply`), not from the variants.
 
 Some checks are **not** wired into `compileJava` / `test`, so they can pass locally yet fail
 CI — build the whole thing before pushing:

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -3,6 +3,22 @@
 
 plugins {
   id("base") // Provides lifecycle tasks like clean, build, assemble
+  alias(libs.plugins.spotless)
+}
+
+// The Scala source lives here (spark/src) and is compiled by each variant subproject against a
+// different Spark/Scala version, so it is formatted once here rather than three times over -- which
+// is why the variants set `isEnforceCheck = false`. An explicit target is required because this
+// project has no Scala source set of its own to infer one from; it covers both the shared
+// src/{main,test}/scala trees and the per-version src/*/spark-<major.minor> overlays.
+spotless {
+  scala {
+    target("src/**/*.scala")
+    // Keep this version in step with the `version` recorded in .scalafmt.conf, which is what
+    // IntelliJ's scalafmt integration reads.
+    scalafmt("3.8.1").configFile(".scalafmt.conf")
+    toggleOffOn()
+  }
 }
 
 // Aggregate task to build all variants
@@ -12,7 +28,7 @@ tasks.register("buildAllVariants") {
   dependsOn(
     ":spark:spark-3.4_2.12:build",
     ":spark:spark-3.5_2.12:build",
-    ":spark:spark-4.0_2.13:build"
+    ":spark:spark-4.0_2.13:build",
   )
 }
 
@@ -23,20 +39,18 @@ tasks.register("publishAllVariants") {
   dependsOn(
     ":spark:spark-3.4_2.12:publishToMavenLocal",
     ":spark:spark-3.5_2.12:publishToMavenLocal",
-    ":spark:spark-4.0_2.13:publishToMavenLocal"
+    ":spark:spark-4.0_2.13:publishToMavenLocal",
   )
 }
 
 // Make the default build task build all variants
-tasks.named("build") {
-  dependsOn("buildAllVariants")
-}
+tasks.named("build") { dependsOn("buildAllVariants") }
 
 // Make clean task clean all variants
 tasks.named("clean") {
   dependsOn(
     ":spark:spark-3.4_2.12:clean",
     ":spark:spark-3.5_2.12:clean",
-    ":spark:spark-4.0_2.13:clean"
+    ":spark:spark-4.0_2.13:clean",
   )
 }

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -273,8 +273,8 @@ class ToSparkExpression(
 
     expr.declaration().name() match {
       // Special handling for multi-variate AND/OR operators
-      case "and" if args.size > 2 => args.reduceLeft { (left, right) => And(left, right) }
-      case "or" if args.size > 2 => args.reduceLeft { (left, right) => Or(left, right) }
+      case "and" if args.size > 2 => args.reduceLeft((left, right) => And(left, right))
+      case "or" if args.size > 2 => args.reduceLeft((left, right) => Or(left, right))
       case _ =>
         scalarFunctionConverter
           .getSparkExpressionFromSubstraitFunc(expr.declaration.key, args)

--- a/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToLogicalPlan.scala
@@ -646,7 +646,8 @@ class ToLogicalPlan(val spark: AnyRef = SparkCompat.instance.getOrCreateSparkSes
     if (remap.isEmpty) {
       return plan
     }
-    val projectExprs = plan.output.map { case ne: NamedExpression => ne.toAttribute }.map(toNamedExpression)
+    val projectExprs =
+      plan.output.map { case ne: NamedExpression => ne.toAttribute }.map(toNamedExpression)
     Project(remap.get().indices().asScala.map(i => projectExprs(i)).toSeq, plan)
   }
 

--- a/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
+++ b/spark/src/main/scala/io/substrait/spark/logical/ToSubstraitRel.scala
@@ -713,7 +713,8 @@ class ToSubstraitRel extends AbstractLogicalPlanVisitor with Logging {
           .producer("substrait-spark")
           .build())
       .executionBehavior(
-        ImmutableExecutionBehavior.builder()
+        ImmutableExecutionBehavior
+          .builder()
           .variableEvaluationMode(VariableEvaluationMode.PER_PLAN)
           .build())
       .roots(

--- a/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/DialectGenerator.scala
@@ -29,7 +29,10 @@ case class Dialect(
 
 // Types section
 case class TypeMetadata(name: String, supported_as_column: Boolean)
-case class SupportedType(`type`: String, system_metadata: TypeMetadata, max_precision: Option[Integer] = None)
+case class SupportedType(
+    `type`: String,
+    system_metadata: TypeMetadata,
+    max_precision: Option[Integer] = None)
 
 // Functions section
 case class FunctionMetadata(name: String, notation: String)
@@ -94,8 +97,7 @@ class DialectGenerator {
     // Generate the dialect YAML
     val mapper = YAMLMapper
       .builder()
-      .defaultPropertyInclusion(
-        JsonInclude.Value.ALL_NON_ABSENT)
+      .defaultPropertyInclusion(JsonInclude.Value.ALL_NON_ABSENT)
       .addModule(DefaultScalaModule)
       .build()
     val yaml = mapper.writeValueAsString(generate())
@@ -127,9 +129,18 @@ class DialectGenerator {
       SupportedType("FIXED_CHAR", TypeMetadata("StringType", true)),
       SupportedType("BINARY", TypeMetadata("BinaryType", true)),
       SupportedType("BOOL", TypeMetadata("BooleanType", true)),
-      SupportedType("PRECISION_TIMESTAMP", TypeMetadata("TimestampNTZType", true), max_precision = Some(9)),
-      SupportedType("PRECISION_TIMESTAMP_TZ", TypeMetadata("TimestampType", true), max_precision = Some(9)),
-      SupportedType("INTERVAL_DAY", TypeMetadata("DayTimeIntervalType", true), max_precision = Some(9)),
+      SupportedType(
+        "PRECISION_TIMESTAMP",
+        TypeMetadata("TimestampNTZType", true),
+        max_precision = Some(9)),
+      SupportedType(
+        "PRECISION_TIMESTAMP_TZ",
+        TypeMetadata("TimestampType", true),
+        max_precision = Some(9)),
+      SupportedType(
+        "INTERVAL_DAY",
+        TypeMetadata("DayTimeIntervalType", true),
+        max_precision = Some(9)),
       SupportedType("INTERVAL_YEAR", TypeMetadata("YearMonthIntervalType", true)),
       SupportedType("LIST", TypeMetadata("ArrayType", true)),
       SupportedType("MAP", TypeMetadata("MapType", true)),

--- a/spark/src/test/scala/io/substrait/spark/AggregateWithJoinSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/AggregateWithJoinSuite.scala
@@ -1,20 +1,23 @@
 package io.substrait.spark
 
-import io.substrait.dsl.SubstraitBuilder
-import io.substrait.expression.{Expression, ExpressionCreator}
-import io.substrait.extension.DefaultExtensionCatalog
-import io.substrait.plan.Plan
-import io.substrait.relation.{Aggregate, Join, Project, Rel, VirtualTableScan}
 import io.substrait.spark.logical.ToLogicalPlan
-import io.substrait.`type`.{NamedStruct, Type, TypeCreator}
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.classic.DatasetUtil
 import org.apache.spark.sql.test.SharedSparkSession
 
+import io.substrait.`type`.{NamedStruct, Type, TypeCreator}
+import io.substrait.dsl.SubstraitBuilder
+import io.substrait.expression.{Expression, ExpressionCreator}
+import io.substrait.extension.DefaultExtensionCatalog
+import io.substrait.plan.Plan
+import io.substrait.relation.{Aggregate, Join, Project, Rel, VirtualTableScan}
+
 import java.util
 import java.util.Arrays
+
 import scala.jdk.CollectionConverters._
 
 /**
@@ -23,15 +26,19 @@ import scala.jdk.CollectionConverters._
  * VirtualTableScan instead of NamedTable for input data.
  *
  * The plan structure is:
- * - Root with output mapping [3, 4, 5] and names ["fuel_type", "postcode_area", "total_test_mileage"]
- * - Project with output mapping [3, 4, 5] (selecting fields 0, 1, 2 from aggregate)
- * - Aggregate grouping by fields 4 and 14, with sum(field 13)
- * - Project with output mapping [15-29] (selecting specific fields from join)
- * - Inner Join on tests.vehicle_id = vehicles.vehicle_id
- * - Left: Project selecting all 8 fields from tests VirtualTableScan
- * - Right: Project selecting all 7 fields from vehicles VirtualTableScan
+ *   - Root with output mapping [3, 4, 5] and names ["fuel_type", "postcode_area",
+ *     "total_test_mileage"]
+ *   - Project with output mapping [3, 4, 5] (selecting fields 0, 1, 2 from aggregate)
+ *   - Aggregate grouping by fields 4 and 14, with sum(field 13)
+ *   - Project with output mapping [15-29] (selecting specific fields from join)
+ *   - Inner Join on tests.vehicle_id = vehicles.vehicle_id
+ *   - Left: Project selecting all 8 fields from tests VirtualTableScan
+ *   - Right: Project selecting all 7 fields from vehicles VirtualTableScan
  */
-class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with SubstraitPlanTestBase {
+class AggregateWithJoinSuite
+  extends SparkFunSuite
+  with SharedSparkSession
+  with SubstraitPlanTestBase {
 
   private val R = TypeCreator.REQUIRED
   private val N = TypeCreator.NULLABLE
@@ -47,7 +54,8 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
       testResult: String,
       testMileage: Int,
       postcodeArea: String): Expression.NestedStruct = {
-    Expression.NestedStruct.builder()
+    Expression.NestedStruct
+      .builder()
       .addFields(ExpressionCreator.i32(true, testId))
       .addFields(ExpressionCreator.i32(true, vehicleId))
       .addFields(ExpressionCreator.date(true, testDate))
@@ -60,30 +68,38 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
   }
 
   /**
-   * Creates a VirtualTableScan for the tests table with schema:
-   * test_id (i32), vehicle_id (i32), test_date (date), test_class (i32),
-   * test_type (varchar), test_result (varchar), test_mileage (i32), postcode_area (varchar)
+   * Creates a VirtualTableScan for the tests table with schema: test_id (i32), vehicle_id (i32),
+   * test_date (date), test_class (i32), test_type (varchar), test_result (varchar), test_mileage
+   * (i32), postcode_area (varchar)
    */
   private def createTestsTable(): VirtualTableScan = {
     val columnNames = Arrays.asList(
-      "test_id", "vehicle_id", "test_date", "test_class",
-      "test_type", "test_result", "test_mileage", "postcode_area")
+      "test_id",
+      "vehicle_id",
+      "test_date",
+      "test_class",
+      "test_type",
+      "test_result",
+      "test_mileage",
+      "postcode_area")
 
-    val struct = Type.Struct.builder()
-      .addFields(N.I32)           // test_id
-      .addFields(N.I32)           // vehicle_id
-      .addFields(N.DATE)          // test_date
-      .addFields(N.I32)           // test_class
-      .addFields(N.STRING)        // test_type
-      .addFields(N.STRING)        // test_result
-      .addFields(N.I32)           // test_mileage
-      .addFields(N.STRING)        // postcode_area
+    val struct = Type.Struct
+      .builder()
+      .addFields(N.I32) // test_id
+      .addFields(N.I32) // vehicle_id
+      .addFields(N.DATE) // test_date
+      .addFields(N.I32) // test_class
+      .addFields(N.STRING) // test_type
+      .addFields(N.STRING) // test_result
+      .addFields(N.I32) // test_mileage
+      .addFields(N.STRING) // postcode_area
       .nullable(false)
       .build()
 
     val namedStruct = NamedStruct.of(columnNames, struct)
 
-    VirtualTableScan.builder()
+    VirtualTableScan
+      .builder()
       .initialSchema(namedStruct)
       .addRows(createTestsRow(151, 100, 19000, 4, "MOT", "PASS", 50000, "GU"))
       .addRows(createTestsRow(385, 102, 20000, 4, "MOT", "PASS", 15000, "GU"))
@@ -100,7 +116,8 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
       fuelType: String,
       cylinderCapacity: Int,
       firstUseDate: Int): Expression.NestedStruct = {
-    Expression.NestedStruct.builder()
+    Expression.NestedStruct
+      .builder()
       .addFields(ExpressionCreator.i32(true, vehicleId))
       .addFields(ExpressionCreator.string(true, make))
       .addFields(ExpressionCreator.string(true, model))
@@ -112,29 +129,36 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
   }
 
   /**
-   * Creates a VirtualTableScan for the vehicles table with schema:
-   * vehicle_id (i32), make (varchar), model (varchar), colour (varchar),
-   * fuel_type (varchar), cylinder_capacity (i32), first_use_date (date)
+   * Creates a VirtualTableScan for the vehicles table with schema: vehicle_id (i32), make
+   * (varchar), model (varchar), colour (varchar), fuel_type (varchar), cylinder_capacity (i32),
+   * first_use_date (date)
    */
   private def createVehiclesTable(): VirtualTableScan = {
     val columnNames = Arrays.asList(
-      "vehicle_id", "make", "model", "colour",
-      "fuel_type", "cylinder_capacity", "first_use_date")
+      "vehicle_id",
+      "make",
+      "model",
+      "colour",
+      "fuel_type",
+      "cylinder_capacity",
+      "first_use_date")
 
-    val struct = Type.Struct.builder()
-      .addFields(N.I32)           // vehicle_id
-      .addFields(N.STRING)        // make
-      .addFields(N.STRING)        // model
-      .addFields(N.STRING)        // colour
-      .addFields(N.STRING)        // fuel_type
-      .addFields(N.I32)           // cylinder_capacity
-      .addFields(N.DATE)          // first_use_date
+    val struct = Type.Struct
+      .builder()
+      .addFields(N.I32) // vehicle_id
+      .addFields(N.STRING) // make
+      .addFields(N.STRING) // model
+      .addFields(N.STRING) // colour
+      .addFields(N.STRING) // fuel_type
+      .addFields(N.I32) // cylinder_capacity
+      .addFields(N.DATE) // first_use_date
       .nullable(false)
       .build()
 
     val namedStruct = NamedStruct.of(columnNames, struct)
 
-    VirtualTableScan.builder()
+    VirtualTableScan
+      .builder()
       .initialSchema(namedStruct)
       .addRows(createVehiclesRow(100, "Ford", "Focus", "Blue", "Petrol", 1600, 18000))
       .addRows(createVehiclesRow(101, "VW", "Golf", "Red", "Diesel", 2000, 19000))
@@ -148,29 +172,31 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
     val vehiclesTable = createVehiclesTable()
 
     // Project all fields from tests table with output mapping [8-15]
-    val leftProject = Project.builder()
+    val leftProject = Project
+      .builder()
       .input(testsTable)
-      .addExpressions(sb.fieldReference(testsTable, 0))  // test_id
-      .addExpressions(sb.fieldReference(testsTable, 1))  // vehicle_id
-      .addExpressions(sb.fieldReference(testsTable, 2))  // test_date
-      .addExpressions(sb.fieldReference(testsTable, 3))  // test_class
-      .addExpressions(sb.fieldReference(testsTable, 4))  // test_type
-      .addExpressions(sb.fieldReference(testsTable, 5))  // test_result
-      .addExpressions(sb.fieldReference(testsTable, 6))  // test_mileage
-      .addExpressions(sb.fieldReference(testsTable, 7))  // postcode_area
+      .addExpressions(sb.fieldReference(testsTable, 0)) // test_id
+      .addExpressions(sb.fieldReference(testsTable, 1)) // vehicle_id
+      .addExpressions(sb.fieldReference(testsTable, 2)) // test_date
+      .addExpressions(sb.fieldReference(testsTable, 3)) // test_class
+      .addExpressions(sb.fieldReference(testsTable, 4)) // test_type
+      .addExpressions(sb.fieldReference(testsTable, 5)) // test_result
+      .addExpressions(sb.fieldReference(testsTable, 6)) // test_mileage
+      .addExpressions(sb.fieldReference(testsTable, 7)) // postcode_area
       .remap(Rel.Remap.of(Arrays.asList(8, 9, 10, 11, 12, 13, 14, 15)))
       .build()
 
     // Project all fields from vehicles table with output mapping [7-13]
-    val rightProject = Project.builder()
+    val rightProject = Project
+      .builder()
       .input(vehiclesTable)
-      .addExpressions(sb.fieldReference(vehiclesTable, 0))  // vehicle_id
-      .addExpressions(sb.fieldReference(vehiclesTable, 1))  // make
-      .addExpressions(sb.fieldReference(vehiclesTable, 2))  // model
-      .addExpressions(sb.fieldReference(vehiclesTable, 3))  // colour
-      .addExpressions(sb.fieldReference(vehiclesTable, 4))  // fuel_type
-      .addExpressions(sb.fieldReference(vehiclesTable, 5))  // cylinder_capacity
-      .addExpressions(sb.fieldReference(vehiclesTable, 6))  // first_use_date
+      .addExpressions(sb.fieldReference(vehiclesTable, 0)) // vehicle_id
+      .addExpressions(sb.fieldReference(vehiclesTable, 1)) // make
+      .addExpressions(sb.fieldReference(vehiclesTable, 2)) // model
+      .addExpressions(sb.fieldReference(vehiclesTable, 3)) // colour
+      .addExpressions(sb.fieldReference(vehiclesTable, 4)) // fuel_type
+      .addExpressions(sb.fieldReference(vehiclesTable, 5)) // cylinder_capacity
+      .addExpressions(sb.fieldReference(vehiclesTable, 6)) // first_use_date
       .remap(Rel.Remap.of(Arrays.asList(7, 8, 9, 10, 11, 12, 13)))
       .build()
 
@@ -178,8 +204,11 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
     val join = sb.innerJoin(
       (joinInput: SubstraitBuilder.JoinInput) => {
         sb.equal(
-          sb.fieldReference(joinInput, 1),   // tests.vehicle_id (field 1 from left)
-          sb.fieldReference(joinInput, 8))   // vehicles.vehicle_id (field 8 in combined output)
+          // tests.vehicle_id (field 1 from left)
+          sb.fieldReference(joinInput, 1),
+          // vehicles.vehicle_id (field 8 in combined output)
+          sb.fieldReference(joinInput, 8)
+        )
       },
       leftProject,
       rightProject
@@ -187,24 +216,26 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
 
     // Project after join with output mapping [15-29]
     // Reorders to: vehicles fields (8-14) + tests fields (0-7)
-    val postJoinProject = Project.builder()
+    val postJoinProject = Project
+      .builder()
       .input(join)
-      .addExpressions(sb.fieldReference(join, 8))   // vehicles.vehicle_id
-      .addExpressions(sb.fieldReference(join, 9))   // vehicles.make
-      .addExpressions(sb.fieldReference(join, 10))  // vehicles.model
-      .addExpressions(sb.fieldReference(join, 11))  // vehicles.colour
-      .addExpressions(sb.fieldReference(join, 12))  // vehicles.fuel_type
-      .addExpressions(sb.fieldReference(join, 13))  // vehicles.cylinder_capacity
-      .addExpressions(sb.fieldReference(join, 14))  // vehicles.first_use_date
-      .addExpressions(sb.fieldReference(join, 0))   // tests.test_id
-      .addExpressions(sb.fieldReference(join, 1))   // tests.vehicle_id
-      .addExpressions(sb.fieldReference(join, 2))   // tests.test_date
-      .addExpressions(sb.fieldReference(join, 3))   // tests.test_class
-      .addExpressions(sb.fieldReference(join, 4))   // tests.test_type
-      .addExpressions(sb.fieldReference(join, 5))   // tests.test_result
-      .addExpressions(sb.fieldReference(join, 6))   // tests.test_mileage
-      .addExpressions(sb.fieldReference(join, 7))   // tests.postcode_area
-      .remap(Rel.Remap.of(Arrays.asList(15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29)))
+      .addExpressions(sb.fieldReference(join, 8)) // vehicles.vehicle_id
+      .addExpressions(sb.fieldReference(join, 9)) // vehicles.make
+      .addExpressions(sb.fieldReference(join, 10)) // vehicles.model
+      .addExpressions(sb.fieldReference(join, 11)) // vehicles.colour
+      .addExpressions(sb.fieldReference(join, 12)) // vehicles.fuel_type
+      .addExpressions(sb.fieldReference(join, 13)) // vehicles.cylinder_capacity
+      .addExpressions(sb.fieldReference(join, 14)) // vehicles.first_use_date
+      .addExpressions(sb.fieldReference(join, 0)) // tests.test_id
+      .addExpressions(sb.fieldReference(join, 1)) // tests.vehicle_id
+      .addExpressions(sb.fieldReference(join, 2)) // tests.test_date
+      .addExpressions(sb.fieldReference(join, 3)) // tests.test_class
+      .addExpressions(sb.fieldReference(join, 4)) // tests.test_type
+      .addExpressions(sb.fieldReference(join, 5)) // tests.test_result
+      .addExpressions(sb.fieldReference(join, 6)) // tests.test_mileage
+      .addExpressions(sb.fieldReference(join, 7)) // tests.postcode_area
+      .remap(Rel.Remap.of(
+        Arrays.asList(15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29)))
       .build()
 
     // Create aggregate with grouping by fuel_type (field 4) and postcode_area (field 14)
@@ -212,38 +243,45 @@ class AggregateWithJoinSuite extends SparkFunSuite with SharedSparkSession with 
     val aggregate = sb.aggregate(
       (input: Rel) => {
         // Create grouping by fuel_type and postcode_area
-        Aggregate.Grouping.builder()
-          .addExpressions(sb.fieldReference(input, 4))   // fuel_type (field 4 in postJoinProject)
-          .addExpressions(sb.fieldReference(input, 14))  // postcode_area (field 14 in postJoinProject)
+        Aggregate.Grouping
+          .builder()
+          // fuel_type (field 4 in postJoinProject)
+          .addExpressions(sb.fieldReference(input, 4))
+          // postcode_area (field 14 in postJoinProject)
+          .addExpressions(sb.fieldReference(input, 14))
           .build()
       },
       (input: Rel) => {
         // Create measure for sum of test_mileage
-        val sumMeasure = sb.sum(input, 13)  // sum of test_mileage (field 13 in postJoinProject)
+        val sumMeasure = sb.sum(input, 13) // sum of test_mileage (field 13 in postJoinProject)
         util.Arrays.asList(sumMeasure)
       },
       postJoinProject
     )
 
     // Project to select final output fields with output mapping [3, 4, 5]
-    val finalProject = Project.builder()
+    val finalProject = Project
+      .builder()
       .input(aggregate)
-      .addExpressions(sb.fieldReference(aggregate, 0))  // fuel_type (grouping key 0)
-      .addExpressions(sb.fieldReference(aggregate, 1))  // postcode_area (grouping key 1)
-      .addExpressions(sb.fieldReference(aggregate, 2))  // total_test_mileage (measure 0)
+      .addExpressions(sb.fieldReference(aggregate, 0)) // fuel_type (grouping key 0)
+      .addExpressions(sb.fieldReference(aggregate, 1)) // postcode_area (grouping key 1)
+      .addExpressions(sb.fieldReference(aggregate, 2)) // total_test_mileage (measure 0)
       .remap(Rel.Remap.of(Arrays.asList(3, 4, 5)))
       .build()
 
     // Wrap in a Plan with Root and output column names
-    val root = Plan.Root.builder()
+    val root = Plan.Root
+      .builder()
       .input(finalProject)
       .addNames("fuel_type", "postcode_area", "total_test_mileage")
       .build()
 
-    val plan = Plan.builder()
+    val plan = Plan
+      .builder()
       .addRoots(root)
       .executionBehavior(
-        Plan.ExecutionBehavior.builder()
+        Plan.ExecutionBehavior
+          .builder()
           .variableEvaluationMode(Plan.ExecutionBehavior.VariableEvaluationMode.PER_PLAN)
           .build()
       )

--- a/spark/src/test/scala/io/substrait/spark/expression/PredicateSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/expression/PredicateSuite.scala
@@ -16,13 +16,14 @@
  */
 package io.substrait.spark.expression
 
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.{And, Literal, Or}
+
+import io.substrait.`type`.TypeCreator
 import io.substrait.dsl.SubstraitBuilder
 import io.substrait.expression.{Expression => SExpression, ExpressionCreator}
 import io.substrait.extension.DefaultExtensionCatalog
-import io.substrait.`type`.TypeCreator
 import io.substrait.util.EmptyVisitationContext
-import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.catalyst.expressions.{And, Literal, Or}
 import org.scalatest.Assertions.assertResult
 
 import scala.jdk.CollectionConverters._
@@ -145,7 +146,9 @@ class PredicateSuite extends SparkFunSuite with SubstraitExpressionTestBase {
     // Verify the result is nested Or expressions: Or(Or(Or(Or(a, b), c), d), e)
     // reduceLeft creates: ((((a OR b) OR c) OR d) OR e)
     sparkExpr match {
-      case Or(Or(Or(Or(Literal(a, _), Literal(b, _)), Literal(c, _)), Literal(d, _)), Literal(e, _)) =>
+      case Or(
+            Or(Or(Or(Literal(a, _), Literal(b, _)), Literal(c, _)), Literal(d, _)),
+            Literal(e, _)) =>
         assertResult(false)(a)
         assertResult(false)(b)
         assertResult(true)(c)
@@ -173,7 +176,9 @@ class PredicateSuite extends SparkFunSuite with SubstraitExpressionTestBase {
 
     // Verify the structure: Or(And(And(a, b), c), And(d, e))
     sparkExpr match {
-      case Or(And(And(Literal(a, _), Literal(b, _)), Literal(c, _)), And(Literal(d, _), Literal(e, _))) =>
+      case Or(
+            And(And(Literal(a, _), Literal(b, _)), Literal(c, _)),
+            And(Literal(d, _), Literal(e, _))) =>
         assertResult(true)(a)
         assertResult(true)(b)
         assertResult(false)(c)


### PR DESCRIPTION
`spark/.scalafmt.conf` is actively maintained but nothing checked it. #707 replaced `spark/build.gradle.kts` wholesale while splitting `spark` into the per-variant subprojects, and the Spotless `scala` step that #304 had added did not survive the restructure. The config did survive, so it read as a guarantee while formatting silently drifted, and the `./gradlew :spark:spotlessApply` that AGENTS.md documents errored out with "task not found".

The step goes back on the parent `:spark` project rather than the variants. The Scala source lives in `spark/src` and all three variants compile it, so a per-variant step would format the same files three times over — which is what their `isEnforceCheck = false` already anticipates. The parent has no Scala source set to infer a target from, hence the explicit `src/**/*.scala`; that also picks up the `src/*/spark-<major.minor>` overlays, which a scala-source-set default would have missed. The scalafmt version is pinned to the 3.8.1 that `.scalafmt.conf` records for IntelliJ, so the editor and the build agree.

The accumulated drift is reformatted in a separate first commit so the second contains only the build change: import grouping and sort order in two test files, plus assorted line-length, Scaladoc, and redundant-brace differences. Two trailing comments that the reformat would have orphaned onto a closing paren are moved above the argument they describe instead.

AGENTS.md's Spark note is corrected in the same change, and the CONTRIBUTING.md style guide now states that Scala style is defined by `spark/.scalafmt.conf` and enforced the same way Java style is.

Closes #1130
