### PR TITLE
fix(isthmus): convert extended expressions with the provider's converter

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -33,6 +33,7 @@ import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
+import org.jspecify.annotations.Nullable;
 
 /**
  * ConverterProvider provides a single-point of configuration for a number of conversions: {@code
@@ -361,7 +362,7 @@ public class ConverterProvider {
    *     rather than converting one
    * @return a new RexExpressionConverter instance
    */
-  public RexExpressionConverter getRexExpressionConverter(SubstraitRelVisitor srv) {
+  public RexExpressionConverter getRexExpressionConverter(@Nullable SubstraitRelVisitor srv) {
     return new RexExpressionConverter(
         srv, getCallConverters(), getWindowFunctionConverter(), getTypeConverter());
   }

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -356,8 +356,9 @@ public class ConverterProvider {
    * A {@link RexExpressionConverter} converts Calcite {@link org.apache.calcite.rex.RexNode}s to
    * Substrait equivalents.
    *
-   * @param srv the SubstraitRelVisitor to use for nested relation conversions, or {@code null} when
-   *     the expressions being converted stand alone and cannot contain a subquery
+   * @param srv the SubstraitRelVisitor to use for nested relation conversions, or {@code null}
+   *     where the expressions being converted stand alone; the converter then rejects a subquery
+   *     rather than converting one
    * @return a new RexExpressionConverter instance
    */
   public RexExpressionConverter getRexExpressionConverter(SubstraitRelVisitor srv) {

--- a/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/ConverterProvider.java
@@ -356,7 +356,8 @@ public class ConverterProvider {
    * A {@link RexExpressionConverter} converts Calcite {@link org.apache.calcite.rex.RexNode}s to
    * Substrait equivalents.
    *
-   * @param srv the SubstraitRelVisitor to use for nested relation conversions
+   * @param srv the SubstraitRelVisitor to use for nested relation conversions, or {@code null} when
+   *     the expressions being converted stand alone and cannot contain a subquery
    * @return a new RexExpressionConverter instance
    */
   public RexExpressionConverter getRexExpressionConverter(SubstraitRelVisitor srv) {

--- a/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SqlExpressionToSubstrait.java
@@ -50,7 +50,9 @@ public class SqlExpressionToSubstrait extends SqlConverterBase {
    */
   public SqlExpressionToSubstrait(ConverterProvider converterProvider) {
     super(converterProvider);
-    this.rexConverter = new RexExpressionConverter(converterProvider.getScalarFunctionConverter());
+    // The provider is the single source of the converter, so an expression converts the same way
+    // here as it does inside a plan. There is no relation to visit: an expression stands alone.
+    this.rexConverter = converterProvider.getRexExpressionConverter(null);
   }
 
   /** Bundled result carrying validator, catalog reader, and name/type and name/node maps. */

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -265,10 +265,19 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
    *
    * @param subQuery the subquery node
    * @return the converted Substrait expression
-   * @throws UnsupportedOperationException for unsupported subquery operators
+   * @throws UnsupportedOperationException for an unsupported subquery operator, or when this
+   *     converter was built without a relation visitor
    */
   @Override
   public Expression visitSubQuery(RexSubQuery subQuery) {
+    if (relVisitor == null) {
+      // A converter built without one converts expressions that stand alone, an extended
+      // expression among them. Say so rather than dereferencing it.
+      throw new UnsupportedOperationException(
+          String.format(
+              "This converter has no relation visitor, so it cannot convert the subquery %s",
+              subQuery));
+    }
     Rel rel = relVisitor.apply(subQuery.rel);
 
     if (subQuery.getOperator() == SqlStdOperatorTable.EXISTS) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -217,7 +217,8 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
    *
    * @param fieldAccess the field access
    * @return the converted Substrait expression
-   * @throws UnsupportedOperationException for unsupported reference kinds
+   * @throws UnsupportedOperationException for an unsupported reference kind, or when this converter
+   *     was built without a relation visitor and the reference is an outer one
    */
   @Override
   public Expression visitFieldAccess(RexFieldAccess fieldAccess) {
@@ -225,6 +226,15 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
     switch (kind) {
       case CORREL_VARIABLE:
         {
+          if (relVisitor == null) {
+            // As for a subquery: a converter built without one converts expressions that stand
+            // alone, and an outer reference is bound by a relation there is none of here.
+            throw new UnsupportedOperationException(
+                String.format(
+                    "This converter has no relation visitor, so it cannot convert the outer"
+                        + " reference %s",
+                    fieldAccess));
+          }
           CorrelationId correlationId = ((RexCorrelVariable) fieldAccess.getReferenceExpr()).id;
           Integer anchor = relVisitor.getOuterReferenceAnchor(correlationId);
           if (anchor == null) {

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/RexExpressionConverter.java
@@ -139,9 +139,24 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
     return String.format(
         "Unable to convert call %s(%s).",
         call.getOperator().getName(),
-        call.getOperands().stream()
-            .map(t -> t.accept(this).getType().accept(new StringTypeVisitor()))
-            .collect(Collectors.joining(", ")));
+        call.getOperands().stream().map(this::operandTypeName).collect(Collectors.joining(", ")));
+  }
+
+  /**
+   * Names an operand's type for a failure message, reading it off the node rather than converting
+   * the operand again. The call being reported is one this converter could not convert, and an
+   * operand it cannot convert either -- a subquery where there is no relation visitor, say -- would
+   * report its own failure in place of the one being described.
+   *
+   * @param operand the operand to name the type of
+   * @return the Substrait name of its type, or the Calcite one where the type does not convert
+   */
+  private String operandTypeName(RexNode operand) {
+    try {
+      return typeConverter.toSubstrait(operand.getType()).accept(new StringTypeVisitor());
+    } catch (RuntimeException e) {
+      return operand.getType().getFullTypeString();
+    }
   }
 
   /**
@@ -161,9 +176,21 @@ public class RexExpressionConverter implements RexVisitor<Expression> {
    * @param over the windowed call
    * @return the converted Substrait expression
    * @throws IllegalArgumentException if {@code IGNORE NULLS} is used or conversion fails
+   * @throws UnsupportedOperationException if this converter was built without a window function
+   *     converter
    */
   @Override
   public Expression visitOver(RexOver over) {
+    if (windowFunctionConverter == null) {
+      // As for a subquery and an outer reference: three of this class's four constructors leave
+      // the collaborator null, and a converter built by one of them cannot convert a windowed call.
+      throw new UnsupportedOperationException(
+          String.format(
+              "This converter has no window function converter, so it cannot convert the windowed"
+                  + " call %s",
+              over));
+    }
+
     if (over.ignoreNulls()) {
       throw new IllegalArgumentException("IGNORE NULLS cannot be expressed in Substrait");
     }

--- a/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
@@ -4,10 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import io.substrait.isthmus.expression.RexExpressionConverter;
 import java.io.IOException;
 import java.util.stream.Stream;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.hep.HepPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -89,5 +98,35 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
     };
 
     assertProtoExtendedExpressionRoundtrip(expressions);
+  }
+
+  /**
+   * The converter this path builds has no relation to visit, so a subquery cannot be converted on
+   * it. What the path accepts today never produces one -- a constant scalar subquery folds before
+   * the conversion sees it, and IN and EXISTS are rejected by Calcite's own validation -- so this
+   * pins the converter rather than a SQL expression that reaches it.
+   */
+  @Test
+  void aSubqueryIsRejectedRatherThanDereferencingTheMissingVisitor() {
+    RexBuilder rexBuilder = new RexBuilder(SubstraitTypeSystem.TYPE_FACTORY);
+    RelOptCluster cluster =
+        RelOptCluster.create(new HepPlanner(HepProgram.builder().build()), rexBuilder);
+    RelNode oneRow =
+        LogicalValues.create(
+            cluster,
+            SubstraitTypeSystem.TYPE_FACTORY.builder().add("a", SqlTypeName.INTEGER).build(),
+            ImmutableList.of(
+                ImmutableList.of(
+                    rexBuilder.makeExactLiteral(
+                        java.math.BigDecimal.ONE,
+                        SubstraitTypeSystem.TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER)))));
+    RexSubQuery subQuery = RexSubQuery.scalar(oneRow);
+
+    UnsupportedOperationException rejected =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                ConverterProvider.DEFAULT.getRexExpressionConverter(null).visitSubQuery(subQuery));
+    assertTrue(rejected.getMessage().contains("no relation visitor"), rejected.getMessage());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
@@ -12,8 +12,11 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -98,6 +101,26 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
     };
 
     assertProtoExtendedExpressionRoundtrip(expressions);
+  }
+
+  /** The same for an outer reference, which is bound by a relation there is none of here. */
+  @Test
+  void anOuterReferenceIsRejectedRatherThanDereferencingTheMissingVisitor() {
+    RexBuilder rexBuilder = new RexBuilder(SubstraitTypeSystem.TYPE_FACTORY);
+    RexNode correlated =
+        rexBuilder.makeCorrel(
+            SubstraitTypeSystem.TYPE_FACTORY.builder().add("a", SqlTypeName.INTEGER).build(),
+            new CorrelationId(0));
+    RexFieldAccess fieldAccess = (RexFieldAccess) rexBuilder.makeFieldAccess(correlated, 0);
+
+    UnsupportedOperationException rejected =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                ConverterProvider.DEFAULT
+                    .getRexExpressionConverter(null)
+                    .visitFieldAccess(fieldAccess));
+    assertTrue(rejected.getMessage().contains("no relation visitor"), rejected.getMessage());
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
@@ -1,8 +1,10 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.substrait.isthmus.expression.RexExpressionConverter;
 import java.io.IOException;
 import java.util.stream.Stream;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -13,6 +15,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
 
+  private static final String MARKER = "provider hook reached";
+
   private static Stream<Arguments> expressionTypeProvider() {
     return Stream.of(
         Arguments.of("2"), // I32LiteralExpression
@@ -21,7 +25,14 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
         Arguments.of("L_ORDERKEY + 10"), // ScalarFunctionExpressionProjection
         Arguments.of("L_ORDERKEY IN (10, 20)"), // ScalarFunctionExpressionIn
         Arguments.of("L_ORDERKEY is not null"), // ScalarFunctionExpressionIsNotNull
-        Arguments.of("L_ORDERKEY is null")); // ScalarFunctionExpressionIsNull
+        Arguments.of("L_ORDERKEY is null"), // ScalarFunctionExpressionIsNull
+        // The rest are handled by CallConverters.defaults rather than by the scalar function
+        // converter, and so reach this path only when it is assembled from the provider.
+        Arguments.of("CAST(L_ORDERKEY AS VARCHAR)"), // CallConverters.CAST
+        Arguments.of("CASE WHEN L_ORDERKEY > 10 THEN 1 ELSE 2 END"), // CallConverters.CASE
+        Arguments.of("CURRENT_DATE"), // CallConverters.EXECUTION_CONTEXT_VARIABLE
+        Arguments.of("ARRAY[1, 2]"), // SqlArrayValueConstructorCallConverter
+        Arguments.of("MAP['a', 1]")); // SqlMapValueConstructorCallConverter
   }
 
   @ParameterizedTest
@@ -42,6 +53,27 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
         illegalArgumentException
             .getMessage()
             .startsWith("There is no support for duplicate column names"));
+  }
+
+  /**
+   * The converter is taken from the provider rather than assembled here, so a provider that
+   * overrides {@link ConverterProvider#getRexExpressionConverter} is honoured on this path as it
+   * already is when converting a plan.
+   */
+  @Test
+  void usesTheProvidersRexExpressionConverter() throws IOException {
+    ConverterProvider provider =
+        new ConverterProvider(ConverterProvider.builder()) {
+          @Override
+          public RexExpressionConverter getRexExpressionConverter(SubstraitRelVisitor srv) {
+            throw new UnsupportedOperationException(MARKER);
+          }
+        };
+
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class, () -> new SqlExpressionToSubstrait(provider));
+    assertEquals(MARKER, e.getMessage());
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SimpleExtendedExpressionsTest.java
@@ -1,25 +1,16 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import io.substrait.isthmus.expression.RexExpressionConverter;
+import io.substrait.proto.Expression.RexTypeCase;
+import io.substrait.proto.ExtendedExpression;
 import java.io.IOException;
 import java.util.stream.Stream;
-import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.hep.HepPlanner;
-import org.apache.calcite.plan.hep.HepProgram;
-import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.core.CorrelationId;
-import org.apache.calcite.rel.logical.LogicalValues;
-import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexFieldAccess;
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.sql.parser.SqlParseException;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -37,14 +28,34 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
         Arguments.of("L_ORDERKEY + 10"), // ScalarFunctionExpressionProjection
         Arguments.of("L_ORDERKEY IN (10, 20)"), // ScalarFunctionExpressionIn
         Arguments.of("L_ORDERKEY is not null"), // ScalarFunctionExpressionIsNotNull
-        Arguments.of("L_ORDERKEY is null"), // ScalarFunctionExpressionIsNull
-        // The rest are handled by CallConverters.defaults rather than by the scalar function
-        // converter, and so reach this path only when it is assembled from the provider.
-        Arguments.of("CAST(L_ORDERKEY AS VARCHAR)"), // CallConverters.CAST
-        Arguments.of("CASE WHEN L_ORDERKEY > 10 THEN 1 ELSE 2 END"), // CallConverters.CASE
-        Arguments.of("CURRENT_DATE"), // CallConverters.EXECUTION_CONTEXT_VARIABLE
-        Arguments.of("ARRAY[1, 2]"), // SqlArrayValueConstructorCallConverter
-        Arguments.of("MAP['a', 1]")); // SqlMapValueConstructorCallConverter
+        Arguments.of("L_ORDERKEY is null")); // ScalarFunctionExpressionIsNull
+  }
+
+  /**
+   * The expressions the scalar function converter does not claim, which reach this path only once
+   * the converter is assembled from the provider. Each is paired with what it converts into: the
+   * round trip these share with the cases above compares a proto against itself, so it holds
+   * whatever the conversion produced.
+   */
+  private static Stream<Arguments> callConverterExpressionProvider() {
+    return Stream.of(
+        Arguments.of("CAST(L_ORDERKEY AS VARCHAR)", RexTypeCase.CAST),
+        Arguments.of("CASE WHEN L_ORDERKEY > 10 THEN 1 ELSE 2 END", RexTypeCase.IF_THEN),
+        Arguments.of("CURRENT_DATE", RexTypeCase.EXECUTION_CONTEXT_VARIABLE),
+        Arguments.of("ARRAY[1, 2]", RexTypeCase.LITERAL),
+        Arguments.of("MAP['a', 1]", RexTypeCase.LITERAL),
+        Arguments.of("ROW_NUMBER() OVER (ORDER BY L_ORDERKEY)", RexTypeCase.WINDOW_FUNCTION));
+  }
+
+  @ParameterizedTest
+  @MethodSource("callConverterExpressionProvider")
+  void aCallTheScalarConverterDoesNotClaimIsConverted(String sqlExpression, RexTypeCase expected)
+      throws SqlParseException, IOException {
+    ExtendedExpression extendedExpression =
+        new SqlExpressionToSubstrait(ConverterProvider.DEFAULT)
+            .convert(sqlExpression, tpchSchemaCreateStatements());
+
+    assertEquals(expected, extendedExpression.getReferredExpr(0).getExpression().getRexTypeCase());
   }
 
   @ParameterizedTest
@@ -73,11 +84,13 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
    * already is when converting a plan.
    */
   @Test
-  void usesTheProvidersRexExpressionConverter() throws IOException {
+  void usesTheProvidersRexExpressionConverter() {
+    SubstraitRelVisitor[] seen = new SubstraitRelVisitor[1];
     ConverterProvider provider =
         new ConverterProvider(ConverterProvider.builder()) {
           @Override
           public RexExpressionConverter getRexExpressionConverter(SubstraitRelVisitor srv) {
+            seen[0] = srv;
             throw new UnsupportedOperationException(MARKER);
           }
         };
@@ -86,6 +99,7 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
         assertThrows(
             UnsupportedOperationException.class, () -> new SqlExpressionToSubstrait(provider));
     assertEquals(MARKER, e.getMessage());
+    assertNull(seen[0]);
   }
 
   @Test
@@ -101,55 +115,5 @@ class SimpleExtendedExpressionsTest extends ExtendedExpressionTestBase {
     };
 
     assertProtoExtendedExpressionRoundtrip(expressions);
-  }
-
-  /** The same for an outer reference, which is bound by a relation there is none of here. */
-  @Test
-  void anOuterReferenceIsRejectedRatherThanDereferencingTheMissingVisitor() {
-    RexBuilder rexBuilder = new RexBuilder(SubstraitTypeSystem.TYPE_FACTORY);
-    RexNode correlated =
-        rexBuilder.makeCorrel(
-            SubstraitTypeSystem.TYPE_FACTORY.builder().add("a", SqlTypeName.INTEGER).build(),
-            new CorrelationId(0));
-    RexFieldAccess fieldAccess = (RexFieldAccess) rexBuilder.makeFieldAccess(correlated, 0);
-
-    UnsupportedOperationException rejected =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                ConverterProvider.DEFAULT
-                    .getRexExpressionConverter(null)
-                    .visitFieldAccess(fieldAccess));
-    assertTrue(rejected.getMessage().contains("no relation visitor"), rejected.getMessage());
-  }
-
-  /**
-   * The converter this path builds has no relation to visit, so a subquery cannot be converted on
-   * it. What the path accepts today never produces one -- a constant scalar subquery folds before
-   * the conversion sees it, and IN and EXISTS are rejected by Calcite's own validation -- so this
-   * pins the converter rather than a SQL expression that reaches it.
-   */
-  @Test
-  void aSubqueryIsRejectedRatherThanDereferencingTheMissingVisitor() {
-    RexBuilder rexBuilder = new RexBuilder(SubstraitTypeSystem.TYPE_FACTORY);
-    RelOptCluster cluster =
-        RelOptCluster.create(new HepPlanner(HepProgram.builder().build()), rexBuilder);
-    RelNode oneRow =
-        LogicalValues.create(
-            cluster,
-            SubstraitTypeSystem.TYPE_FACTORY.builder().add("a", SqlTypeName.INTEGER).build(),
-            ImmutableList.of(
-                ImmutableList.of(
-                    rexBuilder.makeExactLiteral(
-                        java.math.BigDecimal.ONE,
-                        SubstraitTypeSystem.TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER)))));
-    RexSubQuery subQuery = RexSubQuery.scalar(oneRow);
-
-    UnsupportedOperationException rejected =
-        assertThrows(
-            UnsupportedOperationException.class,
-            () ->
-                ConverterProvider.DEFAULT.getRexExpressionConverter(null).visitSubQuery(subQuery));
-    assertTrue(rejected.getMessage().contains("no relation visitor"), rejected.getMessage());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
@@ -3,14 +3,22 @@ package io.substrait.isthmus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.util.JsonFormat;
+import io.substrait.isthmus.expression.RexExpressionConverter;
 import io.substrait.proto.Expression;
 import io.substrait.proto.Expression.Subquery.SetPredicate.PredicateOp;
 import io.substrait.proto.FilterRel;
 import io.substrait.proto.Plan;
 import java.io.IOException;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexSubQuery;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
@@ -349,5 +357,92 @@ class SubqueryPlanTest extends PlanTestBase {
   void correlatedScalarSubQueryInSelect() throws Exception {
     String sql = asString("subquery/nested_scalar_subquery_in_select.sql");
     assertSqlSubstraitRelRoundTrip(sql);
+  }
+
+  /**
+   * A converter built without a relation visitor converts expressions that stand alone -- an
+   * extended expression among them -- so a subquery cannot be converted on it. No SQL reaches this
+   * guard today: validating an extended expression that holds a subquery throws inside Calcite
+   * first, scalar and IN/EXISTS alike, so the converter is pinned directly.
+   */
+  @Test
+  void aSubqueryIsRejectedWhereThereIsNoRelationVisitor() {
+    RexSubQuery subQuery = RexSubQuery.scalar(builder.values(new String[] {"a"}, 1).build());
+
+    UnsupportedOperationException rejected =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                ConverterProvider.DEFAULT.getRexExpressionConverter(null).visitSubQuery(subQuery));
+    assertTrue(rejected.getMessage().contains("no relation visitor"), rejected.getMessage());
+  }
+
+  /** The same for an outer reference, which is bound by a relation there is none of here. */
+  @Test
+  void anOuterReferenceIsRejectedWhereThereIsNoRelationVisitor() {
+    RexBuilder rexBuilder = builder.getRexBuilder();
+    RexFieldAccess fieldAccess =
+        (RexFieldAccess)
+            rexBuilder.makeFieldAccess(
+                rexBuilder.makeCorrel(
+                    builder.values(new String[] {"a"}, 1).build().getRowType(),
+                    new CorrelationId(0)),
+                0);
+
+    UnsupportedOperationException rejected =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                ConverterProvider.DEFAULT
+                    .getRexExpressionConverter(null)
+                    .visitFieldAccess(fieldAccess));
+    assertTrue(rejected.getMessage().contains("no relation visitor"), rejected.getMessage());
+  }
+
+  /**
+   * The message for a call this converter cannot convert names its operands' types, and reading
+   * them off the nodes is what keeps it about the call: converting an operand again would report
+   * that operand's own failure -- a subquery where there is no relation visitor -- in place of it.
+   */
+  @Test
+  void anUnconvertibleCallWithASubqueryOperandReportsTheCall() {
+    RexBuilder rexBuilder = builder.getRexBuilder();
+    RexNode subQuery = RexSubQuery.scalar(builder.values(new String[] {"a"}, 1).build());
+    RexNode call =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.SESSION_USER.getReturnTypeInference() == null
+                ? subQuery.getType()
+                : subQuery.getType(),
+            SqlStdOperatorTable.NULLIF,
+            java.util.List.of(subQuery, subQuery));
+
+    IllegalArgumentException reported =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> call.accept(ConverterProvider.DEFAULT.getRexExpressionConverter(null)));
+    assertTrue(reported.getMessage().startsWith("Unable to convert call"), reported.getMessage());
+  }
+
+  /**
+   * The same for a windowed call: three of the four {@link RexExpressionConverter} constructors
+   * leave the window function converter null, and a converter built by one of them names what is
+   * missing rather than dereferencing it.
+   */
+  @Test
+  void aWindowedCallIsRejectedWhereThereIsNoWindowFunctionConverter() {
+    builder.values(new String[] {"a"}, 1);
+    RexNode over =
+        builder
+            .aggregateCall(SqlStdOperatorTable.ROW_NUMBER)
+            .over()
+            .orderBy(builder.field("a"))
+            .rowsUnbounded()
+            .toRex();
+
+    UnsupportedOperationException rejected =
+        assertThrows(
+            UnsupportedOperationException.class, () -> over.accept(new RexExpressionConverter()));
+    assertTrue(
+        rejected.getMessage().contains("no window function converter"), rejected.getMessage());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubqueryPlanTest.java
@@ -362,8 +362,7 @@ class SubqueryPlanTest extends PlanTestBase {
   /**
    * A converter built without a relation visitor converts expressions that stand alone -- an
    * extended expression among them -- so a subquery cannot be converted on it. No SQL reaches this
-   * guard today: validating an extended expression that holds a subquery throws inside Calcite
-   * first, scalar and IN/EXISTS alike, so the converter is pinned directly.
+   * guard today, so the converter is pinned directly.
    */
   @Test
   void aSubqueryIsRejectedWhereThereIsNoRelationVisitor() {
@@ -410,11 +409,7 @@ class SubqueryPlanTest extends PlanTestBase {
     RexNode subQuery = RexSubQuery.scalar(builder.values(new String[] {"a"}, 1).build());
     RexNode call =
         rexBuilder.makeCall(
-            SqlStdOperatorTable.SESSION_USER.getReturnTypeInference() == null
-                ? subQuery.getType()
-                : subQuery.getType(),
-            SqlStdOperatorTable.NULLIF,
-            java.util.List.of(subQuery, subQuery));
+            subQuery.getType(), SqlStdOperatorTable.NULLIF, java.util.List.of(subQuery, subQuery));
 
     IllegalArgumentException reported =
         assertThrows(


### PR DESCRIPTION
`SqlExpressionToSubstrait` built its own `RexExpressionConverter` from the scalar function converter alone. That varargs constructor takes the whole call-converter list, so the list on this path was just that one converter and `CallConverters.defaults(...)` never reached it — `CAST`, `CASE`, the execution-context variables and the array and map constructors were unconvertible as extended expressions while converting fine inside a plan.

Taking the converter from `ConverterProvider.getRexExpressionConverter` rather than assembling a second one here also means a provider that overrides that method is honoured on this path, as it already is when converting a plan, and that the window function converter and type converter are the provider's rather than `null` and `TypeConverter.DEFAULT`. Only the call-converter half and the provider hook are pinned by tests; a marker `TypeConverter` cannot isolate the third, because `SqlConverterBase` already uses the provider's type converter for the schema, so such a test passes against the old constructor too.

`getRexExpressionConverter` is passed `null` for the relation visitor: an expression that stands alone has no relation to visit. Nothing in this path produces a subquery to convert -- validating an extended expression that holds one throws inside Calcite first, a scalar subquery and `IN`/`EXISTS` alike -- so the converter names what is missing instead of dereferencing it. `visitFieldAccess` did the same dereference for an outer reference, and `visitOver` for the window function converter that three of the four constructors leave null; both say so now.

Naming what is missing has to stay out of the way of the message that names the call. `callConversionFailureMessage` converted each operand again to render its type, so an unconvertible call with a subquery operand reported the operand's failure rather than the call's; the types come off the nodes now.

The expressions the scalar function converter does not claim are pinned by what they convert into -- `CAST`, `IF_THEN`, `EXECUTION_CONTEXT_VARIABLE`, two `LITERAL`s and, since the same wiring admits it, the `WINDOW_FUNCTION` of `ROW_NUMBER() OVER (...)`. The round trip they used to share compares a proto against the one converting it back produces, which holds whatever the conversion made of them, and they no longer feed the duplicate-column test, where they threw before the expression was parsed.

Closes #1165.
