### PR TITLE
fix(isthmus): convert a virtual table with a struct column

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -84,6 +84,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexSlot;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
@@ -796,34 +797,48 @@ public class SubstraitRelNodeConverter
     // they have to be handed to the conversion rather than paired with the row type afterwards:
     // with a nested struct anywhere in the schema the two lists do not even have the same length.
     final NamedStruct schema = virtualTableScan.getInitialSchema();
+    // A relation's row type says what its columns are, not whether a value is there, and Calcite
+    // builds one NOT NULL wherever it derives one -- so a nullable schema struct contributes its
+    // fields and not its nullability.
     final RelDataType rowType =
-        typeConverter.toCalcite(typeFactory, schema.struct(), schema.names());
+        typeFactory.createTypeWithNullability(
+            typeConverter.toCalcite(typeFactory, schema.struct(), schema.names()), false);
 
     List<List<RexNode>> convertedRows = new ArrayList<>();
+    // The same values with the cast a nullable literal converts as taken off, which is the form a
+    // LogicalValues tuple would hold them in -- where they are literals at all.
+    List<List<RexNode>> tupleValues = new ArrayList<>();
     for (final Expression.NestedStruct rowExpr : virtualTableScan.getRows()) {
       List<RexNode> convertedRow = new ArrayList<>();
+      List<RexNode> tupleRow = new ArrayList<>();
       for (int column = 0; column < rowExpr.fields().size(); column++) {
-        RexNode value = rowExpr.fields().get(column).accept(expressionRexConverter, context);
-        convertedRow.add(
-            nameStructFieldsAsDeclared(value, rowType.getFieldList().get(column).getType()));
+        Expression field = rowExpr.fields().get(column);
+        RelDataType declaredType = rowType.getFieldList().get(column).getType();
+        RexNode value =
+            valueAsDeclared(field.accept(expressionRexConverter, context), declaredType);
+        convertedRow.add(value);
+        // Only a converted literal has its nullability cast taken off. A cast the plan carries
+        // itself is doing work -- it has a failure behavior, and it is part of what round-trips --
+        // so a row holding one is computed rather than tabulated.
+        tupleRow.add(field instanceof Expression.Literal ? unwrapNullabilityCast(value) : value);
       }
       convertedRows.add(convertedRow);
+      tupleValues.add(tupleRow);
     }
 
-    // A LogicalValues tuple holds nothing but literals, and whether the values are literals is a
-    // property of what they convert to rather than of the Substrait expressions they came from: a
-    // struct or a list converts to a call, both when it is built from expressions and when Calcite
-    // has no literal of its own for it.
+    // A LogicalValues tuple holds nothing but literals, and whether a value is one is a property of
+    // what it converts to rather than of the Substrait expression it came from: a struct converts
+    // to a ROW call and a list to an array constructor, literal or not. Neither belongs in a tuple
+    // anyway -- Calcite orders tuples by casting each value to Comparable, and the value of a row
+    // literal is a list of RexLiterals, which are not.
     boolean encodableAsTuples =
-        convertedRows.stream()
-            .flatMap(List::stream)
-            .allMatch(value -> unwrapNullabilityCast(value) instanceof RexLiteral);
+        tupleValues.stream().flatMap(List::stream).allMatch(value -> value instanceof RexLiteral);
     if (encodableAsTuples) {
       ImmutableList.Builder<ImmutableList<RexLiteral>> tuplesBuilder = ImmutableList.builder();
-      for (final List<RexNode> convertedRow : convertedRows) {
+      for (final List<RexNode> tupleRow : tupleValues) {
         ImmutableList.Builder<RexLiteral> tupleBuilder = ImmutableList.builder();
-        for (RexNode rexNode : convertedRow) {
-          tupleBuilder.add((RexLiteral) unwrapNullabilityCast(rexNode));
+        for (RexNode value : tupleRow) {
+          tupleBuilder.add((RexLiteral) value);
         }
         tuplesBuilder.add(tupleBuilder.build());
       }
@@ -870,7 +885,7 @@ public class SubstraitRelNodeConverter
   }
 
   /**
-   * Renames the struct fields of a converted row value to the names its column is declared with.
+   * Gives a converted row value the type its column is declared at.
    *
    * <p>A Substrait struct type has no field names of its own -- a schema names every field once, at
    * the relation level -- so a struct-valued expression converts carrying the placeholder names
@@ -878,18 +893,53 @@ public class SubstraitRelNodeConverter
    * Calcite compares field names when it checks a value against the type it is declared at, so a
    * struct is rejected on that difference alone, wherever in the column's type it sits.
    *
-   * <p>Only names change. A row's field types are checked against the schema when the {@link
-   * VirtualTableScan} is built, so a value that is the row, list or map its column declares differs
-   * from it in nothing else. A value that is something else -- a call returning a struct, say -- is
-   * returned untouched, for Calcite to report as the mismatch it is.
+   * <p>Names are what a row, list or map value is rebuilt for: a row's field types are checked
+   * against the schema when the {@link VirtualTableScan} is built, so a value that is one of those
+   * agrees with its declared type on everything a Substrait type says. It can still be stamped
+   * nullable where it was not -- Calcite makes a struct's fields nullable along with the struct,
+   * and a value that cannot be null stands in a column that can. A value that cannot take the
+   * declared type at all -- a call returning a struct, say, whose names are not the declared ones
+   * -- is reported here: {@link LogicalProject} and {@link LogicalValues} check the row type they
+   * are handed with an {@code assert}, which says nothing at all unless assertions are on.
    *
    * @param value the converted row value
    * @param declaredType the type its column is declared at
-   * @return the value, renamed where it has to be
+   * @return the value, at {@code declaredType}
+   * @throws IllegalArgumentException if the value cannot be given that type
    */
-  private RexNode nameStructFieldsAsDeclared(RexNode value, RelDataType declaredType) {
+  private RexNode valueAsDeclared(RexNode value, RelDataType declaredType) {
+    RexNode declared = renamedAsDeclared(value, declaredType);
+    if (!fitsDeclared(declared.getType(), declaredType)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "A virtual table's value %s converts to the type %s, which is not the %s its column is declared at",
+              value, declared.getType().getFullTypeString(), declaredType.getFullTypeString()));
+    }
+    return declared;
+  }
+
+  /**
+   * Whether a converted value can stand at the type it is declared at.
+   *
+   * <p>A value that cannot be null stands in a column that can: Calcite makes a struct's fields
+   * nullable along with the struct, so the fields of a nullable struct are declared that way
+   * whatever the values in them are. The other direction is a mismatch, and so is any difference
+   * beyond nullability -- a field name included, which is the one this rename is about.
+   */
+  private boolean fitsDeclared(RelDataType valueType, RelDataType declaredType) {
+    return SqlTypeUtil.equalSansNullability(typeFactory, valueType, declaredType)
+        && (declaredType.isNullable() || !valueType.isNullable());
+  }
+
+  private RexNode renamedAsDeclared(RexNode value, RelDataType declaredType) {
     if (value.getType().equals(declaredType)) {
       return value;
+    }
+    if (value instanceof RexLiteral && ((RexLiteral) value).isNull()) {
+      // A null value has no fields to rename, only a type to take -- and a list or a map converts
+      // to a literal when it is null and to a constructor call otherwise, so this is where those
+      // two are named as much as a struct is.
+      return rexBuilder.makeNullLiteral(declaredType);
     }
     switch (declaredType.getSqlTypeName()) {
       case ROW:
@@ -904,44 +954,17 @@ public class SubstraitRelNodeConverter
   }
 
   private RexNode nameRowFieldsAsDeclared(RexNode value, RelDataType declaredType) {
-    List<? extends RexNode> fields;
-    if (value instanceof RexLiteral) {
-      @SuppressWarnings("unchecked")
-      List<RexLiteral> literals = (List<RexLiteral>) ((RexLiteral) value).getValueAs(List.class);
-      if (literals == null) {
-        // A null struct has no fields to rename, only a type to take
-        return rexBuilder.makeNullLiteral(declaredType);
-      }
-      fields = literals;
-    } else if (value.isA(SqlKind.ROW)) {
-      fields = ((RexCall) value).getOperands();
-    } else {
+    if (!value.isA(SqlKind.ROW)) {
       return value;
     }
+    List<RexNode> fields = ((RexCall) value).getOperands();
     if (fields.size() != declaredType.getFieldCount()) {
       return value;
     }
-
     List<RexNode> renamed = new ArrayList<>();
     for (int field = 0; field < fields.size(); field++) {
       renamed.add(
-          nameStructFieldsAsDeclared(
-              fields.get(field), declaredType.getFieldList().get(field).getType()));
-    }
-
-    // Rebuilt as a literal only while the parts are literals: renaming a struct can give back a
-    // ROW call, and a literal cannot hold one
-    if (value instanceof RexLiteral
-        && renamed.stream().allMatch(field -> field instanceof RexLiteral)) {
-      List<RexLiteral> literals =
-          renamed.stream().map(RexLiteral.class::cast).collect(Collectors.toList());
-      RexNode asLiteral = rexBuilder.makeLiteral(literals, declaredType);
-      // Calcite has no nullable literal of a row: a value in a nullable column comes back typed NOT
-      // NULL, which neither a tuple nor a projection accepts. A ROW call is built at the type it is
-      // given, so a column like that keeps the projection encoding.
-      if (asLiteral.getType().equals(declaredType)) {
-        return asLiteral;
-      }
+          valueAsDeclared(fields.get(field), declaredType.getFieldList().get(field).getType()));
     }
     return rexBuilder.makeCall(declaredType, SqlStdOperatorTable.ROW, renamed);
   }
@@ -953,7 +976,7 @@ public class SubstraitRelNodeConverter
     RelDataType itemType = Objects.requireNonNull(declaredType.getComponentType());
     List<RexNode> renamed = new ArrayList<>();
     for (RexNode item : ((RexCall) value).getOperands()) {
-      renamed.add(nameStructFieldsAsDeclared(item, itemType));
+      renamed.add(valueAsDeclared(item, itemType));
     }
     return rexBuilder.makeCall(declaredType, SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, renamed);
   }
@@ -968,9 +991,7 @@ public class SubstraitRelNodeConverter
     List<RexNode> renamed = new ArrayList<>();
     for (int operand = 0; operand < operands.size(); operand++) {
       // the constructor takes keys and values alternating
-      renamed.add(
-          nameStructFieldsAsDeclared(
-              operands.get(operand), operand % 2 == 0 ? keyType : entryType));
+      renamed.add(valueAsDeclared(operands.get(operand), operand % 2 == 0 ? keyType : entryType));
     }
     return rexBuilder.makeCall(declaredType, SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, renamed);
   }
@@ -980,22 +1001,13 @@ public class SubstraitRelNodeConverter
    *
    * <p>A nullable literal converts as {@code CAST(literal AS nullable type)}. LogicalValues tuples
    * hold bare literals, and the field's nullability is already declared in the row type, so that
-   * cast has to come off before the literal can go into a tuple. Only that one: a cast that changes
-   * anything else is doing work, and dropping it would leave the literal under a row type that does
-   * not describe it.
+   * cast has to come off before the literal can go into a tuple.
    *
    * @param rexNode the converted node
    * @return the literal the cast wraps, or {@code rexNode} itself
    */
-  private static RexNode unwrapNullabilityCast(RexNode rexNode) {
-    if (rexNode.isA(SqlKind.CAST)) {
-      RexNode castOperand = ((RexCall) rexNode).getOperands().get(0);
-      if (castOperand instanceof RexLiteral
-          && SqlTypeUtil.equalSansNullability(rexNode.getType(), castOperand.getType())) {
-        return castOperand;
-      }
-    }
-    return rexNode;
+  private RexNode unwrapNullabilityCast(RexNode rexNode) {
+    return RexUtil.removeNullabilityCast(typeFactory, rexNode);
   }
 
   private RelNode handleCreateTableAs(NamedWrite namedWrite, Context context) {

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -54,6 +54,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -791,51 +792,46 @@ public class SubstraitRelNodeConverter
 
   @Override
   public RelNode visit(VirtualTableScan virtualTableScan, Context context) {
+    // A schema's names are one per field at every level of the struct, in depth-first order, so
+    // they have to be handed to the conversion rather than paired with the row type afterwards:
+    // with a nested struct anywhere in the schema the two lists do not even have the same length.
+    final NamedStruct schema = virtualTableScan.getInitialSchema();
     final RelDataType rowType =
-        typeConverter.toCalcite(typeFactory, virtualTableScan.getInitialSchema().struct());
+        typeConverter.toCalcite(typeFactory, schema.struct(), schema.names());
 
-    final List<String> correctFieldNames = virtualTableScan.getInitialSchema().names();
+    List<List<RexNode>> convertedRows = new ArrayList<>();
+    for (final Expression.NestedStruct rowExpr : virtualTableScan.getRows()) {
+      List<RexNode> convertedRow = new ArrayList<>();
+      for (int column = 0; column < rowExpr.fields().size(); column++) {
+        RexNode value = rowExpr.fields().get(column).accept(expressionRexConverter, context);
+        convertedRow.add(
+            nameStructFieldsAsDeclared(value, rowType.getFieldList().get(column).getType()));
+      }
+      convertedRows.add(convertedRow);
+    }
 
-    final List<RelDataType> fieldTypes =
-        rowType.getFieldList().stream().map(RelDataTypeField::getType).collect(Collectors.toList());
-
-    final RelDataType rowTypeWithNames =
-        typeFactory.createStructType(fieldTypes, correctFieldNames);
-
-    // When all expression in the VirtualTable are literals, we can encode it in Calcite as a
-    // standard LogicalValues relation.
-    boolean allLiterals =
-        virtualTableScan.getRows().stream()
-            .allMatch(row -> row.fields().stream().allMatch(e -> e instanceof Expression.Literal));
-    if (allLiterals) {
+    // A LogicalValues tuple holds nothing but literals, and whether the values are literals is a
+    // property of what they convert to rather than of the Substrait expressions they came from: a
+    // struct or a list converts to a call, both when it is built from expressions and when Calcite
+    // has no literal of its own for it.
+    boolean encodableAsTuples =
+        convertedRows.stream()
+            .flatMap(List::stream)
+            .allMatch(value -> unwrapNullabilityCast(value) instanceof RexLiteral);
+    if (encodableAsTuples) {
       ImmutableList.Builder<ImmutableList<RexLiteral>> tuplesBuilder = ImmutableList.builder();
-      for (final Expression.NestedStruct rowExpr : virtualTableScan.getRows()) {
+      for (final List<RexNode> convertedRow : convertedRows) {
         ImmutableList.Builder<RexLiteral> tupleBuilder = ImmutableList.builder();
-        for (Expression expr : rowExpr.fields()) {
-          final Expression.Literal literal = (Expression.Literal) expr;
-          RexNode rexNode = literal.accept(expressionRexConverter, context);
-          // A nullable literal converts as CAST(literal AS nullable type). LogicalValues tuples
-          // hold bare literals, and the field's nullability is already declared in the row type,
-          // so unwrap that cast here. Only that one: a cast that changes anything else is doing
-          // work, and dropping it would leave the literal under a row type that does not describe
-          // it. Such a tuple is malformed whatever happens to the cast, and the cast below is what
-          // reports it.
-          if (rexNode.isA(SqlKind.CAST)) {
-            RexNode castOperand = ((RexCall) rexNode).getOperands().get(0);
-            if (castOperand instanceof RexLiteral
-                && SqlTypeUtil.equalSansNullability(rexNode.getType(), castOperand.getType())) {
-              rexNode = castOperand;
-            }
-          }
-          tupleBuilder.add((RexLiteral) rexNode);
+        for (RexNode rexNode : convertedRow) {
+          tupleBuilder.add((RexLiteral) unwrapNullabilityCast(rexNode));
         }
         tuplesBuilder.add(tupleBuilder.build());
       }
-      return LogicalValues.create(relBuilder.getCluster(), rowTypeWithNames, tuplesBuilder.build());
+      return LogicalValues.create(relBuilder.getCluster(), rowType, tuplesBuilder.build());
     } else {
-      // When a VirtualTable contains non-literal expressions, they cannot be put directly into a
-      // LogicalValues relation. Instead, we create a LogicalProject for each row to compute its
-      // values, and combine them together using a LogicalUnion. For example the following:
+      // A row that does not fit a LogicalValues tuple is computed instead: we create a
+      // LogicalProject for each row to compute its values, and combine them together using a
+      // LogicalUnion. For example the following:
       //
       //   VirtualTable
       //     (e1, e2)
@@ -854,11 +850,7 @@ public class SubstraitRelNodeConverter
       ImmutableList<ImmutableList<RexLiteral>> emptyRowValue = ImmutableList.of(ImmutableList.of());
 
       List<RelNode> projects = new ArrayList<>();
-      for (final Expression.NestedStruct rowExpr : virtualTableScan.getRows()) {
-        List<RexNode> rexRow = new ArrayList<>();
-        for (Expression field : rowExpr.fields()) {
-          rexRow.add(field.accept(expressionRexConverter, context));
-        }
+      for (final List<RexNode> rexRow : convertedRows) {
         RelNode values = LogicalValues.create(relBuilder.getCluster(), emptyRowType, emptyRowValue);
         RelNode project =
             LogicalProject.create(
@@ -873,12 +865,137 @@ public class SubstraitRelNodeConverter
         topProjectExprs.add(rexBuilder.makeInputRef(union, i));
       }
       return LogicalProject.create(
-          union,
-          Collections.emptyList(),
-          topProjectExprs,
-          rowTypeWithNames,
-          Collections.emptySet());
+          union, Collections.emptyList(), topProjectExprs, rowType, Collections.emptySet());
     }
+  }
+
+  /**
+   * Renames the struct fields of a converted row value to the names its column is declared with.
+   *
+   * <p>A Substrait struct type has no field names of its own -- a schema names every field once, at
+   * the relation level -- so a struct-valued expression converts carrying the placeholder names
+   * Calcite derives for it, while the row type built from the schema carries the schema's own.
+   * Calcite compares field names when it checks a value against the type it is declared at, so a
+   * struct is rejected on that difference alone, wherever in the column's type it sits.
+   *
+   * <p>Only names change. A row's field types are checked against the schema when the {@link
+   * VirtualTableScan} is built, so a value that is the row, list or map its column declares differs
+   * from it in nothing else. A value that is something else -- a call returning a struct, say -- is
+   * returned untouched, for Calcite to report as the mismatch it is.
+   *
+   * @param value the converted row value
+   * @param declaredType the type its column is declared at
+   * @return the value, renamed where it has to be
+   */
+  private RexNode nameStructFieldsAsDeclared(RexNode value, RelDataType declaredType) {
+    if (value.getType().equals(declaredType)) {
+      return value;
+    }
+    switch (declaredType.getSqlTypeName()) {
+      case ROW:
+        return nameRowFieldsAsDeclared(value, declaredType);
+      case ARRAY:
+        return nameArrayItemsAsDeclared(value, declaredType);
+      case MAP:
+        return nameMapEntriesAsDeclared(value, declaredType);
+      default:
+        return value;
+    }
+  }
+
+  private RexNode nameRowFieldsAsDeclared(RexNode value, RelDataType declaredType) {
+    List<? extends RexNode> fields;
+    if (value instanceof RexLiteral) {
+      @SuppressWarnings("unchecked")
+      List<RexLiteral> literals = (List<RexLiteral>) ((RexLiteral) value).getValueAs(List.class);
+      if (literals == null) {
+        // A null struct has no fields to rename, only a type to take
+        return rexBuilder.makeNullLiteral(declaredType);
+      }
+      fields = literals;
+    } else if (value.isA(SqlKind.ROW)) {
+      fields = ((RexCall) value).getOperands();
+    } else {
+      return value;
+    }
+    if (fields.size() != declaredType.getFieldCount()) {
+      return value;
+    }
+
+    List<RexNode> renamed = new ArrayList<>();
+    for (int field = 0; field < fields.size(); field++) {
+      renamed.add(
+          nameStructFieldsAsDeclared(
+              fields.get(field), declaredType.getFieldList().get(field).getType()));
+    }
+
+    // Rebuilt as a literal only while the parts are literals: renaming a struct can give back a
+    // ROW call, and a literal cannot hold one
+    if (value instanceof RexLiteral
+        && renamed.stream().allMatch(field -> field instanceof RexLiteral)) {
+      List<RexLiteral> literals =
+          renamed.stream().map(RexLiteral.class::cast).collect(Collectors.toList());
+      RexNode asLiteral = rexBuilder.makeLiteral(literals, declaredType);
+      // Calcite has no nullable literal of a row: a value in a nullable column comes back typed NOT
+      // NULL, which neither a tuple nor a projection accepts. A ROW call is built at the type it is
+      // given, so a column like that keeps the projection encoding.
+      if (asLiteral.getType().equals(declaredType)) {
+        return asLiteral;
+      }
+    }
+    return rexBuilder.makeCall(declaredType, SqlStdOperatorTable.ROW, renamed);
+  }
+
+  private RexNode nameArrayItemsAsDeclared(RexNode value, RelDataType declaredType) {
+    if (!value.isA(SqlKind.ARRAY_VALUE_CONSTRUCTOR)) {
+      return value;
+    }
+    RelDataType itemType = Objects.requireNonNull(declaredType.getComponentType());
+    List<RexNode> renamed = new ArrayList<>();
+    for (RexNode item : ((RexCall) value).getOperands()) {
+      renamed.add(nameStructFieldsAsDeclared(item, itemType));
+    }
+    return rexBuilder.makeCall(declaredType, SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, renamed);
+  }
+
+  private RexNode nameMapEntriesAsDeclared(RexNode value, RelDataType declaredType) {
+    if (!value.isA(SqlKind.MAP_VALUE_CONSTRUCTOR)) {
+      return value;
+    }
+    RelDataType keyType = Objects.requireNonNull(declaredType.getKeyType());
+    RelDataType entryType = Objects.requireNonNull(declaredType.getValueType());
+    List<RexNode> operands = ((RexCall) value).getOperands();
+    List<RexNode> renamed = new ArrayList<>();
+    for (int operand = 0; operand < operands.size(); operand++) {
+      // the constructor takes keys and values alternating
+      renamed.add(
+          nameStructFieldsAsDeclared(
+              operands.get(operand), operand % 2 == 0 ? keyType : entryType));
+    }
+    return rexBuilder.makeCall(declaredType, SqlStdOperatorTable.MAP_VALUE_CONSTRUCTOR, renamed);
+  }
+
+  /**
+   * Unwraps the cast a nullable literal converts as, returning any other node unchanged.
+   *
+   * <p>A nullable literal converts as {@code CAST(literal AS nullable type)}. LogicalValues tuples
+   * hold bare literals, and the field's nullability is already declared in the row type, so that
+   * cast has to come off before the literal can go into a tuple. Only that one: a cast that changes
+   * anything else is doing work, and dropping it would leave the literal under a row type that does
+   * not describe it.
+   *
+   * @param rexNode the converted node
+   * @return the literal the cast wraps, or {@code rexNode} itself
+   */
+  private static RexNode unwrapNullabilityCast(RexNode rexNode) {
+    if (rexNode.isA(SqlKind.CAST)) {
+      RexNode castOperand = ((RexCall) rexNode).getOperands().get(0);
+      if (castOperand instanceof RexLiteral
+          && SqlTypeUtil.equalSansNullability(rexNode.getType(), castOperand.getType())) {
+        return castOperand;
+      }
+    }
+    return rexNode;
   }
 
   private RelNode handleCreateTableAs(NamedWrite namedWrite, Context context) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -446,21 +446,6 @@ public class ExpressionRexConverter
     List<RexNode> fieldNodes =
         expr.fields().stream().map(f -> f.accept(this, context)).collect(Collectors.toList());
     RelDataType structType = typeConverter.toCalcite(typeFactory, expr.getType());
-    // Calcite has a literal of its own for a row of literals, and the reverse conversion reads
-    // one, so build that rather than a ROW call whenever the fields allow it: a call is an
-    // expression, and the places that hold only literals -- a LogicalValues tuple -- cannot take
-    // it. A field that converted to a call of its own (a nullable literal becomes a cast) leaves
-    // no choice but the ROW call, and so does a nullable struct: Calcite has no nullable literal
-    // of a row, and building one at that type gives a literal typed NOT NULL, which would drop
-    // the nullability this expression carries.
-    if (fieldNodes.stream().allMatch(field -> field instanceof RexLiteral)) {
-      List<RexLiteral> fieldLiterals =
-          fieldNodes.stream().map(RexLiteral.class::cast).collect(Collectors.toList());
-      RexNode asLiteral = rexBuilder.makeLiteral(fieldLiterals, structType);
-      if (asLiteral.getType().equals(structType)) {
-        return asLiteral;
-      }
-    }
     return rexBuilder.makeCall(structType, SqlStdOperatorTable.ROW, fieldNodes);
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/ExpressionRexConverter.java
@@ -446,6 +446,21 @@ public class ExpressionRexConverter
     List<RexNode> fieldNodes =
         expr.fields().stream().map(f -> f.accept(this, context)).collect(Collectors.toList());
     RelDataType structType = typeConverter.toCalcite(typeFactory, expr.getType());
+    // Calcite has a literal of its own for a row of literals, and the reverse conversion reads
+    // one, so build that rather than a ROW call whenever the fields allow it: a call is an
+    // expression, and the places that hold only literals -- a LogicalValues tuple -- cannot take
+    // it. A field that converted to a call of its own (a nullable literal becomes a cast) leaves
+    // no choice but the ROW call, and so does a nullable struct: Calcite has no nullable literal
+    // of a row, and building one at that type gives a literal typed NOT NULL, which would drop
+    // the nullability this expression carries.
+    if (fieldNodes.stream().allMatch(field -> field instanceof RexLiteral)) {
+      List<RexLiteral> fieldLiterals =
+          fieldNodes.stream().map(RexLiteral.class::cast).collect(Collectors.toList());
+      RexNode asLiteral = rexBuilder.makeLiteral(fieldLiterals, structType);
+      if (asLiteral.getType().equals(structType)) {
+        return asLiteral;
+      }
+    }
     return rexBuilder.makeCall(structType, SqlStdOperatorTable.ROW, fieldNodes);
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
@@ -117,9 +117,9 @@ class LiteralNullabilityRoundtripTest extends PlanTestBase {
   /**
    * A cast doing more than nullability is not this representation, so the tuple unwrap leaves it
    * alone -- and a row whose values are not literals to Calcite is not a Values row at all, so it
-   * takes the projection encoding with the cast still on it. A varchar literal longer than its
-   * declared length is malformed input either way; the point is that the truncation stays visible
-   * instead of landing in a row type that does not describe it.
+   * takes the projection encoding with the cast still on it. The literal here is malformed input:
+   * its value is longer than the length it declares, and nothing rejects it, here or in the POJO
+   * that holds it. What this pins is only the cast, which is the part the conversion decides.
    */
   @Test
   void tupleUnwrapLeavesATruncatingCastAlone() {
@@ -137,6 +137,34 @@ class LiteralNullabilityRoundtripTest extends PlanTestBase {
             + "    LogicalProject(A=[CAST('abcdef'):VARCHAR(3) NOT NULL])\n"
             + "      LogicalValues(tuples=[[{  }]])\n",
         RelOptUtil.toString(substraitToCalcite.convert(overlong)));
+  }
+
+  /**
+   * The unwrap reads the Substrait expression, not just the Calcite node: a cast the plan carries
+   * itself looks exactly like the one a nullable literal converts as, and dropping it would lose
+   * its failure behavior and the {@link Expression.Cast} the round trip owes back. So a row holding
+   * one is computed rather than tabulated.
+   */
+  @Test
+  void aDeclaredNullabilityCastKeepsTheRowOffTheTuplePath() {
+    VirtualTableScan castRow =
+        VirtualTableScan.builder()
+            .initialSchema(NamedStruct.of(List.of("A"), R.struct(N.I32)))
+            .addRows(
+                ExpressionCreator.nestedStruct(
+                    false,
+                    ExpressionCreator.cast(
+                        N.I32,
+                        ExpressionCreator.i32(false, 5),
+                        Expression.FailureBehavior.THROW_EXCEPTION)))
+            .build();
+
+    assertEquals(
+        "LogicalProject(A=[$0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(A=[CAST(5):INTEGER])\n"
+            + "      LogicalValues(tuples=[[{  }]])\n",
+        RelOptUtil.toString(substraitToCalcite.convert(castRow)));
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/LiteralNullabilityRoundtripTest.java
@@ -2,7 +2,6 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.expression.Expression;
@@ -17,6 +16,7 @@ import io.substrait.type.NamedStruct;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.function.Function;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
@@ -116,8 +116,10 @@ class LiteralNullabilityRoundtripTest extends PlanTestBase {
 
   /**
    * A cast doing more than nullability is not this representation, so the tuple unwrap leaves it
-   * alone. A varchar literal longer than its declared length is malformed input either way; the
-   * point is that it stays loud instead of landing in a row type that does not describe it.
+   * alone -- and a row whose values are not literals to Calcite is not a Values row at all, so it
+   * takes the projection encoding with the cast still on it. A varchar literal longer than its
+   * declared length is malformed input either way; the point is that the truncation stays visible
+   * instead of landing in a row type that does not describe it.
    */
   @Test
   void tupleUnwrapLeavesATruncatingCastAlone() {
@@ -128,7 +130,13 @@ class LiteralNullabilityRoundtripTest extends PlanTestBase {
                 ExpressionCreator.nestedStruct(
                     false, ExpressionCreator.varChar(false, "abcdef", 3)))
             .build();
-    assertThrows(ClassCastException.class, () -> substraitToCalcite.convert(overlong));
+
+    assertEquals(
+        "LogicalProject(A=[$0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(A=[CAST('abcdef'):VARCHAR(3) NOT NULL])\n"
+            + "      LogicalValues(tuples=[[{  }]])\n",
+        RelOptUtil.toString(substraitToCalcite.convert(overlong)));
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
@@ -284,6 +284,23 @@ class NestedExpressionsTest extends PlanTestBase {
   }
 
   @Test
+  void nullableStructLiteralWithNonNullFieldsTest() {
+    // The fields being non-null is what makes this one different: every field converts to a
+    // Calcite literal, and the struct's own nullability has to survive that.
+    Expression.StructLiteral structLiteral =
+        ExpressionCreator.struct(true, ExpressionCreator.i32(false, 7));
+
+    Project project =
+        Project.builder().expressions(List.of(structLiteral)).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(project);
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions);
+    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
+    assertEquals(ImmutableExpression.StructLiteral.class, roundTripped.getClass());
+    assertTrue(((Expression.StructLiteral) roundTripped).nullable());
+  }
+
+  @Test
   void nestedStructWithNonLiteralsTest() {
     Expression.NestedStruct nonLiteralNestedStruct =
         Expression.NestedStruct.builder()

--- a/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/NestedExpressionsTest.java
@@ -11,6 +11,7 @@ import io.substrait.expression.ImmutableExpression;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
 import io.substrait.isthmus.sql.SubstraitSqlToCalcite;
 import io.substrait.plan.Plan;
+import io.substrait.relation.Filter;
 import io.substrait.relation.Project;
 import io.substrait.relation.Rel;
 import io.substrait.type.Type;
@@ -283,21 +284,39 @@ class NestedExpressionsTest extends PlanTestBase {
     assertFullRoundTrip(project);
   }
 
+  /**
+   * Calcite simplifies a comparison of two literals by comparing them, and a row literal does not
+   * survive that: its value is a list of {@link org.apache.calcite.rex.RexLiteral}s, which are not
+   * {@link Comparable}. A struct literal converts to a ROW call, which the simplification leaves
+   * alone -- in a projection, where the comparison is simplified in place, and in a filter, where
+   * the whole predicate is.
+   */
   @Test
-  void nullableStructLiteralWithNonNullFieldsTest() {
-    // The fields being non-null is what makes this one different: every field converts to a
-    // Calcite literal, and the struct's own nullability has to survive that.
-    Expression.StructLiteral structLiteral =
-        ExpressionCreator.struct(true, ExpressionCreator.i32(false, 7));
+  void comparingTwoStructLiteralsInAProjectTest() {
+    Expression comparison =
+        sb.equal(
+            ExpressionCreator.struct(false, ExpressionCreator.i32(false, 1)),
+            ExpressionCreator.struct(false, ExpressionCreator.i32(false, 2)));
 
-    Project project =
-        Project.builder().expressions(List.of(structLiteral)).input(emptyTable).build();
+    Project project = Project.builder().expressions(List.of(comparison)).input(emptyTable).build();
 
     RelNode relNode = substraitToCalcite.convert(project);
     Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions);
-    Expression roundTripped = ((Project) substraitRel).getExpressions().get(0);
-    assertEquals(ImmutableExpression.StructLiteral.class, roundTripped.getClass());
-    assertTrue(((Expression.StructLiteral) roundTripped).nullable());
+    assertEquals(comparison, ((Project) substraitRel).getExpressions().get(0));
+  }
+
+  @Test
+  void comparingTwoStructLiteralsInAFilterTest() {
+    Expression comparison =
+        sb.equal(
+            ExpressionCreator.struct(false, ExpressionCreator.i32(false, 1)),
+            ExpressionCreator.struct(false, ExpressionCreator.i32(false, 2)));
+
+    Filter filter = Filter.builder().condition(comparison).input(emptyTable).build();
+
+    RelNode relNode = substraitToCalcite.convert(filter);
+    Rel substraitRel = SubstraitRelVisitor.convert(relNode, extensions);
+    assertEquals(comparison, ((Filter) substraitRel).getCondition());
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
@@ -148,6 +149,195 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         List.of(ExpressionCreator.i32(false, 1), ExpressionCreator.i32(true, 5)),
         converted.getRows().get(1).fields());
+  }
+
+  @Test
+  void structColumnRoundTrip() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("outer", "a", "b"), R.struct(R.struct(R.I32, R.FP64)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema, List.of(ExpressionCreator.struct(false, sb.i32(1), sb.fp64(2.0))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalValues(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], tuples=[[{ [1, 2.0E0] }]])\n",
+        explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
+  }
+
+  /**
+   * Two struct columns, so that the names cannot be recovered by taking the first columns worth of
+   * the schema's flattened list: the second column's name sits at index 3, not at index 1.
+   */
+  @Test
+  void severalStructColumnsRoundTrip() {
+    NamedStruct schema =
+        NamedStruct.of(
+            List.of("first", "a", "b", "second", "c"),
+            R.struct(R.struct(R.I32, R.FP64), R.struct(R.STRING)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema,
+            List.of(
+                ExpressionCreator.struct(false, sb.i32(1), sb.fp64(2.0)),
+                ExpressionCreator.struct(false, sb.str("x"))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalValues(type=[RecordType(RecordType(INTEGER a, DOUBLE b) first, RecordType(VARCHAR c) second)], tuples=[[{ [1, 2.0E0], ['x'] }]])\n",
+        explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
+  }
+
+  /**
+   * A struct column whose fields are not all literals is a row of expressions like any other, so it
+   * takes the projection encoding -- with the schema's names on it, which is what makes the
+   * projection's declared type acceptable to Calcite.
+   */
+  @Test
+  void structColumnWithAComputedField() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("outer", "a", "b"), R.struct(R.struct(R.I32, R.FP64)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema,
+            List.of(
+                ExpressionCreator.nestedStruct(
+                    false, sb.multiply(sb.i32(6), sb.i32(2)), sb.fp64(2.0))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ROW(*(6, 2), 2.0E0:DOUBLE)]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        explain(relNode));
+  }
+
+  /**
+   * A list literal converts to Calcite's array constructor, a call rather than a literal, so a list
+   * column takes the projection encoding too. It used to be handed to a Values tuple, which holds
+   * nothing but literals, and the conversion died on the cast.
+   */
+  @Test
+  void listColumnConverts() {
+    NamedStruct schema = NamedStruct.of(List.of("col1"), R.struct(R.list(R.I32)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema, List.of(ExpressionCreator.list(false, sb.i32(1), sb.i32(2))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ARRAY(1, 2)]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        explain(relNode));
+  }
+
+  /**
+   * Calcite has no nullable literal of a row, so a struct value in a nullable column cannot be a
+   * Values tuple whatever it holds, and the row takes the projection encoding. Pinned as a
+   * conversion rather than a round trip because a nullable struct does not survive one: Calcite
+   * pushes a row's nullability down into its fields, so the schema comes back with nullable fields.
+   */
+  @Test
+  void nullableStructColumnConverts() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("outer", "a", "b"), R.struct(N.struct(R.I32, R.FP64)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema, List.of(ExpressionCreator.struct(true, sb.i32(1), sb.fp64(2.0))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE)]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        explain(relNode));
+  }
+
+  /** A null struct has no fields to rename, but the tuple still needs it at the column's type. */
+  @Test
+  void nullStructColumnConverts() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("outer", "a", "b"), R.struct(N.struct(R.I32, R.FP64)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema, List.of(ExpressionCreator.typedNull(N.struct(R.I32, R.FP64))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalValues(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], tuples=[[{ null }]])\n",
+        explain(relNode));
+  }
+
+  /**
+   * A struct one level down, inside a list column: the names the schema gives it have to reach it
+   * there too, or the projection that holds the row is rejected on them.
+   */
+  @Test
+  void structInListColumnConverts() {
+    NamedStruct schema = NamedStruct.of(List.of("col1", "a"), R.struct(R.list(R.struct(R.I32))));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema,
+            List.of(ExpressionCreator.list(false, ExpressionCreator.struct(false, sb.i32(1)))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ARRAY([1:INTEGER]:RecordType(INTEGER NOT NULL a))]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        explain(relNode));
+  }
+
+  /** The same one level down inside a map, where the names reach a key and a value alike. */
+  @Test
+  void structInMapColumnConverts() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("col1", "a"), R.struct(R.map(R.STRING, R.struct(R.I32))));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema,
+            List.of(
+                ExpressionCreator.map(
+                    false, Map.of(sb.str("k"), ExpressionCreator.struct(false, sb.i32(1))))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[MAP('k':VARCHAR, [1:INTEGER]:RecordType(INTEGER NOT NULL a))]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        explain(relNode));
+  }
+
+  /**
+   * A nullable struct nested in a column: renaming it gives back a ROW call rather than a literal,
+   * so the struct around it cannot be rebuilt as a literal either.
+   */
+  @Test
+  void nullableStructInsideStructColumnConverts() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("outer", "inner", "a"), R.struct(R.struct(N.struct(R.I32))));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema,
+            List.of(ExpressionCreator.struct(false, ExpressionCreator.struct(true, sb.i32(1)))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ROW(ROW(1))]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        explain(relNode));
   }
 
   @SafeVarargs

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
@@ -151,8 +152,14 @@ class VirtualTableScanTest extends PlanTestBase {
         converted.getRows().get(1).fields());
   }
 
+  /**
+   * A struct column takes the projection encoding whatever it holds. Calcite has a row literal, but
+   * it orders Values tuples by casting each value to {@link Comparable} and a row literal's value
+   * is a list of {@link RexLiteral}s, which are not -- so a second row is enough to make one throw,
+   * here and in whatever the consumer's planner does with the relation afterwards.
+   */
   @Test
-  void structColumnRoundTrip() {
+  void structColumnConverts() {
     NamedStruct schema =
         NamedStruct.of(List.of("outer", "a", "b"), R.struct(R.struct(R.I32, R.FP64)));
     VirtualTableScan virtualTableScan =
@@ -161,10 +168,48 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalValues(type=[RecordType(RecordType(INTEGER a, DOUBLE b) outer)], tuples=[[{ [1, 2.0E0] }]])\n",
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE)]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
         explain(relNode));
+  }
 
-    assertFullRoundTrip(virtualTableScan);
+  /** The row after the first is where a row literal in a tuple would be compared to another. */
+  @Test
+  void twoStructRowsConvert() {
+    NamedStruct schema =
+        NamedStruct.of(List.of("outer", "a", "b"), R.struct(R.struct(R.I32, R.FP64)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema,
+            List.of(ExpressionCreator.struct(false, sb.i32(1), sb.fp64(2.0))),
+            List.of(ExpressionCreator.struct(false, sb.i32(3), sb.fp64(4.0))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalProject(inputs=[0])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE)]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n"
+            + "    LogicalProject(exprs=[[ROW(3, 4.0E0:DOUBLE)]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
+        explain(relNode));
+  }
+
+  /**
+   * A schema struct that is itself nullable says nothing about the relation: a row type describes
+   * the columns, and Calcite derives one NOT NULL everywhere else. What the nullability does reach
+   * is the columns -- Calcite makes a struct's fields nullable along with the struct -- which is
+   * the same row type the conversion built before it was given the schema's names.
+   */
+  @Test
+  void nullableSchemaStructGivesANotNullRowType() {
+    NamedStruct schema = NamedStruct.of(List.of("col1"), N.struct(R.I32));
+    VirtualTableScan virtualTableScan = createVirtualTableScan(schema, List.of(sb.i32(1)));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals("RecordType(INTEGER col1) NOT NULL", relNode.getRowType().getFullTypeString());
   }
 
   /**
@@ -172,7 +217,7 @@ class VirtualTableScanTest extends PlanTestBase {
    * the schema's flattened list: the second column's name sits at index 3, not at index 1.
    */
   @Test
-  void severalStructColumnsRoundTrip() {
+  void severalStructColumnsConvert() {
     NamedStruct schema =
         NamedStruct.of(
             List.of("first", "a", "b", "second", "c"),
@@ -186,10 +231,11 @@ class VirtualTableScanTest extends PlanTestBase {
 
     RelNode relNode = substraitToCalcite.convert(virtualTableScan);
     assertEquals(
-        "LogicalValues(type=[RecordType(RecordType(INTEGER a, DOUBLE b) first, RecordType(VARCHAR c) second)], tuples=[[{ [1, 2.0E0], ['x'] }]])\n",
+        "LogicalProject(inputs=[0..1])\n"
+            + "  LogicalUnion(all=[true])\n"
+            + "    LogicalProject(exprs=[[ROW(1, 2.0E0:DOUBLE), ROW('x':VARCHAR)]])\n"
+            + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
         explain(relNode));
-
-    assertFullRoundTrip(virtualTableScan);
   }
 
   /**
@@ -277,6 +323,63 @@ class VirtualTableScanTest extends PlanTestBase {
   }
 
   /**
+   * A value that cannot take the type its column is declared at is reported here. Calcite types a
+   * scalar subquery nullable -- no row means no value -- whatever the Substrait expression says its
+   * type is, so this row cannot stand in a NOT NULL column. Without the check the relation is built
+   * at the declared type regardless, and Calcite reports the mismatch through an {@code assert},
+   * which says nothing unless assertions are on.
+   */
+  @Test
+  void aValueThatCannotTakeItsColumnsTypeIsReported() {
+    VirtualTableScan inner =
+        createVirtualTableScan(NamedStruct.of(List.of("a"), R.struct(R.I32)), List.of(sb.i32(7)));
+    Expression subquery = Expression.ScalarSubquery.builder().input(inner).type(R.I32).build();
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(NamedStruct.of(List.of("col1"), R.struct(R.I32)), List.of(subquery));
+
+    IllegalArgumentException reported =
+        assertThrows(
+            IllegalArgumentException.class, () -> substraitToCalcite.convert(virtualTableScan));
+    assertTrue(
+        reported.getMessage().contains("is not the INTEGER NOT NULL its column is declared at"),
+        reported.getMessage());
+  }
+
+  /**
+   * A list and a map convert to a constructor call, except when they are null: then they are a
+   * literal, carrying the placeholder name Calcite derives, and the tuple needs them at the
+   * column's own type just as a struct does.
+   */
+  @Test
+  void nullListColumnConverts() {
+    NamedStruct schema = NamedStruct.of(List.of("col1"), R.struct(N.list(R.I32)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(schema, List.of(ExpressionCreator.typedNull(N.list(R.I32))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalValues(type=[RecordType(INTEGER ARRAY col1)], tuples=[[{ null }]])\n",
+        explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
+  }
+
+  @Test
+  void nullMapColumnConverts() {
+    NamedStruct schema = NamedStruct.of(List.of("col1"), R.struct(N.map(R.STRING, R.I32)));
+    VirtualTableScan virtualTableScan =
+        createVirtualTableScan(
+            schema, List.of(ExpressionCreator.typedNull(N.map(R.STRING, R.I32))));
+
+    RelNode relNode = substraitToCalcite.convert(virtualTableScan);
+    assertEquals(
+        "LogicalValues(type=[RecordType((VARCHAR, INTEGER) MAP col1)], tuples=[[{ null }]])\n",
+        explain(relNode));
+
+    assertFullRoundTrip(virtualTableScan);
+  }
+
+  /**
    * A struct one level down, inside a list column: the names the schema gives it have to reach it
    * there too, or the projection that holds the row is rejected on them.
    */
@@ -292,7 +395,7 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         "LogicalProject(inputs=[0])\n"
             + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[ARRAY([1:INTEGER]:RecordType(INTEGER NOT NULL a))]])\n"
+            + "    LogicalProject(exprs=[[ARRAY(ROW(1))]])\n"
             + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
         explain(relNode));
   }
@@ -313,7 +416,7 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         "LogicalProject(inputs=[0])\n"
             + "  LogicalUnion(all=[true])\n"
-            + "    LogicalProject(exprs=[[MAP('k':VARCHAR, [1:INTEGER]:RecordType(INTEGER NOT NULL a))]])\n"
+            + "    LogicalProject(exprs=[[MAP('k':VARCHAR, ROW(1))]])\n"
             + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
         explain(relNode));
   }


### PR DESCRIPTION
The Calcite row type for a `VirtualTableScan` was assembled from two lists that count fields differently: one type per top-level field, paired with the schema's flattened depth-first names. `createStructType` asserts the two are the same length, so a schema with a struct anywhere in it died on a bare `AssertionError` before a row was looked at -- a plain assert, so with assertions off the mismatched lists go straight on to be canonized. The row type is now built by the conversion that takes those names, the one the named-scan path already uses.

Past that, the choice of encoding was made on the Substrait expressions rather than on what they convert to. A struct or list literal converts to a Calcite call, and a `LogicalValues` tuple holds nothing but literals, so those rows reached the tuple builder and died on a cast. The choice now looks at the converted values, and a row that does not fit a tuple takes the projection encoding that already existed for computed rows.

Then the names themselves. A struct value carries the field names Calcite derives for it while the row type carries the schema's, and Calcite compares those names when it checks a value against its column, so the values are renamed to the schema's -- inside a list or a map as well, where the schema names a struct just the same.

A struct column takes the projection encoding rather than a tuple. Calcite has a row literal, but it orders tuples by casting each value to `Comparable` and a row literal's value is a list of `RexLiteral`s, which are not: a two-row struct table throws out of `RelMdCollation.values`, and so does whatever a consumer's planner does with the relation afterwards. Round-tripping such a table is #631's business.

A value that cannot take the type its column is declared at is now reported instead of stamped with it. `LogicalProject` and `LogicalValues` check the row type they are handed with an `assert`, which says nothing unless assertions are on, so a struct-typed call whose names are not the declared ones used to build a plan Calcite considers invalid and say nothing about it.

Two smaller ones: the relation's row type stays NOT NULL, which is what `createStructType` produced, so a nullable schema struct contributes its fields and not its nullability; and the tuple encoding no longer takes the nullability cast off a cast the plan carries itself, which looks the same but has a failure behavior and is part of what round-trips.

Closes #1152
