### PR TITLE
feat(isthmus): let the builder transform the call converter list

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionProperty;
@@ -106,10 +107,10 @@ public class ConverterProvider {
   protected TypeConverter typeConverter;
 
   /**
-   * Caller-supplied {@link CallConverter}s, consulted ahead of the built-in ones. See {@link
+   * The transform applied to the assembled {@link CallConverter} list. See {@link
    * #getCallConverters()}.
    */
-  protected final List<CallConverter> additionalCallConverters;
+  protected final UnaryOperator<List<CallConverter>> callConverters;
 
   /** The execution behavior configuration for plans created by this converter. */
   protected final Plan.ExecutionBehavior executionBehavior;
@@ -234,7 +235,7 @@ public class ConverterProvider {
             .orElse(builder.sqlParserConfig);
     this.typeObserver = builder.typeObserver;
     this.aggregateConversion = builder.aggregateConversion;
-    this.additionalCallConverters = List.copyOf(builder.additionalCallConverters);
+    this.callConverters = builder.callConverters;
 
     this.scalarFunctionConverter =
         builder.scalarFunctionConverter.orElseGet(
@@ -378,24 +379,24 @@ public class ConverterProvider {
    * {@link CallConverter}s are used to convert Calcite {@link org.apache.calcite.rex.RexCall}s to
    * Substrait equivalents.
    *
-   * <p>The converters are consulted in order and the first one to return a result wins. Any {@link
-   * Builder#additionalCallConverters(List) additional converters} come first, so a caller whose
-   * dialect gives a call different semantics can claim it before the built-in converter for it
-   * does.
+   * <p>The converters are consulted in order and the first one to return a result wins. The
+   * built-in ones are assembled here and handed to the {@link Builder#callConverters(UnaryOperator)
+   * transform} a caller configured, which decides where its own converters sit: ahead of a built-in
+   * one to claim a call it would otherwise take, or behind them to catch what none of them claims.
    *
-   * <p>This list covers plain calls only. A windowed call is a {@link
-   * org.apache.calcite.rex.RexOver}, which {@link
-   * io.substrait.isthmus.expression.RexExpressionConverter} routes to the window function converter
-   * without consulting these.
+   * <p>Some calls never reach this list: the {@link org.apache.calcite.rex.RexOver} node of a
+   * windowed call, an aggregate call, a {@link org.apache.calcite.rex.RexSubQuery}, and the
+   * reference expression of a {@link org.apache.calcite.rex.RexFieldAccess} outside the item,
+   * input-reference and field-access kinds it walks through. A windowed call's operands, partition
+   * keys and sort keys are converted through this list as usual.
    *
    * @return a list of CallConverter instances
    */
   public List<CallConverter> getCallConverters() {
-    ArrayList<CallConverter> callConverters = new ArrayList<>(additionalCallConverters);
-    callConverters.addAll(CallConverters.defaults(typeConverter));
-    callConverters.add(CallConverters.CREATE_SEARCH_CONV.apply(new RexBuilder(typeFactory)));
-    callConverters.add(scalarFunctionConverter);
-    return callConverters;
+    ArrayList<CallConverter> builtIns = new ArrayList<>(CallConverters.defaults(typeConverter));
+    builtIns.add(CallConverters.CREATE_SEARCH_CONV.apply(new RexBuilder(typeFactory)));
+    builtIns.add(scalarFunctionConverter);
+    return callConverters.apply(builtIns);
   }
 
   // Substrait To Calcite Processing
@@ -602,7 +603,7 @@ public class ConverterProvider {
     private TypeObserver typeObserver = TypeObserver.NOOP;
     private AggregateConversion aggregateConversion = AggregateConversion.DEFAULT;
     private Optional<Casing> unquotedCasing = Optional.empty();
-    private List<CallConverter> additionalCallConverters = List.of();
+    private UnaryOperator<List<CallConverter>> callConverters = UnaryOperator.identity();
 
     // Derived from the extensions and type factory at build time when left unset.
     private Optional<ScalarFunctionConverter> scalarFunctionConverter = Optional.empty();
@@ -707,20 +708,26 @@ public class ConverterProvider {
     }
 
     /**
-     * Sets {@link CallConverter}s for calls the built-in converters do not handle, or handle
-     * differently than the caller's dialect needs. Like the other setters this replaces what was
-     * configured before rather than adding to it.
+     * Sets a transform over the assembled {@link CallConverter} list, letting a caller insert,
+     * replace, reorder or remove converters. The list handed to the operator is mutable and holds
+     * the built-in converters in the order {@link ConverterProvider#getCallConverters()} assembles
+     * them; the list the operator returns is the one used.
      *
-     * <p>They are consulted ahead of the built-in converters, so one of them may claim a call a
-     * built-in converter would otherwise have taken, and they do not apply to windowed calls. See
-     * {@link ConverterProvider#getCallConverters()}.
+     * <p>Where a caller's converter sits is its own decision. Ahead of the built-in ones it claims
+     * a call one of them would otherwise take -- which is what a dialect that gives a call
+     * different semantics needs, and also what puts it ahead of {@code CAST}, {@code REINTERPRET}
+     * and {@code ROW}, this repository's encoding of nullable and user-defined literals rather than
+     * dialect behaviour. Behind them it catches only what none of them claims.
      *
-     * @param additionalCallConverters the call converters to consult first
+     * <p>The transform runs on every call to {@link ConverterProvider#getCallConverters()}, so it
+     * sees the scalar function converter and the type converter as they are then, rather than as
+     * they were when the provider was built.
+     *
+     * @param callConverters the transform to apply to the assembled list
      * @return this builder
      */
-    public Builder additionalCallConverters(List<CallConverter> additionalCallConverters) {
-      this.additionalCallConverters =
-          List.copyOf(Objects.requireNonNull(additionalCallConverters, "additionalCallConverters"));
+    public Builder callConverters(UnaryOperator<List<CallConverter>> callConverters) {
+      this.callConverters = Objects.requireNonNull(callConverters, "callConverters");
       return this;
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -720,6 +720,10 @@ public class ConverterProvider {
      * and {@code ROW}, this repository's encoding of nullable and user-defined literals rather than
      * dialect behaviour. Behind them it catches only what none of them claims.
      *
+     * <p>A converter must not pass the call it is claiming to the top-level converter, which
+     * re-enters this list from the start and recurses without end. To build on a built-in
+     * converter's result, call that converter directly rather than routing back through the list.
+     *
      * <p>The transform runs on every call to {@link ConverterProvider#getCallConverters()}, so it
      * sees the scalar function converter and the type converter as they are then, rather than as
      * they were when the provider was built.

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -711,7 +711,8 @@ public class ConverterProvider {
      * Sets a transform over the assembled {@link CallConverter} list, letting a caller insert,
      * replace, reorder or remove converters. The list handed to the operator is mutable and holds
      * the built-in converters in the order {@link ConverterProvider#getCallConverters()} assembles
-     * them; the list the operator returns is the one used.
+     * them; the list the operator returns is the one used, and must be mutable too, since a
+     * subclass may append to it.
      *
      * <p>Where a caller's converter sits is its own decision. Ahead of the built-in ones it claims
      * a call one of them would otherwise take -- which is what a dialect that gives a call

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -105,6 +105,12 @@ public class ConverterProvider {
   /** Converter for Substrait types to Calcite types and vice versa. */
   protected TypeConverter typeConverter;
 
+  /**
+   * Caller-supplied {@link CallConverter}s, consulted ahead of the built-in ones. See {@link
+   * #getCallConverters()}.
+   */
+  protected final List<CallConverter> additionalCallConverters;
+
   /** The execution behavior configuration for plans created by this converter. */
   protected final Plan.ExecutionBehavior executionBehavior;
 
@@ -228,6 +234,7 @@ public class ConverterProvider {
             .orElse(builder.sqlParserConfig);
     this.typeObserver = builder.typeObserver;
     this.aggregateConversion = builder.aggregateConversion;
+    this.additionalCallConverters = List.copyOf(builder.additionalCallConverters);
 
     this.scalarFunctionConverter =
         builder.scalarFunctionConverter.orElseGet(
@@ -371,11 +378,21 @@ public class ConverterProvider {
    * {@link CallConverter}s are used to convert Calcite {@link org.apache.calcite.rex.RexCall}s to
    * Substrait equivalents.
    *
+   * <p>The converters are consulted in order and the first one to return a result wins. Any {@link
+   * Builder#additionalCallConverters(List) additional converters} come first, so a caller whose
+   * dialect gives a call different semantics can claim it before the built-in converter for it
+   * does.
+   *
+   * <p>This list covers plain calls only. A windowed call is a {@link
+   * org.apache.calcite.rex.RexOver}, which {@link
+   * io.substrait.isthmus.expression.RexExpressionConverter} routes to the window function converter
+   * without consulting these.
+   *
    * @return a list of CallConverter instances
    */
   public List<CallConverter> getCallConverters() {
-    ArrayList<CallConverter> callConverters =
-        new ArrayList<>(CallConverters.defaults(typeConverter));
+    ArrayList<CallConverter> callConverters = new ArrayList<>(additionalCallConverters);
+    callConverters.addAll(CallConverters.defaults(typeConverter));
     callConverters.add(CallConverters.CREATE_SEARCH_CONV.apply(new RexBuilder(typeFactory)));
     callConverters.add(scalarFunctionConverter);
     return callConverters;
@@ -585,6 +602,7 @@ public class ConverterProvider {
     private TypeObserver typeObserver = TypeObserver.NOOP;
     private AggregateConversion aggregateConversion = AggregateConversion.DEFAULT;
     private Optional<Casing> unquotedCasing = Optional.empty();
+    private List<CallConverter> additionalCallConverters = List.of();
 
     // Derived from the extensions and type factory at build time when left unset.
     private Optional<ScalarFunctionConverter> scalarFunctionConverter = Optional.empty();
@@ -685,6 +703,24 @@ public class ConverterProvider {
      */
     public Builder aggregateConversion(AggregateConversion aggregateConversion) {
       this.aggregateConversion = Objects.requireNonNull(aggregateConversion, "aggregateConversion");
+      return this;
+    }
+
+    /**
+     * Sets {@link CallConverter}s for calls the built-in converters do not handle, or handle
+     * differently than the caller's dialect needs. Like the other setters this replaces what was
+     * configured before rather than adding to it.
+     *
+     * <p>They are consulted ahead of the built-in converters, so one of them may claim a call a
+     * built-in converter would otherwise have taken, and they do not apply to windowed calls. See
+     * {@link ConverterProvider#getCallConverters()}.
+     *
+     * @param additionalCallConverters the call converters to consult first
+     * @return this builder
+     */
+    public Builder additionalCallConverters(List<CallConverter> additionalCallConverters) {
+      this.additionalCallConverters =
+          List.copyOf(Objects.requireNonNull(additionalCallConverters, "additionalCallConverters"));
       return this;
     }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
@@ -253,6 +253,22 @@ class ConverterProviderBuilderTest {
       assertEquals(List.of("+", "-"), seen);
     }
 
+    /**
+     * A subclass appends to what {@code super.getCallConverters()} returns -- which is now the list
+     * the transform handed back -- so the transform has to leave it mutable.
+     */
+    @Test
+    void leaveTheListMutableForASubclassToAppendTo() {
+      ConverterProvider provider =
+          ConverterProvider.builder()
+              .callConverters(prepending(claiming(call -> false, null)))
+              .build();
+
+      List<CallConverter> converters = provider.getCallConverters();
+
+      assertDoesNotThrow(() -> converters.add(claiming(call -> false, null)));
+    }
+
     /** A transform putting the given converter ahead of the built-in ones. */
     private UnaryOperator<List<CallConverter>> prepending(CallConverter converter) {
       return builtIns -> {

--- a/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
@@ -17,9 +17,11 @@ import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.TypeObserver;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
@@ -34,6 +36,7 @@ import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.tools.RelBuilder;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -180,7 +183,7 @@ class ConverterProviderBuilderTest {
   }
 
   @Nested
-  class AdditionalCallConverters {
+  class CallConverterTransform {
 
     /** A function no built-in {@link CallConverter} claims. */
     private final SqlFunction unclaimed =
@@ -213,6 +216,53 @@ class ConverterProviderBuilderTest {
       return node.accept(provider.getRexExpressionConverter(null));
     }
 
+    /**
+     * A windowed call goes to the window function converter, but the expressions inside it do not:
+     * its operands, partition keys and sort keys are converted like any others, so a caller's
+     * converter is consulted for them.
+     */
+    @Test
+    void areConsultedForTheExpressionsInsideAWindowedCall() {
+      List<String> seen = new ArrayList<>();
+      ConverterProvider provider =
+          ConverterProvider.builder()
+              .callConverters(
+                  prepending(
+                      (call, top) -> {
+                        seen.add(call.getOperator().getName());
+                        return Optional.empty();
+                      }))
+              .build();
+      RelBuilder relBuilder = new RelCreator().createRelBuilder();
+      relBuilder.values(new String[] {"a"}, 1, 2);
+      RexNode over =
+          relBuilder
+              .aggregateCall(SqlStdOperatorTable.ROW_NUMBER)
+              .over()
+              .partitionBy(
+                  relBuilder.call(
+                      SqlStdOperatorTable.PLUS, relBuilder.field("a"), relBuilder.literal(1)))
+              .orderBy(
+                  relBuilder.call(
+                      SqlStdOperatorTable.MINUS, relBuilder.field("a"), relBuilder.literal(2)))
+              .rowsUnbounded()
+              .toRex();
+
+      over.accept(provider.getRexExpressionConverter(null));
+
+      assertEquals(List.of("+", "-"), seen);
+    }
+
+    /** A transform putting the given converter ahead of the built-in ones. */
+    private UnaryOperator<List<CallConverter>> prepending(CallConverter converter) {
+      return builtIns -> {
+        List<CallConverter> converters = new ArrayList<>();
+        converters.add(converter);
+        converters.addAll(builtIns);
+        return converters;
+      };
+    }
+
     private CallConverter claiming(Predicate<RexCall> claims, Expression result) {
       return (call, topLevelConverter) ->
           claims.test(call) ? Optional.of(result) : Optional.empty();
@@ -231,8 +281,8 @@ class ConverterProviderBuilderTest {
       Expression sentinel = ExpressionCreator.i64(false, 1);
       ConverterProvider provider =
           ConverterProvider.builder()
-              .additionalCallConverters(
-                  List.of(claiming(call -> call.getOperator() == unclaimed, sentinel)))
+              .callConverters(
+                  prepending(claiming(call -> call.getOperator() == unclaimed, sentinel)))
               .build();
 
       assertEquals(sentinel, convert(provider, unclaimedCall()));
@@ -255,8 +305,8 @@ class ConverterProviderBuilderTest {
       Expression sentinel = ExpressionCreator.i64(false, 2);
       ConverterProvider provider =
           ConverterProvider.builder()
-              .additionalCallConverters(
-                  List.of(
+              .callConverters(
+                  prepending(
                       claiming(call -> call.getOperator() == SqlStdOperatorTable.CAST, sentinel)))
               .build();
 

--- a/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
@@ -204,14 +204,13 @@ class ConverterProviderBuilderTest {
           rex.makeInputRef(TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER), 0));
     }
 
+    /**
+     * Converts through the provider's own {@link RexExpressionConverter}, which is what every
+     * conversion path uses, rather than assembling one out of the provider's parts: whether the
+     * added converters reach a conversion at all is what these tests are about.
+     */
     private Expression convert(ConverterProvider provider, RexNode node) {
-      RexExpressionConverter converter =
-          new RexExpressionConverter(
-              null,
-              provider.getCallConverters(),
-              provider.getWindowFunctionConverter(),
-              provider.getTypeConverter());
-      return node.accept(converter);
+      return node.accept(provider.getRexExpressionConverter(null));
     }
 
     private CallConverter claiming(Predicate<RexCall> claims, Expression result) {

--- a/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/ConverterProviderBuilderTest.java
@@ -2,20 +2,37 @@ package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.substrait.expression.Expression;
+import io.substrait.expression.ExpressionCreator;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.isthmus.expression.AggregateFunctionConverter;
+import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.isthmus.expression.ScalarFunctionConverter;
 import io.substrait.isthmus.expression.TypeObserver;
 import io.substrait.isthmus.expression.WindowFunctionConverter;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -159,6 +176,92 @@ class ConverterProviderBuilderTest {
           SqlConformanceEnum.PRAGMATIC_2003, casingLast.getSqlParserConfig().conformance());
       assertEquals(
           SqlConformanceEnum.PRAGMATIC_2003, casingFirst.getSqlParserConfig().conformance());
+    }
+  }
+
+  @Nested
+  class AdditionalCallConverters {
+
+    /** A function no built-in {@link CallConverter} claims. */
+    private final SqlFunction unclaimed =
+        new SqlFunction(
+            "UNCLAIMED",
+            SqlKind.OTHER_FUNCTION,
+            ReturnTypes.BIGINT,
+            null,
+            OperandTypes.NILADIC,
+            SqlFunctionCategory.USER_DEFINED_FUNCTION);
+
+    private final RexBuilder rex = new RexBuilder(TYPE_FACTORY);
+
+    private RexNode unclaimedCall() {
+      return rex.makeCall(TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT), unclaimed, List.of());
+    }
+
+    private RexNode castCall() {
+      return rex.makeAbstractCast(
+          TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT),
+          rex.makeInputRef(TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER), 0));
+    }
+
+    private Expression convert(ConverterProvider provider, RexNode node) {
+      RexExpressionConverter converter =
+          new RexExpressionConverter(
+              null,
+              provider.getCallConverters(),
+              provider.getWindowFunctionConverter(),
+              provider.getTypeConverter());
+      return node.accept(converter);
+    }
+
+    private CallConverter claiming(Predicate<RexCall> claims, Expression result) {
+      return (call, topLevelConverter) ->
+          claims.test(call) ? Optional.of(result) : Optional.empty();
+    }
+
+    /** Without the extra converter, nothing in the built-in set handles the call. */
+    @Test
+    void areNeededForACallNoBuiltInConverterHandles() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> convert(ConverterProvider.builder().build(), unclaimedCall()));
+    }
+
+    @Test
+    void handleACallNoBuiltInConverterHandles() {
+      Expression sentinel = ExpressionCreator.i64(false, 1);
+      ConverterProvider provider =
+          ConverterProvider.builder()
+              .additionalCallConverters(
+                  List.of(claiming(call -> call.getOperator() == unclaimed, sentinel)))
+              .build();
+
+      assertEquals(sentinel, convert(provider, unclaimedCall()));
+    }
+
+    /** The built-in CAST converter is what handles this call when nothing is added. */
+    @Test
+    void builtInConverterHandlesCastWhenNoneAreAdded() {
+      assertInstanceOf(
+          Expression.Cast.class, convert(ConverterProvider.builder().build(), castCall()));
+    }
+
+    /**
+     * A caller whose dialect gives a call different semantics has to be able to claim it before the
+     * built-in converter for it does, which is what overriding {@link
+     * ConverterProvider#getCallConverters()} allowed.
+     */
+    @Test
+    void areConsultedBeforeTheBuiltInOnes() {
+      Expression sentinel = ExpressionCreator.i64(false, 2);
+      ConverterProvider provider =
+          ConverterProvider.builder()
+              .additionalCallConverters(
+                  List.of(
+                      claiming(call -> call.getOperator() == SqlStdOperatorTable.CAST, sentinel)))
+              .build();
+
+      assertEquals(sentinel, convert(provider, castCall()));
     }
   }
 


### PR DESCRIPTION
`ConverterProvider.getCallConverters()` assembles its list internally, so a consumer whose Calcite dialect emits calls the built-in converters do not handle has to subclass the provider to add one. The builder already takes the scalar, aggregate and window function converters; call converters are the remaining piece. This is item 1 of #1048 — `sqlOperatorTable` is untouched here.

The builder takes a transform over the assembled list rather than converters to prepend. Where a caller's converter sits is a decision only the caller can make: ahead of a built-in one it claims a call that one would otherwise take, which is what a dialect giving a call different semantics needs, and also what puts it ahead of `CAST`, `REINTERPRET` and `ROW` — this repository's encoding of nullable and user-defined literals rather than dialect behaviour. Behind them it catches only what none of them claims. A transform says both, and it says replace and remove as well, which is what retiring the dynamic subclasses in item 3 of that issue needs.

The transform is applied where the list is assembled rather than at build time, so it sees the type converter and the scalar function converter as they are then. That matters here: the scalar function converter is derived during construction, and `DynamicConverterProvider` reassigns it after `super(builder)` returns, so anything frozen at `build()` would capture the wrong one. Both dynamic providers keep working — `AutomaticDynamicFunctionMappingConverterProvider` does not override `getCallConverters()`, and `DynamicConverterProvider` appends to what `super` returns, which is now the caller's list.

The case this comes from is an external consumer exporting Impala's Calcite plans through Isthmus: Impala rewrites `IF` and `cast` into operators carrying `SqlKind.OTHER`, which `CallConverters.CASE` and `CallConverters.CAST` decline, so today it subclasses `ConverterProvider` for both.

What does not reach these converters is narrower than an earlier revision of this description claimed: the `RexOver` node of a windowed call, an aggregate call, a subquery, and the reference expression of a field access outside the item, input-reference and field-access kinds it walks through. A windowed call's operands, partition keys and sort keys are converted through the list as usual, which `areConsultedForTheExpressionsInsideAWindowedCall` pins. The extended-expression path is honoured too now that #1168 takes its converter from the provider.

Part of #1048.
