### PR TITLE
fix(core): derive precision_time from PrecisionTimeLiteral

### DIFF
--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -443,7 +443,7 @@ public interface Expression extends FunctionArg {
 
     @Override
     public Type getType() {
-      return Type.withNullability(nullable()).precisionTimestamp(precision());
+      return Type.withNullability(nullable()).precisionTime(precision());
     }
 
     /**

--- a/core/src/test/java/io/substrait/expression/LiteralTypeDerivationTest.java
+++ b/core/src/test/java/io/substrait/expression/LiteralTypeDerivationTest.java
@@ -1,0 +1,57 @@
+package io.substrait.expression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.type.TypeCreator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that literals carrying a fractional-second precision derive their own type class, with the
+ * precision and nullability reaching the derived type.
+ *
+ * <p>Neither proto direction consults {@link Expression.Literal#getType()} — both work off the
+ * literal's own fields — so a proto round trip cannot observe these derivations.
+ */
+class LiteralTypeDerivationTest {
+
+  static final TypeCreator R = TypeCreator.REQUIRED;
+  static final TypeCreator N = TypeCreator.NULLABLE;
+
+  @Test
+  void precisionTime() {
+    assertEquals(R.precisionTime(6), ExpressionCreator.precisionTime(false, 42L, 6).getType());
+    assertEquals(N.precisionTime(3), ExpressionCreator.precisionTime(true, 42L, 3).getType());
+  }
+
+  @Test
+  void precisionTimestamp() {
+    assertEquals(
+        R.precisionTimestamp(6), ExpressionCreator.precisionTimestamp(false, 42L, 6).getType());
+    assertEquals(
+        N.precisionTimestamp(3), ExpressionCreator.precisionTimestamp(true, 42L, 3).getType());
+  }
+
+  @Test
+  void precisionTimestampTZ() {
+    assertEquals(
+        R.precisionTimestampTZ(6), ExpressionCreator.precisionTimestampTZ(false, 42L, 6).getType());
+    assertEquals(
+        N.precisionTimestampTZ(3), ExpressionCreator.precisionTimestampTZ(true, 42L, 3).getType());
+  }
+
+  @Test
+  void intervalDay() {
+    assertEquals(R.intervalDay(6), ExpressionCreator.intervalDay(false, 1, 2, 3L, 6).getType());
+    assertEquals(N.intervalDay(3), ExpressionCreator.intervalDay(true, 1, 2, 3L, 3).getType());
+  }
+
+  @Test
+  void intervalCompound() {
+    assertEquals(
+        R.intervalCompound(6),
+        ExpressionCreator.intervalCompound(false, 1, 2, 3, 4, 5L, 6).getType());
+    assertEquals(
+        N.intervalCompound(3),
+        ExpressionCreator.intervalCompound(true, 1, 2, 3, 4, 5L, 3).getType());
+  }
+}


### PR DESCRIPTION
`PrecisionTimeLiteral.getType()` named `precisionTimestamp(precision())` instead of `precisionTime(precision())`, so a time-of-day literal advertised itself as a timestamp. Every sibling literal derives its own type class correctly — `PrecisionTimestampLiteral`, `PrecisionTimestampTZLiteral`, `IntervalDayLiteral`, and `IntervalCompoundLiteral` all name themselves — so this was an isolated slip rather than a systematic gap, present since the literal was added in v0.83.0.

Neither proto direction consults `getType()`: `ExpressionProtoConverter` writes the literal's own fields and `ProtoExpressionConverter` dispatches on the `PRECISION_TIME` oneof case back into `ExpressionCreator.precisionTime`. A round trip therefore cannot observe the derivation, which is why the existing tests stayed green. The regression test asserts the derived type directly, and covers the sibling precision-carrying literals against the same class of slip.

The Spark adapter has no `Type.PrecisionTime` mapping at all, so a plan projecting a `precision_time` literal is now rejected there rather than silently read as a Spark timestamp. Extending Spark's type coverage to `precision_time` is a separate gap and left out of scope here.

Closes #1134