### PR TITLE
feat(isthmus): apply hint.output_names when converting a plan to Calcite

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -198,7 +198,7 @@ public class SubstraitRelNodeConverter
     context.enterScope(AnchoredInput.of(filter.getInput().getRelAnchor(), input.getRowType()));
     RexNode filterCondition = filter.getCondition().accept(expressionRexConverter, context);
     RelNode node = relBuilder.push(input).filter(context.exitScope(), filterCondition).build();
-    return applyRelCommon(node, filter);
+    return applyRelCommon(node, filter, input);
   }
 
   @Override
@@ -229,7 +229,7 @@ public class SubstraitRelNodeConverter
 
     RelNode node =
         relBuilder.push(child).project(rexExprs, List.of(), false, context.exitScope()).build();
-    return applyRelCommon(node, project);
+    return applyRelCommon(node, project, child);
   }
 
   @Override
@@ -239,7 +239,7 @@ public class SubstraitRelNodeConverter
     // Calcite represents CROSS JOIN as the equivalent INNER JOIN with true condition
     RelNode node =
         relBuilder.push(left).push(right).join(JoinRelType.INNER, relBuilder.literal(true)).build();
-    return applyRelCommon(node, cross);
+    return applyRelCommon(node, cross, left, right);
   }
 
   @Override
@@ -256,7 +256,7 @@ public class SubstraitRelNodeConverter
     JoinRelType joinType = asJoinRelType(join);
     RelNode node =
         relBuilder.push(left).push(right).join(joinType, condition, context.exitScope()).build();
-    return applyRelCommon(node, join);
+    return applyRelCommon(node, join, left, right);
   }
 
   private JoinRelType asJoinRelType(Join join) {
@@ -289,14 +289,15 @@ public class SubstraitRelNodeConverter
 
   @Override
   public RelNode visit(Set set, Context context) throws RuntimeException {
-    set.getInputs()
-        .forEach(
-            input -> {
-              relBuilder.push(input.accept(this, context));
-            });
+    List<RelNode> inputs = new ArrayList<>(set.getInputs().size());
+    for (Rel input : set.getInputs()) {
+      RelNode converted = input.accept(this, context);
+      inputs.add(converted);
+      relBuilder.push(converted);
+    }
     RelBuilder builder = getRelBuilder(set);
     RelNode node = builder.build();
-    return applyRelCommon(node, set);
+    return applyRelCommon(node, set, inputs.toArray(new RelNode[0]));
   }
 
   private RelBuilder getRelBuilder(Set set) {
@@ -410,7 +411,7 @@ public class SubstraitRelNodeConverter
     RelNode node = aggregateBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
     // Not applyRelCommon: the mapping applied here is the one rewritten above, not the one the
     // relation carries.
-    return applyOutputNames(applyRemap(node, remap), aggregate);
+    return applyOutputNames(applyRemap(node, remap), aggregate, child);
   }
 
   /**
@@ -628,7 +629,7 @@ public class SubstraitRelNodeConverter
             .collect(Collectors.toList());
     exitUncorrelatedScope(context, Sort.class);
     RelNode node = relBuilder.push(child).sort(sortExpressions).build();
-    return applyRelCommon(node, sort);
+    return applyRelCommon(node, sort, child);
   }
 
   private RexNode directedRexNode(Expression.SortField sortField, Context context) {
@@ -669,7 +670,7 @@ public class SubstraitRelNodeConverter
         fetch.getCount().map(e -> e.accept(expressionRexConverter, context)).orElse(null);
     exitUncorrelatedScope(context, Fetch.class);
     RelNode node = relBuilder.push(child).sortLimit(offset, count, ImmutableList.of()).build();
-    return applyRelCommon(node, fetch);
+    return applyRelCommon(node, fetch, child);
   }
 
   private RelFieldCollation toRelFieldCollation(Expression.SortField sortField, Context context) {
@@ -1143,15 +1144,17 @@ public class SubstraitRelNodeConverter
    * first, and then the alternative output field names of its hint.
    *
    * <p>The rest is dropped. A Calcite {@code RelNode} has no place for a relation's alias, its
-   * statistics, the computations it saves or loads, or its anchor, and inventing one would mean
-   * defining a convention on every consumer's behalf.
+   * statistics, the computations it saves or loads, or its common advanced extension, and inventing
+   * one would mean defining a convention on every consumer's behalf. Its anchor is consumed by the
+   * correlation machinery instead.
    *
    * @param relNode the node the relation was converted into
    * @param rel the relation being converted
+   * @param inputs the nodes this relation's inputs were converted into
    * @return the node, remapped and renamed
    */
-  protected RelNode applyRelCommon(RelNode relNode, Rel rel) {
-    return applyOutputNames(applyRemap(relNode, rel.getRemap()), rel);
+  protected RelNode applyRelCommon(RelNode relNode, Rel rel, RelNode... inputs) {
+    return applyOutputNames(applyRemap(relNode, rel.getRemap()), rel, inputs);
   }
 
   /**
@@ -1161,9 +1164,17 @@ public class SubstraitRelNodeConverter
    * <p>The names are applied to the projection this relation's own conversion produced: the one a
    * {@link Project} becomes, or the one {@link #applyRemap(RelNode, Optional)} adds for a relation
    * with an emit mapping. Anywhere else they are dropped, rather than renaming a node that stands
-   * for another relation or adding a projection the plan never asked for. That leaves a relation
-   * converted into a bare Calcite operator, such as an aggregate that emits its output directly,
-   * without its names.
+   * for another relation or adding a projection the plan never asked for. A relation converted into
+   * a bare Calcite operator therefore keeps the names Calcite derives, and so does one Calcite
+   * builds no operator for at all -- a filter that cannot filter, a sort with no sort fields, an
+   * identity emit mapping -- where the node handed back is the input's, which is what the given
+   * inputs are compared against.
+   *
+   * <p>They are dropped as well where the columns of that projection are not the columns of the
+   * relation's record type, type by type. An aggregate over several grouping sets orders its
+   * grouping columns by first appearance where Calcite orders them by group key, so the two
+   * disagree on what the third column is, and binding the names by position would name columns the
+   * plan does not name.
    *
    * <p>Only the names of the top-level fields are applied. The names of the fields nested inside
    * them belong to the type of the expression that produces the field, which a projection cannot
@@ -1174,23 +1185,31 @@ public class SubstraitRelNodeConverter
    * conversion: a hint holds no meaning of its own and should not be able to break an otherwise
    * valid plan.
    *
+   * <p>The names live in the row type of the projection, which Calcite treats as non-semantic: a
+   * planner may discard them, and two projections that differ only in their names share one digest.
+   * They describe the tree as it is returned here, and do not survive planning.
+   *
    * @param relNode the node to rename, with any emit mapping already applied
    * @param rel the relation being converted
+   * @param inputs the nodes this relation's inputs were converted into
    * @return the renamed node, or the node unchanged where the names do not apply
    */
-  protected RelNode applyOutputNames(RelNode relNode, Rel rel) {
+  protected RelNode applyOutputNames(RelNode relNode, Rel rel, RelNode... inputs) {
     List<String> names = rel.getHint().map(Hint::getOutputNames).orElse(List.of());
-    boolean ownsProjection = rel instanceof Project || rel.getRemap().isPresent();
-    if (names.isEmpty()
-        || !ownsProjection
-        || !(relNode instanceof org.apache.calcite.rel.core.Project)) {
+    if (names.isEmpty() || !(relNode instanceof org.apache.calcite.rel.core.Project)) {
       return relNode;
+    }
+    for (RelNode input : inputs) {
+      if (relNode == input) {
+        return relNode;
+      }
     }
     org.apache.calcite.rel.core.Project project = (org.apache.calcite.rel.core.Project) relNode;
     RelDataType rowType = project.getRowType();
     List<Type> fields = rel.getRecordType().fields();
     if (names.size() != NamedFieldCountingTypeVisitor.countNames(rel.getRecordType())
-        || fields.size() != rowType.getFieldCount()) {
+        || fields.size() != rowType.getFieldCount()
+        || !describesColumnsOf(fields, rowType)) {
       return relNode;
     }
     List<String> fieldNames = new ArrayList<>(fields.size());
@@ -1198,9 +1217,11 @@ public class SubstraitRelNodeConverter
       fieldNames.add(names.get(nameIndex));
       nameIndex += 1 + NamedFieldCountingTypeVisitor.countNames(fields.get(field));
     }
-    if (new HashSet<>(fieldNames).size() != fieldNames.size()) {
-      // Calcite requires the field names of a projection to be distinct, and uniquifying the names
-      // here would hand back names the producer did not ask for.
+    if (fieldNames.stream().anyMatch(String::isEmpty)
+        || new HashSet<>(fieldNames).size() != fieldNames.size()) {
+      // Calcite requires the field names of a projection to be distinct and non-empty -- it reads
+      // an empty one as the star identifier -- and uniquifying the names here would hand back names
+      // the producer did not ask for.
       return relNode;
     }
     return project.copy(
@@ -1209,6 +1230,26 @@ public class SubstraitRelNodeConverter
         project.getProjects(),
         typeFactory.createStructType(
             rowType.getStructKind(), RelOptUtil.getFieldTypeList(rowType), fieldNames));
+  }
+
+  /**
+   * Returns whether the given row type holds the given fields, one for one and in the same order,
+   * ignoring nullability: Calcite derives that from the expression producing the column, and a
+   * relation's record type says what its columns are, not whether a value is there.
+   *
+   * @param fields the field types of a relation's record type
+   * @param rowType the row type of the node it was converted into
+   * @return whether the two describe the same columns in the same order
+   */
+  private boolean describesColumnsOf(List<Type> fields, RelDataType rowType) {
+    for (int field = 0; field < fields.size(); field++) {
+      RelDataType declared = typeConverter.toCalcite(typeFactory, fields.get(field));
+      if (!SqlTypeUtil.equalSansNullability(
+          declared, rowType.getFieldList().get(field).getType())) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -64,6 +64,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.calcite.plan.RelOptSchema;
 import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelCollation;
@@ -407,6 +408,8 @@ public class SubstraitRelNodeConverter
             : relBuilder;
 
     RelNode node = aggregateBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
+    // Not applyRelCommon: the mapping applied here is the one rewritten above, not the one the
+    // relation carries.
     return applyOutputNames(applyRemap(node, remap), aggregate);
   }
 
@@ -1136,8 +1139,12 @@ public class SubstraitRelNodeConverter
   }
 
   /**
-   * Applies the {@code RelCommon} data of a relation to the node it was converted into: its emit
-   * mapping first, and then the alternative output field names of its hint.
+   * Applies the parts of a relation's {@code RelCommon} that Calcite can hold: its emit mapping
+   * first, and then the alternative output field names of its hint.
+   *
+   * <p>The rest is dropped. A Calcite {@code RelNode} has no place for a relation's alias, its
+   * statistics, the computations it saves or loads, or its anchor, and inventing one would mean
+   * defining a convention on every consumer's behalf.
    *
    * @param relNode the node the relation was converted into
    * @param rel the relation being converted
@@ -1151,17 +1158,21 @@ public class SubstraitRelNodeConverter
    * Applies the alternative output field names a relation carries in its hint to the node it was
    * converted into.
    *
-   * <p>The names are applied where they fit the node the conversion already produced, which is a
-   * projection: the one a {@link Project} is converted into, or the one added for a relation with
-   * an emit mapping. Renaming any other node would mean adding a projection the plan never asked
-   * for, so there the names are dropped instead. A name list that does not fit the relation is
-   * dropped as well, rather than failing the conversion: a hint holds no meaning of its own and
-   * should not be able to break an otherwise valid plan.
+   * <p>The names are applied to the projection this relation's own conversion produced: the one a
+   * {@link Project} becomes, or the one {@link #applyRemap(RelNode, Optional)} adds for a relation
+   * with an emit mapping. Anywhere else they are dropped, rather than renaming a node that stands
+   * for another relation or adding a projection the plan never asked for. That leaves a relation
+   * converted into a bare Calcite operator, such as an aggregate that emits its output directly,
+   * without its names.
    *
    * <p>Only the names of the top-level fields are applied. The names of the fields nested inside
    * them belong to the type of the expression that produces the field, which a projection cannot
    * restate: Calcite compares the two, nested names included, and rejects a projection whose row
    * type says something the expressions do not.
+   *
+   * <p>A name list that does not fit the relation is dropped as well, rather than failing the
+   * conversion: a hint holds no meaning of its own and should not be able to break an otherwise
+   * valid plan.
    *
    * @param relNode the node to rename, with any emit mapping already applied
    * @param rel the relation being converted
@@ -1169,33 +1180,35 @@ public class SubstraitRelNodeConverter
    */
   protected RelNode applyOutputNames(RelNode relNode, Rel rel) {
     List<String> names = rel.getHint().map(Hint::getOutputNames).orElse(List.of());
-    if (names.isEmpty() || !(relNode instanceof org.apache.calcite.rel.core.Project)) {
+    boolean ownsProjection = rel instanceof Project || rel.getRemap().isPresent();
+    if (names.isEmpty()
+        || !ownsProjection
+        || !(relNode instanceof org.apache.calcite.rel.core.Project)) {
       return relNode;
     }
-    List<Type> fields = rel.getRecordType().fields();
     org.apache.calcite.rel.core.Project project = (org.apache.calcite.rel.core.Project) relNode;
     RelDataType rowType = project.getRowType();
+    List<Type> fields = rel.getRecordType().fields();
     if (names.size() != NamedFieldCountingTypeVisitor.countNames(rel.getRecordType())
         || fields.size() != rowType.getFieldCount()) {
       return relNode;
     }
     List<String> fieldNames = new ArrayList<>(fields.size());
-    for (int index = 0, name = 0; index < fields.size(); index++) {
-      fieldNames.add(names.get(name));
-      name += 1 + NamedFieldCountingTypeVisitor.countNames(fields.get(index));
+    for (int field = 0, nameIndex = 0; field < fields.size(); field++) {
+      fieldNames.add(names.get(nameIndex));
+      nameIndex += 1 + NamedFieldCountingTypeVisitor.countNames(fields.get(field));
     }
     if (new HashSet<>(fieldNames).size() != fieldNames.size()) {
       // Calcite requires the field names of a projection to be distinct, and uniquifying the names
       // here would hand back names the producer did not ask for.
       return relNode;
     }
-    List<RelDataType> fieldTypes =
-        rowType.getFieldList().stream().map(RelDataTypeField::getType).collect(Collectors.toList());
     return project.copy(
         project.getTraitSet(),
         project.getInput(),
         project.getProjects(),
-        typeFactory.createStructType(rowType.getStructKind(), fieldTypes, fieldNames));
+        typeFactory.createStructType(
+            rowType.getStructKind(), RelOptUtil.getFieldTypeList(rowType), fieldNames));
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -8,6 +8,7 @@ import io.substrait.extension.FunctionBindingResolver;
 import io.substrait.extension.ResolvedAggregateBinding;
 import io.substrait.extension.ResolvedArgument;
 import io.substrait.extension.SimpleExtension;
+import io.substrait.hint.Hint;
 import io.substrait.isthmus.calcite.rel.CreateTable;
 import io.substrait.isthmus.calcite.rel.CreateView;
 import io.substrait.isthmus.expression.AggregateFunctionConverter;
@@ -40,7 +41,9 @@ import io.substrait.relation.physical.MultiBucketExchange;
 import io.substrait.relation.physical.RoundRobinExchange;
 import io.substrait.relation.physical.ScatterExchange;
 import io.substrait.relation.physical.SingleBucketExchange;
+import io.substrait.type.NamedFieldCountingTypeVisitor;
 import io.substrait.type.NamedStruct;
+import io.substrait.type.Type;
 import io.substrait.type.TypeCreator;
 import io.substrait.util.VisitationContext;
 import java.util.ArrayDeque;
@@ -194,13 +197,13 @@ public class SubstraitRelNodeConverter
     context.enterScope(AnchoredInput.of(filter.getInput().getRelAnchor(), input.getRowType()));
     RexNode filterCondition = filter.getCondition().accept(expressionRexConverter, context);
     RelNode node = relBuilder.push(input).filter(context.exitScope(), filterCondition).build();
-    return applyRemap(node, filter.getRemap());
+    return applyRelCommon(node, filter);
   }
 
   @Override
   public RelNode visit(NamedScan namedScan, Context context) throws RuntimeException {
     RelNode node = relBuilder.scan(namedScan.getNames()).build();
-    return applyRemap(node, namedScan.getRemap());
+    return applyRelCommon(node, namedScan);
   }
 
   @Override
@@ -225,7 +228,7 @@ public class SubstraitRelNodeConverter
 
     RelNode node =
         relBuilder.push(child).project(rexExprs, List.of(), false, context.exitScope()).build();
-    return applyRemap(node, project.getRemap());
+    return applyRelCommon(node, project);
   }
 
   @Override
@@ -235,7 +238,7 @@ public class SubstraitRelNodeConverter
     // Calcite represents CROSS JOIN as the equivalent INNER JOIN with true condition
     RelNode node =
         relBuilder.push(left).push(right).join(JoinRelType.INNER, relBuilder.literal(true)).build();
-    return applyRemap(node, cross.getRemap());
+    return applyRelCommon(node, cross);
   }
 
   @Override
@@ -252,7 +255,7 @@ public class SubstraitRelNodeConverter
     JoinRelType joinType = asJoinRelType(join);
     RelNode node =
         relBuilder.push(left).push(right).join(joinType, condition, context.exitScope()).build();
-    return applyRemap(node, join.getRemap());
+    return applyRelCommon(node, join);
   }
 
   private JoinRelType asJoinRelType(Join join) {
@@ -292,7 +295,7 @@ public class SubstraitRelNodeConverter
             });
     RelBuilder builder = getRelBuilder(set);
     RelNode node = builder.build();
-    return applyRemap(node, set.getRemap());
+    return applyRelCommon(node, set);
   }
 
   private RelBuilder getRelBuilder(Set set) {
@@ -404,7 +407,7 @@ public class SubstraitRelNodeConverter
             : relBuilder;
 
     RelNode node = aggregateBuilder.push(child).aggregate(groupKey, aggregateCalls).build();
-    return applyRemap(node, remap);
+    return applyOutputNames(applyRemap(node, remap), aggregate);
   }
 
   /**
@@ -622,7 +625,7 @@ public class SubstraitRelNodeConverter
             .collect(Collectors.toList());
     exitUncorrelatedScope(context, Sort.class);
     RelNode node = relBuilder.push(child).sort(sortExpressions).build();
-    return applyRemap(node, sort.getRemap());
+    return applyRelCommon(node, sort);
   }
 
   private RexNode directedRexNode(Expression.SortField sortField, Context context) {
@@ -663,7 +666,7 @@ public class SubstraitRelNodeConverter
         fetch.getCount().map(e -> e.accept(expressionRexConverter, context)).orElse(null);
     exitUncorrelatedScope(context, Fetch.class);
     RelNode node = relBuilder.push(child).sortLimit(offset, count, ImmutableList.of()).build();
-    return applyRemap(node, fetch.getRemap());
+    return applyRelCommon(node, fetch);
   }
 
   private RelFieldCollation toRelFieldCollation(Expression.SortField sortField, Context context) {
@@ -1130,6 +1133,69 @@ public class SubstraitRelNodeConverter
         String.format(
             "Rel %s of type %s not handled by visitor type %s.",
             rel, rel.getClass().getCanonicalName(), this.getClass().getCanonicalName()));
+  }
+
+  /**
+   * Applies the {@code RelCommon} data of a relation to the node it was converted into: its emit
+   * mapping first, and then the alternative output field names of its hint.
+   *
+   * @param relNode the node the relation was converted into
+   * @param rel the relation being converted
+   * @return the node, remapped and renamed
+   */
+  protected RelNode applyRelCommon(RelNode relNode, Rel rel) {
+    return applyOutputNames(applyRemap(relNode, rel.getRemap()), rel);
+  }
+
+  /**
+   * Applies the alternative output field names a relation carries in its hint to the node it was
+   * converted into.
+   *
+   * <p>The names are applied where they fit the node the conversion already produced, which is a
+   * projection: the one a {@link Project} is converted into, or the one added for a relation with
+   * an emit mapping. Renaming any other node would mean adding a projection the plan never asked
+   * for, so there the names are dropped instead. A name list that does not fit the relation is
+   * dropped as well, rather than failing the conversion: a hint holds no meaning of its own and
+   * should not be able to break an otherwise valid plan.
+   *
+   * <p>Only the names of the top-level fields are applied. The names of the fields nested inside
+   * them belong to the type of the expression that produces the field, which a projection cannot
+   * restate: Calcite compares the two, nested names included, and rejects a projection whose row
+   * type says something the expressions do not.
+   *
+   * @param relNode the node to rename, with any emit mapping already applied
+   * @param rel the relation being converted
+   * @return the renamed node, or the node unchanged where the names do not apply
+   */
+  protected RelNode applyOutputNames(RelNode relNode, Rel rel) {
+    List<String> names = rel.getHint().map(Hint::getOutputNames).orElse(List.of());
+    if (names.isEmpty() || !(relNode instanceof org.apache.calcite.rel.core.Project)) {
+      return relNode;
+    }
+    List<Type> fields = rel.getRecordType().fields();
+    org.apache.calcite.rel.core.Project project = (org.apache.calcite.rel.core.Project) relNode;
+    RelDataType rowType = project.getRowType();
+    if (names.size() != NamedFieldCountingTypeVisitor.countNames(rel.getRecordType())
+        || fields.size() != rowType.getFieldCount()) {
+      return relNode;
+    }
+    List<String> fieldNames = new ArrayList<>(fields.size());
+    for (int index = 0, name = 0; index < fields.size(); index++) {
+      fieldNames.add(names.get(name));
+      name += 1 + NamedFieldCountingTypeVisitor.countNames(fields.get(index));
+    }
+    if (new HashSet<>(fieldNames).size() != fieldNames.size()) {
+      // Calcite requires the field names of a projection to be distinct, and uniquifying the names
+      // here would hand back names the producer did not ask for.
+      return relNode;
+    }
+    List<RelDataType> fieldTypes =
+        rowType.getFieldList().stream().map(RelDataTypeField::getType).collect(Collectors.toList());
+    return project.copy(
+        project.getTraitSet(),
+        project.getInput(),
+        project.getProjects(),
+        typeFactory.createStructType(rowType.getStructKind(), fieldTypes, fieldNames));
   }
 
   /**

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -216,8 +216,9 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   @Override
   public Rel visit(org.apache.calcite.rel.core.Project project) {
     // An identity projection (input refs in order, with matching types) passes every input field
-    // through unchanged and only ever renames fields. Substrait carries output names on Plan.Root,
-    // not on the Project, so emitting one here is redundant: the reverse conversion drops it, which
+    // through unchanged and only ever renames fields. Substrait carries output names on Plan.Root
+    // and, for a single relation, in its hint -- neither of them a Project, and this conversion
+    // writes no hints -- so emitting one here is redundant: the reverse conversion drops it, which
     // leaves the two sides structurally different and breaks round-trips. Skip it instead. Output
     // names are still preserved because convert(RelRoot, ...) takes them from validatedRowType.
     if (RexUtil.isIdentity(project.getProjects(), project.getInput().getRowType())) {

--- a/isthmus/src/test/java/io/substrait/isthmus/OutputNamesTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OutputNamesTest.java
@@ -143,24 +143,77 @@ class OutputNamesTest extends PlanTestBase {
   }
 
   @Test
-  void namesAnAggregateOverSeveralGroupingSets() {
-    // The conversion rewrites the emit mapping of an aggregate over more than one grouping set, so
-    // the node the names land on is not the one the relation's own mapping describes.
+  void leavesAnAggregateThatEmitsDirectlyAlone() {
+    // The conversion of an aggregate over several grouping sets ends in a projection, but that
+    // projection carries the grouping-set index rather than this relation's emit mapping, and the
+    // columns underneath it are ordered by Calcite's group key rather than by the relation's own
+    // record type. Names are dropped rather than pinned onto columns chosen by something else.
     Rel aggregate =
         sb.aggregate(
             input -> List.of(sb.grouping(input, 0), sb.grouping(input, 1)),
             input -> List.of(sb.count(input, 0)),
             Optional.empty(),
             scan);
-    Rel named =
-        aggregate.withHint(
-            Optional.of(Hint.builder().addOutputNames("k1", "k2", "n", "g").build()));
 
     RelNode plain = substraitToCalcite.convert(aggregate);
-    RelNode node = substraitToCalcite.convert(named);
+    RelNode node =
+        substraitToCalcite.convert(
+            aggregate.withHint(
+                Optional.of(Hint.builder().addOutputNames("k1", "k2", "n", "g").build())));
 
-    assertEquals(List.of("a", "b", "$f2", "$f3"), plain.getRowType().getFieldNames());
-    assertEquals(List.of("k1", "k2", "n", "g"), node.getRowType().getFieldNames());
+    assertEquals(plain.getRowType().getFieldNames(), node.getRowType().getFieldNames());
+  }
+
+  @Test
+  void namesTheOutputOfAJoinWithAnEmitMapping() {
+    Rel join =
+        sb.innerJoin(
+            input -> sb.equal(sb.fieldReference(input, 0), sb.fieldReference(input, 2)),
+            Rel.Remap.of(List.of(2, 0)),
+            scan,
+            scan);
+    Rel named = join.withHint(Optional.of(Hint.builder().addOutputNames("right", "left").build()));
+
+    assertEquals(
+        List.of("right", "left"), substraitToCalcite.convert(named).getRowType().getFieldNames());
+  }
+
+  @Test
+  void leavesARelationWithAnIdentityEmitMappingAlone() {
+    // An identity mapping needs no projection, so there is no node to hang the names on.
+    Rel filter =
+        Filter.builder()
+            .input(scan)
+            .condition(sb.equal(sb.fieldReference(scan, 0), sb.i64(1)))
+            .remap(Rel.Remap.of(List.of(0, 1)))
+            .hint(Hint.builder().addOutputNames("k", "v").build())
+            .build();
+
+    RelNode node = substraitToCalcite.convert(filter);
+
+    assertEquals(List.of("a", "b"), node.getRowType().getFieldNames());
+    assertEquals(0, countProjections(node));
+  }
+
+  @Test
+  void leavesTheNamesOfAnotherRelationAlone() {
+    // The always-true condition means Calcite builds no filter at all, so the node on top is the
+    // projection of the inner relation, with the names that relation asked for.
+    Rel inner =
+        Project.builder()
+            .input(scan)
+            .remap(Rel.Remap.offset(2, 1))
+            .addExpressions(sb.add(sb.fieldReference(scan, 0), sb.i64(1)))
+            .hint(Hint.builder().addOutputNames("inner").build())
+            .build();
+    Rel filter =
+        Filter.builder()
+            .input(inner)
+            .condition(sb.bool(true))
+            .hint(Hint.builder().addOutputNames("outer").build())
+            .build();
+
+    assertEquals(List.of("inner"), substraitToCalcite.convert(filter).getRowType().getFieldNames());
   }
 
   private static int countProjections(RelNode node) {

--- a/isthmus/src/test/java/io/substrait/isthmus/OutputNamesTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OutputNamesTest.java
@@ -1,0 +1,173 @@
+package io.substrait.isthmus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.hint.Hint;
+import io.substrait.relation.Filter;
+import io.substrait.relation.ImmutableProject;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import io.substrait.type.Type;
+import io.substrait.type.TypeCreator;
+import java.util.List;
+import java.util.Optional;
+import org.apache.calcite.rel.RelNode;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that the alternative output field names a relation carries in its hint are applied when the
+ * relation is converted to Calcite.
+ */
+class OutputNamesTest extends PlanTestBase {
+
+  private final Rel scan = sb.namedScan(List.of("t"), List.of("a", "b"), List.of(R.I64, N.STRING));
+
+  private Project projectWithHint(Optional<Hint> hint) {
+    ImmutableProject.Builder builder =
+        Project.builder()
+            .input(scan)
+            .remap(Rel.Remap.offset(2, 1))
+            .addExpressions(sb.add(sb.fieldReference(scan, 0), sb.i64(1)));
+    hint.ifPresent(builder::hint);
+    return builder.build();
+  }
+
+  @Test
+  void namesAProjection() {
+    RelNode node =
+        substraitToCalcite.convert(
+            projectWithHint(Optional.of(Hint.builder().addOutputNames("total").build())));
+
+    assertEquals(List.of("total"), node.getRowType().getFieldNames());
+    // The names ride along on the projection the conversion already produced, rather than on one
+    // added to carry them.
+    assertEquals(1, countProjections(node));
+  }
+
+  @Test
+  void namesTheOutputOfARelationWithAnEmitMapping() {
+    // The mapping drops the first column, so the name has to land on the second one.
+    Rel filter =
+        Filter.builder()
+            .input(scan)
+            .condition(sb.equal(sb.fieldReference(scan, 0), sb.i64(1)))
+            .remap(Rel.Remap.of(List.of(1)))
+            .hint(Hint.builder().addOutputNames("label").build())
+            .build();
+
+    RelNode node = substraitToCalcite.convert(filter);
+
+    assertEquals(List.of("label"), node.getRowType().getFieldNames());
+  }
+
+  @Test
+  void namesTopLevelFieldsOfANestedRow() {
+    // output_names is written depth first, like the names of a RelRoot, so a struct column is
+    // named along with the fields inside it. Only the column itself can be renamed here: the names
+    // inside it belong to the type of the expression producing it.
+    Type.Struct inner = TypeCreator.REQUIRED.struct(R.I64, N.STRING);
+    Rel structScan = sb.namedScan(List.of("t"), List.of("s", "x", "y"), List.of(inner));
+
+    RelNode plain = substraitToCalcite.convert(structColumnProject(structScan, Optional.empty()));
+    RelNode named =
+        substraitToCalcite.convert(
+            structColumnProject(
+                structScan,
+                Optional.of(Hint.builder().addOutputNames("renamed", "first", "second").build())));
+
+    assertEquals(List.of("renamed"), named.getRowType().getFieldNames());
+    assertEquals(
+        plain.getRowType().getFieldList().get(0).getType().getFieldNames(),
+        named.getRowType().getFieldList().get(0).getType().getFieldNames(),
+        "the names inside the struct are left as the projection had them");
+  }
+
+  private Project structColumnProject(Rel structScan, Optional<Hint> hint) {
+    ImmutableProject.Builder builder =
+        Project.builder()
+            .input(structScan)
+            .remap(Rel.Remap.offset(1, 1))
+            .addExpressions(sb.fieldReference(structScan, 0));
+    hint.ifPresent(builder::hint);
+    return builder.build();
+  }
+
+  @Test
+  void keepsCalciteNamesWithoutAHint() {
+    RelNode node = substraitToCalcite.convert(projectWithHint(Optional.empty()));
+
+    assertEquals(List.of("$f2"), node.getRowType().getFieldNames());
+  }
+
+  @Test
+  void dropsNamesThatDoNotFitTheRelation() {
+    RelNode node =
+        substraitToCalcite.convert(
+            projectWithHint(Optional.of(Hint.builder().addOutputNames("x", "y", "z").build())));
+
+    assertEquals(List.of("$f2"), node.getRowType().getFieldNames());
+  }
+
+  @Test
+  void leavesARelationThatIsNotAProjectionAlone() {
+    Rel filter =
+        Filter.builder()
+            .input(scan)
+            .condition(sb.equal(sb.fieldReference(scan, 0), sb.i64(1)))
+            .hint(Hint.builder().addOutputNames("k", "v").build())
+            .build();
+
+    RelNode node = substraitToCalcite.convert(filter);
+
+    // No projection is added to carry the names, so the plan keeps the shape it had.
+    assertEquals(List.of("a", "b"), node.getRowType().getFieldNames());
+    assertEquals(0, countProjections(node));
+  }
+
+  @Test
+  void dropsNamesThatRepeat() {
+    // Calcite requires the field names of a projection to be distinct.
+    Rel project =
+        Project.builder()
+            .input(scan)
+            .remap(Rel.Remap.offset(2, 2))
+            .addExpressions(
+                sb.add(sb.fieldReference(scan, 0), sb.i64(1)),
+                sb.add(sb.fieldReference(scan, 0), sb.i64(2)))
+            .hint(Hint.builder().addOutputNames("same", "same").build())
+            .build();
+
+    RelNode node = substraitToCalcite.convert(project);
+
+    assertEquals(List.of("$f2", "$f3"), node.getRowType().getFieldNames());
+  }
+
+  @Test
+  void namesAnAggregateOverSeveralGroupingSets() {
+    // The conversion rewrites the emit mapping of an aggregate over more than one grouping set, so
+    // the node the names land on is not the one the relation's own mapping describes.
+    Rel aggregate =
+        sb.aggregate(
+            input -> List.of(sb.grouping(input, 0), sb.grouping(input, 1)),
+            input -> List.of(sb.count(input, 0)),
+            Optional.empty(),
+            scan);
+    Rel named =
+        aggregate.withHint(
+            Optional.of(Hint.builder().addOutputNames("k1", "k2", "n", "g").build()));
+
+    RelNode plain = substraitToCalcite.convert(aggregate);
+    RelNode node = substraitToCalcite.convert(named);
+
+    assertEquals(List.of("a", "b", "$f2", "$f3"), plain.getRowType().getFieldNames());
+    assertEquals(List.of("k1", "k2", "n", "g"), node.getRowType().getFieldNames());
+  }
+
+  private static int countProjections(RelNode node) {
+    int count = node instanceof org.apache.calcite.rel.core.Project ? 1 : 0;
+    for (RelNode input : node.getInputs()) {
+      count += countProjections(input);
+    }
+    return count;
+  }
+}

--- a/isthmus/src/test/java/io/substrait/isthmus/OutputNamesTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/OutputNamesTest.java
@@ -3,6 +3,7 @@ package io.substrait.isthmus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.substrait.hint.Hint;
+import io.substrait.isthmus.sql.SubstraitSqlDialect;
 import io.substrait.relation.Filter;
 import io.substrait.relation.ImmutableProject;
 import io.substrait.relation.Project;
@@ -96,16 +97,19 @@ class OutputNamesTest extends PlanTestBase {
   void keepsCalciteNamesWithoutAHint() {
     RelNode node = substraitToCalcite.convert(projectWithHint(Optional.empty()));
 
+    // Calcite's own name for an expression that has none. The tests that drop a name list compare
+    // against this conversion rather than repeating it.
     assertEquals(List.of("$f2"), node.getRowType().getFieldNames());
   }
 
   @Test
   void dropsNamesThatDoNotFitTheRelation() {
+    RelNode plain = substraitToCalcite.convert(projectWithHint(Optional.empty()));
     RelNode node =
         substraitToCalcite.convert(
             projectWithHint(Optional.of(Hint.builder().addOutputNames("x", "y", "z").build())));
 
-    assertEquals(List.of("$f2"), node.getRowType().getFieldNames());
+    assertEquals(plain.getRowType().getFieldNames(), node.getRowType().getFieldNames());
   }
 
   @Test
@@ -127,19 +131,40 @@ class OutputNamesTest extends PlanTestBase {
   @Test
   void dropsNamesThatRepeat() {
     // Calcite requires the field names of a projection to be distinct.
-    Rel project =
-        Project.builder()
-            .input(scan)
-            .remap(Rel.Remap.offset(2, 2))
-            .addExpressions(
-                sb.add(sb.fieldReference(scan, 0), sb.i64(1)),
-                sb.add(sb.fieldReference(scan, 0), sb.i64(2)))
-            .hint(Hint.builder().addOutputNames("same", "same").build())
-            .build();
+    Rel project = twoColumnProject();
+    RelNode named =
+        substraitToCalcite.convert(
+            project.withHint(Optional.of(Hint.builder().addOutputNames("same", "same").build())));
 
-    RelNode node = substraitToCalcite.convert(project);
+    assertEquals(
+        substraitToCalcite.convert(project).getRowType().getFieldNames(),
+        named.getRowType().getFieldNames());
+  }
 
-    assertEquals(List.of("$f2", "$f3"), node.getRowType().getFieldNames());
+  @Test
+  void dropsNamesThatAreEmpty() {
+    // Calcite reads an empty field name as the star identifier, so a projection carrying one
+    // renders as SELECT ... AS *, which does not parse. The spec does not say whether a name may
+    // be empty; dropping the list is the reading that cannot produce such a plan.
+    Rel project = twoColumnProject();
+    RelNode plain = substraitToCalcite.convert(project);
+    RelNode named =
+        substraitToCalcite.convert(
+            project.withHint(Optional.of(Hint.builder().addOutputNames("", "x").build())));
+
+    assertEquals(plain.getRowType().getFieldNames(), named.getRowType().getFieldNames());
+    assertEquals(
+        SubstraitSqlDialect.toSql(plain).getSql(), SubstraitSqlDialect.toSql(named).getSql());
+  }
+
+  private Rel twoColumnProject() {
+    return Project.builder()
+        .input(scan)
+        .remap(Rel.Remap.offset(2, 2))
+        .addExpressions(
+            sb.add(sb.fieldReference(scan, 0), sb.i64(1)),
+            sb.add(sb.fieldReference(scan, 0), sb.i64(2)))
+        .build();
   }
 
   @Test
@@ -199,21 +224,78 @@ class OutputNamesTest extends PlanTestBase {
   void leavesTheNamesOfAnotherRelationAlone() {
     // The always-true condition means Calcite builds no filter at all, so the node on top is the
     // projection of the inner relation, with the names that relation asked for.
-    Rel inner =
-        Project.builder()
-            .input(scan)
-            .remap(Rel.Remap.offset(2, 1))
-            .addExpressions(sb.add(sb.fieldReference(scan, 0), sb.i64(1)))
-            .hint(Hint.builder().addOutputNames("inner").build())
-            .build();
     Rel filter =
         Filter.builder()
-            .input(inner)
+            .input(hintedInnerProject())
             .condition(sb.bool(true))
             .hint(Hint.builder().addOutputNames("outer").build())
             .build();
 
     assertEquals(List.of("inner"), substraitToCalcite.convert(filter).getRowType().getFieldNames());
+  }
+
+  @Test
+  void namesAProjectionWithoutAnEmitMapping() {
+    // A projection is the one relation whose conversion produces a Calcite projection of its own,
+    // with no emit mapping needed to ask for one.
+    Rel project =
+        Project.builder()
+            .input(scan)
+            .addExpressions(sb.add(sb.fieldReference(scan, 0), sb.i64(1)))
+            .hint(Hint.builder().addOutputNames("a", "b", "total").build())
+            .build();
+
+    RelNode node = substraitToCalcite.convert(project);
+
+    assertEquals(List.of("a", "b", "total"), node.getRowType().getFieldNames());
+    assertEquals(1, countProjections(node));
+  }
+
+  @Test
+  void leavesTheNamesOfAnotherRelationAloneWhenItsOwnOperatorIsElided() {
+    // Same as above, with an emit mapping that changes nothing either: Calcite builds no filter
+    // and no projection, so the node on top is still the inner relation's, hint and all.
+    Rel filter =
+        Filter.builder()
+            .input(hintedInnerProject())
+            .condition(sb.bool(true))
+            .remap(Rel.Remap.of(List.of(0)))
+            .hint(Hint.builder().addOutputNames("outer").build())
+            .build();
+
+    assertEquals(List.of("inner"), substraitToCalcite.convert(filter).getRowType().getFieldNames());
+  }
+
+  @Test
+  void dropsNamesWhereTheColumnsAreNotTheRelationsColumns() {
+    // An aggregate over several grouping sets orders its grouping columns by first appearance,
+    // where Calcite orders them by group key: the record type reads (b, a, count, index) and the
+    // converted node (a, b, count, ...), so the names would land on columns the plan does not name.
+    Rel scan3 =
+        sb.namedScan(List.of("t3"), List.of("a", "b", "c"), List.of(R.I64, N.STRING, R.FP64));
+    Rel aggregate =
+        sb.aggregate(
+            input -> List.of(sb.grouping(input, 1), sb.grouping(input, 0)),
+            input -> List.of(sb.count(input, 0)),
+            Optional.of(Rel.Remap.of(List.of(0, 1, 2, 3))),
+            scan3);
+
+    RelNode plain = substraitToCalcite.convert(aggregate);
+    RelNode named =
+        substraitToCalcite.convert(
+            aggregate.withHint(
+                Optional.of(Hint.builder().addOutputNames("k_b", "k_a", "n", "gs").build())));
+
+    assertEquals(plain.getRowType().getFieldNames(), named.getRowType().getFieldNames());
+  }
+
+  private Rel hintedInnerProject() {
+    return Project.builder()
+        .input(scan)
+        .remap(Rel.Remap.offset(2, 1))
+        .addExpressions(sb.add(sb.fieldReference(scan, 0), sb.i64(1)))
+        .hint(Hint.builder().addOutputNames("inner").build())
+        .build();
   }
 
   private static int countProjections(RelNode node) {


### PR DESCRIPTION
Isthmus did not look at `RelCommon.hint` at all, so the alternative output field names a producer put on a relation were dropped: a `Project` carrying `output_names = [total_price]` came out as `SELECT a + 1 AS $f2`. The Spark module writes those names and reads them back, so a plan crossing from Spark into Isthmus lost the column names it carried.

The names are applied to the projection this relation's own conversion produced — the one a `Project` becomes, or the one added for a relation with an emit mapping — so the plan keeps the shape it had. Which projection that is is decided by the node, not by the relation: where Calcite builds no operator at all — a filter that cannot filter, a sort with no sort fields, an identity emit mapping — it hands back the node it was given, and that one belongs to the input.

They are dropped where the relation's record type does not describe that projection's columns, type by type. An aggregate over several grouping sets orders its grouping columns by first appearance where Calcite orders them by group key, so the two disagree on which column is which and the names would land on columns the plan does not name.

Only the top-level names are applied. `output_names` is written depth first and names the fields inside a struct column as well, but those belong to the type of the expression producing the column, and Calcite rejects a projection whose row type restates them differently.

A name list that does not fit the relation is dropped as well, rather than failing the conversion: the wrong length, a repeated name, or an empty one. Calcite requires a projection's field names to be distinct, and reads an empty name as the star identifier — `output_names = ["", "x"]` renders as `SELECT "a" + 1 AS *, "a" + 2 AS "x"`, which does not parse. The spec says neither, so both are this repo's reading of it; substrait-io/substrait#1188 asks for it to be settled.

The names live in the row type of the projection, which Calcite treats as non-semantic on purpose, so they describe the tree as it is returned here and do not survive a planner: two projections differing only in their names share one digest — `LogicalProject.NONE.[](input=LogicalTableScan#3,exprs=[+($0, 1)])` for both — and `deepEquals` holds between them, so a planner is free to collapse the two and let one inherit the other's names. Neither forcing a projection nor attaching a `RelHint` changes that, since the digest omits hints too.

`visit(VirtualTableScan)`, `NamedDdl`, `NamedWrite` and `NamedUpdate` route neither their emit mapping nor their hint through this; that is #1160.

The export half, writing the names back from the Calcite row type, is left out until the question in #1157 is settled: always, or behind a switch on `ConverterProvider`.

Sits on top of #1181: without it the names applied here would reach the schema of a created table, which is declared and must not depend on a hint.

Part of #1157
