### PR TITLE
fix(isthmus)!: round-trip a virtual table whose rows are not all literals

### DIFF
--- a/examples/isthmus-api/src/main/java/io/substrait/examples/ToOptimizedSql.java
+++ b/examples/isthmus-api/src/main/java/io/substrait/examples/ToOptimizedSql.java
@@ -3,6 +3,7 @@ package io.substrait.examples;
 import io.substrait.examples.IsthmusAppExamples.Action;
 import io.substrait.isthmus.ConverterProvider;
 import io.substrait.isthmus.SubstraitToCalcite;
+import io.substrait.isthmus.sql.SubstraitRelToSqlConverter;
 import io.substrait.plan.Plan;
 import io.substrait.plan.ProtoPlanConverter;
 import java.io.IOException;
@@ -45,7 +46,7 @@ public class ToOptimizedSql implements Action {
 
       // Configure Calcite Utilities
       final SqlDialect sqlDialect = SqlDialect.DatabaseProduct.MYSQL.getDialect();
-      final RelToSqlConverter relToSql = new RelToSqlConverter(sqlDialect);
+      final RelToSqlConverter relToSql = new SubstraitRelToSqlConverter(sqlDialect);
       final HepProgramBuilder programBuilder = new HepProgramBuilder();
       programBuilder.addMatchOrder(HepMatchOrder.BOTTOM_UP).addRuleCollection(SIMPLIFICATION_RULES);
       final HepPlanner planner = new HepPlanner(programBuilder.build());

--- a/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
@@ -118,8 +118,10 @@ public class OuterReferenceResolver extends RelNodeVisitor<RelNode, RuntimeExcep
     // A relation's own expressions can hold a subquery binding outer references, and a subquery's
     // relation is not an input, so walking inputs never reaches it. Filter and Project scan theirs
     // before they get here; a virtual table's rows, and a join, calc or sort condition, arrive
-    // here. AbstractRelNode.accept(RexShuttle) returns the relation itself, so the result is the
-    // one already in the tree.
+    // here. The rewrite is an identity -- RexVisitor.visitSubQuery returns the subquery it was
+    // given -- so the relation the tree holds is unchanged and the result is discarded. Relations
+    // that do not override accept(RexShuttle) at all -- TableModify, Window, Match, Aggregate --
+    // keep their expressions to themselves; a correlation among those is still unresolved.
     other.accept(rexVisitor);
     for (RelNode child : other.getInputs()) {
       reverseAccept(child);

--- a/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
@@ -1,6 +1,5 @@
 package io.substrait.isthmus;
 
-import io.substrait.isthmus.calcite.rel.VirtualTable;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -116,12 +115,12 @@ public class OuterReferenceResolver extends RelNodeVisitor<RelNode, RuntimeExcep
 
   @Override
   public RelNode visitOther(RelNode other) throws RuntimeException {
-    if (other instanceof VirtualTable) {
-      // A virtual table's rows are expressions, and a subquery among them binds outer references
-      // like one anywhere else. A subquery's relation is not an input, so walking inputs never
-      // reaches it; Filter and Project scan their own before they get here.
-      other.accept(rexVisitor);
-    }
+    // A relation's own expressions can hold a subquery binding outer references, and a subquery's
+    // relation is not an input, so walking inputs never reaches it. Filter and Project scan theirs
+    // before they get here; a virtual table's rows, and a join, calc or sort condition, arrive
+    // here. AbstractRelNode.accept(RexShuttle) returns the relation itself, so the result is the
+    // one already in the tree.
+    other.accept(rexVisitor);
     for (RelNode child : other.getInputs()) {
       reverseAccept(child);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/OuterReferenceResolver.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus;
 
+import io.substrait.isthmus.calcite.rel.VirtualTable;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -115,6 +116,12 @@ public class OuterReferenceResolver extends RelNodeVisitor<RelNode, RuntimeExcep
 
   @Override
   public RelNode visitOther(RelNode other) throws RuntimeException {
+    if (other instanceof VirtualTable) {
+      // A virtual table's rows are expressions, and a subquery among them binds outer references
+      // like one anywhere else. A subquery's relation is not an input, so walking inputs never
+      // reaches it; Filter and Project scan their own before they get here.
+      other.accept(rexVisitor);
+    }
     for (RelNode child : other.getInputs()) {
       reverseAccept(child);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/RelNodeVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/RelNodeVisitor.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus;
 
+import io.substrait.isthmus.calcite.rel.VirtualTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Calc;
@@ -61,6 +62,18 @@ public abstract class RelNodeVisitor<OUTPUT, EXCEPTION extends Throwable> {
    */
   public OUTPUT visit(Values values) throws EXCEPTION {
     return visitOther(values);
+  }
+
+  /**
+   * Visits a {@link VirtualTable} node, the relation isthmus converts a virtual table whose rows
+   * are not all literals into.
+   *
+   * @param virtualTable the virtual table node
+   * @return the result of visiting this node
+   * @throws EXCEPTION if the visit fails
+   */
+  public OUTPUT visit(VirtualTable virtualTable) throws EXCEPTION {
+    return visitOther(virtualTable);
   }
 
   /**
@@ -261,6 +274,8 @@ public abstract class RelNodeVisitor<OUTPUT, EXCEPTION extends Throwable> {
       return this.visit((Aggregate) node);
     } else if (node instanceof TableModify) {
       return this.visit((TableModify) node);
+    } else if (node instanceof VirtualTable) {
+      return this.visit((VirtualTable) node);
     } else {
       return this.visitOther(node);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -11,6 +11,7 @@ import io.substrait.extension.SimpleExtension;
 import io.substrait.hint.Hint;
 import io.substrait.isthmus.calcite.rel.CreateTable;
 import io.substrait.isthmus.calcite.rel.CreateView;
+import io.substrait.isthmus.calcite.rel.VirtualTable;
 import io.substrait.isthmus.expression.AggregateFunctionConverter;
 import io.substrait.isthmus.expression.ExpressionRexConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
@@ -63,6 +64,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
@@ -78,7 +80,6 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalTableModify;
-import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -924,45 +925,18 @@ public class SubstraitRelNodeConverter
           LogicalValues.create(relBuilder.getCluster(), rowType, tuplesBuilder.build()),
           virtualTableScan);
     } else {
-      // A row that does not fit a LogicalValues tuple is computed instead: we create a
-      // LogicalProject for each row to compute its values, and combine them together using a
-      // LogicalUnion. For example the following:
-      //
-      //   VirtualTable
-      //     (e1, e2)
-      //     (e3, e4)
-      //
-      //  Becomes:
-      //
-      //   LogicalUnion(all=[true])
-      //     LogicalProject(exprs=[e1, e2])
-      //       <Empty Row>
-      //     LogicalProject(exprs=[e3, e4])
-      //       <Empty Row>
-      //
-
-      RelDataType emptyRowType = typeFactory.createStructType(List.of(), List.of());
-      ImmutableList<ImmutableList<RexLiteral>> emptyRowValue = ImmutableList.of(ImmutableList.of());
-
-      List<RelNode> projects = new ArrayList<>();
-      for (final List<RexNode> rexRow : convertedRows) {
-        RelNode values = LogicalValues.create(relBuilder.getCluster(), emptyRowType, emptyRowValue);
-        RelNode project =
-            LogicalProject.create(
-                values, Collections.emptyList(), rexRow, rowType, Collections.emptySet());
-        projects.add(project);
-      }
-      RelNode union = LogicalUnion.create(projects, true);
-
-      // Apply a final LogicalProject on top to capture the field names from the VirtualTable
-      List<RexNode> topProjectExprs = new ArrayList<>();
-      for (int i = 0; i < rowType.getFieldCount(); i++) {
-        topProjectExprs.add(rexBuilder.makeInputRef(union, i));
-      }
-      RelNode topProject =
-          LogicalProject.create(
-              union, Collections.emptyList(), topProjectExprs, rowType, Collections.emptySet());
-      return applyRelCommon(topProject, virtualTableScan, topProject);
+      // A row that does not fit a LogicalValues tuple keeps its expressions, in a relation of our
+      // own: Calcite has none that holds them, and expanding the table into a projection per row
+      // does not come back -- the projection is what converts back, and the table is gone. A
+      // consumer whose planner only knows Calcite's own relations can expand it with
+      // VirtualTableExpansionRule.
+      return applyRelCommon(
+          new VirtualTable(
+              relBuilder.getCluster(),
+              relBuilder.getCluster().traitSetOf(Convention.NONE),
+              rowType,
+              convertedRows),
+          virtualTableScan);
     }
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -64,7 +64,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
@@ -931,12 +930,7 @@ public class SubstraitRelNodeConverter
       // consumer whose planner only knows Calcite's own relations can expand it with
       // VirtualTableExpansionRule.
       return applyRelCommon(
-          new VirtualTable(
-              relBuilder.getCluster(),
-              relBuilder.getCluster().traitSetOf(Convention.NONE),
-              rowType,
-              convertedRows),
-          virtualTableScan);
+          VirtualTable.create(relBuilder.getCluster(), rowType, convertedRows), virtualTableScan);
     }
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -62,6 +62,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
@@ -972,17 +973,30 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   }
 
   /**
-   * Handles the isthmus {@link VirtualTable}, which is what a virtual table whose rows are not all
+   * Converts the isthmus {@link VirtualTable}, which is what a virtual table whose rows are not all
    * literals converts to.
    *
    * @param virtualTable Calcite virtual table
    * @return Substrait virtual table scan
    */
-  public Rel handleVirtualTable(VirtualTable virtualTable) {
+  @Override
+  public Rel visit(VirtualTable virtualTable) {
+    // At the row type's field types rather than the values' own, as visit(Values) does: a literal
+    // narrower than its column -- Calcite infers one for a tuple value, and pushes a struct's
+    // nullability down into its fields -- would otherwise disagree with the schema built from the
+    // same row type, and VirtualTableScan rejects the relation on that.
+    List<RelDataTypeField> rowFields = virtualTable.getRowType().getFieldList();
+    LiteralConverter literalConverter = new LiteralConverter(typeConverter);
     List<Expression.NestedStruct> rows = new ArrayList<>(virtualTable.getRows().size());
     for (List<RexNode> row : virtualTable.getRows()) {
-      List<Expression> fields =
-          row.stream().map(this::toExpression).collect(Collectors.toUnmodifiableList());
+      List<Expression> fields = new ArrayList<>(row.size());
+      for (int column = 0; column < row.size(); column++) {
+        RexNode value = row.get(column);
+        fields.add(
+            value instanceof RexLiteral
+                ? literalConverter.convert((RexLiteral) value, rowFields.get(column).getType())
+                : toExpression(value));
+      }
       rows.add(ExpressionCreator.nestedStruct(false, fields));
     }
     return VirtualTableScan.builder()
@@ -1005,9 +1019,6 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
     } else if (other instanceof CreateView) {
       return handleCreateView((CreateView) other);
-
-    } else if (other instanceof VirtualTable) {
-      return handleVirtualTable((VirtualTable) other);
     }
     throw new UnsupportedOperationException("Unable to handle node: " + other);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -992,10 +992,24 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
       List<Expression> fields = new ArrayList<>(row.size());
       for (int column = 0; column < row.size(); column++) {
         RexNode value = row.get(column);
-        fields.add(
+        RelDataType declaredType = rowFields.get(column).getType();
+        Expression converted =
             value instanceof RexLiteral
-                ? literalConverter.convert((RexLiteral) value, rowFields.get(column).getType())
-                : toExpression(value));
+                ? literalConverter.convert((RexLiteral) value, declaredType)
+                : toExpression(value);
+        // A value that is not a literal is converted from the expressions it is built of and
+        // takes its type from them, which the declared type cannot be put back on: casting at it
+        // would put an expression in the output the input did not have. Refused here rather than
+        // left to VirtualTableScan, whose check compares the two types without promoting either.
+        Type declared = typeConverter.toSubstrait(declaredType);
+        if (!converted.getType().equals(declared)) {
+          throw new UnsupportedOperationException(
+              String.format(
+                  "A virtual table's value %s converts to %s where its column is declared %s: "
+                      + "isthmus cannot convert a value that does not carry its column's type",
+                  value, converted.getType(), declared));
+        }
+        fields.add(converted);
       }
       rows.add(ExpressionCreator.nestedStruct(false, fields));
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -8,6 +8,7 @@ import io.substrait.expression.FieldReference;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.calcite.rel.CreateTable;
 import io.substrait.isthmus.calcite.rel.CreateView;
+import io.substrait.isthmus.calcite.rel.VirtualTable;
 import io.substrait.isthmus.expression.AggregateFunctionConverter;
 import io.substrait.isthmus.expression.LiteralConverter;
 import io.substrait.isthmus.expression.RexExpressionConverter;
@@ -971,6 +972,26 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   }
 
   /**
+   * Handles the isthmus {@link VirtualTable}, which is what a virtual table whose rows are not all
+   * literals converts to.
+   *
+   * @param virtualTable Calcite virtual table
+   * @return Substrait virtual table scan
+   */
+  public Rel handleVirtualTable(VirtualTable virtualTable) {
+    List<Expression.NestedStruct> rows = new ArrayList<>(virtualTable.getRows().size());
+    for (List<RexNode> row : virtualTable.getRows()) {
+      List<Expression> fields =
+          row.stream().map(this::toExpression).collect(Collectors.toUnmodifiableList());
+      rows.add(ExpressionCreator.nestedStruct(false, fields));
+    }
+    return VirtualTableScan.builder()
+        .initialSchema(typeConverter.toNamedStruct(virtualTable.getRowType()))
+        .addAllRows(rows)
+        .build();
+  }
+
+  /**
    * Visits other Calcite nodes (e.g., DDL wrappers).
    *
    * @param other Calcite node
@@ -984,6 +1005,9 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
     } else if (other instanceof CreateView) {
       return handleCreateView((CreateView) other);
+
+    } else if (other instanceof VirtualTable) {
+      return handleVirtualTable((VirtualTable) other);
     }
     throw new UnsupportedOperationException("Unable to handle node: " + other);
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus;
 
 import io.substrait.extension.SimpleExtension;
+import io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule;
 import io.substrait.plan.Plan;
 import io.substrait.plan.Plan.Root;
 import io.substrait.relation.Rel;
@@ -66,6 +67,8 @@ public class SubstraitToSql extends SqlConverterBase {
    *
    * @param plan the Substrait {@link Plan} to convert to SQL, must not be null
    * @param dialect the {@link SqlDialect} to generate the SQL strings for, must not be null
+   *     <p>Any {@link io.substrait.isthmus.calcite.rel.VirtualTable} the conversion produced is
+   *     expanded first: {@link RelToSqlConverter} knows Calcite's own relations only.
    * @return list containing a SQL string for each {@link Plan.Root} in {@code plan}
    */
   public List<String> convert(Plan plan, SqlDialect dialect) {
@@ -75,7 +78,9 @@ public class SubstraitToSql extends SqlConverterBase {
     for (Root root : plan.getRoots()) {
       result.add(
           relToSql
-              .visitRoot(substraitToCalcite.convert(root).project(true))
+              .visitRoot(
+                  VirtualTableExpansionRule.expandAll(
+                      substraitToCalcite.convert(root).project(true)))
               .asStatement()
               .toSqlString(dialect)
               .getSql());

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitToSql.java
@@ -1,7 +1,7 @@
 package io.substrait.isthmus;
 
 import io.substrait.extension.SimpleExtension;
-import io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule;
+import io.substrait.isthmus.sql.SubstraitRelToSqlConverter;
 import io.substrait.plan.Plan;
 import io.substrait.plan.Plan.Root;
 import io.substrait.relation.Rel;
@@ -67,20 +67,19 @@ public class SubstraitToSql extends SqlConverterBase {
    *
    * @param plan the Substrait {@link Plan} to convert to SQL, must not be null
    * @param dialect the {@link SqlDialect} to generate the SQL strings for, must not be null
-   *     <p>Any {@link io.substrait.isthmus.calcite.rel.VirtualTable} the conversion produced is
-   *     expanded first: {@link RelToSqlConverter} knows Calcite's own relations only.
+   *     <p>Generated with {@link SubstraitRelToSqlConverter}: {@link RelToSqlConverter} knows
+   *     Calcite's own relations only, and the conversion can produce an {@link
+   *     io.substrait.isthmus.calcite.rel.VirtualTable}.
    * @return list containing a SQL string for each {@link Plan.Root} in {@code plan}
    */
   public List<String> convert(Plan plan, SqlDialect dialect) {
     List<String> result = new ArrayList<>();
-    RelToSqlConverter relToSql = new RelToSqlConverter(dialect);
+    RelToSqlConverter relToSql = new SubstraitRelToSqlConverter(dialect);
 
     for (Root root : plan.getRoots()) {
       result.add(
           relToSql
-              .visitRoot(
-                  VirtualTableExpansionRule.expandAll(
-                      substraitToCalcite.convert(root).project(true)))
+              .visitRoot(substraitToCalcite.convert(root).project(true))
               .asStatement()
               .toSqlString(dialect)
               .getSql());

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
@@ -131,6 +131,10 @@ public class VirtualTable extends AbstractRelNode {
    * join, and by {@code RelDecorrelator}: a consumer's planner leaves it unexpanded, and the
    * variables it resolves against have to travel with the relation that holds it.
    *
+   * <p>Only a consumer populates it. A conversion never does: an id is bound to a relation whose
+   * fields the reference names, and a leaf with no inputs has none, so an outer reference in a row
+   * belongs to the relation around the table the way one in a projection's expression does.
+   *
    * @return the correlation variables
    */
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
@@ -1,19 +1,27 @@
 package io.substrait.isthmus.calcite.rel;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.calcite.util.Litmus;
 
 /**
  * A table of rows given as expressions, which is what a Substrait virtual table is and what Calcite
@@ -24,15 +32,15 @@ import org.apache.calcite.sql.SqlExplainLevel;
  * rows into stock Calcite relations -- a projection per row, unioned -- loses that: the shape a
  * planner leaves behind is a projection over an empty table, which is what converts back. A
  * consumer that needs the expansion can ask for it with {@link
- * io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule}, knowing it is one-way; nothing
- * in isthmus runs that rule.
+ * io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule}, knowing it is one-way.
  *
  * <p>The rows are held at the row type's own field types, names included, so that the expansion has
  * nothing left to derive.
  */
 public class VirtualTable extends AbstractRelNode {
 
-  private final ImmutableList<ImmutableList<RexNode>> rows;
+  private final ImmutableList<List<RexNode>> rows;
+  private final ImmutableSet<CorrelationId> variablesSet;
 
   /**
    * VirtualTable constructor.
@@ -40,20 +48,70 @@ public class VirtualTable extends AbstractRelNode {
    * @param cluster the cluster this relation belongs to
    * @param traitSet the relation's traits
    * @param rowType the table's row type, carrying the schema's field names
+   * @param variablesSet the correlation variables the rows resolve against
    * @param rows one list of values per row, each value at the type its column is declared at
+   * @throws IllegalArgumentException if a row does not fit the row type
    */
   public VirtualTable(
       RelOptCluster cluster,
       RelTraitSet traitSet,
       RelDataType rowType,
+      Set<CorrelationId> variablesSet,
       List<? extends List<RexNode>> rows) {
     super(cluster, traitSet);
     this.rowType = rowType;
-    ImmutableList.Builder<ImmutableList<RexNode>> builder = ImmutableList.builder();
+    this.variablesSet = ImmutableSet.copyOf(variablesSet);
+    ImmutableList.Builder<List<RexNode>> builder = ImmutableList.builder();
     for (List<RexNode> row : rows) {
+      // Nothing else checks this: the deleted LogicalProject got it from RexUtil.compatibleTypes,
+      // and AbstractRelNode.isValid succeeds unconditionally.
+      if (row.size() != rowType.getFieldCount()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "A virtual table's row has %d values where its type declares %d columns: %s",
+                row.size(), rowType.getFieldCount(), row));
+      }
+      if (!RexUtil.compatibleTypes(row, rowType, Litmus.IGNORE)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "A virtual table's row %s does not fit the type %s its columns are declared at",
+                row, rowType.getFullTypeString()));
+      }
       builder.add(ImmutableList.copyOf(row));
     }
     this.rows = builder.build();
+  }
+
+  /**
+   * Creates a virtual table with no correlation variables, in the convention every relation this
+   * conversion builds is in.
+   *
+   * @param cluster the cluster this relation belongs to
+   * @param rowType the table's row type, carrying the schema's field names
+   * @param rows one list of values per row
+   * @return the virtual table
+   */
+  public static VirtualTable create(
+      RelOptCluster cluster, RelDataType rowType, List<? extends List<RexNode>> rows) {
+    return create(cluster, rowType, ImmutableSet.of(), rows);
+  }
+
+  /**
+   * Creates a virtual table whose rows resolve against the given correlation variables.
+   *
+   * @param cluster the cluster this relation belongs to
+   * @param rowType the table's row type, carrying the schema's field names
+   * @param variablesSet the correlation variables the rows resolve against
+   * @param rows one list of values per row
+   * @return the virtual table
+   */
+  public static VirtualTable create(
+      RelOptCluster cluster,
+      RelDataType rowType,
+      Set<CorrelationId> variablesSet,
+      List<? extends List<RexNode>> rows) {
+    return new VirtualTable(
+        cluster, cluster.traitSetOf(Convention.NONE), rowType, variablesSet, rows);
   }
 
   /**
@@ -61,18 +119,50 @@ public class VirtualTable extends AbstractRelNode {
    *
    * @return one list of values per row
    */
-  public List<? extends List<RexNode>> getRows() {
+  public List<List<RexNode>> getRows() {
     return rows;
   }
 
+  /**
+   * Returns the correlation variables the rows resolve against.
+   *
+   * <p>A row holding a {@link org.apache.calcite.rex.RexSubQuery} that binds an outer reference is
+   * unreachable by {@code SubQueryRemoveRule}, whose operands are a projection, a filter and a
+   * join, and by {@code RelDecorrelator}: a consumer's planner leaves it unexpanded, and the
+   * variables it resolves against have to travel with the relation that holds it.
+   *
+   * @return the correlation variables
+   */
   @Override
-  protected RelDataType deriveRowType() {
-    return rowType;
+  public Set<CorrelationId> getVariablesSet() {
+    return variablesSet;
   }
 
   @Override
   public double estimateRowCount(RelMetadataQuery mq) {
     return rows.size();
+  }
+
+  /**
+   * Returns the cost of this relation, which is the cost of what it expands into.
+   *
+   * <p>The inherited cost is a row count alone, which is cheaper than the projection per row the
+   * expansion builds -- a cost-based planner would fire {@link
+   * io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule} and then keep the unexpanded
+   * relation it started from.
+   *
+   * @param planner the planner asking
+   * @param mq the metadata query
+   * @return the cost of this relation
+   */
+  @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+    // Three relations per row -- an empty table, the projection over it, and the row's share of the
+    // union -- each costing its own row and the values it computes.
+    double relations = 3 * rows.size();
+    return planner
+        .getCostFactory()
+        .makeCost(relations, relations * (rowType.getFieldCount() + 1), 0);
   }
 
   /**
@@ -82,23 +172,32 @@ public class VirtualTable extends AbstractRelNode {
    * not pass one on keeps its expressions out of everything built on that -- finding the subqueries
    * that bind outer references among them.
    *
+   * <p>A rewrite that retypes a value retypes the column it stands in, so the row type is rebuilt
+   * from the rewritten rows where they no longer carry the declared types. The names of a rebuilt
+   * column are the expression's own below the top level, which is the most a relation can say
+   * without the schema that named them.
+   *
    * @param shuttle the rewrite to apply
    * @return this table with the rewritten rows, or itself where nothing changed
    */
   @Override
   public RelNode accept(RexShuttle shuttle) {
-    boolean changed = false;
     List<List<RexNode>> rewritten = new ArrayList<>(rows.size());
+    boolean changed = false;
     for (List<RexNode> row : rows) {
-      List<RexNode> rewrittenRow = new ArrayList<>(row.size());
-      for (RexNode value : row) {
-        RexNode visited = value.accept(shuttle);
-        changed |= visited != value;
-        rewrittenRow.add(visited);
-      }
+      List<RexNode> rewrittenRow = shuttle.apply(row);
+      changed |= rewrittenRow != row;
       rewritten.add(rewrittenRow);
     }
-    return changed ? new VirtualTable(getCluster(), getTraitSet(), rowType, rewritten) : this;
+    if (!changed) {
+      return this;
+    }
+    RelDataType rewrittenType =
+        rewritten.stream().allMatch(row -> RexUtil.compatibleTypes(row, rowType, Litmus.IGNORE))
+            ? rowType
+            : RexUtil.createStructType(
+                getCluster().getTypeFactory(), rewritten.get(0), rowType.getFieldNames(), null);
+    return new VirtualTable(getCluster(), getTraitSet(), rewrittenType, variablesSet, rewritten);
   }
 
   /**
@@ -111,6 +210,8 @@ public class VirtualTable extends AbstractRelNode {
   public RelWriter explainTerms(RelWriter pw) {
     return super.explainTerms(pw)
         .itemIf("type", rowType, pw.getDetailLevel() == SqlExplainLevel.DIGEST_ATTRIBUTES)
+        .itemIf("type", rowType.getFieldList(), pw.nest())
+        .itemIf("variablesSet", variablesSet, !variablesSet.isEmpty())
         .item(
             "rows",
             rows.stream()
@@ -135,6 +236,6 @@ public class VirtualTable extends AbstractRelNode {
     if (!inputs.isEmpty()) {
       throw new IllegalArgumentException("VirtualTable takes no inputs, but got " + inputs.size());
     }
-    return new VirtualTable(getCluster(), traitSet, rowType, rows);
+    return new VirtualTable(getCluster(), traitSet, rowType, variablesSet, rows);
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
@@ -175,7 +175,9 @@ public class VirtualTable extends AbstractRelNode {
       }
       RelDataType columnType = typeFactory.leastRestrictive(valueTypes);
       // Nothing in Calcite's type system unifies every pair -- a rewrite that leaves two rows with
-      // no common type keeps the declared one, and the constructor is left to report the row.
+      // no common type keeps the declared one, which then fits neither. The constructor checks the
+      // count and not the types, so the expansion is where that surfaces: Project.isValid with
+      // assertions on, and a projection whose declared type does not fit its expressions without.
       columnTypes.add(
           columnType == null ? rowType.getFieldList().get(column).getType() : columnType);
     }

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
@@ -1,10 +1,8 @@
 package io.substrait.isthmus.calcite.rel;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
@@ -14,9 +12,9 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
-import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.rex.RexUtil;
@@ -40,7 +38,6 @@ import org.apache.calcite.util.Litmus;
 public class VirtualTable extends AbstractRelNode {
 
   private final ImmutableList<List<RexNode>> rows;
-  private final ImmutableSet<CorrelationId> variablesSet;
 
   /**
    * VirtualTable constructor.
@@ -48,34 +45,27 @@ public class VirtualTable extends AbstractRelNode {
    * @param cluster the cluster this relation belongs to
    * @param traitSet the relation's traits
    * @param rowType the table's row type, carrying the schema's field names
-   * @param variablesSet the correlation variables the rows resolve against
    * @param rows one list of values per row, each value at the type its column is declared at
-   * @throws IllegalArgumentException if a row does not fit the row type
+   * @throws IllegalArgumentException if a row has more or fewer values than the type has columns
    */
   public VirtualTable(
       RelOptCluster cluster,
       RelTraitSet traitSet,
       RelDataType rowType,
-      Set<CorrelationId> variablesSet,
       List<? extends List<RexNode>> rows) {
     super(cluster, traitSet);
     this.rowType = rowType;
-    this.variablesSet = ImmutableSet.copyOf(variablesSet);
     ImmutableList.Builder<List<RexNode>> builder = ImmutableList.builder();
     for (List<RexNode> row : rows) {
-      // Nothing else checks this: the deleted LogicalProject got it from RexUtil.compatibleTypes,
-      // and AbstractRelNode.isValid succeeds unconditionally.
+      // Nothing else checks the count: the deleted LogicalProject got it from
+      // RexUtil.compatibleTypes, and AbstractRelNode.isValid succeeds unconditionally. The value
+      // types are not checked at all: the conversion gives every value the type its column is
+      // declared at before building the table, so a check here would only bind a direct caller.
       if (row.size() != rowType.getFieldCount()) {
         throw new IllegalArgumentException(
             String.format(
                 "A virtual table's row has %d values where its type declares %d columns: %s",
                 row.size(), rowType.getFieldCount(), row));
-      }
-      if (!RexUtil.compatibleTypes(row, rowType, Litmus.IGNORE)) {
-        throw new IllegalArgumentException(
-            String.format(
-                "A virtual table's row %s does not fit the type %s its columns are declared at",
-                row, rowType.getFullTypeString()));
       }
       builder.add(ImmutableList.copyOf(row));
     }
@@ -83,8 +73,7 @@ public class VirtualTable extends AbstractRelNode {
   }
 
   /**
-   * Creates a virtual table with no correlation variables, in the convention every relation this
-   * conversion builds is in.
+   * Creates a virtual table in the convention every relation this conversion builds is in.
    *
    * @param cluster the cluster this relation belongs to
    * @param rowType the table's row type, carrying the schema's field names
@@ -93,25 +82,7 @@ public class VirtualTable extends AbstractRelNode {
    */
   public static VirtualTable create(
       RelOptCluster cluster, RelDataType rowType, List<? extends List<RexNode>> rows) {
-    return create(cluster, rowType, ImmutableSet.of(), rows);
-  }
-
-  /**
-   * Creates a virtual table whose rows resolve against the given correlation variables.
-   *
-   * @param cluster the cluster this relation belongs to
-   * @param rowType the table's row type, carrying the schema's field names
-   * @param variablesSet the correlation variables the rows resolve against
-   * @param rows one list of values per row
-   * @return the virtual table
-   */
-  public static VirtualTable create(
-      RelOptCluster cluster,
-      RelDataType rowType,
-      Set<CorrelationId> variablesSet,
-      List<? extends List<RexNode>> rows) {
-    return new VirtualTable(
-        cluster, cluster.traitSetOf(Convention.NONE), rowType, variablesSet, rows);
+    return new VirtualTable(cluster, cluster.traitSetOf(Convention.NONE), rowType, rows);
   }
 
   /**
@@ -121,25 +92,6 @@ public class VirtualTable extends AbstractRelNode {
    */
   public List<List<RexNode>> getRows() {
     return rows;
-  }
-
-  /**
-   * Returns the correlation variables the rows resolve against.
-   *
-   * <p>A row holding a {@link org.apache.calcite.rex.RexSubQuery} that binds an outer reference is
-   * unreachable by {@code SubQueryRemoveRule}, whose operands are a projection, a filter and a
-   * join, and by {@code RelDecorrelator}: a consumer's planner leaves it unexpanded, and the
-   * variables it resolves against have to travel with the relation that holds it.
-   *
-   * <p>Only a consumer populates it. A conversion never does: an id is bound to a relation whose
-   * fields the reference names, and a leaf with no inputs has none, so an outer reference in a row
-   * belongs to the relation around the table the way one in a projection's expression does.
-   *
-   * @return the correlation variables
-   */
-  @Override
-  public Set<CorrelationId> getVariablesSet() {
-    return variablesSet;
   }
 
   @Override
@@ -196,12 +148,38 @@ public class VirtualTable extends AbstractRelNode {
     if (!changed) {
       return this;
     }
-    RelDataType rewrittenType =
-        rewritten.stream().allMatch(row -> RexUtil.compatibleTypes(row, rowType, Litmus.IGNORE))
-            ? rowType
-            : RexUtil.createStructType(
-                getCluster().getTypeFactory(), rewritten.get(0), rowType.getFieldNames(), null);
-    return new VirtualTable(getCluster(), getTraitSet(), rewrittenType, variablesSet, rewritten);
+    return new VirtualTable(getCluster(), getTraitSet(), rebuiltRowType(rewritten), rewritten);
+  }
+
+  /**
+   * The row type the rewritten rows fit.
+   *
+   * <p>The declared one where every row still carries it, so that a substitution keeping the types
+   * keeps the schema's names, nested ones included. Otherwise the least restrictive type each
+   * column takes across all of the rows: a shuttle that retypes a value in one row need not retype
+   * the same column in the next, and a type taken from one row alone need not fit the others.
+   *
+   * @param rewritten the rows after the rewrite
+   * @return the row type to build the rewritten table at
+   */
+  private RelDataType rebuiltRowType(List<List<RexNode>> rewritten) {
+    if (rewritten.stream().allMatch(row -> RexUtil.compatibleTypes(row, rowType, Litmus.IGNORE))) {
+      return rowType;
+    }
+    RelDataTypeFactory typeFactory = getCluster().getTypeFactory();
+    List<RelDataType> columnTypes = new ArrayList<>(rowType.getFieldCount());
+    for (int column = 0; column < rowType.getFieldCount(); column++) {
+      List<RelDataType> valueTypes = new ArrayList<>(rewritten.size());
+      for (List<RexNode> row : rewritten) {
+        valueTypes.add(row.get(column).getType());
+      }
+      RelDataType columnType = typeFactory.leastRestrictive(valueTypes);
+      // Nothing in Calcite's type system unifies every pair -- a rewrite that leaves two rows with
+      // no common type keeps the declared one, and the constructor is left to report the row.
+      columnTypes.add(
+          columnType == null ? rowType.getFieldList().get(column).getType() : columnType);
+    }
+    return typeFactory.createStructType(columnTypes, rowType.getFieldNames());
   }
 
   /**
@@ -215,7 +193,6 @@ public class VirtualTable extends AbstractRelNode {
     return super.explainTerms(pw)
         .itemIf("type", rowType, pw.getDetailLevel() == SqlExplainLevel.DIGEST_ATTRIBUTES)
         .itemIf("type", rowType.getFieldList(), pw.nest())
-        .itemIf("variablesSet", variablesSet, !variablesSet.isEmpty())
         .item(
             "rows",
             rows.stream()
@@ -240,6 +217,6 @@ public class VirtualTable extends AbstractRelNode {
     if (!inputs.isEmpty()) {
       throw new IllegalArgumentException("VirtualTable takes no inputs, but got " + inputs.size());
     }
-    return new VirtualTable(getCluster(), traitSet, rowType, variablesSet, rows);
+    return new VirtualTable(getCluster(), traitSet, rowType, rows);
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/VirtualTable.java
@@ -1,0 +1,140 @@
+package io.substrait.isthmus.calcite.rel;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelWriter;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.SqlExplainLevel;
+
+/**
+ * A table of rows given as expressions, which is what a Substrait virtual table is and what Calcite
+ * has no relation for: {@link org.apache.calcite.rel.core.Values} holds literals and nothing else.
+ *
+ * <p>Isthmus emits this for a virtual table whose rows do not all fit Values tuples, and recognises
+ * it by type on the way back, so the relation comes back as the one it went in as. Expanding the
+ * rows into stock Calcite relations -- a projection per row, unioned -- loses that: the shape a
+ * planner leaves behind is a projection over an empty table, which is what converts back. A
+ * consumer that needs the expansion can ask for it with {@link
+ * io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule}, knowing it is one-way; nothing
+ * in isthmus runs that rule.
+ *
+ * <p>The rows are held at the row type's own field types, names included, so that the expansion has
+ * nothing left to derive.
+ */
+public class VirtualTable extends AbstractRelNode {
+
+  private final ImmutableList<ImmutableList<RexNode>> rows;
+
+  /**
+   * VirtualTable constructor.
+   *
+   * @param cluster the cluster this relation belongs to
+   * @param traitSet the relation's traits
+   * @param rowType the table's row type, carrying the schema's field names
+   * @param rows one list of values per row, each value at the type its column is declared at
+   */
+  public VirtualTable(
+      RelOptCluster cluster,
+      RelTraitSet traitSet,
+      RelDataType rowType,
+      List<? extends List<RexNode>> rows) {
+    super(cluster, traitSet);
+    this.rowType = rowType;
+    ImmutableList.Builder<ImmutableList<RexNode>> builder = ImmutableList.builder();
+    for (List<RexNode> row : rows) {
+      builder.add(ImmutableList.copyOf(row));
+    }
+    this.rows = builder.build();
+  }
+
+  /**
+   * Returns the table's rows.
+   *
+   * @return one list of values per row
+   */
+  public List<? extends List<RexNode>> getRows() {
+    return rows;
+  }
+
+  @Override
+  protected RelDataType deriveRowType() {
+    return rowType;
+  }
+
+  @Override
+  public double estimateRowCount(RelMetadataQuery mq) {
+    return rows.size();
+  }
+
+  /**
+   * Applies an expression rewrite to the rows.
+   *
+   * <p>Calcite rewrites a relation's expressions by handing it a shuttle, and a relation that does
+   * not pass one on keeps its expressions out of everything built on that -- finding the subqueries
+   * that bind outer references among them.
+   *
+   * @param shuttle the rewrite to apply
+   * @return this table with the rewritten rows, or itself where nothing changed
+   */
+  @Override
+  public RelNode accept(RexShuttle shuttle) {
+    boolean changed = false;
+    List<List<RexNode>> rewritten = new ArrayList<>(rows.size());
+    for (List<RexNode> row : rows) {
+      List<RexNode> rewrittenRow = new ArrayList<>(row.size());
+      for (RexNode value : row) {
+        RexNode visited = value.accept(shuttle);
+        changed |= visited != value;
+        rewrittenRow.add(visited);
+      }
+      rewritten.add(rewrittenRow);
+    }
+    return changed ? new VirtualTable(getCluster(), getTraitSet(), rowType, rewritten) : this;
+  }
+
+  /**
+   * Explains the node terms for plan output.
+   *
+   * @param pw plan writer
+   * @return the plan writer with this node's fields added
+   */
+  @Override
+  public RelWriter explainTerms(RelWriter pw) {
+    return super.explainTerms(pw)
+        .itemIf("type", rowType, pw.getDetailLevel() == SqlExplainLevel.DIGEST_ATTRIBUTES)
+        .item(
+            "rows",
+            rows.stream()
+                .map(
+                    row ->
+                        row.stream()
+                            .map(RexNode::toString)
+                            .collect(Collectors.joining(", ", "{ ", " }")))
+                .collect(Collectors.joining(", ", "[", "]")));
+  }
+
+  /**
+   * Copies this node with the given traits.
+   *
+   * @param traitSet the RelTraitSet
+   * @param inputs List of RelNodes, which has to be empty
+   * @return a copy of this node
+   * @throws IllegalArgumentException if given any input
+   */
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    if (!inputs.isEmpty()) {
+      throw new IllegalArgumentException("VirtualTable takes no inputs, but got " + inputs.size());
+    }
+    return new VirtualTable(getCluster(), traitSet, rowType, rows);
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
@@ -134,7 +134,10 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
    *
    * <p>Written out rather than generated: the generated implementation copies {@link
    * RelRule.Config#description()}, which Calcite declares nullable, and so imports {@code
-   * javax.annotation.Nullable} -- which isthmus does not have on its compile classpath.
+   * javax.annotation.Nullable} -- which isthmus does not have on its compile classpath. The
+   * annotation lands in the builder method that copies from the supertype, where {@code
+   * Value.Style}'s {@code allowedClasspathAnnotations}, {@code nullableAnnotation} and {@code
+   * fallbackNullableAnnotation} do not reach it.
    *
    * <p>{@link #relBuilderFactory()} is inert: the expansion is built directly and never asks the
    * call for a builder. The interface requires an answer, so this is Calcite's own default.

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
@@ -10,8 +10,6 @@ import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
-import org.apache.calcite.plan.hep.HepPlanner;
-import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -69,26 +67,6 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
   @Override
   public void onMatch(RelOptRuleCall call) {
     call.transformTo(expand(call.rel(0)));
-  }
-
-  /**
-   * Expands every {@link VirtualTable} in the given tree, leaving the rest of it alone.
-   *
-   * <p>For a consumer that has to hand the tree to something knowing only Calcite's own relations:
-   * {@link org.apache.calcite.rel.rel2sql.RelToSqlConverter} has no case for a relation it does not
-   * know and throws an {@link AssertionError} naming it. Isthmus' own SQL generation does not need
-   * this -- {@link io.substrait.isthmus.sql.SubstraitRelToSqlConverter} has the case instead, which
-   * a tree pass cannot substitute for: a table inside a {@code RexSubQuery} is in no relation's
-   * inputs, so nothing walking them reaches it.
-   *
-   * @param relNode the tree to expand
-   * @return the tree with every virtual table expanded
-   */
-  public static RelNode expandAll(RelNode relNode) {
-    HepPlanner planner =
-        new HepPlanner(new HepProgramBuilder().addRuleInstance(instance()).build());
-    planner.setRoot(relNode);
-    return planner.findBestExp();
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
@@ -5,17 +5,22 @@ import io.substrait.isthmus.calcite.rel.VirtualTable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.tools.RelBuilderFactory;
 
 /**
@@ -39,8 +44,21 @@ import org.apache.calcite.tools.RelBuilderFactory;
  */
 public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule.Config> {
 
-  /** The rule instance to add to a planner. */
-  public static final VirtualTableExpansionRule INSTANCE = Config.DEFAULT.toRule();
+  /**
+   * Returns the rule instance to add to a planner.
+   *
+   * <p>Held by a nested class rather than a field of this one: the configuration builds a rule and
+   * the rule reads its configuration, so a field here would have the two initialize each other.
+   *
+   * @return the rule instance
+   */
+  public static VirtualTableExpansionRule instance() {
+    return InstanceHolder.INSTANCE;
+  }
+
+  private static final class InstanceHolder {
+    private static final VirtualTableExpansionRule INSTANCE = Config.DEFAULT.toRule();
+  }
 
   private VirtualTableExpansionRule(Config config) {
     super(config);
@@ -49,6 +67,23 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
   @Override
   public void onMatch(RelOptRuleCall call) {
     call.transformTo(expand(call.rel(0)));
+  }
+
+  /**
+   * Expands every {@link VirtualTable} in the given tree, leaving the rest of it alone.
+   *
+   * <p>For a consumer that has to hand the tree to something knowing only Calcite's own relations.
+   * Isthmus' own SQL generation is one: {@link org.apache.calcite.rel.rel2sql.RelToSqlConverter}
+   * has no case for a relation it does not know and throws an {@link AssertionError} naming it.
+   *
+   * @param relNode the tree to expand
+   * @return the tree with every virtual table expanded
+   */
+  public static RelNode expandAll(RelNode relNode) {
+    HepPlanner planner =
+        new HepPlanner(new HepProgramBuilder().addRuleInstance(instance()).build());
+    planner.setRoot(relNode);
+    return planner.findBestExp();
   }
 
   private static RelNode expand(VirtualTable virtualTable) {
@@ -60,13 +95,34 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
 
     RelDataType emptyRowType = cluster.getTypeFactory().createStructType(List.of(), List.of());
     ImmutableList<ImmutableList<RexLiteral>> singleEmptyRow = ImmutableList.of(ImmutableList.of());
+    // One empty row for every projection: they share a digest, so a planner keeps one of them
+    // whether the rule builds one or many.
+    RelNode emptyRow = LogicalValues.create(cluster, emptyRowType, singleEmptyRow);
+
+    // A projection carries the variables the rows resolve against: a subquery among them is
+    // unreachable by SubQueryRemoveRule and RelDecorrelator, and the expansion is what a consumer
+    // hands to a planner that only knows Calcite's own relations.
+    List<String> fieldNames =
+        SqlValidatorUtil.uniquify(
+            rowType.getFieldNames(), SqlValidatorUtil.F_SUGGESTER, /* caseSensitive= */ true);
+    RelDataType projectRowType =
+        cluster
+            .getTypeFactory()
+            .createStructType(
+                rowType.getFieldList().stream()
+                    .map(RelDataTypeField::getType)
+                    .collect(Collectors.toList()),
+                fieldNames);
 
     List<RelNode> rowProjects = new ArrayList<>();
     for (List<RexNode> row : virtualTable.getRows()) {
-      RelNode emptyRow = LogicalValues.create(cluster, emptyRowType, singleEmptyRow);
       rowProjects.add(
           LogicalProject.create(
-              emptyRow, Collections.emptyList(), row, rowType, Collections.emptySet()));
+              emptyRow,
+              Collections.emptyList(),
+              row,
+              projectRowType,
+              virtualTable.getVariablesSet()));
     }
     // A one-input union is not a relation a planner keeps -- UNION_REMOVE strips it -- and the
     // projection is what the expansion means anyway.
@@ -76,15 +132,19 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
   /**
    * Rule configuration.
    *
-   * <p>Written out rather than generated: the rule matches one relation and has nothing to
-   * configure, so the three properties {@link RelRule.Config} declares are all there is.
+   * <p>Written out rather than generated: the generated implementation copies {@link
+   * RelRule.Config#description()}, which Calcite declares nullable, and so imports {@code
+   * javax.annotation.Nullable} -- which isthmus does not have on its compile classpath.
+   *
+   * <p>{@link #relBuilderFactory()} is inert: the expansion is built directly and never asks the
+   * call for a builder. The interface requires an answer, so this is Calcite's own default.
    */
   public static class Config implements RelRule.Config {
 
     private static final OperandTransform TABLE =
         operand -> operand.operand(VirtualTable.class).noInputs();
 
-    /** The configuration {@link VirtualTableExpansionRule#INSTANCE} is built from. */
+    /** The configuration {@link VirtualTableExpansionRule#instance()} is built from. */
     public static final Config DEFAULT =
         new Config(RelFactories.LOGICAL_BUILDER, "VirtualTableExpansionRule", TABLE);
 

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
@@ -1,0 +1,137 @@
+package io.substrait.isthmus.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import io.substrait.isthmus.calcite.rel.VirtualTable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilderFactory;
+
+/**
+ * Expands a {@link VirtualTable} into stock Calcite relations: a projection computing each row over
+ * a single empty row, and a UNION ALL of those where there is more than one.
+ *
+ * <pre>{@code
+ * VirtualTable(rows=[{ e1, e2 }, { e3, e4 }])
+ *
+ *   LogicalUnion(all=[true])
+ *     LogicalProject(exprs=[e1, e2])
+ *       LogicalValues(tuples=[[{ }]])
+ *     LogicalProject(exprs=[e3, e4])
+ *       LogicalValues(tuples=[[{ }]])
+ * }</pre>
+ *
+ * <p>This is for a consumer whose planner only knows Calcite's own relations. It is one-way: the
+ * expansion is a plan like any other, and converting it back to Substrait gives the relation it is,
+ * not the virtual table it came from. Isthmus never runs it -- a plan it converts keeps the {@link
+ * VirtualTable}, which is what makes the round trip exact.
+ */
+public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule.Config> {
+
+  /** The rule instance to add to a planner. */
+  public static final VirtualTableExpansionRule INSTANCE = Config.DEFAULT.toRule();
+
+  private VirtualTableExpansionRule(Config config) {
+    super(config);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    call.transformTo(expand(call.rel(0)));
+  }
+
+  private static RelNode expand(VirtualTable virtualTable) {
+    RelOptCluster cluster = virtualTable.getCluster();
+    RelDataType rowType = virtualTable.getRowType();
+    if (virtualTable.getRows().isEmpty()) {
+      return LogicalValues.create(cluster, rowType, ImmutableList.of());
+    }
+
+    RelDataType emptyRowType = cluster.getTypeFactory().createStructType(List.of(), List.of());
+    ImmutableList<ImmutableList<RexLiteral>> singleEmptyRow = ImmutableList.of(ImmutableList.of());
+
+    List<RelNode> rowProjects = new ArrayList<>();
+    for (List<RexNode> row : virtualTable.getRows()) {
+      RelNode emptyRow = LogicalValues.create(cluster, emptyRowType, singleEmptyRow);
+      rowProjects.add(
+          LogicalProject.create(
+              emptyRow, Collections.emptyList(), row, rowType, Collections.emptySet()));
+    }
+    // A one-input union is not a relation a planner keeps -- UNION_REMOVE strips it -- and the
+    // projection is what the expansion means anyway.
+    return rowProjects.size() == 1 ? rowProjects.get(0) : LogicalUnion.create(rowProjects, true);
+  }
+
+  /**
+   * Rule configuration.
+   *
+   * <p>Written out rather than generated: the rule matches one relation and has nothing to
+   * configure, so the three properties {@link RelRule.Config} declares are all there is.
+   */
+  public static class Config implements RelRule.Config {
+
+    private static final OperandTransform TABLE =
+        operand -> operand.operand(VirtualTable.class).noInputs();
+
+    /** The configuration {@link VirtualTableExpansionRule#INSTANCE} is built from. */
+    public static final Config DEFAULT =
+        new Config(RelFactories.LOGICAL_BUILDER, "VirtualTableExpansionRule", TABLE);
+
+    private final RelBuilderFactory relBuilderFactory;
+    private final String description;
+    private final OperandTransform operandSupplier;
+
+    private Config(
+        RelBuilderFactory relBuilderFactory, String description, OperandTransform operandSupplier) {
+      this.relBuilderFactory = relBuilderFactory;
+      this.description = description;
+      this.operandSupplier = operandSupplier;
+    }
+
+    @Override
+    public VirtualTableExpansionRule toRule() {
+      return new VirtualTableExpansionRule(this);
+    }
+
+    @Override
+    public RelBuilderFactory relBuilderFactory() {
+      return relBuilderFactory;
+    }
+
+    @Override
+    public Config withRelBuilderFactory(RelBuilderFactory factory) {
+      return new Config(factory, description, operandSupplier);
+    }
+
+    @Override
+    public String description() {
+      return description;
+    }
+
+    @Override
+    public Config withDescription(String description) {
+      return new Config(relBuilderFactory, description, operandSupplier);
+    }
+
+    @Override
+    public OperandTransform operandSupplier() {
+      return operandSupplier;
+    }
+
+    @Override
+    public Config withOperandSupplier(OperandTransform transform) {
+      return new Config(relBuilderFactory, description, transform);
+    }
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/rules/VirtualTableExpansionRule.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus.calcite.rel.rules;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.substrait.isthmus.calcite.rel.VirtualTable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,8 +40,9 @@ import org.apache.calcite.tools.RelBuilderFactory;
  *
  * <p>This is for a consumer whose planner only knows Calcite's own relations. It is one-way: the
  * expansion is a plan like any other, and converting it back to Substrait gives the relation it is,
- * not the virtual table it came from. Isthmus never runs it -- a plan it converts keeps the {@link
- * VirtualTable}, which is what makes the round trip exact.
+ * not the virtual table it came from. Isthmus never runs it as a planner rule -- a plan it converts
+ * keeps the {@link VirtualTable}, which is what makes the round trip exact -- and its SQL generator
+ * takes only the shape, through {@link #expand(VirtualTable)}.
  */
 public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule.Config> {
 
@@ -72,9 +74,12 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
   /**
    * Expands every {@link VirtualTable} in the given tree, leaving the rest of it alone.
    *
-   * <p>For a consumer that has to hand the tree to something knowing only Calcite's own relations.
-   * Isthmus' own SQL generation is one: {@link org.apache.calcite.rel.rel2sql.RelToSqlConverter}
-   * has no case for a relation it does not know and throws an {@link AssertionError} naming it.
+   * <p>For a consumer that has to hand the tree to something knowing only Calcite's own relations:
+   * {@link org.apache.calcite.rel.rel2sql.RelToSqlConverter} has no case for a relation it does not
+   * know and throws an {@link AssertionError} naming it. Isthmus' own SQL generation does not need
+   * this -- {@link io.substrait.isthmus.sql.SubstraitRelToSqlConverter} has the case instead, which
+   * a tree pass cannot substitute for: a table inside a {@code RexSubQuery} is in no relation's
+   * inputs, so nothing walking them reaches it.
    *
    * @param relNode the tree to expand
    * @return the tree with every virtual table expanded
@@ -86,26 +91,26 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
     return planner.findBestExp();
   }
 
-  private static RelNode expand(VirtualTable virtualTable) {
+  /**
+   * Expands one virtual table into the projections its rows stand for.
+   *
+   * <p>The shape both this rule and isthmus' SQL generation use, so that the two cannot drift: the
+   * generator has its own case for the relation rather than a planner pass, and takes the expansion
+   * from here.
+   *
+   * @param virtualTable the table to expand
+   * @return the union of one projection per row, or the projection itself where there is one row
+   */
+  public static RelNode expand(VirtualTable virtualTable) {
     RelOptCluster cluster = virtualTable.getCluster();
     RelDataType rowType = virtualTable.getRowType();
-    if (virtualTable.getRows().isEmpty()) {
-      return LogicalValues.create(cluster, rowType, ImmutableList.of());
-    }
-
-    RelDataType emptyRowType = cluster.getTypeFactory().createStructType(List.of(), List.of());
-    ImmutableList<ImmutableList<RexLiteral>> singleEmptyRow = ImmutableList.of(ImmutableList.of());
-    // One empty row for every projection: they share a digest, so a planner keeps one of them
-    // whether the rule builds one or many.
-    RelNode emptyRow = LogicalValues.create(cluster, emptyRowType, singleEmptyRow);
-
-    // A projection carries the variables the rows resolve against: a subquery among them is
-    // unreachable by SubQueryRemoveRule and RelDecorrelator, and the expansion is what a consumer
-    // hands to a planner that only knows Calcite's own relations.
+    // A schema may name two columns the same -- the spec asks only that the names are a depth-first
+    // list -- and the table carries them as they are. Calcite's own relations cannot, so both
+    // branches below build their row type from the uniquified names.
     List<String> fieldNames =
         SqlValidatorUtil.uniquify(
             rowType.getFieldNames(), SqlValidatorUtil.F_SUGGESTER, /* caseSensitive= */ true);
-    RelDataType projectRowType =
+    RelDataType uniquifiedRowType =
         cluster
             .getTypeFactory()
             .createStructType(
@@ -114,6 +119,16 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
                     .collect(Collectors.toList()),
                 fieldNames);
 
+    if (virtualTable.getRows().isEmpty()) {
+      return LogicalValues.create(cluster, uniquifiedRowType, ImmutableList.of());
+    }
+
+    RelDataType emptyRowType = cluster.getTypeFactory().createStructType(List.of(), List.of());
+    ImmutableList<ImmutableList<RexLiteral>> singleEmptyRow = ImmutableList.of(ImmutableList.of());
+    // One empty row for every projection: they share a digest, so a planner keeps one of them
+    // whether the rule builds one or many.
+    RelNode emptyRow = LogicalValues.create(cluster, emptyRowType, singleEmptyRow);
+
     List<RelNode> rowProjects = new ArrayList<>();
     for (List<RexNode> row : virtualTable.getRows()) {
       rowProjects.add(
@@ -121,8 +136,10 @@ public class VirtualTableExpansionRule extends RelRule<VirtualTableExpansionRule
               emptyRow,
               Collections.emptyList(),
               row,
-              projectRowType,
-              virtualTable.getVariablesSet()));
+              uniquifiedRowType,
+              // Not the table's own set: a leaf declares none, and a projection over a zero-field
+              // Values cannot resolve one anyway.
+              ImmutableSet.of()));
     }
     // A one-input union is not a relation a planner keeps -- UNION_REMOVE strips it -- and the
     // projection is what the expansion means anyway.

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitRelToSqlConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitRelToSqlConverter.java
@@ -1,0 +1,41 @@
+package io.substrait.isthmus.sql;
+
+import io.substrait.isthmus.calcite.rel.VirtualTable;
+import io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule;
+import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
+import org.apache.calcite.sql.SqlDialect;
+
+/**
+ * The {@link RelToSqlConverter} isthmus generates SQL with.
+ *
+ * <p>Calcite's own knows Calcite's own relations and throws an {@link AssertionError} naming
+ * anything else, so a {@link VirtualTable} needs a case here. Rewriting the tree before handing it
+ * over does not reach one: a subquery's relation is not an input, and {@code
+ * org.apache.calcite.rel.rel2sql.SqlImplementor} converts it through {@code visitRoot}, which
+ * arrives here like any other position.
+ */
+public class SubstraitRelToSqlConverter extends RelToSqlConverter {
+
+  /**
+   * Constructs a converter generating SQL in the given dialect.
+   *
+   * @param dialect the dialect to generate
+   */
+  public SubstraitRelToSqlConverter(SqlDialect dialect) {
+    super(dialect);
+  }
+
+  /**
+   * Converts a virtual table as the projections its rows stand for.
+   *
+   * <p>Found by the reflective dispatch {@link RelToSqlConverter} is built on, which resolves
+   * {@code visit} against this class before the {@link org.apache.calcite.rel.RelNode} overload
+   * that throws.
+   *
+   * @param virtualTable the table to convert
+   * @return the SQL for its expansion
+   */
+  public Result visit(VirtualTable virtualTable) {
+    return dispatch(VirtualTableExpansionRule.expand(virtualTable));
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlDialect.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlDialect.java
@@ -1,5 +1,6 @@
 package io.substrait.isthmus.sql;
 
+import io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.sql.SqlDialect;
@@ -23,12 +24,16 @@ public class SubstraitSqlDialect extends SqlDialect {
   /**
    * Converts a Calcite {@link RelNode} to its SQL representation using the default dialect.
    *
+   * <p>Any {@link io.substrait.isthmus.calcite.rel.VirtualTable} in the tree is expanded first:
+   * {@link RelToSqlConverter} knows Calcite's own relations only.
+   *
    * @param relNode The Calcite relational node to convert.
    * @return A {@link SqlString} representing the SQL equivalent of the given {@link RelNode}.
    */
   public static SqlString toSql(RelNode relNode) {
     RelToSqlConverter relToSql = new RelToSqlConverter(DEFAULT);
-    SqlNode sqlNode = relToSql.visitRoot(relNode).asStatement();
+    SqlNode sqlNode =
+        relToSql.visitRoot(VirtualTableExpansionRule.expandAll(relNode)).asStatement();
     return sqlNode.toSqlString(
         c ->
             c.withAlwaysUseParentheses(false)

--- a/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlDialect.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/sql/SubstraitSqlDialect.java
@@ -1,6 +1,5 @@
 package io.substrait.isthmus.sql;
 
-import io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.sql.SqlDialect;
@@ -24,16 +23,16 @@ public class SubstraitSqlDialect extends SqlDialect {
   /**
    * Converts a Calcite {@link RelNode} to its SQL representation using the default dialect.
    *
-   * <p>Any {@link io.substrait.isthmus.calcite.rel.VirtualTable} in the tree is expanded first:
-   * {@link RelToSqlConverter} knows Calcite's own relations only.
+   * <p>Generated with {@link SubstraitRelToSqlConverter}: {@link RelToSqlConverter} knows Calcite's
+   * own relations only, and a plan isthmus converts can hold an {@link
+   * io.substrait.isthmus.calcite.rel.VirtualTable}.
    *
    * @param relNode The Calcite relational node to convert.
    * @return A {@link SqlString} representing the SQL equivalent of the given {@link RelNode}.
    */
   public static SqlString toSql(RelNode relNode) {
-    RelToSqlConverter relToSql = new RelToSqlConverter(DEFAULT);
-    SqlNode sqlNode =
-        relToSql.visitRoot(VirtualTableExpansionRule.expandAll(relNode)).asStatement();
+    RelToSqlConverter relToSql = new SubstraitRelToSqlConverter(DEFAULT);
+    SqlNode sqlNode = relToSql.visitRoot(relNode).asStatement();
     return sqlNode.toSqlString(
         c ->
             c.withAlwaysUseParentheses(false)

--- a/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
@@ -132,10 +132,7 @@ class LiteralNullabilityRoundtripTest extends PlanTestBase {
             .build();
 
     assertEquals(
-        "LogicalProject(A=[$0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(A=[CAST('abcdef'):VARCHAR(3) NOT NULL])\n"
-            + "      LogicalValues(tuples=[[{  }]])\n",
+        "VirtualTable(rows=[[{ CAST('abcdef'):VARCHAR(3) NOT NULL }]])\n",
         RelOptUtil.toString(substraitToCalcite.convert(overlong)));
   }
 
@@ -160,10 +157,7 @@ class LiteralNullabilityRoundtripTest extends PlanTestBase {
             .build();
 
     assertEquals(
-        "LogicalProject(A=[$0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(A=[CAST(5):INTEGER])\n"
-            + "      LogicalValues(tuples=[[{  }]])\n",
+        "VirtualTable(rows=[[{ CAST(5):INTEGER }]])\n",
         RelOptUtil.toString(substraitToCalcite.convert(castRow)));
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
@@ -1,9 +1,13 @@
 package io.substrait.isthmus;
 
+import io.substrait.isthmus.calcite.rel.VirtualTable;
+import java.util.List;
+import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Holder;
@@ -127,6 +131,40 @@ class OuterReferenceResolverTest extends PlanTestBase {
     Assertions.assertNotNull(anchor0);
     Assertions.assertNotNull(anchor1);
     Assertions.assertNotEquals(anchor0, anchor1);
+  }
+
+  /**
+   * A virtual table's rows are expressions, and a subquery among them is a tree the resolver only
+   * reaches through the row: a subquery's relation is not an input, so walking inputs never gets
+   * there and a correlation declared inside it is left unbound.
+   */
+  @Test
+  void correlationInsideASubqueryInAVirtualTableRow() {
+    final Holder<RexCorrelVariable> cor0 = Holder.empty();
+    final RelNode correlated =
+        tpcDsRelBuilder
+            .scan("tpcds", "STORE_SALES")
+            .variable(cor0::set)
+            .scan("tpcds", "ITEM")
+            .filter(
+                tpcDsRelBuilder.equals(
+                    tpcDsRelBuilder.field("I_ITEM_SK"),
+                    tpcDsRelBuilder.field(cor0.get(), "SS_ITEM_SK")))
+            .project(tpcDsRelBuilder.field("I_ITEM_SK"))
+            .correlate(JoinRelType.INNER, cor0.get().id, tpcDsRelBuilder.field(2, 0, "SS_ITEM_SK"))
+            .project(tpcDsRelBuilder.field("SS_ITEM_SK"))
+            .build();
+    final RexNode subQuery = RexSubQuery.scalar(correlated);
+
+    final RelNode virtualTable =
+        new VirtualTable(
+            tpcDsRelBuilder.getCluster(),
+            tpcDsRelBuilder.getCluster().traitSetOf(Convention.NONE),
+            tpcDsRelBuilder.getTypeFactory().builder().add("col1", subQuery.getType()).build(),
+            List.of(List.of(subQuery)));
+
+    final OuterReferenceResolver resolver = resolve(virtualTable);
+    Assertions.assertNotNull(resolver.anchorForCorrelationId(cor0.get().id));
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
@@ -2,7 +2,6 @@ package io.substrait.isthmus;
 
 import io.substrait.isthmus.calcite.rel.VirtualTable;
 import java.util.List;
-import org.apache.calcite.plan.Convention;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexCorrelVariable;
@@ -157,10 +156,10 @@ class OuterReferenceResolverTest extends PlanTestBase {
     final RexNode subQuery = RexSubQuery.scalar(correlated);
 
     final RelNode virtualTable =
-        new VirtualTable(
+        VirtualTable.create(
             tpcDsRelBuilder.getCluster(),
-            tpcDsRelBuilder.getCluster().traitSetOf(Convention.NONE),
             tpcDsRelBuilder.getTypeFactory().builder().add("col1", subQuery.getType()).build(),
+            java.util.Set.of(cor0.get().id),
             List.of(List.of(subQuery)));
 
     final OuterReferenceResolver resolver = resolve(virtualTable);

--- a/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
@@ -2,6 +2,8 @@ package io.substrait.isthmus;
 
 import io.substrait.isthmus.calcite.rel.VirtualTable;
 import java.util.List;
+import java.util.Set;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rex.RexCorrelVariable;
@@ -10,6 +12,7 @@ import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Holder;
+import org.apache.calcite.util.Litmus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -193,6 +196,39 @@ class OuterReferenceResolverTest extends PlanTestBase {
     Assertions.assertNotNull(anchor0);
     Assertions.assertNotNull(anchor1);
     Assertions.assertNotEquals(anchor0, anchor1);
+  }
+
+  /**
+   * A correlation in a row is visible to Calcite's own collector, which is what a consumer's
+   * decorrelation is built on. It arrives there through {@code accept(RexShuttle)} -- {@code
+   * RelOptUtil.VariableUsedVisitor} is a shuttle, and the collector hands it to every relation.
+   *
+   * <p>Declaring the ids on the relation instead would do the opposite: {@code
+   * RelOptUtil.CorrelationCollector} subtracts {@code getVariablesSet} from what it collected, so a
+   * leaf naming the ids its rows resolve against empties its own result.
+   */
+  @Test
+  void aCorrelationInARowIsVisibleToTheCollector() {
+    final Holder<RexCorrelVariable> cor = Holder.empty();
+    tpcDsRelBuilder.scan("tpcds", "ITEM").variable(cor::set);
+    final RexNode promoOfItem =
+        RexSubQuery.scalar(
+            tpcDsRelBuilder
+                .scan("tpcds", "PROMOTION")
+                .filter(
+                    tpcDsRelBuilder.equals(
+                        tpcDsRelBuilder.field("P_ITEM_SK"),
+                        tpcDsRelBuilder.field(cor.get(), "I_ITEM_SK")))
+                .project(tpcDsRelBuilder.field("P_PROMO_SK"))
+                .build());
+    final RelNode table =
+        VirtualTable.create(
+            tpcDsRelBuilder.getCluster(),
+            tpcDsRelBuilder.getTypeFactory().builder().add("col1", promoOfItem.getType()).build(),
+            List.of(List.of(promoOfItem)));
+
+    Assertions.assertEquals(Set.of(cor.get().id), RelOptUtil.getVariablesUsed(table));
+    Assertions.assertFalse(RelOptUtil.notContainsCorrelation(table, cor.get().id, Litmus.IGNORE));
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OuterReferenceResolverTest.java
@@ -135,35 +135,64 @@ class OuterReferenceResolverTest extends PlanTestBase {
   /**
    * A virtual table's rows are expressions, and a subquery among them is a tree the resolver only
    * reaches through the row: a subquery's relation is not an input, so walking inputs never gets
-   * there and a correlation declared inside it is left unbound.
+   * there and a correlation the subquery declares is left unbound.
+   *
+   * <p>The table itself declares nothing. It is a leaf with no inputs and so no fields to bind an
+   * id to, which puts a row's outer reference where one in a {@link
+   * org.apache.calcite.rel.core.Project} expression sits: bound by the relation around it, here the
+   * correlate the table is the right input of.
    */
   @Test
   void correlationInsideASubqueryInAVirtualTableRow() {
     final Holder<RexCorrelVariable> cor0 = Holder.empty();
-    final RelNode correlated =
-        tpcDsRelBuilder
-            .scan("tpcds", "STORE_SALES")
-            .variable(cor0::set)
-            .scan("tpcds", "ITEM")
-            .filter(
-                tpcDsRelBuilder.equals(
-                    tpcDsRelBuilder.field("I_ITEM_SK"),
-                    tpcDsRelBuilder.field(cor0.get(), "SS_ITEM_SK")))
-            .project(tpcDsRelBuilder.field("I_ITEM_SK"))
-            .correlate(JoinRelType.INNER, cor0.get().id, tpcDsRelBuilder.field(2, 0, "SS_ITEM_SK"))
-            .project(tpcDsRelBuilder.field("SS_ITEM_SK"))
-            .build();
-    final RexNode subQuery = RexSubQuery.scalar(correlated);
+    final Holder<RexCorrelVariable> cor1 = Holder.empty();
+    tpcDsRelBuilder.scan("tpcds", "STORE_SALES").variable(cor0::set);
+
+    // SELECT i_item_sk FROM item
+    // WHERE i_item_sk = $cor0.ss_item_sk
+    //   AND i_item_sk = (SELECT p_promo_sk FROM promotion WHERE p_item_sk = item.i_item_sk)
+    tpcDsRelBuilder.scan("tpcds", "ITEM").variable(cor1::set);
+    final RexNode promoOfItem =
+        RexSubQuery.scalar(
+            tpcDsRelBuilder
+                .scan("tpcds", "PROMOTION")
+                .filter(
+                    tpcDsRelBuilder.equals(
+                        tpcDsRelBuilder.field("P_ITEM_SK"),
+                        tpcDsRelBuilder.field(cor1.get(), "I_ITEM_SK")))
+                .project(tpcDsRelBuilder.field("P_PROMO_SK"))
+                .build());
+    final RexNode itemOfSale =
+        RexSubQuery.scalar(
+            tpcDsRelBuilder
+                .filter(
+                    List.of(cor1.get().id),
+                    tpcDsRelBuilder.equals(
+                        tpcDsRelBuilder.field("I_ITEM_SK"),
+                        tpcDsRelBuilder.field(cor0.get(), "SS_ITEM_SK")),
+                    tpcDsRelBuilder.equals(tpcDsRelBuilder.field("I_ITEM_SK"), promoOfItem))
+                .project(tpcDsRelBuilder.field("I_ITEM_SK"))
+                .build());
 
     final RelNode virtualTable =
         VirtualTable.create(
             tpcDsRelBuilder.getCluster(),
-            tpcDsRelBuilder.getTypeFactory().builder().add("col1", subQuery.getType()).build(),
-            java.util.Set.of(cor0.get().id),
-            List.of(List.of(subQuery)));
+            tpcDsRelBuilder.getTypeFactory().builder().add("col1", itemOfSale.getType()).build(),
+            List.of(List.of(itemOfSale)));
+    final RelNode calciteRel =
+        tpcDsRelBuilder
+            .push(virtualTable)
+            .correlate(JoinRelType.INNER, cor0.get().id, tpcDsRelBuilder.field(2, 0, "SS_ITEM_SK"))
+            .build();
 
-    final OuterReferenceResolver resolver = resolve(virtualTable);
-    Assertions.assertNotNull(resolver.anchorForCorrelationId(cor0.get().id));
+    final OuterReferenceResolver resolver = resolve(calciteRel);
+    final Integer anchor0 = resolver.anchorForCorrelationId(cor0.get().id);
+    // Bound by the filter inside the row's subquery, which nothing but the row walk reaches.
+    final Integer anchor1 = resolver.anchorForCorrelationId(cor1.get().id);
+
+    Assertions.assertNotNull(anchor0);
+    Assertions.assertNotNull(anchor1);
+    Assertions.assertNotEquals(anchor0, anchor1);
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.google.common.annotations.Beta;
 import com.google.common.io.Resources;
 import io.substrait.dsl.SubstraitBuilder;
+import io.substrait.expression.Expression;
 import io.substrait.extension.ExtensionCollector;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.calcite.adapter.tpcds.TpcdsSchema;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.RelOptRule;
@@ -382,16 +384,11 @@ public class PlanTestBase {
    * @return the virtual table scan
    */
   @SafeVarargs
-  protected final VirtualTableScan virtualTable(
-      NamedStruct schema, List<io.substrait.expression.Expression>... rows) {
-    List<io.substrait.expression.Expression.NestedStruct> structs =
-        java.util.Arrays.stream(rows)
-            .map(
-                row ->
-                    io.substrait.expression.Expression.NestedStruct.builder()
-                        .addAllFields(row)
-                        .build())
-            .collect(java.util.stream.Collectors.toList());
+  protected final VirtualTableScan virtualTable(NamedStruct schema, List<Expression>... rows) {
+    List<Expression.NestedStruct> structs =
+        Arrays.stream(rows)
+            .map(row -> Expression.NestedStruct.builder().addAllFields(row).build())
+            .collect(Collectors.toList());
     return VirtualTableScan.builder().initialSchema(schema).addAllRows(structs).build();
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/PlanTestBase.java
@@ -19,6 +19,8 @@ import io.substrait.plan.ProtoPlanConverter;
 import io.substrait.relation.ProtoRelConverter;
 import io.substrait.relation.Rel;
 import io.substrait.relation.RelProtoConverter;
+import io.substrait.relation.VirtualTableScan;
+import io.substrait.type.NamedStruct;
 import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import java.io.IOException;
@@ -27,6 +29,9 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.adapter.tpcds.TpcdsSchema;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
@@ -367,6 +372,44 @@ public class PlanTestBase {
     RelRoot relRoot = new SubstraitToCalcite(converterProvider).convert(root);
     RelNode project = relRoot.project(true);
     return SubstraitSqlDialect.toSql(project).getSql();
+  }
+
+  /**
+   * Builds a virtual table of the given rows at the given schema.
+   *
+   * @param schema the table's schema
+   * @param rows one list of values per row
+   * @return the virtual table scan
+   */
+  @SafeVarargs
+  protected final VirtualTableScan virtualTable(
+      NamedStruct schema, List<io.substrait.expression.Expression>... rows) {
+    List<io.substrait.expression.Expression.NestedStruct> structs =
+        java.util.Arrays.stream(rows)
+            .map(
+                row ->
+                    io.substrait.expression.Expression.NestedStruct.builder()
+                        .addAllFields(row)
+                        .build())
+            .collect(java.util.stream.Collectors.toList());
+    return VirtualTableScan.builder().initialSchema(schema).addAllRows(structs).build();
+  }
+
+  /**
+   * Runs the given rules over the given tree, exhaustively and in order.
+   *
+   * @param rel the tree to plan
+   * @param rules the rules to run
+   * @return the planned tree
+   */
+  protected RelNode plan(RelNode rel, RelOptRule... rules) {
+    HepProgramBuilder program = new HepProgramBuilder();
+    for (RelOptRule rule : rules) {
+      program.addRuleInstance(rule);
+    }
+    HepPlanner planner = new HepPlanner(program.build());
+    planner.setRoot(rel);
+    return planner.findBestExp();
   }
 
   protected io.substrait.proto.Plan toProto(Plan plan) {

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -66,13 +66,10 @@ class VirtualTableScanTest extends PlanTestBase {
     // Check the specific Calcite encoding
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0..1])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[2, +(4.4E0:DOUBLE, 4.5E0:DOUBLE)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n"
-            + "    LogicalProject(exprs=[[*(6, 2), 8.8E0:DOUBLE]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(INTEGER col1, DOUBLE col2)], rows=[[{ 2, +(4.4E0:DOUBLE, 4.5E0:DOUBLE) }, { *(6, 2), 8.8E0:DOUBLE }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   @Test
@@ -171,11 +168,10 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], rows=[[{ ROW(1, 2.0E0:DOUBLE) }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   /** The row after the first is where a row literal in a tuple would be compared to another. */
@@ -191,13 +187,10 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n"
-            + "    LogicalProject(exprs=[[ROW(3, 4.0E0:DOUBLE)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], rows=[[{ ROW(1, 2.0E0:DOUBLE) }, { ROW(3, 4.0E0:DOUBLE) }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   /**
@@ -234,11 +227,10 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0..1])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE), ROW('x':VARCHAR)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(RecordType(INTEGER a, DOUBLE b) first, RecordType(VARCHAR c) second)], rows=[[{ ROW(1, 2.0E0:DOUBLE), ROW('x':VARCHAR) }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   /**
@@ -259,10 +251,7 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ROW(*(6, 2), 2.0E0:DOUBLE)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], rows=[[{ ROW(*(6, 2), 2.0E0:DOUBLE) }]])\n",
         explain(relNode));
   }
 
@@ -280,10 +269,7 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ARRAY(1, 2)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(INTEGER ARRAY col1)], rows=[[{ ARRAY(1, 2) }]])\n",
         explain(relNode));
   }
 
@@ -303,10 +289,7 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE)]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], rows=[[{ ROW(1, 2.0E0:DOUBLE) }]])\n",
         explain(relNode));
   }
 
@@ -396,10 +379,7 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ARRAY(ROW(1))]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(RecordType(INTEGER a) ARRAY col1)], rows=[[{ ARRAY(ROW(1)) }]])\n",
         explain(relNode));
   }
 
@@ -417,10 +397,7 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[MAP('k':VARCHAR, ROW(1))]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType((VARCHAR, RecordType(INTEGER a)) MAP col1)], rows=[[{ MAP('k':VARCHAR, ROW(1)) }]])\n",
         explain(relNode));
   }
 
@@ -439,10 +416,7 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalProject(inputs=[0])\n"
-            + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ROW(ROW(1))]])\n"
-            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        "VirtualTable(type=[RecordType(RecordType(RecordType(INTEGER a) inner) outer)], rows=[[{ ROW(ROW(1)) }]])\n",
         explain(relNode));
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -253,6 +253,8 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         "VirtualTable(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], rows=[[{ ROW(*(6, 2), 2.0E0:DOUBLE) }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   /**
@@ -271,6 +273,8 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         "VirtualTable(type=[RecordType(INTEGER ARRAY col1)], rows=[[{ ARRAY(1, 2) }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   /**
@@ -381,6 +385,8 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         "VirtualTable(type=[RecordType(RecordType(INTEGER a) ARRAY col1)], rows=[[{ ARRAY(ROW(1)) }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   /** The same one level down inside a map, where the names reach a key and a value alike. */
@@ -399,11 +405,15 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         "VirtualTable(type=[RecordType((VARCHAR, RecordType(INTEGER a)) MAP col1)], rows=[[{ MAP('k':VARCHAR, ROW(1)) }]])\n",
         explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
   }
 
   /**
    * A nullable struct nested in a column: renaming it gives back a ROW call rather than a literal,
-   * so the struct around it cannot be rebuilt as a literal either.
+   * so the struct around it cannot be rebuilt as a literal either. Pinned as a conversion rather
+   * than a round trip for the same reason as its sibling above: Calcite pushes a struct's
+   * nullability down into its fields, so the schema comes back with nullable fields.
    */
   @Test
   void nullableStructInsideStructColumnConverts() {

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -18,10 +18,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.externalize.RelWriterImpl;
@@ -39,7 +37,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("col1", "col2", "col3"), R.struct(R.I32, R.FP64, R.STRING));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(sb.i32(2), sb.fp64(4), sb.str("a")),
             List.of(sb.i32(6), sb.fp64(8.8), sb.str("b")));
@@ -58,7 +56,7 @@ class VirtualTableScanTest extends PlanTestBase {
   void expressionContainingVirtualTable() {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.FP64));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5))),
             List.of(sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(8.8)));
@@ -75,29 +73,27 @@ class VirtualTableScanTest extends PlanTestBase {
   @Test
   void emptyVirtualTableScan() {
     NamedStruct schema = NamedStruct.of(List.of(), R.struct());
-    assertDoesNotThrow(() -> createVirtualTableScan(schema, new ArrayList<>()));
+    assertDoesNotThrow(() -> virtualTable(schema, new ArrayList<>()));
   }
 
   @Test
   void emptyTableNonEmptySchema() {
     NamedStruct schema = NamedStruct.of(List.of("col1"), R.struct(R.I32));
-    assertDoesNotThrow(() -> createVirtualTableScan(schema));
+    assertDoesNotThrow(() -> virtualTable(schema));
   }
 
   @Test
   void emptySchemaNonEmptyTable() {
     NamedStruct schema = NamedStruct.of(List.of(), R.struct());
     assertThrows(
-        IllegalArgumentException.class,
-        () -> createVirtualTableScan(schema, List.of(sb.i32(3), sb.fp64(8))));
+        IllegalArgumentException.class, () -> virtualTable(schema, List.of(sb.i32(3), sb.fp64(8))));
   }
 
   @Test
   void nullableFieldRoundTrip() {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(N.I32, R.FP64));
     Expression nullableI32 = ExpressionCreator.i32(true, 6);
-    VirtualTableScan virtualTableScan =
-        createVirtualTableScan(schema, List.of(nullableI32, sb.fp64(8)));
+    VirtualTableScan virtualTableScan = virtualTable(schema, List.of(nullableI32, sb.fp64(8)));
     assertFullRoundTrip(virtualTableScan);
   }
 
@@ -106,7 +102,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(N.I32, N.FP64));
     Expression nullI32 = ExpressionCreator.typedNull(N.I32);
     Expression nullFp64 = ExpressionCreator.typedNull(N.FP64);
-    VirtualTableScan virtualTableScan = createVirtualTableScan(schema, List.of(nullI32, nullFp64));
+    VirtualTableScan virtualTableScan = virtualTable(schema, List.of(nullI32, nullFp64));
     assertFullRoundTrip(virtualTableScan);
   }
 
@@ -117,7 +113,7 @@ class VirtualTableScanTest extends PlanTestBase {
     Expression nullI32 = ExpressionCreator.typedNull(N.I32);
     Expression nullString = ExpressionCreator.typedNull(N.STRING);
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(schema, List.of(nullI32, sb.fp64(8), nullString));
+        virtualTable(schema, List.of(nullI32, sb.fp64(8), nullString));
     assertFullRoundTrip(virtualTableScan);
   }
 
@@ -163,8 +159,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "a", "b"), R.struct(R.struct(R.I32, R.FP64)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
-            schema, List.of(ExpressionCreator.struct(false, sb.i32(1), sb.fp64(2.0))));
+        virtualTable(schema, List.of(ExpressionCreator.struct(false, sb.i32(1), sb.fp64(2.0))));
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
@@ -180,7 +175,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "a", "b"), R.struct(R.struct(R.I32, R.FP64)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(ExpressionCreator.struct(false, sb.i32(1), sb.fp64(2.0))),
             List.of(ExpressionCreator.struct(false, sb.i32(3), sb.fp64(4.0))));
@@ -202,7 +197,7 @@ class VirtualTableScanTest extends PlanTestBase {
   @Test
   void nullableSchemaStructGivesANotNullRowType() {
     NamedStruct schema = NamedStruct.of(List.of("col1"), N.struct(R.I32));
-    VirtualTableScan virtualTableScan = createVirtualTableScan(schema, List.of(sb.i32(1)));
+    VirtualTableScan virtualTableScan = virtualTable(schema, List.of(sb.i32(1)));
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals("RecordType(INTEGER col1) NOT NULL", relNode.getRowType().getFullTypeString());
@@ -219,7 +214,7 @@ class VirtualTableScanTest extends PlanTestBase {
             List.of("first", "a", "b", "second", "c"),
             R.struct(R.struct(R.I32, R.FP64), R.struct(R.STRING)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(
                 ExpressionCreator.struct(false, sb.i32(1), sb.fp64(2.0)),
@@ -243,7 +238,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "a", "b"), R.struct(R.struct(R.I32, R.FP64)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(
                 ExpressionCreator.nestedStruct(
@@ -266,8 +261,7 @@ class VirtualTableScanTest extends PlanTestBase {
   void listColumnConverts() {
     NamedStruct schema = NamedStruct.of(List.of("col1"), R.struct(R.list(R.I32)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
-            schema, List.of(ExpressionCreator.list(false, sb.i32(1), sb.i32(2))));
+        virtualTable(schema, List.of(ExpressionCreator.list(false, sb.i32(1), sb.i32(2))));
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
@@ -288,8 +282,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "a", "b"), R.struct(N.struct(R.I32, R.FP64)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
-            schema, List.of(ExpressionCreator.struct(true, sb.i32(1), sb.fp64(2.0))));
+        virtualTable(schema, List.of(ExpressionCreator.struct(true, sb.i32(1), sb.fp64(2.0))));
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
@@ -303,8 +296,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "a", "b"), R.struct(N.struct(R.I32, R.FP64)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
-            schema, List.of(ExpressionCreator.typedNull(N.struct(R.I32, R.FP64))));
+        virtualTable(schema, List.of(ExpressionCreator.typedNull(N.struct(R.I32, R.FP64))));
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
@@ -322,10 +314,10 @@ class VirtualTableScanTest extends PlanTestBase {
   @Test
   void aValueThatCannotTakeItsColumnsTypeIsReported() {
     VirtualTableScan inner =
-        createVirtualTableScan(NamedStruct.of(List.of("a"), R.struct(R.I32)), List.of(sb.i32(7)));
+        virtualTable(NamedStruct.of(List.of("a"), R.struct(R.I32)), List.of(sb.i32(7)));
     Expression subquery = Expression.ScalarSubquery.builder().input(inner).type(R.I32).build();
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(NamedStruct.of(List.of("col1"), R.struct(R.I32)), List.of(subquery));
+        virtualTable(NamedStruct.of(List.of("col1"), R.struct(R.I32)), List.of(subquery));
 
     IllegalArgumentException reported =
         assertThrows(
@@ -344,7 +336,7 @@ class VirtualTableScanTest extends PlanTestBase {
   void nullListColumnConverts() {
     NamedStruct schema = NamedStruct.of(List.of("col1"), R.struct(N.list(R.I32)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(schema, List.of(ExpressionCreator.typedNull(N.list(R.I32))));
+        virtualTable(schema, List.of(ExpressionCreator.typedNull(N.list(R.I32))));
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
@@ -358,8 +350,7 @@ class VirtualTableScanTest extends PlanTestBase {
   void nullMapColumnConverts() {
     NamedStruct schema = NamedStruct.of(List.of("col1"), R.struct(N.map(R.STRING, R.I32)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
-            schema, List.of(ExpressionCreator.typedNull(N.map(R.STRING, R.I32))));
+        virtualTable(schema, List.of(ExpressionCreator.typedNull(N.map(R.STRING, R.I32))));
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
@@ -377,7 +368,7 @@ class VirtualTableScanTest extends PlanTestBase {
   void structInListColumnConverts() {
     NamedStruct schema = NamedStruct.of(List.of("col1", "a"), R.struct(R.list(R.struct(R.I32))));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(ExpressionCreator.list(false, ExpressionCreator.struct(false, sb.i32(1)))));
 
@@ -395,7 +386,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("col1", "a"), R.struct(R.map(R.STRING, R.struct(R.I32))));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(
                 ExpressionCreator.map(
@@ -420,7 +411,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "a", "b"), R.struct(N.struct(R.I32, R.FP64)));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(
                 ExpressionCreator.nestedStruct(
@@ -446,7 +437,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "inner", "a"), R.struct(R.struct(N.struct(R.I32))));
     VirtualTableScan virtualTableScan =
-        createVirtualTableScan(
+        virtualTable(
             schema,
             List.of(ExpressionCreator.struct(false, ExpressionCreator.struct(true, sb.i32(1)))));
 
@@ -467,7 +458,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
     VirtualTableScan table =
         VirtualTableScan.builder()
-            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .from(virtualTable(schema, List.of(sb.i32(2), sb.str("a"))))
             .remap(Rel.Remap.of(List.of(1)))
             .build();
 
@@ -488,7 +479,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
     VirtualTableScan table =
         VirtualTableScan.builder()
-            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .from(virtualTable(schema, List.of(sb.i32(2), sb.str("a"))))
             .hint(Hint.builder().addOutputNames("x", "y").build())
             .build();
 
@@ -510,7 +501,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
     VirtualTableScan table =
         VirtualTableScan.builder()
-            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .from(virtualTable(schema, List.of(sb.i32(2), sb.str("a"))))
             .projection(
                 MaskExpression.builder()
                     .select(
@@ -536,7 +527,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema = NamedStruct.of(List.of("c", "c"), R.struct(R.I32, R.STRING));
     VirtualTableScan table =
         VirtualTableScan.builder()
-            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .from(virtualTable(schema, List.of(sb.i32(2), sb.str("a"))))
             .remap(Rel.Remap.of(List.of(1)))
             .build();
 
@@ -549,17 +540,16 @@ class VirtualTableScanTest extends PlanTestBase {
 
   /**
    * The same as {@link #outputNamesWithoutAMappingAreLeftAlone()} for a table whose rows are
-   * computed. That one comes back under a projection of its own, which is not one a mapping added
-   * and so not one the names are for.
+   * computed. It comes back as a bare {@link io.substrait.isthmus.calcite.rel.VirtualTable} now, so
+   * it passes for the reason its sibling does: with no mapping there is no projection for the names
+   * to reach.
    */
   @Test
   void outputNamesWithoutAMappingAreLeftAloneOnAComputedTable() {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.FP64));
     VirtualTableScan table =
         VirtualTableScan.builder()
-            .from(
-                createVirtualTableScan(
-                    schema, List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5)))))
+            .from(virtualTable(schema, List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5)))))
             .hint(Hint.builder().addOutputNames("x", "y").build())
             .build();
 
@@ -574,7 +564,7 @@ class VirtualTableScanTest extends PlanTestBase {
     NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
     VirtualTableScan table =
         VirtualTableScan.builder()
-            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .from(virtualTable(schema, List.of(sb.i32(2), sb.str("a"))))
             .remap(Rel.Remap.of(List.of(1)))
             .hint(Hint.builder().addOutputNames("label").build())
             .build();
@@ -582,14 +572,22 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(List.of("label"), substraitToCalcite.convert(table).getRowType().getFieldNames());
   }
 
-  @SafeVarargs
-  private VirtualTableScan createVirtualTableScan(NamedStruct schema, List<Expression>... rows) {
-    List<Expression.NestedStruct> structs =
-        Arrays.stream(rows)
-            .map(row -> Expression.NestedStruct.builder().addAllFields(row).build())
-            .collect(Collectors.toList());
+  /** The same for a computed table, where the projection has no table to merge into. */
+  @Test
+  void outputNamesReachTheProjectionTheMappingAddsOnAComputedTable() {
+    NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.FP64));
+    VirtualTableScan table =
+        VirtualTableScan.builder()
+            .from(virtualTable(schema, List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5)))))
+            .remap(Rel.Remap.of(List.of(1)))
+            .hint(Hint.builder().addOutputNames("label").build())
+            .build();
 
-    return VirtualTableScan.builder().initialSchema(schema).addAllRows(structs).build();
+    RelNode relNode = substraitToCalcite.convert(table);
+
+    assertEquals(List.of("label"), relNode.getRowType().getFieldNames());
+    assertEquals(
+        List.of(R.FP64), SubstraitRelVisitor.convert(relNode, extensions).getRecordType().fields());
   }
 
   private String explain(RelNode relNode) {

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -410,6 +410,32 @@ class VirtualTableScanTest extends PlanTestBase {
   }
 
   /**
+   * A computed field inside a nullable struct is where the row type stops being able to say what
+   * the schema said: Calcite pushes the struct's nullability into its fields, and a value built
+   * from expressions takes its type from them, so the trip back cannot rebuild the declared type.
+   * Reported here rather than as a type mismatch from {@link VirtualTableScan}'s own check.
+   */
+  @Test
+  void aComputedFieldInsideANullableStructIsReportedOnTheWayBack() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("outer", "a", "b"), R.struct(N.struct(R.I32, R.FP64)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema,
+            List.of(
+                ExpressionCreator.nestedStruct(
+                    true, List.of(sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(2.0)))));
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+
+    assertTrue(
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> SubstraitRelVisitor.convert(relNode, converterProvider))
+            .getMessage()
+            .contains("does not carry its column's type"));
+  }
+
+  /**
    * A nullable struct nested in a column: renaming it gives back a ROW call rather than a literal,
    * so the struct around it cannot be rebuilt as a literal either. Pinned as a conversion rather
    * than a round trip for the same reason as its sibling above: Calcite pushes a struct's

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
@@ -1,0 +1,235 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import com.google.common.collect.ImmutableList;
+import io.substrait.expression.Expression;
+import io.substrait.isthmus.calcite.rel.VirtualTable;
+import io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import io.substrait.relation.VirtualTableScan;
+import io.substrait.type.NamedStruct;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalUnion;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@link VirtualTable} relation and the rule that expands it: what isthmus emits, what survives
+ * a planner, and what the expansion costs.
+ */
+class VirtualTableTest extends PlanTestBase {
+
+  private final NamedStruct schema =
+      NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.FP64));
+
+  private VirtualTableScan computedRows() {
+    return virtualTable(
+        List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5))),
+        List.of(sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(8.8)));
+  }
+
+  @Test
+  void aComputedRowConvertsToTheIsthmusRelation() {
+    assertInstanceOf(VirtualTable.class, substraitToCalcite.convert(computedRows()));
+  }
+
+  @Test
+  void theRuleExpandsTheRowsIntoAUnionOfProjections() {
+    RelNode expanded =
+        plan(substraitToCalcite.convert(computedRows()), VirtualTableExpansionRule.INSTANCE);
+
+    assertEquals(
+        "LogicalUnion(all=[true])\n"
+            + "  LogicalProject(col1=[2], col2=[+(4.4E0:DOUBLE, 4.5E0:DOUBLE)])\n"
+            + "    LogicalValues(tuples=[[{  }]])\n"
+            + "  LogicalProject(col1=[*(6, 2)], col2=[8.8E0:DOUBLE])\n"
+            + "    LogicalValues(tuples=[[{  }]])\n",
+        RelOptUtil.toString(expanded));
+  }
+
+  /** One row needs no union, and a planner would strip a one-input one anyway. */
+  @Test
+  void theRuleExpandsASingleRowIntoAProjection() {
+    RelNode expanded =
+        plan(
+            substraitToCalcite.convert(
+                virtualTable(List.of(sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(8.8)))),
+            VirtualTableExpansionRule.INSTANCE);
+
+    assertEquals(
+        "LogicalProject(col1=[*(6, 2)], col2=[8.8E0:DOUBLE])\n"
+            + "  LogicalValues(tuples=[[{  }]])\n",
+        RelOptUtil.toString(expanded));
+  }
+
+  /**
+   * The expansion is one-way, and this is what that costs: what comes back is the relation the
+   * expansion is, not the table it came from. That is the reason isthmus does not run the rule
+   * itself.
+   */
+  @Test
+  void theExpansionDoesNotConvertBackToAVirtualTable() {
+    RelNode expanded =
+        plan(substraitToCalcite.convert(computedRows()), VirtualTableExpansionRule.INSTANCE);
+
+    assertInstanceOf(
+        io.substrait.relation.Set.class, SubstraitRelVisitor.convert(expanded, extensions));
+  }
+
+  /**
+   * The unexpanded relation is opaque to the rules that rewrite the expansion -- UNION_REMOVE
+   * strips the one-input union a single-row table would expand to, and PROJECT_MERGE takes a row's
+   * projection into whatever sits above it -- so the table is still a table after a planner has run
+   * over it.
+   */
+  @Test
+  void theRelationSurvivesPlanning() {
+    RelNode planned =
+        plan(
+            substraitToCalcite.convert(computedRows()),
+            CoreRules.UNION_REMOVE,
+            CoreRules.UNION_MERGE,
+            CoreRules.PROJECT_MERGE);
+
+    assertInstanceOf(VirtualTable.class, planned);
+    assertEquals(computedRows(), SubstraitRelVisitor.convert(planned, extensions));
+  }
+
+  /**
+   * The rows are expressions, and Calcite rewrites a relation's expressions by handing it a
+   * shuttle. A relation that does not pass one on keeps its rows out of every rewrite built on
+   * that, including the scan that finds the subqueries binding outer references.
+   */
+  @Test
+  void aShuttleReachesTheRows() {
+    RelNode table = substraitToCalcite.convert(computedRows());
+    RexBuilder rexBuilder = table.getCluster().getRexBuilder();
+
+    RelNode rewritten =
+        table.accept(
+            new RexShuttle() {
+              @Override
+              public RexNode visitCall(RexCall call) {
+                return call.getOperator().getName().equals("*")
+                    ? rexBuilder.makeExactLiteral(BigDecimal.valueOf(12), call.getType())
+                    : super.visitCall(call);
+              }
+            });
+
+    assertEquals(
+        "VirtualTable(rows=[[{ 2, +(4.4E0:DOUBLE, 4.5E0:DOUBLE) }, { 12, 8.8E0:DOUBLE }]])\n",
+        RelOptUtil.toString(rewritten));
+  }
+
+  /**
+   * A projection above the table is where the expansion used to lose the schema's names: the
+   * renaming projection it carried was merged into this one, and nothing was left to rebuild the
+   * table from.
+   */
+  @Test
+  void theTableIsStillATableUnderAProjection() {
+    VirtualTableScan table = computedRows();
+    Project project =
+        Project.builder().input(table).expressions(List.of(sb.fieldReference(table, 0))).build();
+
+    Rel converted = SubstraitRelVisitor.convert(substraitToCalcite.convert(project), extensions);
+
+    assertEquals(table, assertInstanceOf(Project.class, converted).getInput());
+  }
+
+  /**
+   * A union someone wrote out of single-row projections is a union. It converts to the same Calcite
+   * tree the expansion does, so nothing in the tree can tell the two apart -- which is why the
+   * table is recognised by its own type instead.
+   */
+  @Test
+  void aHandWrittenUnionOfSingleRowProjectionsStaysAUnion() {
+    RelDataType i32 = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    RexBuilder rexBuilder = builder.getRexBuilder();
+
+    RelNode union =
+        LogicalUnion.create(
+            List.of(
+                singleRowProjection(rexBuilder.makeExactLiteral(BigDecimal.ONE, i32)),
+                singleRowProjection(rexBuilder.makeExactLiteral(BigDecimal.valueOf(2), i32))),
+            true);
+
+    assertInstanceOf(
+        io.substrait.relation.Set.class, SubstraitRelVisitor.convert(union, extensions));
+  }
+
+  /**
+   * The same where the arms differ in nullability, which is the case a shape match cannot take: the
+   * rows come from the arms and the schema from the union's own row type, and the type the union
+   * widened to is not the type of either row.
+   */
+  @Test
+  void aHandWrittenUnionOfArmsDifferingInNullabilityStaysAUnion() {
+    RelDataType i32 = typeFactory.createSqlType(SqlTypeName.INTEGER);
+    RelDataType nullableI32 = typeFactory.createTypeWithNullability(i32, true);
+    RexBuilder rexBuilder = builder.getRexBuilder();
+
+    RelNode union =
+        LogicalUnion.create(
+            List.of(
+                singleRowProjection(rexBuilder.makeExactLiteral(BigDecimal.ONE, i32)),
+                singleRowProjection(rexBuilder.makeNullLiteral(nullableI32))),
+            true);
+
+    Rel converted = SubstraitRelVisitor.convert(union, extensions);
+    assertInstanceOf(io.substrait.relation.Set.class, converted);
+    assertEquals(List.of(N.I32), converted.getRecordType().fields());
+  }
+
+  /**
+   * A projection of one row over the single empty row, which is what an expanded row looks like.
+   */
+  private RelNode singleRowProjection(RexNode value) {
+    RelDataType emptyRowType = typeFactory.createStructType(List.of(), List.of());
+    RelNode emptyRow =
+        LogicalValues.create(
+            builder.getCluster(), emptyRowType, ImmutableList.of(ImmutableList.of()));
+    RelDataType rowType = typeFactory.builder().add("col1", value.getType()).build();
+    return LogicalProject.create(
+        emptyRow, Collections.emptyList(), List.of(value), rowType, Collections.emptySet());
+  }
+
+  @SafeVarargs
+  private VirtualTableScan virtualTable(List<Expression>... rows) {
+    List<Expression.NestedStruct> structs =
+        Arrays.stream(rows)
+            .map(row -> Expression.NestedStruct.builder().addAllFields(row).build())
+            .collect(Collectors.toList());
+    return VirtualTableScan.builder().initialSchema(schema).addAllRows(structs).build();
+  }
+
+  private RelNode plan(RelNode rel, RelOptRule... rules) {
+    HepProgramBuilder program = new HepProgramBuilder();
+    for (RelOptRule rule : rules) {
+      program.addRuleInstance(rule);
+    }
+    HepPlanner planner = new HepPlanner(program.build());
+    planner.setRoot(rel);
+    return planner.findBestExp();
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
@@ -1,30 +1,28 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
-import io.substrait.expression.Expression;
 import io.substrait.isthmus.calcite.rel.VirtualTable;
 import io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule;
+import io.substrait.isthmus.sql.SubstraitSqlDialect;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
 import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.NamedStruct;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptUtil;
-import org.apache.calcite.plan.hep.HepPlanner;
-import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
@@ -45,6 +43,7 @@ class VirtualTableTest extends PlanTestBase {
 
   private VirtualTableScan computedRows() {
     return virtualTable(
+        schema,
         List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5))),
         List.of(sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(8.8)));
   }
@@ -57,7 +56,7 @@ class VirtualTableTest extends PlanTestBase {
   @Test
   void theRuleExpandsTheRowsIntoAUnionOfProjections() {
     RelNode expanded =
-        plan(substraitToCalcite.convert(computedRows()), VirtualTableExpansionRule.INSTANCE);
+        plan(substraitToCalcite.convert(computedRows()), VirtualTableExpansionRule.instance());
 
     assertEquals(
         "LogicalUnion(all=[true])\n"
@@ -74,8 +73,8 @@ class VirtualTableTest extends PlanTestBase {
     RelNode expanded =
         plan(
             substraitToCalcite.convert(
-                virtualTable(List.of(sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(8.8)))),
-            VirtualTableExpansionRule.INSTANCE);
+                virtualTable(schema, List.of(sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(8.8)))),
+            VirtualTableExpansionRule.instance());
 
     assertEquals(
         "LogicalProject(col1=[*(6, 2)], col2=[8.8E0:DOUBLE])\n"
@@ -91,10 +90,10 @@ class VirtualTableTest extends PlanTestBase {
   @Test
   void theExpansionDoesNotConvertBackToAVirtualTable() {
     RelNode expanded =
-        plan(substraitToCalcite.convert(computedRows()), VirtualTableExpansionRule.INSTANCE);
+        plan(substraitToCalcite.convert(computedRows()), VirtualTableExpansionRule.instance());
 
     assertInstanceOf(
-        io.substrait.relation.Set.class, SubstraitRelVisitor.convert(expanded, extensions));
+        io.substrait.relation.Set.class, SubstraitRelVisitor.convert(expanded, converterProvider));
   }
 
   /**
@@ -105,15 +104,19 @@ class VirtualTableTest extends PlanTestBase {
    */
   @Test
   void theRelationSurvivesPlanning() {
+    VirtualTableScan table = computedRows();
+    Project project =
+        Project.builder().input(table).expressions(List.of(sb.fieldReference(table, 0))).build();
+
     RelNode planned =
         plan(
-            substraitToCalcite.convert(computedRows()),
+            substraitToCalcite.convert(project),
             CoreRules.UNION_REMOVE,
             CoreRules.UNION_MERGE,
             CoreRules.PROJECT_MERGE);
 
-    assertInstanceOf(VirtualTable.class, planned);
-    assertEquals(computedRows(), SubstraitRelVisitor.convert(planned, extensions));
+    Rel converted = SubstraitRelVisitor.convert(planned, converterProvider);
+    assertEquals(table, assertInstanceOf(Project.class, converted).getInput());
   }
 
   /**
@@ -153,30 +156,10 @@ class VirtualTableTest extends PlanTestBase {
     Project project =
         Project.builder().input(table).expressions(List.of(sb.fieldReference(table, 0))).build();
 
-    Rel converted = SubstraitRelVisitor.convert(substraitToCalcite.convert(project), extensions);
+    Rel converted =
+        SubstraitRelVisitor.convert(substraitToCalcite.convert(project), converterProvider);
 
     assertEquals(table, assertInstanceOf(Project.class, converted).getInput());
-  }
-
-  /**
-   * A union someone wrote out of single-row projections is a union. It converts to the same Calcite
-   * tree the expansion does, so nothing in the tree can tell the two apart -- which is why the
-   * table is recognised by its own type instead.
-   */
-  @Test
-  void aHandWrittenUnionOfSingleRowProjectionsStaysAUnion() {
-    RelDataType i32 = typeFactory.createSqlType(SqlTypeName.INTEGER);
-    RexBuilder rexBuilder = builder.getRexBuilder();
-
-    RelNode union =
-        LogicalUnion.create(
-            List.of(
-                singleRowProjection(rexBuilder.makeExactLiteral(BigDecimal.ONE, i32)),
-                singleRowProjection(rexBuilder.makeExactLiteral(BigDecimal.valueOf(2), i32))),
-            true);
-
-    assertInstanceOf(
-        io.substrait.relation.Set.class, SubstraitRelVisitor.convert(union, extensions));
   }
 
   /**
@@ -197,7 +180,7 @@ class VirtualTableTest extends PlanTestBase {
                 singleRowProjection(rexBuilder.makeNullLiteral(nullableI32))),
             true);
 
-    Rel converted = SubstraitRelVisitor.convert(union, extensions);
+    Rel converted = SubstraitRelVisitor.convert(union, converterProvider);
     assertInstanceOf(io.substrait.relation.Set.class, converted);
     assertEquals(List.of(N.I32), converted.getRecordType().fields());
   }
@@ -223,12 +206,99 @@ class VirtualTableTest extends PlanTestBase {
   @Test
   void theRuleExpandsATableOfNoRowsIntoAnEmptyValues() {
     RelNode table = substraitToCalcite.convert(computedRows());
-    RelNode empty =
-        new VirtualTable(table.getCluster(), table.getTraitSet(), table.getRowType(), List.of());
+    RelNode empty = VirtualTable.create(table.getCluster(), table.getRowType(), List.of());
 
-    RelNode expanded = plan(empty, VirtualTableExpansionRule.INSTANCE);
+    RelNode expanded = plan(empty, VirtualTableExpansionRule.instance());
 
     assertEquals("LogicalValues(tuples=[[]])\n", RelOptUtil.toString(expanded));
+  }
+
+  /**
+   * SQL generation is the consumer the rule exists for: {@link
+   * org.apache.calcite.rel.rel2sql.RelToSqlConverter} knows Calcite's own relations only, and
+   * throws an {@code AssertionError} naming anything else -- unconditionally, so assertions being
+   * off does not help. Both of isthmus' entry points expand before they convert.
+   */
+  @Test
+  void sqlGenerationExpandsTheTable() {
+    RelNode table = substraitToCalcite.convert(computedRows());
+    io.substrait.plan.Plan plan = sb.plan(sb.root(computedRows(), List.of("col1", "col2")));
+
+    assertAll(
+        () ->
+            assertEquals(
+                "SELECT 2 AS \"col1\", 4.4E0 + 4.5E0 AS \"col2\"\n"
+                    + "FROM (VALUES ()) AS \"t\"\n"
+                    + "UNION ALL\n"
+                    + "SELECT 6 * 2 AS \"col1\", 8.8E0 AS \"col2\"\n"
+                    + "FROM (VALUES ()) AS \"t\"",
+                SubstraitSqlDialect.toSql(table).getSql()),
+        () ->
+            assertEquals(
+                1,
+                new SubstraitToSql(converterProvider)
+                    .convert(plan, SubstraitSqlDialect.DEFAULT)
+                    .size()));
+  }
+
+  /**
+   * The rows have to fit the row type: the projection this used to be built as gave that check for
+   * free through {@code RexUtil.compatibleTypes}, and {@code AbstractRelNode.isValid} succeeds
+   * whatever it is handed.
+   */
+  @Test
+  void theRowsHaveToFitTheRowType() {
+    RelNode table = substraitToCalcite.convert(computedRows());
+    RelDataType rowType = table.getRowType();
+    RexBuilder rexBuilder = table.getCluster().getRexBuilder();
+    RexNode i32 =
+        rexBuilder.makeExactLiteral(BigDecimal.ONE, typeFactory.createSqlType(SqlTypeName.INTEGER));
+
+    assertAll(
+        () ->
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> VirtualTable.create(table.getCluster(), rowType, List.of(List.of(i32)))),
+        () ->
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    VirtualTable.create(table.getCluster(), rowType, List.of(List.of(i32, i32)))));
+  }
+
+  /**
+   * A schema may name two columns the same -- the spec asks only that the names are a depth-first
+   * list -- and the table carries them as they are. The expansion cannot: a Calcite projection
+   * requires distinct names, so it uniquifies them there rather than failing on a table that
+   * converts and round-trips.
+   */
+  @Test
+  void theExpansionUniquifiesRepeatedFieldNames() {
+    NamedStruct repeated = NamedStruct.of(List.of("c", "c"), R.struct(R.I32, R.FP64));
+    RelNode table =
+        substraitToCalcite.convert(
+            virtualTable(repeated, List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5)))));
+
+    assertEquals(List.of("c", "c"), table.getRowType().getFieldNames());
+    assertEquals(
+        List.of("c", "c1"),
+        plan(table, VirtualTableExpansionRule.instance()).getRowType().getFieldNames());
+  }
+
+  /**
+   * The relation costs what its expansion costs. The inherited estimate is a row count alone, which
+   * is less than the projection per row the rule builds, so a cost-based planner would fire the
+   * rule and then keep the relation it started from.
+   */
+  @Test
+  void theRelationCostsWhatItsExpansionCosts() {
+    RelNode table = substraitToCalcite.convert(computedRows());
+    RelNode expanded = plan(table, VirtualTableExpansionRule.instance());
+    RelMetadataQuery mq = table.getCluster().getMetadataQuery();
+
+    assertFalse(
+        mq.getCumulativeCost(table).isLt(mq.getCumulativeCost(expanded)),
+        mq.getCumulativeCost(table) + " < " + mq.getCumulativeCost(expanded));
   }
 
   /**
@@ -242,24 +312,5 @@ class VirtualTableTest extends PlanTestBase {
     RelDataType rowType = typeFactory.builder().add("col1", value.getType()).build();
     return LogicalProject.create(
         emptyRow, Collections.emptyList(), List.of(value), rowType, Collections.emptySet());
-  }
-
-  @SafeVarargs
-  private VirtualTableScan virtualTable(List<Expression>... rows) {
-    List<Expression.NestedStruct> structs =
-        Arrays.stream(rows)
-            .map(row -> Expression.NestedStruct.builder().addAllFields(row).build())
-            .collect(Collectors.toList());
-    return VirtualTableScan.builder().initialSchema(schema).addAllRows(structs).build();
-  }
-
-  private RelNode plan(RelNode rel, RelOptRule... rules) {
-    HepProgramBuilder program = new HepProgramBuilder();
-    for (RelOptRule rule : rules) {
-      program.addRuleInstance(rule);
-    }
-    HepPlanner planner = new HepPlanner(program.build());
-    planner.setRoot(rel);
-    return planner.findBestExp();
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
@@ -199,6 +200,35 @@ class VirtualTableTest extends PlanTestBase {
     Rel converted = SubstraitRelVisitor.convert(union, extensions);
     assertInstanceOf(io.substrait.relation.Set.class, converted);
     assertEquals(List.of(N.I32), converted.getRecordType().fields());
+  }
+
+  /** The relation stands on its own: it has no inputs, and a copy cannot give it any. */
+  @Test
+  void theRelationTakesNoInputs() {
+    RelNode table = substraitToCalcite.convert(computedRows());
+
+    assertEquals(List.of(), table.getInputs());
+    assertEquals(
+        RelOptUtil.toString(table),
+        RelOptUtil.toString(table.copy(table.getTraitSet(), List.of())));
+    assertThrows(
+        IllegalArgumentException.class, () -> table.copy(table.getTraitSet(), List.of(table)));
+  }
+
+  /**
+   * A table of no rows does not reach the relation through a conversion -- a virtual table with no
+   * rows has no row that fails to fit a tuple, so it converts to an empty {@code LogicalValues} --
+   * but a consumer can build one, and the expansion of no rows is that same empty table.
+   */
+  @Test
+  void theRuleExpandsATableOfNoRowsIntoAnEmptyValues() {
+    RelNode table = substraitToCalcite.convert(computedRows());
+    RelNode empty =
+        new VirtualTable(table.getCluster(), table.getTraitSet(), table.getRowType(), List.of());
+
+    RelNode expanded = plan(empty, VirtualTableExpansionRule.INSTANCE);
+
+    assertEquals("LogicalValues(tuples=[[]])\n", RelOptUtil.toString(expanded));
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
@@ -175,6 +175,17 @@ class VirtualTableTest extends PlanTestBase {
     assertEquals(
         SqlTypeName.BIGINT,
         rewritten.getRowType().getFieldList().get(0).getType().getSqlTypeName());
+    // The widened column fits every row, but only the row the shuttle retyped carries it, so the
+    // way back refuses on the other one -- which is what the rebuilt type costs.
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> SubstraitRelVisitor.convert(rewritten, converterProvider));
+    assertEquals(
+        "A virtual table's value *(6, 2) converts to I32{nullable=false} where its column is"
+            + " declared I64{nullable=false}: isthmus cannot convert a value that does not carry"
+            + " its column's type",
+        e.getMessage());
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableTest.java
@@ -27,6 +27,7 @@ import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -146,6 +147,55 @@ class VirtualTableTest extends PlanTestBase {
   }
 
   /**
+   * A shuttle need not retype the same column in every row, so the rebuilt type is the least
+   * restrictive each column takes across all of them. Taken from the first row alone it would not
+   * fit the rest, and the constructor would report a row that the rewrite itself produced.
+   */
+  @Test
+  void aShuttleRetypingOneRowRebuildsATypeThatFitsThemAll() {
+    RelNode table = substraitToCalcite.convert(computedRows());
+    RexBuilder rexBuilder = table.getCluster().getRexBuilder();
+    RelDataType bigint = typeFactory.createSqlType(SqlTypeName.BIGINT);
+
+    RelNode rewritten =
+        table.accept(
+            new RexShuttle() {
+              private boolean firstRow = true;
+
+              @Override
+              public RexNode visitLiteral(RexLiteral literal) {
+                if (firstRow && literal.getType().getSqlTypeName() == SqlTypeName.INTEGER) {
+                  firstRow = false;
+                  return rexBuilder.makeCast(bigint, literal);
+                }
+                return literal;
+              }
+            });
+
+    assertEquals(
+        SqlTypeName.BIGINT,
+        rewritten.getRowType().getFieldList().get(0).getType().getSqlTypeName());
+  }
+
+  /**
+   * A table of no rows takes the uniquified names too: {@link
+   * org.apache.calcite.rel.logical.LogicalValues} is a Calcite relation like the projection the row
+   * branch builds, and cannot hold a name twice either.
+   */
+  @Test
+  void theExpansionOfNoRowsUniquifiesRepeatedFieldNames() {
+    NamedStruct repeated = NamedStruct.of(List.of("c", "c"), R.struct(R.I32, R.FP64));
+    RelNode table =
+        substraitToCalcite.convert(
+            virtualTable(repeated, List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5)))));
+    RelNode empty = VirtualTable.create(table.getCluster(), table.getRowType(), List.of());
+
+    assertEquals(
+        List.of("c", "c1"),
+        plan(empty, VirtualTableExpansionRule.instance()).getRowType().getFieldNames());
+  }
+
+  /**
    * A projection above the table is where the expansion used to lose the schema's names: the
    * renaming projection it carried was merged into this one, and nothing was left to rebuild the
    * table from.
@@ -214,13 +264,14 @@ class VirtualTableTest extends PlanTestBase {
   }
 
   /**
-   * SQL generation is the consumer the rule exists for: {@link
+   * SQL generation is where the relation meets stock Calcite: {@link
    * org.apache.calcite.rel.rel2sql.RelToSqlConverter} knows Calcite's own relations only, and
    * throws an {@code AssertionError} naming anything else -- unconditionally, so assertions being
-   * off does not help. Both of isthmus' entry points expand before they convert.
+   * off does not help. Both of isthmus' entry points go through {@link
+   * io.substrait.isthmus.sql.SubstraitRelToSqlConverter}, which has a case for it.
    */
   @Test
-  void sqlGenerationExpandsTheTable() {
+  void sqlGenerationRendersTheTable() {
     RelNode table = substraitToCalcite.convert(computedRows());
     io.substrait.plan.Plan plan = sb.plan(sb.root(computedRows(), List.of("col1", "col2")));
 
@@ -235,19 +286,60 @@ class VirtualTableTest extends PlanTestBase {
                 SubstraitSqlDialect.toSql(table).getSql()),
         () ->
             assertEquals(
-                1,
-                new SubstraitToSql(converterProvider)
-                    .convert(plan, SubstraitSqlDialect.DEFAULT)
-                    .size()));
+                List.of(
+                    "SELECT *\n"
+                        + "FROM (SELECT 2 AS col1, 4.4E0 + 4.5E0 AS col2\n"
+                        + "FROM (VALUES ()) AS t\n"
+                        + "UNION ALL\n"
+                        + "SELECT 6 * 2 AS col1, 8.8E0 AS col2\n"
+                        + "FROM (VALUES ()) AS t) AS t3"),
+                new SubstraitToSql(converterProvider).convert(plan, SubstraitSqlDialect.DEFAULT)));
   }
 
   /**
-   * The rows have to fit the row type: the projection this used to be built as gave that check for
-   * free through {@code RexUtil.compatibleTypes}, and {@code AbstractRelNode.isValid} succeeds
-   * whatever it is handed.
+   * A table inside a subquery is the position a tree pass ahead of the converter cannot reach: a
+   * subquery's relation is in no relation's inputs, so walking them never arrives at it. {@code
+   * SqlImplementor} converts it through {@code visitRoot}, which lands on the same {@code visit} as
+   * every other position.
    */
   @Test
-  void theRowsHaveToFitTheRowType() {
+  void sqlGenerationReachesATableInsideASubquery() {
+    VirtualTableScan oneRow =
+        virtualTable(
+            NamedStruct.of(List.of("col1"), R.struct(R.I32)),
+            List.of(sb.multiply(sb.i32(6), sb.i32(2))));
+    Rel root =
+        sb.project(
+            input -> List.of(sb.scalarSubquery(oneRow, R.I32)),
+            Rel.Remap.of(List.of(1)),
+            sb.namedScan(List.of("example"), List.of("a"), List.of(R.I32)));
+
+    assertAll(
+        () ->
+            assertEquals(
+                "SELECT (SELECT 6 * 2 AS \"col1\"\n"
+                    + "FROM (VALUES ()) AS \"t\") AS \"$f1\"\n"
+                    + "FROM \"example\"",
+                SubstraitSqlDialect.toSql(substraitToCalcite.convert(root)).getSql()),
+        () ->
+            assertEquals(
+                List.of(
+                    "SELECT (SELECT 6 * 2 AS col1\n"
+                        + "FROM (VALUES ()) AS t) AS q\n"
+                        + "FROM example"),
+                new SubstraitToSql(converterProvider)
+                    .convert(sb.plan(sb.root(root, List.of("q"))), SubstraitSqlDialect.DEFAULT)));
+  }
+
+  /**
+   * A row has one value per column, and that is all the relation checks: the projection this used
+   * to be built as got the count from {@code RexUtil.compatibleTypes}, and {@code
+   * AbstractRelNode.isValid} succeeds whatever it is handed. The value types are deliberately not
+   * checked -- the conversion gives each value the type its column is declared at before building
+   * the table, and checking here would reject a value it allows.
+   */
+  @Test
+  void aRowHasOneValuePerColumn() {
     RelNode table = substraitToCalcite.convert(computedRows());
     RelDataType rowType = table.getRowType();
     RexBuilder rexBuilder = table.getCluster().getRexBuilder();
@@ -263,7 +355,14 @@ class VirtualTableTest extends PlanTestBase {
             assertThrows(
                 IllegalArgumentException.class,
                 () ->
-                    VirtualTable.create(table.getCluster(), rowType, List.of(List.of(i32, i32)))));
+                    VirtualTable.create(
+                        table.getCluster(), rowType, List.of(List.of(i32, i32, i32)))),
+        // The second column is declared FP64, and an i32 value in it is taken as it comes.
+        () ->
+            assertEquals(
+                rowType,
+                VirtualTable.create(table.getCluster(), rowType, List.of(List.of(i32, i32)))
+                    .getRowType()));
   }
 
   /**


### PR DESCRIPTION
A `VirtualTableScan` whose rows are not all literals was expanded into a `UNION ALL` of one single-row projection per row, each over an empty `Values`. Nothing in that shape says it was a table, so the plan came back from Calcite as a `Set` of `Project`s -- a different relation than the one that went in -- and the schema's names went with it.

Emit an isthmus-owned relation instead. `VirtualTable` holds the rows as `RexNode`s and the schema as its row type, and `visitOther` recognises it by type. `SubstraitRelToSqlConverter` generates SQL for it, reaching a table inside a `RexSubQuery` that a pass over the tree cannot. `VirtualTableExpansionRule` still builds the union for a consumer whose planner knows only Calcite's own relations, one way: converting that expansion back to Substrait gives the union it is.

Coming back from Calcite, a value that is not a literal carries the type its own expressions give it. For a computed value inside a nullable struct that is not the type the column declares -- Calcite makes a nullable struct's fields nullable while the expression keeps its own -- and the conversion is now refused rather than cast, since casting would put an expression in the output the input did not have. Whether the spec lets a row differ from its column at all is open: substrait-io/substrait#1211 has the plans and what four implementations do with them.

Closes #631, #1227, #1228

BREAKING CHANGE: two changes, one per direction.

Substrait to Calcite: a virtual table whose rows are not all literals now converts to `io.substrait.isthmus.calcite.rel.VirtualTable` instead of a `UNION ALL` of single-row projections over an empty table. Code that hands the tree to something knowing only Calcite's own relations can expand it with `io.substrait.isthmus.calcite.rel.rules.VirtualTableExpansionRule`, which is one-way: converting the expansion back to Substrait gives that union, not the virtual table.

Calcite to Substrait: where a row's value carries a type its column does not declare -- a computed value inside a nullable struct, Calcite having made the struct's fields nullable while the expression keeps its own -- converting the table back now throws an `UnsupportedOperationException` naming the value and both types. It used to produce the `UNION ALL` above, which is the shape this release stops producing, so there is no way to keep the old output; whether the spec permits the mismatch at all is being settled in substrait-io/substrait#1211.
