### PR TITLE
feat(core): derive return types parameterized by a length or precision

### DIFF
--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -40,7 +40,7 @@ import java.util.OptionalInt;
  * assume_timezone:date_str_i8} and the {@code strptime_*} family. Among the standard aggregates,
  * {@code quantile} cannot be derived at all: its declared return {@code LIST?<any>} uses a plain
  * {@code any}, which carries no identity to bind. Both lists are pinned against the catalog by
- * {@code ParameterizedReturnTypeTest}, which is spec v0.101.0 today.
+ * {@code ParameterizedReturnTypeTest}.
  */
 public class TypeExpressionEvaluator {
 
@@ -229,7 +229,31 @@ public class TypeExpressionEvaluator {
             ((ParameterizedType.IntervalCompound) declared).precision().value(),
             ((Type.IntervalCompound) actual).precision(),
             bindNames);
+      } else if (!(declared instanceof Type) && !isContainer(declared)) {
+        // A shape one of the arms above should have taken: the declaration carries a parameter and
+        // the actual type is not the class that would bind it. Binding nothing here would enforce
+        // the shared-parameter rule for some calls and skip it for others.
+        throw new UnsupportedOperationException(
+            String.format(
+                "Cannot bind parameters from declared argument type %s to actual type %s",
+                declared, actual));
       }
+    }
+
+    /**
+     * Whether the declared type holds other types rather than an integer parameter. Binding does
+     * not descend into these, so their parameters bind nothing and a mismatch cannot be told from a
+     * shape this method simply does not reach yet -- unlike the classes above, refusing here would
+     * reject declarations that resolve today without binding anything, such as a {@code list<any1>}
+     * argument to a function returning a concrete type.
+     *
+     * @param declared the declared argument type
+     * @return {@code true} if the type is a list, map or struct declaration
+     */
+    private boolean isContainer(ParameterizedType declared) {
+      return declared instanceof ParameterizedType.ListType
+          || declared instanceof ParameterizedType.Map
+          || declared instanceof ParameterizedType.Struct;
     }
 
     private void bindType(String name, Type actual) {

--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -27,20 +27,21 @@ import java.util.OptionalInt;
  * type classes whose parameter is an integer to substitute: {@code DECIMAL<P,S>}, {@code
  * varchar<L1>}, {@code fixedchar<L1>}, {@code fixedbinary<L1>}, {@code precision_time<P>}, {@code
  * precision_timestamp<P>}, {@code precision_timestamp_tz<P>}, {@code interval_day<P>} and {@code
- * interval_compound<P>}. No standard extension returns a parameterized {@code fixedbinary} or
- * {@code interval_compound} -- those two are supported for symmetry, and pinned against
- * hand-written declarations rather than the catalog.
+ * interval_compound<P>}. No standard extension declares a parameterized {@code fixedbinary} or
+ * {@code interval_compound} at all, as an argument or as a return -- those two are supported for
+ * symmetry, and pinned against hand-written declarations rather than the catalog.
  *
- * <p>What still fails on the standard extension catalog is a return of {@code list<anyN>}, whose
- * parameter is a type to evaluate rather than an integer to substitute ({@code filter}, {@code
- * sort}, {@code transform}, {@code string_split}, {@code regexp_string_split}, {@code
- * regexp_match_substring_all}), and a multi-line return program -- the decimal variants of {@code
- * add}, {@code subtract}, {@code multiply}, {@code divide}, {@code modulus}, {@code ceil}, {@code
- * floor}, {@code round} and the {@code bitwise_*} family, together with {@code
- * assume_timezone:date_str_i8} and the {@code strptime_*} family. Among the standard aggregates,
- * {@code quantile} cannot be derived at all: its declared return {@code LIST?<any>} uses a plain
- * {@code any}, which carries no identity to bind. Both lists are pinned against the catalog by
- * {@code ParameterizedReturnTypeTest}.
+ * <p>A {@code list} return still fails whatever its element, because the evaluator does not descend
+ * into a container -- so an element parameter it would otherwise substitute, as in {@code
+ * list<varchar<L1>>}, is out of reach just as an element type to evaluate is. A multi-line return
+ * program still fails because evaluating one needs integer arithmetic over the bound parameters
+ * rather than substitution. And a plain {@code any} cannot be derived at all: unlike {@code any1}
+ * it names nothing, so there is no identity to bind.
+ *
+ * <p>Which shipped variants those cover is pinned by {@code ParameterizedReturnTypeTest} against
+ * the declarations the catalog ships, and deliberately not repeated here -- the catalog is owned
+ * upstream, so a list of names in this Javadoc would go stale on a {@code substrait-packaging} bump
+ * with nothing to catch it.
  */
 public class TypeExpressionEvaluator {
 
@@ -248,12 +249,13 @@ public class TypeExpressionEvaluator {
      * argument to a function returning a concrete type.
      *
      * @param declared the declared argument type
-     * @return {@code true} if the type is a list, map or struct declaration
+     * @return {@code true} if the type is a list, map, struct or function declaration
      */
     private boolean isContainer(ParameterizedType declared) {
       return declared instanceof ParameterizedType.ListType
           || declared instanceof ParameterizedType.Map
-          || declared instanceof ParameterizedType.Struct;
+          || declared instanceof ParameterizedType.Struct
+          || declared instanceof ParameterizedType.Func;
     }
 
     private void bindType(String name, Type actual) {

--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -27,8 +27,9 @@ import java.util.OptionalInt;
  * type classes whose parameter is an integer to substitute: {@code DECIMAL<P,S>}, {@code
  * varchar<L1>}, {@code fixedchar<L1>}, {@code fixedbinary<L1>}, {@code precision_time<P>}, {@code
  * precision_timestamp<P>}, {@code precision_timestamp_tz<P>}, {@code interval_day<P>} and {@code
- * interval_compound<P>}. The last two of those are supported for symmetry; no standard extension
- * declares them parameterized today.
+ * interval_compound<P>}. No standard extension returns a parameterized {@code fixedbinary} or
+ * {@code interval_compound} -- those two are supported for symmetry, and pinned against
+ * hand-written declarations rather than the catalog.
  *
  * <p>What still fails on the standard extension catalog is a return of {@code list<anyN>}, whose
  * parameter is a type to evaluate rather than an integer to substitute ({@code filter}, {@code

--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -33,11 +33,13 @@ import java.util.OptionalInt;
  * <p>What still fails on the standard extension catalog is a return of {@code list<anyN>}, whose
  * parameter is a type to evaluate rather than an integer to substitute ({@code filter}, {@code
  * sort}, {@code transform}, {@code string_split}, {@code regexp_string_split}, {@code
- * regexp_match_substring_all}), and a multi-line return program ({@code add}, {@code subtract},
- * {@code multiply}, {@code divide}, {@code modulus}, {@code ceil}, {@code floor}, {@code round},
- * the {@code bitwise_*} family, {@code assume_timezone} and {@code strptime_*}). Among the standard
- * aggregates, {@code quantile} cannot be derived at all: its declared return {@code LIST?<any>}
- * uses a plain {@code any}, which carries no identity to bind (spec v0.101.0).
+ * regexp_match_substring_all}), and a multi-line return program -- the decimal variants of {@code
+ * add}, {@code subtract}, {@code multiply}, {@code divide}, {@code modulus}, {@code ceil}, {@code
+ * floor}, {@code round} and the {@code bitwise_*} family, together with {@code
+ * assume_timezone:date_str_i8} and the {@code strptime_*} family. Among the standard aggregates,
+ * {@code quantile} cannot be derived at all: its declared return {@code LIST?<any>} uses a plain
+ * {@code any}, which carries no identity to bind. Both lists are pinned against the catalog by
+ * {@code ParameterizedReturnTypeTest}, which is spec v0.101.0 today.
  */
 public class TypeExpressionEvaluator {
 

--- a/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
+++ b/core/src/main/java/io/substrait/type/TypeExpressionEvaluator.java
@@ -23,15 +23,21 @@ import java.util.OptionalInt;
  * UnsupportedOperationException}. The evaluator never falls back to a caller-supplied type: an
  * unresolved expression is an error, not a default.
  *
- * <p>Supported shapes are concrete types, numbered wildcards ({@code any1}) and parameterized
- * decimals ({@code DECIMAL<P,S>}). What actually fails on the standard extension catalog is the
- * other parameterized type classes — {@code varchar<L1>}, {@code fixedchar<L1>}, {@code
- * precision_time<P>}, {@code precision_timestamp<P>}, {@code precision_timestamp_tz<P>}, {@code
- * interval_day<P>}, {@code list<anyN>}, parameterized structs — and multi-line return programs;
- * {@code concat}, {@code concat_ws}, {@code assume_timezone} and the {@code strptime_*} family are
- * all rejected today. Among the standard aggregates, {@code quantile} is the one whose output type
- * cannot be derived at all: its declared return {@code LIST?<any>} uses a plain {@code any}, which
- * carries no identity to bind (spec v0.99.0).
+ * <p>Supported shapes are concrete types, numbered wildcards ({@code any1}), and the parameterized
+ * type classes whose parameter is an integer to substitute: {@code DECIMAL<P,S>}, {@code
+ * varchar<L1>}, {@code fixedchar<L1>}, {@code fixedbinary<L1>}, {@code precision_time<P>}, {@code
+ * precision_timestamp<P>}, {@code precision_timestamp_tz<P>}, {@code interval_day<P>} and {@code
+ * interval_compound<P>}. The last two of those are supported for symmetry; no standard extension
+ * declares them parameterized today.
+ *
+ * <p>What still fails on the standard extension catalog is a return of {@code list<anyN>}, whose
+ * parameter is a type to evaluate rather than an integer to substitute ({@code filter}, {@code
+ * sort}, {@code transform}, {@code string_split}, {@code regexp_string_split}, {@code
+ * regexp_match_substring_all}), and a multi-line return program ({@code add}, {@code subtract},
+ * {@code multiply}, {@code divide}, {@code modulus}, {@code ceil}, {@code floor}, {@code round},
+ * the {@code bitwise_*} family, {@code assume_timezone} and {@code strptime_*}). Among the standard
+ * aggregates, {@code quantile} cannot be derived at all: its declared return {@code LIST?<any>}
+ * uses a plain {@code any}, which carries no identity to bind (spec v0.101.0).
  */
 public class TypeExpressionEvaluator {
 
@@ -173,6 +179,53 @@ public class TypeExpressionEvaluator {
         Type.Decimal actualDecimal = (Type.Decimal) actual;
         bindInteger(declaredDecimal.precision().value(), actualDecimal.precision(), bindNames);
         bindInteger(declaredDecimal.scale().value(), actualDecimal.scale(), bindNames);
+      } else if (declared instanceof ParameterizedType.FixedChar
+          && actual instanceof Type.FixedChar) {
+        bindInteger(
+            ((ParameterizedType.FixedChar) declared).length().value(),
+            ((Type.FixedChar) actual).length(),
+            bindNames);
+      } else if (declared instanceof ParameterizedType.VarChar && actual instanceof Type.VarChar) {
+        bindInteger(
+            ((ParameterizedType.VarChar) declared).length().value(),
+            ((Type.VarChar) actual).length(),
+            bindNames);
+      } else if (declared instanceof ParameterizedType.FixedBinary
+          && actual instanceof Type.FixedBinary) {
+        bindInteger(
+            ((ParameterizedType.FixedBinary) declared).length().value(),
+            ((Type.FixedBinary) actual).length(),
+            bindNames);
+      } else if (declared instanceof ParameterizedType.PrecisionTime
+          && actual instanceof Type.PrecisionTime) {
+        bindInteger(
+            ((ParameterizedType.PrecisionTime) declared).precision().value(),
+            ((Type.PrecisionTime) actual).precision(),
+            bindNames);
+      } else if (declared instanceof ParameterizedType.PrecisionTimestamp
+          && actual instanceof Type.PrecisionTimestamp) {
+        bindInteger(
+            ((ParameterizedType.PrecisionTimestamp) declared).precision().value(),
+            ((Type.PrecisionTimestamp) actual).precision(),
+            bindNames);
+      } else if (declared instanceof ParameterizedType.PrecisionTimestampTZ
+          && actual instanceof Type.PrecisionTimestampTZ) {
+        bindInteger(
+            ((ParameterizedType.PrecisionTimestampTZ) declared).precision().value(),
+            ((Type.PrecisionTimestampTZ) actual).precision(),
+            bindNames);
+      } else if (declared instanceof ParameterizedType.IntervalDay
+          && actual instanceof Type.IntervalDay) {
+        bindInteger(
+            ((ParameterizedType.IntervalDay) declared).precision().value(),
+            ((Type.IntervalDay) actual).precision(),
+            bindNames);
+      } else if (declared instanceof ParameterizedType.IntervalCompound
+          && actual instanceof Type.IntervalCompound) {
+        bindInteger(
+            ((ParameterizedType.IntervalCompound) declared).precision().value(),
+            ((Type.IntervalCompound) actual).precision(),
+            bindNames);
       }
     }
 
@@ -243,6 +296,53 @@ public class TypeExpressionEvaluator {
       int precision = resolveInteger(decimal.precision().value());
       int scale = resolveInteger(decimal.scale().value());
       return TypeCreator.of(decimal.nullable()).decimal(precision, scale);
+    }
+
+    @Override
+    public Type visit(ParameterizedType.FixedChar fixedChar) {
+      return TypeCreator.of(fixedChar.nullable())
+          .fixedChar(resolveInteger(fixedChar.length().value()));
+    }
+
+    @Override
+    public Type visit(ParameterizedType.VarChar varChar) {
+      return TypeCreator.of(varChar.nullable()).varChar(resolveInteger(varChar.length().value()));
+    }
+
+    @Override
+    public Type visit(ParameterizedType.FixedBinary fixedBinary) {
+      return TypeCreator.of(fixedBinary.nullable())
+          .fixedBinary(resolveInteger(fixedBinary.length().value()));
+    }
+
+    @Override
+    public Type visit(ParameterizedType.PrecisionTime precisionTime) {
+      return TypeCreator.of(precisionTime.nullable())
+          .precisionTime(resolveInteger(precisionTime.precision().value()));
+    }
+
+    @Override
+    public Type visit(ParameterizedType.PrecisionTimestamp precisionTimestamp) {
+      return TypeCreator.of(precisionTimestamp.nullable())
+          .precisionTimestamp(resolveInteger(precisionTimestamp.precision().value()));
+    }
+
+    @Override
+    public Type visit(ParameterizedType.PrecisionTimestampTZ precisionTimestampTZ) {
+      return TypeCreator.of(precisionTimestampTZ.nullable())
+          .precisionTimestampTZ(resolveInteger(precisionTimestampTZ.precision().value()));
+    }
+
+    @Override
+    public Type visit(ParameterizedType.IntervalDay intervalDay) {
+      return TypeCreator.of(intervalDay.nullable())
+          .intervalDay(resolveInteger(intervalDay.precision().value()));
+    }
+
+    @Override
+    public Type visit(ParameterizedType.IntervalCompound intervalCompound) {
+      return TypeCreator.of(intervalCompound.nullable())
+          .intervalCompound(resolveInteger(intervalCompound.precision().value()));
     }
 
     @Override

--- a/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
+++ b/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
@@ -85,6 +85,40 @@ class ParameterizedReturnTypeTest {
         resolve("add:ptstz_iyear_str", R.precisionTimestampTZ(9), R.INTERVAL_YEAR, R.STRING));
   }
 
+  /**
+   * fixedbinary and interval_compound are the two parameterized shapes no standard extension
+   * declares as a return, so they are pinned against a hand-written declaration instead of the
+   * catalog.
+   */
+  @Test
+  void theShapesTheCatalogDoesNotDeclareDeriveToo() {
+    assertEquals(
+        R.fixedBinary(9),
+        derive(
+            ParameterizedType.FixedBinary.builder().nullable(false).length(parameter("L1")).build(),
+            R.fixedBinary(9)));
+    assertEquals(
+        R.intervalCompound(3),
+        derive(
+            ParameterizedType.IntervalCompound.builder()
+                .nullable(false)
+                .precision(parameter("P"))
+                .build(),
+            R.intervalCompound(3)));
+  }
+
+  private static ParameterizedType.StringLiteral parameter(String name) {
+    return ParameterizedType.StringLiteral.builder().nullable(false).value(name).build();
+  }
+
+  /** Derives the return of a one-argument declaration whose argument has the return's own shape. */
+  private static Type derive(ParameterizedType declaredReturn, Type actual) {
+    return TypeExpressionEvaluator.evaluateExpression(
+        declaredReturn,
+        List.of(SimpleExtension.ValueArgument.builder().value(declaredReturn).name("arg1").build()),
+        List.of(actual));
+  }
+
   @Test
   void mirrorNullabilityStillApplies() {
     // The declared return is non-null; MIRROR makes it nullable because an argument is.

--- a/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
+++ b/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
+import io.substrait.function.ParameterizedType;
+import io.substrait.function.TypeExpression;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -86,5 +89,57 @@ class ParameterizedReturnTypeTest {
   void mirrorNullabilityStillApplies() {
     // The declared return is non-null; MIRROR makes it nullable because an argument is.
     assertEquals(N.intervalDay(6), resolve("multiply:i8_iday", R.I8, N.intervalDay(6)));
+  }
+
+  /**
+   * The two return shapes the evaluator does not derive, pinned by the variants that carry them so
+   * that the list in {@link TypeExpressionEvaluator}'s Javadoc cannot go stale on its own. A
+   * parameter that is a type to evaluate rather than an integer to substitute is the first; a
+   * multi-line return program is the second.
+   */
+  @Test
+  void theReturnShapesThatAreNotDerivedYet() {
+    assertEquals(
+        List.of(
+            "filter:list_func",
+            "quantile:req_req_i64_any",
+            "regexp_match_substring_all:vchar_vchar_i64_i64",
+            "regexp_string_split:vchar_vchar",
+            "sort:list",
+            "string_split:vchar_vchar",
+            "transform:list_func"),
+        variantsReturning(ParameterizedType.ListType.class));
+
+    assertEquals(
+        List.of(
+            "add:dec_dec",
+            "assume_timezone:date_str_i8",
+            "bitwise_and:dec_dec",
+            "bitwise_or:dec_dec",
+            "bitwise_xor:dec_dec",
+            "ceil:dec",
+            "divide:dec_dec",
+            "floor:dec",
+            "modulus:dec_dec",
+            "multiply:dec_dec",
+            "round:dec_i32",
+            "strptime_time:str_str_i8",
+            "strptime_timestamp:str_str_i8",
+            "strptime_timestamp:str_str_str_i8",
+            "subtract:dec_dec"),
+        variantsReturning(TypeExpression.ReturnProgram.class));
+  }
+
+  private static List<String> variantsReturning(Class<?> returnShape) {
+    return Stream.of(
+            EXTENSIONS.scalarFunctions(),
+            EXTENSIONS.aggregateFunctions(),
+            EXTENSIONS.windowFunctions())
+        .flatMap(List::stream)
+        .filter(f -> returnShape.isInstance(f.returnType()))
+        .map(SimpleExtension.Function::key)
+        .distinct()
+        .sorted()
+        .collect(Collectors.toList());
   }
 }

--- a/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
+++ b/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
@@ -53,8 +53,8 @@ class ParameterizedReturnTypeTest {
 
   @Test
   void dateMinusIntervalDayDerivesAPrecisionTimestamp() {
-    // The signature #1117 is about: the spec declares precision_timestamp<P>, where P is the
-    // interval's, and nothing but the interval carries it.
+    // subtract(date, interval_day<P>) declares precision_timestamp<P>, and nothing but the
+    // interval carries P.
     assertEquals(R.precisionTimestamp(6), resolve("subtract:date_iday", R.DATE, R.intervalDay(6)));
     assertEquals(R.precisionTimestamp(3), resolve("subtract:date_iday", R.DATE, R.intervalDay(3)));
   }
@@ -68,7 +68,48 @@ class ParameterizedReturnTypeTest {
         assertThrows(
             UnsupportedOperationException.class,
             () -> resolve("add_intervals:iday_iday", R.intervalDay(3), R.intervalDay(6)));
-    assertTrue(e.getMessage().contains("P"), e.getMessage());
+    assertTrue(
+        e.getMessage().contains("Inconsistent binding for type parameter 'P'"), e.getMessage());
+  }
+
+  @Test
+  void aParameterizedDeclarationRejectsAnotherActualShape() {
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> resolve("concat:vchar", R.varChar(20), R.STRING));
+
+    assertTrue(
+        e.getMessage().contains("Cannot bind parameters from declared argument type"),
+        e.getMessage());
+  }
+
+  @Test
+  void aContainerDeclarationIsNotRefusedForABindingItNeverMakes() {
+    // Binding does not descend into a list declaration, so a `list<any1>` argument binds nothing.
+    // Both of these declare a concrete return and need no binding at all, so refusing the shape
+    // would reject calls that resolve today.
+    assertEquals(R.I64, resolve("cardinality:list", R.list(R.I64)));
+    assertEquals(N.I64, resolve("index_in:any_list", R.I64, R.list(R.I64)));
+  }
+
+  @Test
+  void aConcreteReturnStillChecksSharedParameters() {
+    UnsupportedOperationException comparison =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> resolve("lt:any_any", R.precisionTimestamp(3), R.precisionTimestamp(6)));
+    assertTrue(
+        comparison.getMessage().contains("Inconsistent binding for type parameter 'any1'"),
+        comparison.getMessage());
+
+    UnsupportedOperationException strpos =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> resolve("strpos:vchar_vchar", R.varChar(20), R.varChar(3)));
+    assertTrue(
+        strpos.getMessage().contains("Inconsistent binding for type parameter 'L1'"),
+        strpos.getMessage());
   }
 
   @Test

--- a/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
+++ b/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
@@ -1,0 +1,90 @@
+package io.substrait.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.substrait.extension.DefaultExtensionCatalog;
+import io.substrait.extension.SimpleExtension;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the return-type derivation for the parameterized shapes, against the declarations the
+ * standard extensions actually ship rather than against hand-written ones.
+ */
+class ParameterizedReturnTypeTest {
+
+  private static final TypeCreator R = TypeCreator.REQUIRED;
+  private static final TypeCreator N = TypeCreator.NULLABLE;
+  private static final SimpleExtension.ExtensionCollection EXTENSIONS =
+      DefaultExtensionCatalog.DEFAULT_COLLECTION;
+
+  private static SimpleExtension.Function variant(String key) {
+    return Stream.of(
+            EXTENSIONS.scalarFunctions(),
+            EXTENSIONS.aggregateFunctions(),
+            EXTENSIONS.windowFunctions())
+        .flatMap(List::stream)
+        .filter(f -> f.key().equals(key))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no such variant: " + key));
+  }
+
+  private static Type resolve(String key, Type... args) {
+    return variant(key).resolveType(List.of(args));
+  }
+
+  @Test
+  void precisionTimestampCarriesItsPrecision() {
+    assertEquals(
+        R.precisionTimestamp(3),
+        resolve("add:pts_iyear", R.precisionTimestamp(3), R.INTERVAL_YEAR));
+  }
+
+  @Test
+  void intervalDayCarriesItsPrecision() {
+    assertEquals(R.intervalDay(9), resolve("multiply:i8_iday", R.I8, R.intervalDay(9)));
+  }
+
+  @Test
+  void dateMinusIntervalDayDerivesAPrecisionTimestamp() {
+    // The signature #1117 is about: the spec declares precision_timestamp<P>, where P is the
+    // interval's, and nothing but the interval carries it.
+    assertEquals(R.precisionTimestamp(6), resolve("subtract:date_iday", R.DATE, R.intervalDay(6)));
+    assertEquals(R.precisionTimestamp(3), resolve("subtract:date_iday", R.DATE, R.intervalDay(3)));
+  }
+
+  @Test
+  void oneParameterSharedByTwoArgumentsHasToAgree() {
+    assertEquals(
+        R.intervalDay(3), resolve("add_intervals:iday_iday", R.intervalDay(3), R.intervalDay(3)));
+
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> resolve("add_intervals:iday_iday", R.intervalDay(3), R.intervalDay(6)));
+    assertTrue(e.getMessage().contains("P"), e.getMessage());
+  }
+
+  @Test
+  void varCharAndFixedCharCarryTheirLength() {
+    assertEquals(R.varChar(20), resolve("concat:vchar", R.varChar(20), R.varChar(20)));
+    assertEquals(R.fixedChar(8), resolve("reverse:fchar", R.fixedChar(8)));
+  }
+
+  @Test
+  void theOtherTemporalShapesCarryTheirPrecision() {
+    assertEquals(N.precisionTime(3), resolve("min:pt", R.precisionTime(3)));
+    assertEquals(
+        R.precisionTimestampTZ(9),
+        resolve("add:ptstz_iyear_str", R.precisionTimestampTZ(9), R.INTERVAL_YEAR, R.STRING));
+  }
+
+  @Test
+  void mirrorNullabilityStillApplies() {
+    // The declared return is non-null; MIRROR makes it nullable because an argument is.
+    assertEquals(N.intervalDay(6), resolve("multiply:i8_iday", R.I8, N.intervalDay(6)));
+  }
+}

--- a/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
+++ b/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
@@ -131,8 +131,8 @@ class ParameterizedReturnTypeTest {
 
   /**
    * fixedbinary and interval_compound are the two parameterized shapes no standard extension
-   * declares as a return, so they are pinned against a hand-written declaration instead of the
-   * catalog.
+   * declares at all, as an argument or as a return, so they are pinned against a hand-written
+   * declaration instead of the catalog.
    */
   @Test
   void theShapesTheCatalogDoesNotDeclareDeriveToo() {

--- a/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
+++ b/core/src/test/java/io/substrait/type/ParameterizedReturnTypeTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.function.ParameterizedType;
+import io.substrait.function.ParameterizedTypeCreator;
 import io.substrait.function.TypeExpression;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -86,11 +87,13 @@ class ParameterizedReturnTypeTest {
 
   @Test
   void aContainerDeclarationIsNotRefusedForABindingItNeverMakes() {
-    // Binding does not descend into a list declaration, so a `list<any1>` argument binds nothing.
-    // Both of these declare a concrete return and need no binding at all, so refusing the shape
-    // would reject calls that resolve today.
+    // Binding descends into none of the container declarations, so a `list<any1>` or a
+    // `func<any1 -> boolean?>` argument binds nothing. All four of these declare a concrete return
+    // and need no binding at all, so refusing the shape would reject calls that resolve today.
     assertEquals(R.I64, resolve("cardinality:list", R.list(R.I64)));
     assertEquals(N.I64, resolve("index_in:any_list", R.I64, R.list(R.I64)));
+    assertEquals(N.BOOLEAN, resolve("all_match:list_func", R.list(R.I64), N.BOOLEAN));
+    assertEquals(N.BOOLEAN, resolve("any_match:list_func", R.list(R.I64), N.BOOLEAN));
   }
 
   @Test
@@ -133,23 +136,9 @@ class ParameterizedReturnTypeTest {
    */
   @Test
   void theShapesTheCatalogDoesNotDeclareDeriveToo() {
-    assertEquals(
-        R.fixedBinary(9),
-        derive(
-            ParameterizedType.FixedBinary.builder().nullable(false).length(parameter("L1")).build(),
-            R.fixedBinary(9)));
-    assertEquals(
-        R.intervalCompound(3),
-        derive(
-            ParameterizedType.IntervalCompound.builder()
-                .nullable(false)
-                .precision(parameter("P"))
-                .build(),
-            R.intervalCompound(3)));
-  }
-
-  private static ParameterizedType.StringLiteral parameter(String name) {
-    return ParameterizedType.StringLiteral.builder().nullable(false).value(name).build();
+    ParameterizedTypeCreator P = ParameterizedTypeCreator.REQUIRED;
+    assertEquals(R.fixedBinary(9), derive(P.fixedBinaryE("L1"), R.fixedBinary(9)));
+    assertEquals(R.intervalCompound(3), derive(P.intervalCompoundE("P"), R.intervalCompound(3)));
   }
 
   /** Derives the return of a one-argument declaration whose argument has the return's own shape. */
@@ -167,10 +156,10 @@ class ParameterizedReturnTypeTest {
   }
 
   /**
-   * The two return shapes the evaluator does not derive, pinned by the variants that carry them so
-   * that the list in {@link TypeExpressionEvaluator}'s Javadoc cannot go stale on its own. A
-   * parameter that is a type to evaluate rather than an integer to substitute is the first; a
-   * multi-line return program is the second.
+   * The census of what the evaluator does not derive: a {@code list} return is the first shape, a
+   * multi-line return program the second. {@link TypeExpressionEvaluator}'s Javadoc describes those
+   * shapes and points here rather than naming variants, so this test is the only place a {@code
+   * substrait-packaging} bump can make the two disagree.
    */
   @Test
   void theReturnShapesThatAreNotDerivedYet() {
@@ -203,6 +192,15 @@ class ParameterizedReturnTypeTest {
             "strptime_timestamp:str_str_str_i8",
             "subtract:dec_dec"),
         variantsReturning(TypeExpression.ReturnProgram.class));
+
+    // The lists above pin which variants carry each shape; these pin that the shapes actually fail,
+    // so making one derivable cannot leave the census passing and the Javadoc stale.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> resolve("string_split:vchar_vchar", R.varChar(20), R.varChar(20)));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> resolve("add:dec_dec", R.decimal(10, 2), R.decimal(10, 2)));
   }
 
   private static List<String> variantsReturning(Class<?> returnShape) {

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
@@ -32,14 +32,14 @@ public final class AggregateConversion {
      *
      * <p>Type derivation is fail-closed: a function whose return expression the derivation does not
      * yet support is rejected rather than assumed valid, so this mode is not adoptable for plans
-     * that use such functions. On the standard extension catalog the unsupported shapes are the
-     * parameterized type classes other than decimal — {@code varchar<L1>}, {@code fixedchar<L1>},
-     * {@code precision_time<P>}, {@code precision_timestamp<P>}, {@code precision_timestamp_tz<P>},
-     * {@code interval_day<P>}, {@code list<anyN>}, parameterized structs — and multi-line return
-     * programs; for example {@code concat}, {@code concat_ws}, {@code assume_timezone} and the
-     * {@code strptime_*} family are rejected today. {@code quantile}'s output type cannot be
+     * that use such functions. On the standard extension catalog what remains unsupported is a
+     * return of {@code list<anyN>} ({@code filter}, {@code sort}, {@code transform}, {@code
+     * string_split}, {@code regexp_string_split}, {@code regexp_match_substring_all}) and a
+     * multi-line return program ({@code add}, {@code subtract}, {@code multiply}, {@code divide},
+     * {@code modulus}, {@code ceil}, {@code floor}, {@code round}, the {@code bitwise_*} family,
+     * {@code assume_timezone} and {@code strptime_*}). {@code quantile}'s output type cannot be
      * derived at all: its declared return {@code LIST?<any>} uses a plain {@code any}, which
-     * carries no identity to bind (spec v0.99.0).
+     * carries no identity to bind (spec v0.101.0).
      */
     EXTENSION_DECLARATION
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/AggregateConversion.java
@@ -32,14 +32,11 @@ public final class AggregateConversion {
      *
      * <p>Type derivation is fail-closed: a function whose return expression the derivation does not
      * yet support is rejected rather than assumed valid, so this mode is not adoptable for plans
-     * that use such functions. On the standard extension catalog what remains unsupported is a
-     * return of {@code list<anyN>} ({@code filter}, {@code sort}, {@code transform}, {@code
-     * string_split}, {@code regexp_string_split}, {@code regexp_match_substring_all}) and a
-     * multi-line return program ({@code add}, {@code subtract}, {@code multiply}, {@code divide},
-     * {@code modulus}, {@code ceil}, {@code floor}, {@code round}, the {@code bitwise_*} family,
-     * {@code assume_timezone} and {@code strptime_*}). {@code quantile}'s output type cannot be
-     * derived at all: its declared return {@code LIST?<any>} uses a plain {@code any}, which
-     * carries no identity to bind (spec v0.101.0).
+     * that use such functions. Among the standard aggregates that means {@code quantile}, whose
+     * declared return {@code LIST?<any>} uses a plain {@code any} carrying no identity to bind, and
+     * {@code avg} over a decimal, whose intermediate {@code STRUCT<DECIMAL<38,S>,i64>} is a
+     * parameterized struct the derivation has no case for. Because an unspecified aggregate phase
+     * consumes that intermediate state, an ordinary decimal {@code avg} is rejected too.
      */
     EXTENSION_DECLARATION
   }


### PR DESCRIPTION
`TypeExpressionEvaluator` bound and evaluated two shapes — a numbered wildcard and `DECIMAL<P,S>` — and every other parameterized class reached the throwing base of `TypeExpressionVisitor`. So `resolveType`, which `FunctionBindingResolver.deriveOutputType` and `validateOutputType` are built on, could not derive the output type of 94 of the 602 variants the standard extensions ship: 320 of 396 scalar answered, 86 of 95 aggregate, 102 of 111 window. 71 of those derive now, and 23 are left, every one of them a `list` return or a multi-line return program.

The remaining classes whose parameter is an integer to substitute now bind and evaluate the way `DECIMAL` already did: `varchar`, `fixedchar`, `fixedbinary`, the three `precision_*` types, `interval_day` and `interval_compound`. The last two are there for symmetry; no standard extension declares them parameterized at all, as an argument or as a return.

What this changes in practice is `AggregateConversion.FunctionBindingValidation.EXTENSION_DECLARATION`, whose own documentation said it was not adoptable for plans using these functions. It still is not adoptable for the two groups below, and that Javadoc was wrong twice over: it filed `assume_timezone` and the `strptime_*` family under the parameterized classes when they fail on a return program, and everything else it listed was a scalar declaration the aggregate path never sees. It names the two standard aggregates that do reach that mode now — `quantile` and `avg` over a decimal — since that doc exists to tell a reader whether the mode is adoptable. Which shipped variants carry the shapes that stay underivable is left to `ParameterizedReturnTypeTest` instead, so no Javadoc goes stale on a `substrait-packaging` bump.

`list` returns and return programs are unchanged, and are worth their own issues rather than being folded in here: #1241 and #1242. A `list` return fails whatever its element, because the evaluator does not descend into a container: an element parameter it would otherwise substitute, as in `list<varchar<L1>>`, is as far out of reach as an element type to evaluate.

Isthmus derives the same declared return a second time, in `SimpleExtensionToSqlOperator`, from the first operand; core throwing for these classes is why the two were never compared, and with core answering they differ for eight scalar variants in the catalog — `multiply:i8_iday` derives `interval_day<P>` where the first operand is `i8`. Nothing goes red: under `PLAN_OUTPUT` that inference only decides whether the plan's type travels on a wrapper. #1240 has the rest.

Part of #1139. The inconsistent-`P` question raised there is not settled by this: binding now makes `bindType`'s existing `Inconsistent binding` reachable for a shared parameter, which is what the tests pin, but nothing turns validation on by default. Binding also fails closed on a declared and actual pair whose shapes do not match, throwing an `UnsupportedOperationException` naming both rather than binding nothing and saying nothing: otherwise `concat:vchar(varchar(20), string)` would have started deriving `varchar(20)` here, since isthmus lets a `string` operand through against a declared `varchar<L1>`, where main throws. List, map, struct and function declarations are exempt, because binding never descends into them and refusing them would reject calls that resolve today — `cardinality:list` and `all_match:list_func` among them.
