### PR TITLE
fix(spark): report interval_year overflow instead of wrapping

### DIFF
--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -148,10 +148,12 @@ class ToSparkExpression(
   override def visit(
       expr: SExpression.IntervalYearLiteral,
       context: EmptyVisitationContext): Literal = {
-    // Spark uses a single months Int as the "physical" type for YearMonthInterval. Both operands
-    // are int32 on the wire, so unlike the day-time case nothing widens the arithmetic and a large
-    // year count wraps a positive interval into a negative one; report it instead.
-    val months = Math.addExact(Math.multiplyExact(expr.years(), 12), expr.months())
+    // Spark uses a single months Int as the "physical" type for YearMonthInterval, and both
+    // components are int32, so the flattened total can outrun that carrier: a large year count
+    // used to wrap a positive interval into a negative one. Only the total is significant, so
+    // the check belongs on it rather than on the intermediate product.
+    val months =
+      Math.toIntExact(expr.years().toLong * Util.MONTHS_PER_YEAR + expr.months())
     Literal(months, ToSparkType.convert(expr.getType))
   }
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -152,8 +152,7 @@ class ToSparkExpression(
     // components are int32, so the flattened total can outrun that carrier: a large year count
     // used to wrap a positive interval into a negative one. Only the total is significant, so
     // the check belongs on it rather than on the intermediate product.
-    val months =
-      Math.toIntExact(expr.years().toLong * Util.MONTHS_PER_YEAR + expr.months())
+    val months = Math.toIntExact(expr.years() * Util.MONTHS_PER_YEAR + expr.months())
     Literal(months, ToSparkType.convert(expr.getType))
   }
 

--- a/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
+++ b/spark/src/main/scala/io/substrait/spark/expression/ToSparkExpression.scala
@@ -148,8 +148,10 @@ class ToSparkExpression(
   override def visit(
       expr: SExpression.IntervalYearLiteral,
       context: EmptyVisitationContext): Literal = {
-    // Spark uses a single months Int as the "physical" type for YearMonthInterval
-    val months = expr.years() * 12 + expr.months()
+    // Spark uses a single months Int as the "physical" type for YearMonthInterval. Both operands
+    // are int32 on the wire, so unlike the day-time case nothing widens the arithmetic and a large
+    // year count wraps a positive interval into a negative one; report it instead.
+    val months = Math.addExact(Math.multiplyExact(expr.years(), 12), expr.months())
     Literal(months, ToSparkType.convert(expr.getType))
   }
 

--- a/spark/src/main/scala/io/substrait/spark/utils/Util.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/Util.scala
@@ -23,6 +23,7 @@ object Util {
 
   val SECONDS_PER_DAY: Long = 24 * 60 * 60
   val MICROS_PER_SECOND: Long = 1000 * 1000
+  val MONTHS_PER_YEAR: Int = 12
   val MICROSECOND_PRECISION = 6 // for PrecisionTimestamp(TZ) and IntervalDay types
 
   /** Indexed by exponent, which [[toMicroseconds]] bounds to 0..MICROSECOND_PRECISION. */

--- a/spark/src/main/scala/io/substrait/spark/utils/Util.scala
+++ b/spark/src/main/scala/io/substrait/spark/utils/Util.scala
@@ -23,7 +23,7 @@ object Util {
 
   val SECONDS_PER_DAY: Long = 24 * 60 * 60
   val MICROS_PER_SECOND: Long = 1000 * 1000
-  val MONTHS_PER_YEAR: Int = 12
+  val MONTHS_PER_YEAR: Long = 12
   val MICROSECOND_PRECISION = 6 // for PrecisionTimestamp(TZ) and IntervalDay types
 
   /** Indexed by exponent, which [[toMicroseconds]] bounds to 0..MICROSECOND_PRECISION. */

--- a/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
@@ -308,17 +308,23 @@ class TypesAndLiteralsSuite extends SparkFunSuite {
   }
 
   test("a year-month interval reports overflow instead of wrapping") {
-    // years and months are int32 on the wire and Spark's physical type is a months Int, so there
-    // is no Long operand to widen this the way the day-time case is widened. Far outside the
-    // spec's 10,000-year bound, but it used to turn a large positive interval into a negative one:
-    // 178,956,971 years came out as -2,147,483,644 months, and Int.MaxValue years as -12.
+    // years and months are both int32 and Spark's physical type is a months Int, so the flattened
+    // total can outrun the carrier: 178,956,971 years used to come out as -2,147,483,644 months,
+    // and Int.MinValue years as exactly 0 — a zero-length interval. This is the carrier's bound,
+    // not the spec's much tighter 10,000-year one, so it takes a producer already far past that.
     intercept[ArithmeticException](
       sparkLiteral(ExpressionCreator.intervalYear(false, 178956971, 0)))
     intercept[ArithmeticException](
-      sparkLiteral(ExpressionCreator.intervalYear(false, Int.MaxValue, 0)))
+      sparkLiteral(ExpressionCreator.intervalYear(false, 178956970, 8)))
+    intercept[ArithmeticException](
+      sparkLiteral(ExpressionCreator.intervalYear(false, Int.MinValue, 0)))
 
-    // The spec's maximum still converts, and the months carry through.
-    val atTheBound = sparkLiteral(ExpressionCreator.intervalYear(false, 10000, 0))
+    // Only the total is significant, so an intermediate past Int.MaxValue is not itself an error.
+    val mixedSigns = sparkLiteral(ExpressionCreator.intervalYear(false, 178956971, -12))
+    assert(mixedSigns.value === 2147483640)
+
+    // The spec's maximum still converts, and the months component carries through.
+    val atTheBound = sparkLiteral(ExpressionCreator.intervalYear(false, 9999, 12))
     assert(atTheBound.value === 120000)
     assert(atTheBound.dataType === YearMonthIntervalType.DEFAULT)
   }

--- a/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
+++ b/spark/src/test/scala/io/substrait/spark/TypesAndLiteralsSuite.scala
@@ -307,6 +307,22 @@ class TypesAndLiteralsSuite extends SparkFunSuite {
       sparkLiteral(ExpressionCreator.intervalDay(false, Int.MaxValue, 0, 0L, 6)))
   }
 
+  test("a year-month interval reports overflow instead of wrapping") {
+    // years and months are int32 on the wire and Spark's physical type is a months Int, so there
+    // is no Long operand to widen this the way the day-time case is widened. Far outside the
+    // spec's 10,000-year bound, but it used to turn a large positive interval into a negative one:
+    // 178,956,971 years came out as -2,147,483,644 months, and Int.MaxValue years as -12.
+    intercept[ArithmeticException](
+      sparkLiteral(ExpressionCreator.intervalYear(false, 178956971, 0)))
+    intercept[ArithmeticException](
+      sparkLiteral(ExpressionCreator.intervalYear(false, Int.MaxValue, 0)))
+
+    // The spec's maximum still converts, and the months carry through.
+    val atTheBound = sparkLiteral(ExpressionCreator.intervalYear(false, 10000, 0))
+    assert(atTheBound.value === 120000)
+    assert(atTheBound.dataType === YearMonthIntervalType.DEFAULT)
+  }
+
   test("a coarser precision on a type is rejected, since a type has no value to rescale") {
     // A Spark type carries no precision of its own, so mapping precision_timestamp<3> onto
     // TimestampNTZType would reinterpret millisecond counts as microsecond ones. Only the literal


### PR DESCRIPTION
`ToSparkExpression.visit(IntervalYearLiteral)` flattened years and months with unchecked `Int` arithmetic, and Spark's physical type for `YearMonthInterval` is a single months `Int`. A large year count outran that carrier silently: 178,956,971 years came out as −2,147,483,644 months, and `Int.MinValue` years as exactly 0 — a zero-length interval rather than a sign flip. It throws `ArithmeticException` now.

Only the total is significant, so the check sits on it rather than on the intermediate product: 178,956,971 years with −12 months is 2,147,483,640 months and still converts. The bound is the carrier's, not the spec's much tighter 10,000-year one, so reaching it takes a producer already far past that.

Closes #1138.
