### PR TITLE
docs: correct the claim that a PR description is changelog input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,8 +189,11 @@ CI runs, and a `:core` change can break the visitor implementors in the other mo
 ## Conventions & workflow
 
 - **Keep PR descriptions high-signal.** The PR title and body together become the
-  squash-merge commit message that `semantic-release` uses to build `CHANGELOG.md` — the body
-  is changelog input, not a review scratchpad. Follow
+  squash-merge commit message, which `semantic-release` parses in full — but only the
+  **title** is published, as the `CHANGELOG.md` entry and in the release notes. The body
+  reaches neither, with one exception: a `BREAKING CHANGE:` footer, whose note is emitted
+  verbatim (see below). It is still the commit body that `git log` and every reviewer reads,
+  and still where that footer is found, so it is not a review scratchpad. Follow
   [`CONTRIBUTING.md`](CONTRIBUTING.md#pull-requests) rather than
   [`.github/pull_request_template.md`](.github/pull_request_template.md), which a PR opened
   with an explicitly supplied body never shows you. Beyond forming a valid conventional

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,11 @@ Examples of commit messages can be seen [here](https://www.conventionalcommits.o
 
 ## Pull requests
 
-Pull requests are squash-merged, and the **PR title and description become the commit message** that `semantic-release` parses to build [`CHANGELOG.md`](CHANGELOG.md). The title is the subject and the description is the body, so the two together must form a valid conventional commit; CI checks both and comments on the PR when they don't. [`.github/pull_request_template.md`](.github/pull_request_template.md) restates that where you write the description.
+Pull requests are squash-merged, and the **PR title and description become the commit message** that `semantic-release` parses. The title is the subject and the description is the body, so the two together must form a valid conventional commit; CI checks both and comments on the PR when they don't. [`.github/pull_request_template.md`](.github/pull_request_template.md) restates that where you write the description. A maintainer can edit the body while merging, so write it as though it will be kept verbatim.
 
-Because the description is changelog input rather than a review scratchpad, leave out anything the diff and the CI checks already show:
+Only the **title** is published — as the [`CHANGELOG.md`](CHANGELOG.md) entry and in the GitHub release notes. The description reaches neither, with one exception: a `BREAKING CHANGE:` footer, whose note is emitted verbatim (see [Breaking changes](#breaking-changes)). So write the title to stand on its own. The description still matters for two other reasons — `semantic-release` scans all of it for that footer, and it is the commit body that `git log` and every reviewer reads.
+
+Keep it to what those readers need, and leave out anything the diff and the CI checks already show:
 
 * **Lists of files touched** — they are in the diff.
 * **Claims that CI-verified things pass** — "tests pass", "spotless clean". If they didn't, the checks would be red.


### PR DESCRIPTION
`AGENTS.md` and `CONTRIBUTING.md` both said the PR description is changelog input. It isn't. `semantic-release` publishes only the commit subject as the `CHANGELOG.md` entry and in the GitHub release notes; the body reaches neither, with one exception — a `BREAKING CHANGE:` footer, whose note is emitted verbatim. Every `Features` and `Bug Fixes` entry in `CHANGELOG.md` is subject-only, and the only prose in the file sits under `### ⚠ BREAKING CHANGES`.

`AGENTS.md` contradicted itself because of it: the bullet immediately below the wrong sentence already described the accurate behaviour, that a stray trailing line gets absorbed into the breaking-change note and published there. That bullet's premise is precisely that the body is parsed in full while not being published.

The guidance the two files give is unchanged and still right — the point of the fix is to give it accurate reasons, because the body does still matter: `semantic-release` scans all of it for that footer, and it is the commit body that `git log` and every reviewer reads. `CONTRIBUTING.md` also now records that a maintainer may edit the body while merging, which is why it should be written as though it will be kept verbatim.
