### PR TITLE
refactor(isthmus): drop the unused TIME_WITH_LOCAL_TIME_ZONE precision override

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -110,7 +110,6 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
       case INTERVAL_YEAR:
       case INTERVAL_YEAR_MONTH:
       case TIME:
-      case TIME_WITH_LOCAL_TIME_ZONE:
       case TIMESTAMP:
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         return 6;

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -162,6 +162,20 @@ class SubstraitTypeSystemTest {
   }
 
   @Test
+  void timeWithLocalTimeZoneHasNoSubstraitMaxPrecision() {
+    // Substrait has precision_timestamp_tz but no time-with-timezone counterpart, so this type
+    // converts in neither direction and there is no Substrait maximum to report for it.
+    assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            TypeConverter.DEFAULT.toSubstrait(
+                TYPE_FACTORY.createSqlType(SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE, 3)));
+    assertEquals(
+        RelDataTypeSystem.DEFAULT.getMaxPrecision(SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE),
+        typeSystem.getMaxPrecision(SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE));
+  }
+
+  @Test
   void canCreateDecimalWithMaxPrecision() {
     RelDataType decimalType = TYPE_FACTORY.createSqlType(SqlTypeName.DECIMAL, 38, 10);
     assertEquals(38, decimalType.getPrecision());


### PR DESCRIPTION
`getMaxPrecision` raised the maximum precision to 6 for `TIME_WITH_LOCAL_TIME_ZONE` alongside the types Isthmus actually converts. Substrait has `precision_timestamp_tz` but no time-with-timezone counterpart, so the type appears in neither direction of `TypeConverter`, and the `case` was the only mention of the name in the repository. It has been there since the initial commit rather than added to keep a validation path working.

Removing it changes nothing observable. Calcite's type factory clamps a precision above the maximum instead of rejecting it, so the entry was not letting a bad precision get further than it otherwise would: with it `CAST(NULL AS TIME(4) WITH LOCAL TIME ZONE)` reaches the converter as `TIME_WITH_LOCAL_TIME_ZONE(4)`, without it as `TIME_WITH_LOCAL_TIME_ZONE(3)`, and both fail with the same `UnsupportedOperationException`. Precisions 0 through 6 failed at conversion before and still do.

The test pins the premise as well as the entry: if the type ever does convert, the assertion that `toSubstrait` rejects it fails and points at the maximum that would then need setting.

Closes #1149.
