### PR TITLE
build(core): declare shadowJar as core's outgoing artifact

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -162,7 +162,12 @@ tasks {
     relocate("org.antlr.v4.runtime", "io.substrait.org.antlr.v4.runtime")
   }
 
-  jar { manifest { from("build/generated/sources/manifest/META-INF/MANIFEST.MF") } }
+  jar {
+    // shadowJar takes the unclassified name, so the plain jar needs one of its own: two tasks
+    // writing one path leaves it to the task graph which of them consumers end up with.
+    archiveClassifier.set("plain")
+    manifest { from("build/generated/sources/manifest/META-INF/MANIFEST.MF") }
+  }
 
   // Set the release instead of using a Java 8 toolchain since ANTLR requires Java 11+ to run.
   // Only set the compile release since JUnit 6 requires Java 17 to run tests.
@@ -170,6 +175,25 @@ tasks {
     options.release = 8
     dependsOn("writeManifest")
   }
+}
+
+// Only shadowJar's output carries the io.substrait.antlr parser and its relocated ANTLR runtime,
+// so it is what consumers and the publication have to resolve. Declaring it as the outgoing
+// artifact is what lets Gradle derive the task dependency, for every consumer and for signing.
+listOf("apiElements", "runtimeElements").forEach { variant ->
+  configurations.named(variant) {
+    outgoing.artifacts.clear()
+    outgoing.artifact(tasks.shadowJar)
+  }
+}
+
+// The bundled deps are declared on shadowImplementation, which is kept out of the POM on purpose,
+// so shadow's injected variant would be published advertising no dependencies at all. Its file is
+// the jar the runtime variant now serves anyway.
+(components["java"] as AdhocComponentWithVariants).withVariantsFromConfiguration(
+  configurations["shadowRuntimeElements"]
+) {
+  skip()
 }
 
 java {

--- a/examples/isthmus-api/build.gradle.kts
+++ b/examples/isthmus-api/build.gradle.kts
@@ -18,5 +18,3 @@ application { mainClass = "io.substrait.examples.IsthmusAppExamples" }
 tasks.named<Test>("test") { useJUnitPlatform() }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.pmdMain { dependsOn(":core:shadowJar") }

--- a/examples/substrait-spark/build.gradle.kts
+++ b/examples/substrait-spark/build.gradle.kts
@@ -35,7 +35,8 @@ dependencies {
 }
 
 tasks.jar {
-  dependsOn("$sparkProject:jar", ":core:jar", ":core:shadowJar")
+  // zipTree drops the task dependencies the resolved classpath carried, so declare it here.
+  dependsOn(configurations.runtimeClasspath)
 
   isZip64 = true
   exclude("META-INF/*.RSA")
@@ -53,5 +54,3 @@ tasks.named<Test>("test") {
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.pmdMain { dependsOn(":core:shadowJar") }

--- a/isthmus/build.gradle.kts
+++ b/isthmus/build.gradle.kts
@@ -131,8 +131,6 @@ dependencies {
 }
 
 tasks {
-  classes { dependsOn(":core:shadowJar") }
-
   jar {
     manifest {
       from("../core/build/generated/sources/manifest/META-INF/MANIFEST.MF")

--- a/spark/spark-3.4_2.12/build.gradle.kts
+++ b/spark/spark-3.4_2.12/build.gradle.kts
@@ -146,16 +146,6 @@ dependencies {
 spotless { isEnforceCheck = false }
 
 tasks {
-  // Ensure shadowJar runs before compilation, but skip core tests
-  named("compileJava") {
-    dependsOn(":core:shadowJar")
-    mustRunAfter(":core:compileJava")
-  }
-  named("compileScala") {
-    dependsOn(":core:shadowJar")
-    mustRunAfter(":core:compileJava")
-  }
-
   jar {
     manifest {
       from("../../core/build/generated/sources/manifest/META-INF/MANIFEST.MF")
@@ -164,7 +154,6 @@ tasks {
   }
 
   test {
-    dependsOn(":core:shadowJar")
     useJUnitPlatform { includeEngines("scalatest") }
 
     // Set system properties for variant identification

--- a/spark/spark-3.5_2.12/build.gradle.kts
+++ b/spark/spark-3.5_2.12/build.gradle.kts
@@ -147,10 +147,6 @@ dependencies {
 spotless { isEnforceCheck = false }
 
 tasks {
-  // Ensure shadowJar runs before compilation
-  named("compileJava") { dependsOn(":core:shadowJar") }
-  named("compileScala") { dependsOn(":core:shadowJar") }
-
   jar {
     manifest {
       from("../../core/build/generated/sources/manifest/META-INF/MANIFEST.MF")
@@ -159,7 +155,6 @@ tasks {
   }
 
   test {
-    dependsOn(":core:shadowJar")
     useJUnitPlatform { includeEngines("scalatest") }
 
     // Set system properties for variant identification

--- a/spark/spark-4.0_2.13/build.gradle.kts
+++ b/spark/spark-4.0_2.13/build.gradle.kts
@@ -147,17 +147,12 @@ dependencies {
 spotless { isEnforceCheck = false }
 
 tasks.register<JavaExec>("dialect") {
-  dependsOn(":core:shadowJar")
   classpath = java.sourceSets["main"].runtimeClasspath
   mainClass = "io.substrait.spark.utils.DialectGenerator"
   args = listOf("../spark_dialect.yaml")
 }
 
 tasks {
-  // Ensure shadowJar runs before compilation
-  named("compileJava") { dependsOn(":core:shadowJar") }
-  named("compileScala") { dependsOn(":core:shadowJar") }
-
   jar {
     manifest {
       from("../../core/build/generated/sources/manifest/META-INF/MANIFEST.MF")
@@ -166,7 +161,6 @@ tasks {
   }
 
   test {
-    dependsOn(":core:shadowJar")
     useJUnitPlatform { includeEngines("scalatest") }
 
     // Set system properties for variant identification


### PR DESCRIPTION
`shadowJar` sets its classifier to the empty string on purpose, so that it replaces the plain jar instead of sitting beside it as `-all.jar`. Both tasks then write `core/build/libs/core-<version>.jar`, nothing orders them, and which one survives depends on where each ends up in the task graph. Only shadowJar's output carries the generated `io.substrait.antlr` parser and its relocated ANTLR runtime.

Building a downstream module on its own gets the plain one. On a clean tree at `d331f47`, `./gradlew :isthmus:build` fails 930 of 989 tests -- 918 of them on a `NoClassDefFoundError`, one naming `org/antlr/v4/runtime/tree/ParseTreeVisitor` outright and 917 reporting the 60 isthmus classes whose static initialization it broke, plus 12 assertions that catch the same exception -- and `./gradlew :spark:build --no-build-cache` fails all three variants with `ClassSelector ... resolution failed`. The root build CI runs happens to order the two the other way round, which is why none of this shows up on a pull request. What has kept the downstream modules working is 14 hand-wired `dependsOn(":core:shadowJar")` across six build files.

So give the two tasks separate paths instead of ordering them: the plain jar takes the classifier `plain`, and shadowJar becomes the outgoing artifact of `apiElements` and `runtimeElements`. Gradle derives the dependency for every consumer from that, and all 14 hooks come out, along with the two `mustRunAfter(":core:compileJava")` lines in spark-3.4. The one hook that was not redundant is `examples/substrait-spark`'s fat jar, where `zipTree` drops the task dependencies the resolved classpath carried; it becomes `dependsOn(configurations.runtimeClasspath)`.

Three things follow that the ordering could not fix.

`./gradlew :core:jar` on its own no longer leaves an ANTLR-less jar where consumers read it. It writes `core-<version>-plain.jar` (1,820,901 bytes, no `io/substrait/antlr` entries) and leaves `core-<version>.jar` (2,229,802 bytes, 62 of them) alone. Nothing in a normal build asks for it any more: `:core:jar` does not run during `./gradlew build` at all.

Both jar tasks used to re-execute on every run, because Gradle will not cache a task whose output path it cannot attribute — `--info` spells it out: *"Gradle does not know how file 'build/libs/core-0.101.0.jar' was created (output property 'archiveFile'). Task output caching requires exclusive access to output paths"*. With separate paths both go `UP-TO-DATE` on a repeat run and `shadowJar` is cacheable.

Shadow injects a `shadowRuntimeElements` variant into the java component, and `from(components["java"])` publishes it. Its dependency list in the module metadata is empty, because the bundled deps are declared on the custom `shadowImplementation` configuration — so a Gradle consumer asking for `Bundling.SHADOWED` on 0.101.0 gets the jar with no Jackson, protobuf, extensions or slf4j behind it. The regular runtime variant now serves that same jar with the real dependency list, so the injected variant is skipped.

The release path is the clearest case for doing it this way. Today the publication declares the plain jar as its artifact (`builtBy [:core:jar]`) and `signMaven-publishPublication` depends on `:core:jar`, while `shadowJar` is reached only transitively through `generateMetadataFileForMaven-publishPublication`: a signature over a file identified by the wrong task, correct only because both tasks write one path and the ordering decides who wrote last. The artifact is now `builtBy [:core:shadowJar]`, and `:core:jar` leaves the publish graph entirely, so there is no longer a file a wrong-jar publish could select. The release path did order them the right way -- the jar published for 0.101.0 is 2,229,802 bytes, the shadowed one -- so this was a latent risk there rather than a defect in what has been released.

One thing left as it is: `runtimeElements` still carries `org.gradle.dependency.bundling=external` while the jar it serves bundles the relocated ANTLR runtime. That is the attribute and the bytes consumers already resolve today, and the relocated classes are not visible to them as a dependency, so nothing in resolution turns on it.

Closes #1142
