### PR TITLE
fix(isthmus)!: keep the declared length of a wide character or binary type

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -81,12 +81,24 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   /**
    * Returns the maximum precision for the given SQL type.
    *
+   * <p>For the three types that carry a length across the Substrait boundary — {@link
+   * SqlTypeName#CHAR}, {@link SqlTypeName#VARCHAR} and {@link SqlTypeName#BINARY}, holding {@code
+   * fixedchar}, {@code varchar} and {@code fixed_binary} — this is Substrait's own limit: those
+   * lengths are 32-bit integers. Calcite's default of 65536 is narrower, and the type factory caps
+   * a converted type at it rather than reporting that it cannot represent the declared width.
+   * {@link SqlTypeName#VARBINARY} is left alone because Substrait's {@code binary} carries no
+   * length for it to lose.
+   *
    * @param typeName The {@link SqlTypeName} for which precision is requested.
    * @return Maximum precision for the type.
    */
   @Override
   public int getMaxPrecision(final SqlTypeName typeName) {
     switch (typeName) {
+      case CHAR:
+      case VARCHAR:
+      case BINARY:
+        return Integer.MAX_VALUE;
       case INTERVAL_DAY:
       case INTERVAL_YEAR:
       case INTERVAL_YEAR_MONTH:

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -86,8 +86,14 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
    * fixedchar}, {@code varchar} and {@code fixed_binary} — this is Substrait's own limit: those
    * lengths are 32-bit integers. Calcite's default of 65536 is narrower, and the type factory caps
    * a converted type at it rather than reporting that it cannot represent the declared width.
-   * {@link SqlTypeName#VARBINARY} is left alone because Substrait's {@code binary} carries no
-   * length for it to lose.
+   *
+   * <p>{@link SqlTypeName#VARBINARY} is raised with them even though Substrait's {@code binary}
+   * carries no length of its own, because the cap bites inside Calcite's own type unification:
+   * {@link #shouldConvertRaggedUnionTypesToVarying()} is true here, so a union of fixed-width
+   * binaries of different widths is unified as a {@code VARBINARY} of the widest. Left at 65536,
+   * the least restrictive type of {@code BINARY(100000)} and {@code BINARY(5)} is {@code
+   * VARBINARY(65536)} -- narrower than one of its own inputs, and the cap this method removes
+   * reimposed.
    *
    * @param typeName The {@link SqlTypeName} for which precision is requested.
    * @return Maximum precision for the type.
@@ -98,6 +104,7 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
       case CHAR:
       case VARCHAR:
       case BINARY:
+      case VARBINARY:
         return Integer.MAX_VALUE;
       case INTERVAL_DAY:
       case INTERVAL_YEAR:

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -79,25 +79,6 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   }
 
   /**
-   * Checks that a Substrait decimal scale is one the Calcite type system in effect allows, and
-   * reports the bound it exceeds if it is not.
-   *
-   * @param typeSystem the type system the converted type will live under, which need not be this
-   *     one
-   * @param scale the scale carried by the Substrait type
-   * @throws IllegalArgumentException if the scale exceeds what the type system allows
-   */
-  public static void requireSupportedScale(final RelDataTypeSystem typeSystem, final int scale) {
-    int maxScale = typeSystem.getMaxScale(SqlTypeName.DECIMAL);
-    if (scale > maxScale) {
-      throw new IllegalArgumentException(
-          String.format(
-              "unsupported decimal scale %s, max scale in Calcite type system is set to %s",
-              scale, maxScale));
-    }
-  }
-
-  /**
    * Returns the maximum precision for the given SQL type.
    *
    * <p>For the three types that carry a length across the Substrait boundary — {@link

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -83,7 +83,7 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
    *
    * <p>For the three types that carry a length across the Substrait boundary — {@link
    * SqlTypeName#CHAR}, {@link SqlTypeName#VARCHAR} and {@link SqlTypeName#BINARY}, holding {@code
-   * fixedchar}, {@code varchar} and {@code fixed_binary} — this is Substrait's own limit: those
+   * fixedchar}, {@code varchar} and {@code fixedbinary} — this is Substrait's own limit: those
    * lengths are 32-bit integers. Calcite's default of 65536 is narrower, and the type factory caps
    * a converted type at it rather than reporting that it cannot represent the declared width.
    *

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitTypeSystem.java
@@ -79,6 +79,25 @@ public class SubstraitTypeSystem extends RelDataTypeSystemImpl {
   }
 
   /**
+   * Checks that a Substrait decimal scale is one the Calcite type system in effect allows, and
+   * reports the bound it exceeds if it is not.
+   *
+   * @param typeSystem the type system the converted type will live under, which need not be this
+   *     one
+   * @param scale the scale carried by the Substrait type
+   * @throws IllegalArgumentException if the scale exceeds what the type system allows
+   */
+  public static void requireSupportedScale(final RelDataTypeSystem typeSystem, final int scale) {
+    int maxScale = typeSystem.getMaxScale(SqlTypeName.DECIMAL);
+    if (scale > maxScale) {
+      throw new IllegalArgumentException(
+          String.format(
+              "unsupported decimal scale %s, max scale in Calcite type system is set to %s",
+              scale, maxScale));
+    }
+  }
+
+  /**
    * Returns the maximum precision for the given SQL type.
    *
    * <p>For the three types that carry a length across the Substrait boundary — {@link

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -31,6 +31,9 @@ import org.jspecify.annotations.Nullable;
  */
 public class TypeConverter {
 
+  /** The widest precision the spec gives a decimal: {@code DECIMAL<P, S>} puts P at 38 or less. */
+  private static final int MAX_DECIMAL_PRECISION = 38;
+
   private final UserTypeMapper userTypeMapper;
 
   /**
@@ -143,7 +146,7 @@ public class TypeConverter {
         return creator.FP64;
       case DECIMAL:
         {
-          if (type.getPrecision() > 38) {
+          if (type.getPrecision() > MAX_DECIMAL_PRECISION) {
             throw new UnsupportedOperationException(
                 "unsupported decimal precision " + type.getPrecision());
           }
@@ -441,6 +444,15 @@ public class TypeConverter {
             String.format(
                 "A decimal cannot declare a negative precision, and this one is %d",
                 expr.precision()));
+      }
+      // The spec's own ceiling, not just the factory's: handed a type system whose DECIMAL maximum
+      // is above it, the factory builds the type and the outbound conversion above then refuses it,
+      // so the type would convert in and have no way back.
+      if (expr.precision() > MAX_DECIMAL_PRECISION) {
+        throw new IllegalArgumentException(
+            String.format(
+                "A decimal cannot declare a precision of %d, above the %d the spec allows",
+                expr.precision(), MAX_DECIMAL_PRECISION));
       }
       SubstraitTypeSystem.requireSupportedPrecision(
           typeFactory.getTypeSystem(), SqlTypeName.DECIMAL, "decimal", expr.precision());

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -376,17 +376,41 @@ public class TypeConverter {
 
     @Override
     public RelDataType visit(Type.FixedChar expr) {
-      return t(n(expr), SqlTypeName.CHAR, expr.length());
+      return withLength(n(expr), SqlTypeName.CHAR, expr.length());
     }
 
     @Override
     public RelDataType visit(Type.VarChar expr) {
-      return t(n(expr), SqlTypeName.VARCHAR, expr.length());
+      return withLength(n(expr), SqlTypeName.VARCHAR, expr.length());
     }
 
     @Override
     public RelDataType visit(Type.FixedBinary expr) {
-      return t(n(expr), SqlTypeName.BINARY, expr.length());
+      return withLength(n(expr), SqlTypeName.BINARY, expr.length());
+    }
+
+    /**
+     * Returns the type the given factory builds for a declared length, having checked that it holds
+     * it. A factory caps a width at its type system's maximum without saying so, and this
+     * conversion takes whatever factory it is handed, so a factory whose limits are not Substrait's
+     * would otherwise return a type narrower than the plan declares.
+     *
+     * @param nullable whether the type is nullable
+     * @param typeName the Calcite type name to build
+     * @param length the declared length
+     * @return the built type
+     * @throws IllegalArgumentException if the factory built a type of another length
+     */
+    private RelDataType withLength(boolean nullable, SqlTypeName typeName, int length) {
+      RelDataType type = t(nullable, typeName, length);
+      if (type.getPrecision() != length) {
+        throw new IllegalArgumentException(
+            String.format(
+                "The type factory cannot hold %s(%d), which it narrowed to %s; its type system"
+                    + " allows up to %d",
+                typeName, length, type, typeFactory.getTypeSystem().getMaxPrecision(typeName)));
+      }
+      return type;
     }
 
     @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -433,8 +433,18 @@ public class TypeConverter {
 
     @Override
     public RelDataType visit(Type.Decimal expr) {
+      // Before the factory, for the reason the lengths are: -1 is Calcite's unspecified precision,
+      // so a negative one is answered with an unparameterised DECIMAL whose precision reads back as
+      // the type system's maximum. A zero or negative scale Calcite reports itself.
+      if (expr.precision() < 0) {
+        throw new IllegalArgumentException(
+            String.format(
+                "A decimal cannot declare a negative precision, and this one is %d",
+                expr.precision()));
+      }
       SubstraitTypeSystem.requireSupportedPrecision(
           typeFactory.getTypeSystem(), SqlTypeName.DECIMAL, "decimal", expr.precision());
+      SubstraitTypeSystem.requireSupportedScale(typeFactory.getTypeSystem(), expr.scale());
       return t(n(expr), SqlTypeName.DECIMAL, expr.precision(), expr.scale());
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -395,13 +395,27 @@ public class TypeConverter {
      * conversion takes whatever factory it is handed, so a factory whose limits are not Substrait's
      * would otherwise return a type narrower than the plan declares.
      *
+     * <p>A negative length is refused before the factory is asked, because asking tells us nothing:
+     * with assertions off the factory stores the negative and reports it back, so the width below
+     * certifies itself, and with them on Calcite raises a bare {@code AssertionError} in place of
+     * this message. A length of -1 is Calcite's unspecified precision besides, so the factory
+     * answers with an unparameterised type whose precision equals what was asked for. A zero length
+     * is left to the factory: the spec puts a fixedchar's width at 1 or more, but Calcite types the
+     * empty character literal as a {@code CHAR(0)}, so plans carrying one exist.
+     *
      * @param nullable whether the type is nullable
      * @param typeName the Calcite type name to build
      * @param length the declared length
      * @return the built type
-     * @throws IllegalArgumentException if the factory built a type of another length
+     * @throws IllegalArgumentException if the length is negative, or the factory built a type of
+     *     another length
      */
     private RelDataType withLength(boolean nullable, SqlTypeName typeName, int length) {
+      if (length < 0) {
+        throw new IllegalArgumentException(
+            String.format(
+                "A %s cannot declare a negative length, and this one is %d", typeName, length));
+      }
       RelDataType type = t(nullable, typeName, length);
       if (type.getPrecision() != length) {
         throw new IllegalArgumentException(

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -226,6 +226,8 @@ public class TypeConverter {
    * @return Calcite relational type.
    * @throws UnsupportedOperationException if the expression contains unsupported precision or
    *     user-defined types cannot be mapped.
+   * @throws IllegalArgumentException if a declared length or precision is negative, or the given
+   *     factory cannot hold it.
    */
   public RelDataType toCalcite(
       RelDataTypeFactory relDataTypeFactory, TypeExpression typeExpression) {
@@ -242,6 +244,8 @@ public class TypeConverter {
    * @return Calcite relational type.
    * @throws UnsupportedOperationException if the expression contains unsupported precision or
    *     user-defined types cannot be mapped.
+   * @throws IllegalArgumentException if a declared length or precision is negative, or the given
+   *     factory cannot hold it.
    */
   public RelDataType toCalcite(
       RelDataTypeFactory relDataTypeFactory,
@@ -429,6 +433,8 @@ public class TypeConverter {
 
     @Override
     public RelDataType visit(Type.Decimal expr) {
+      SubstraitTypeSystem.requireSupportedPrecision(
+          typeFactory.getTypeSystem(), SqlTypeName.DECIMAL, "decimal", expr.precision());
       return t(n(expr), SqlTypeName.DECIMAL, expr.precision(), expr.scale());
     }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -444,7 +444,15 @@ public class TypeConverter {
       }
       SubstraitTypeSystem.requireSupportedPrecision(
           typeFactory.getTypeSystem(), SqlTypeName.DECIMAL, "decimal", expr.precision());
-      SubstraitTypeSystem.requireSupportedScale(typeFactory.getTypeSystem(), expr.scale());
+      // The spec puts a decimal's scale in [0..P]. No factory reports a scale above the precision:
+      // Calcite builds the type as asked, and its own maximum cannot catch it either, since both
+      // type systems here set maxScale equal to maxPrecision.
+      if (expr.scale() > expr.precision()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "A decimal cannot declare a scale of %d above its precision of %d",
+                expr.scale(), expr.precision()));
+      }
       return t(n(expr), SqlTypeName.DECIMAL, expr.precision(), expr.scale());
     }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -15,6 +15,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class CalciteTypeTest extends CalciteObjs {
@@ -218,6 +219,42 @@ class CalciteTypeTest extends CalciteObjs {
     assertEquals(
         TypeCreator.NULLABLE.fixedChar(1),
         TypeConverter.DEFAULT.toSubstrait(javaTypeFactory.createJavaType(Character.class)));
+  }
+
+  /**
+   * A width above Calcite's default 65536 cap, for each type whose length crosses the Substrait
+   * boundary. The expected precision is asserted directly rather than through {@link #testType},
+   * whose expectation is built with the same type factory and would be narrowed alongside the value
+   * under test.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    "CHAR, 65537",
+    "CHAR, 2147483647",
+    "VARCHAR, 65537",
+    "VARCHAR, 2147483647",
+    "BINARY, 65537",
+    "BINARY, 2147483647"
+  })
+  void wideLengthCarryingTypesKeepTheirLength(SqlTypeName typeName, int length) {
+    TypeExpression substrait;
+    switch (typeName) {
+      case CHAR:
+        substrait = TypeCreator.REQUIRED.fixedChar(length);
+        break;
+      case VARCHAR:
+        substrait = TypeCreator.REQUIRED.varChar(length);
+        break;
+      default:
+        substrait = TypeCreator.REQUIRED.fixedBinary(length);
+        break;
+    }
+
+    RelDataType calcite = TypeConverter.DEFAULT.toCalcite(type, substrait, null);
+
+    assertEquals(typeName, calcite.getSqlTypeName());
+    assertEquals(length, calcite.getPrecision());
+    assertEquals(substrait, TypeConverter.DEFAULT.toSubstrait(calcite));
   }
 
   @ParameterizedTest

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -245,9 +245,11 @@ class CalciteTypeTest extends CalciteObjs {
       case VARCHAR:
         substrait = TypeCreator.REQUIRED.varChar(length);
         break;
-      default:
+      case BINARY:
         substrait = TypeCreator.REQUIRED.fixedBinary(length);
         break;
+      default:
+        throw new IllegalArgumentException("no Substrait type mapped for " + typeName);
     }
 
     RelDataType calcite = TypeConverter.DEFAULT.toCalcite(type, substrait, null);

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -1,6 +1,7 @@
 package io.substrait.isthmus;
 
 import static io.substrait.isthmus.SubstraitTypeSystem.TYPE_FACTORY;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -101,6 +102,46 @@ class SubstraitTypeSystemTest {
         TypeConverter.DEFAULT
             .toCalcite(TYPE_FACTORY, TypeCreator.REQUIRED.varChar(100_000), null)
             .getPrecision());
+  }
+
+  /**
+   * Asking the factory first cannot tell a negative width from a width it holds: with assertions
+   * off it stores the negative and reports it back, and -1 is its unspecified precision besides, so
+   * the answer equals what was asked for either way.
+   */
+  @Test
+  void aNegativeLengthIsRefusedBeforeTheFactoryIsAsked() {
+    assertAll(
+        () -> {
+          IllegalArgumentException e =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () ->
+                      TypeConverter.DEFAULT.toCalcite(
+                          TYPE_FACTORY, TypeCreator.REQUIRED.varChar(-5), null));
+          assertTrue(
+              e.getMessage().contains("negative length, and this one is -5"), e.getMessage());
+        },
+        () -> {
+          IllegalArgumentException e =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () ->
+                      TypeConverter.DEFAULT.toCalcite(
+                          TYPE_FACTORY, TypeCreator.REQUIRED.fixedChar(-1), null));
+          assertTrue(
+              e.getMessage().contains("negative length, and this one is -1"), e.getMessage());
+        },
+        () -> {
+          IllegalArgumentException e =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () ->
+                      TypeConverter.DEFAULT.toCalcite(
+                          TYPE_FACTORY, TypeCreator.REQUIRED.fixedBinary(-5), null));
+          assertTrue(
+              e.getMessage().contains("negative length, and this one is -5"), e.getMessage());
+        });
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -2,6 +2,8 @@ package io.substrait.isthmus;
 
 import static io.substrait.isthmus.SubstraitTypeSystem.TYPE_FACTORY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
 import io.substrait.plan.Plan;
@@ -9,7 +11,9 @@ import io.substrait.type.TypeCreator;
 import java.util.List;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +80,30 @@ class SubstraitTypeSystemTest {
     assertEquals(100_000, TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR, 100_000).getPrecision());
     assertEquals(100_000, TYPE_FACTORY.createSqlType(SqlTypeName.CHAR, 100_000).getPrecision());
     assertEquals(100_000, TYPE_FACTORY.createSqlType(SqlTypeName.BINARY, 100_000).getPrecision());
+  }
+
+  /**
+   * The conversion takes whatever type factory it is handed, and one built on Calcite's default
+   * type system cannot hold these widths. Narrowing them is what this fix is about, so a factory
+   * that would narrow is reported rather than followed.
+   */
+  @Test
+  void aFactoryThatCannotHoldTheDeclaredLengthIsReported() {
+    RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                TypeConverter.DEFAULT.toCalcite(
+                    defaultFactory, TypeCreator.REQUIRED.varChar(100_000), null));
+    assertTrue(e.getMessage().contains("65536"), e.getMessage());
+
+    assertEquals(
+        100_000,
+        TypeConverter.DEFAULT
+            .toCalcite(TYPE_FACTORY, TypeCreator.REQUIRED.varChar(100_000), null)
+            .getPrecision());
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -14,6 +14,7 @@ import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
@@ -177,6 +178,37 @@ class SubstraitTypeSystemTest {
     assertEquals(19, defaultMaxScale);
     assertEquals(38, typeSystem.getMaxPrecision(SqlTypeName.DECIMAL));
     assertEquals(38, typeSystem.getMaxScale(SqlTypeName.DECIMAL));
+  }
+
+  /**
+   * A type system whose DECIMAL maximum is above the spec's 38 would let a wider decimal through
+   * the factory, and {@code toSubstrait} refuses it on the way back -- so the type would convert in
+   * with no way out. The bound is the spec's rather than the factory's for that reason.
+   */
+  @Test
+  void aDecimalPrecisionAboveTheSpecsCeilingIsRefused() {
+    RelDataTypeFactory wideFactory =
+        new SqlTypeFactoryImpl(
+            new RelDataTypeSystemImpl() {
+              @Override
+              public int getMaxPrecision(SqlTypeName typeName) {
+                return typeName == SqlTypeName.DECIMAL ? 76 : super.getMaxPrecision(typeName);
+              }
+
+              @Override
+              public int getMaxScale(SqlTypeName typeName) {
+                return typeName == SqlTypeName.DECIMAL ? 76 : super.getMaxScale(typeName);
+              }
+            });
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                TypeConverter.DEFAULT.toCalcite(
+                    wideFactory, TypeCreator.REQUIRED.decimal(45, 2), null));
+
+    assertTrue(e.getMessage().contains("above the 38 the spec allows"), e.getMessage());
   }
 
   /**

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -185,6 +185,44 @@ class SubstraitTypeSystemTest {
    * the default came out of the conversion as a {@code varchar<65536>}.
    */
   /**
+   * The same two ends as a length, for the same reasons: -1 is Calcite's unspecified precision, so
+   * the factory answers with an unparameterised DECIMAL whose precision reads back as the type
+   * system's maximum, and a scale past the maximum is narrowed rather than reported. Calcite
+   * reports a zero or negative scale and a zero precision itself.
+   */
+  @Test
+  void aDecimalParameterOutsideWhatTheFactoryHoldsIsRefused() {
+    RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+
+    assertAll(
+        () -> {
+          IllegalArgumentException e =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () ->
+                      TypeConverter.DEFAULT.toCalcite(
+                          TYPE_FACTORY, TypeCreator.REQUIRED.decimal(-1, 0), null));
+          assertTrue(
+              e.getMessage().contains("negative precision, and this one is -1"), e.getMessage());
+        },
+        () -> {
+          IllegalArgumentException e =
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () ->
+                      TypeConverter.DEFAULT.toCalcite(
+                          defaultFactory, TypeCreator.REQUIRED.decimal(19, 25), null));
+          assertTrue(e.getMessage().contains("max scale"), e.getMessage());
+        },
+        () ->
+            assertEquals(
+                25,
+                TypeConverter.DEFAULT
+                    .toCalcite(TYPE_FACTORY, TypeCreator.REQUIRED.decimal(19, 25), null)
+                    .getScale()));
+  }
+
+  /**
    * The raised maximum is also Calcite's overflow threshold for concatenation, in {@code
    * ReturnTypes.DYADIC_STRING_SUM_PRECISION}: a sum of widths past it falls back to an
    * unparameterised type. So two columns nowhere near the old cap decide the result type between

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -185,6 +185,25 @@ class SubstraitTypeSystemTest {
    * the default came out of the conversion as a {@code varchar<65536>}.
    */
   /**
+   * The raised maximum is also Calcite's overflow threshold for concatenation, in {@code
+   * ReturnTypes.DYADIC_STRING_SUM_PRECISION}: a sum of widths past it falls back to an
+   * unparameterised type. So two columns nowhere near the old cap decide the result type between
+   * them, and the conversion emitted a {@code string} for them before.
+   */
+  @Test
+  void concatenatingTwoVarcharsKeepsTheSumOfTheirWidths() throws Exception {
+    CalciteCatalogReader catalog =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "CREATE TABLE t (a VARCHAR(40000), b VARCHAR(40000))");
+
+    Plan plan = new SqlToSubstrait().convert("SELECT a || b FROM t", catalog);
+
+    assertEquals(
+        List.of(TypeCreator.NULLABLE.varChar(80000)),
+        plan.getRoots().get(0).getInput().getRecordType().fields());
+  }
+
+  /**
    * A decimal loses its precision to a foreign factory the same silent way a length does: Calcite's
    * default type system caps it at 19, and the narrowed type reads back as one the plan never
    * declared.

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -3,6 +3,11 @@ package io.substrait.isthmus;
 import static io.substrait.isthmus.SubstraitTypeSystem.TYPE_FACTORY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import io.substrait.plan.Plan;
+import io.substrait.type.TypeCreator;
+import java.util.List;
+import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -90,5 +95,23 @@ class SubstraitTypeSystemTest {
     assertEquals(19, defaultMaxScale);
     assertEquals(38, typeSystem.getMaxPrecision(SqlTypeName.DECIMAL));
     assertEquals(38, typeSystem.getMaxScale(SqlTypeName.DECIMAL));
+  }
+
+  /**
+   * The cap reaches the conversion from SQL as well. Calcite narrows a declared width to its
+   * maximum silently rather than reporting that it cannot hold it, so before this a cast wider than
+   * the default came out of the conversion as a {@code varchar<65536>}.
+   */
+  @Test
+  void aWideVarcharDeclaredInSqlKeepsItsLength() throws Exception {
+    CalciteCatalogReader catalog =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(
+            "CREATE TABLE t (a VARCHAR(10))");
+
+    Plan plan = new SqlToSubstrait().convert("SELECT CAST(a AS VARCHAR(100000)) FROM t", catalog);
+
+    assertEquals(
+        List.of(TypeCreator.NULLABLE.varChar(100000)),
+        plan.getRoots().get(0).getInput().getRecordType().fields());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -180,20 +180,15 @@ class SubstraitTypeSystemTest {
   }
 
   /**
-   * The cap reaches the conversion from SQL as well. Calcite narrows a declared width to its
-   * maximum silently rather than reporting that it cannot hold it, so before this a cast wider than
-   * the default came out of the conversion as a {@code varchar<65536>}.
-   */
-  /**
-   * The same two ends as a length, for the same reasons: -1 is Calcite's unspecified precision, so
-   * the factory answers with an unparameterised DECIMAL whose precision reads back as the type
-   * system's maximum, and a scale past the maximum is narrowed rather than reported. Calcite
-   * reports a zero or negative scale and a zero precision itself.
+   * Two ends the factory does not report. A precision of -1 is Calcite's unspecified precision, so
+   * it answers with an unparameterised DECIMAL whose precision reads back as the type system's
+   * maximum. A scale above the precision is outside the spec's {@code 0 <= S <= P} and Calcite
+   * builds it anyway, where its own maximum would not catch it: both type systems here set {@code
+   * maxScale} equal to {@code maxPrecision}, so a scale within the precision is within that too.
+   * Calcite reports a zero or negative scale and a zero precision itself.
    */
   @Test
-  void aDecimalParameterOutsideWhatTheFactoryHoldsIsRefused() {
-    RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
-
+  void aDecimalParameterOutsideItsDeclaredBoundsIsRefused() {
     assertAll(
         () -> {
           IllegalArgumentException e =
@@ -211,14 +206,14 @@ class SubstraitTypeSystemTest {
                   IllegalArgumentException.class,
                   () ->
                       TypeConverter.DEFAULT.toCalcite(
-                          defaultFactory, TypeCreator.REQUIRED.decimal(19, 25), null));
-          assertTrue(e.getMessage().contains("max scale"), e.getMessage());
+                          TYPE_FACTORY, TypeCreator.REQUIRED.decimal(19, 25), null));
+          assertTrue(e.getMessage().contains("scale of 25 above its precision"), e.getMessage());
         },
         () ->
             assertEquals(
-                25,
+                19,
                 TypeConverter.DEFAULT
-                    .toCalcite(TYPE_FACTORY, TypeCreator.REQUIRED.decimal(19, 25), null)
+                    .toCalcite(TYPE_FACTORY, TypeCreator.REQUIRED.decimal(19, 19), null)
                     .getScale()));
   }
 
@@ -265,6 +260,11 @@ class SubstraitTypeSystemTest {
             .getPrecision());
   }
 
+  /**
+   * The cap reaches the conversion from SQL as well. Calcite narrows a declared width to its
+   * maximum silently rather than reporting that it cannot hold it, so before this a cast wider than
+   * the default came out of the conversion as a {@code varchar<65536>}.
+   */
   @Test
   void aWideVarcharDeclaredInSqlKeepsItsLength() throws Exception {
     CalciteCatalogReader catalog =

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -95,7 +95,7 @@ class SubstraitTypeSystemTest {
             () ->
                 TypeConverter.DEFAULT.toCalcite(
                     defaultFactory, TypeCreator.REQUIRED.varChar(100_000), null));
-    assertTrue(e.getMessage().contains("65536"), e.getMessage());
+    assertTrue(e.getMessage().contains("allows up to 65536"), e.getMessage());
 
     assertEquals(
         100_000,
@@ -184,6 +184,30 @@ class SubstraitTypeSystemTest {
    * maximum silently rather than reporting that it cannot hold it, so before this a cast wider than
    * the default came out of the conversion as a {@code varchar<65536>}.
    */
+  /**
+   * A decimal loses its precision to a foreign factory the same silent way a length does: Calcite's
+   * default type system caps it at 19, and the narrowed type reads back as one the plan never
+   * declared.
+   */
+  @Test
+  void aFactoryThatCannotHoldTheDeclaredPrecisionIsReported() {
+    RelDataTypeFactory defaultFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                TypeConverter.DEFAULT.toCalcite(
+                    defaultFactory, TypeCreator.REQUIRED.decimal(38, 10), null));
+    assertTrue(e.getMessage().contains("is set to 19"), e.getMessage());
+
+    assertEquals(
+        38,
+        TypeConverter.DEFAULT
+            .toCalcite(TYPE_FACTORY, TypeCreator.REQUIRED.decimal(38, 10), null)
+            .getPrecision());
+  }
+
   @Test
   void aWideVarcharDeclaredInSqlKeepsItsLength() throws Exception {
     CalciteCatalogReader catalog =

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -56,12 +56,9 @@ class SubstraitTypeSystemTest {
     assertEquals(Integer.MAX_VALUE, typeSystem.getMaxPrecision(SqlTypeName.VARCHAR));
     assertEquals(Integer.MAX_VALUE, typeSystem.getMaxPrecision(SqlTypeName.CHAR));
     assertEquals(Integer.MAX_VALUE, typeSystem.getMaxPrecision(SqlTypeName.BINARY));
-  }
-
-  /** Substrait's {@code binary} carries no length, so VARBINARY has none to lose. */
-  @Test
-  void varbinaryKeepsTheCalciteDefault() {
-    assertEquals(65536, typeSystem.getMaxPrecision(SqlTypeName.VARBINARY));
+    // Substrait's binary carries no length of its own, but Calcite unifies a ragged binary union
+    // through this type, so a cap here caps the union.
+    assertEquals(Integer.MAX_VALUE, typeSystem.getMaxPrecision(SqlTypeName.VARBINARY));
   }
 
   /**
@@ -104,6 +101,22 @@ class SubstraitTypeSystemTest {
         TypeConverter.DEFAULT
             .toCalcite(TYPE_FACTORY, TypeCreator.REQUIRED.varChar(100_000), null)
             .getPrecision());
+  }
+
+  /**
+   * A union of fixed-width binaries of different widths is unified as a VARBINARY, so leaving that
+   * type at Calcite's default would reimpose the cap the wide types are raised past -- on a type
+   * wider than one of the union's own inputs.
+   */
+  @Test
+  void aRaggedBinaryUnionKeepsTheWidestWidth() {
+    RelDataType wide = TYPE_FACTORY.createSqlType(SqlTypeName.BINARY, 100_000);
+    RelDataType narrow = TYPE_FACTORY.createSqlType(SqlTypeName.BINARY, 5);
+
+    RelDataType unified = TYPE_FACTORY.leastRestrictive(List.of(wide, narrow));
+
+    assertEquals(SqlTypeName.VARBINARY, unified.getSqlTypeName());
+    assertEquals(100_000, unified.getPrecision());
   }
 
   @Test

--- a/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/SubstraitTypeSystemTest.java
@@ -43,6 +43,37 @@ class SubstraitTypeSystemTest {
   }
 
   @Test
+  void lengthCarryingTypesMaxPrecisionIsSubstraitsOwnLimit() {
+    assertEquals(Integer.MAX_VALUE, typeSystem.getMaxPrecision(SqlTypeName.VARCHAR));
+    assertEquals(Integer.MAX_VALUE, typeSystem.getMaxPrecision(SqlTypeName.CHAR));
+    assertEquals(Integer.MAX_VALUE, typeSystem.getMaxPrecision(SqlTypeName.BINARY));
+  }
+
+  /** Substrait's {@code binary} carries no length, so VARBINARY has none to lose. */
+  @Test
+  void varbinaryKeepsTheCalciteDefault() {
+    assertEquals(65536, typeSystem.getMaxPrecision(SqlTypeName.VARBINARY));
+  }
+
+  /**
+   * Calcite's default caps a character type at 65536, which is narrower than the {@code int} length
+   * Substrait declares, so a wider converted type would be silently narrowed by the type factory.
+   */
+  @Test
+  void lengthCarryingTypesMaxPrecisionDiffersFromDefaultTypeSystem() {
+    assertEquals(65536, RelDataTypeSystem.DEFAULT.getMaxPrecision(SqlTypeName.VARCHAR));
+    assertEquals(65536, RelDataTypeSystem.DEFAULT.getMaxPrecision(SqlTypeName.CHAR));
+    assertEquals(65536, RelDataTypeSystem.DEFAULT.getMaxPrecision(SqlTypeName.BINARY));
+  }
+
+  @Test
+  void canCreateCharacterTypesWiderThanTheCalciteDefault() {
+    assertEquals(100_000, TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR, 100_000).getPrecision());
+    assertEquals(100_000, TYPE_FACTORY.createSqlType(SqlTypeName.CHAR, 100_000).getPrecision());
+    assertEquals(100_000, TYPE_FACTORY.createSqlType(SqlTypeName.BINARY, 100_000).getPrecision());
+  }
+
+  @Test
   void canCreateDecimalWithMaxPrecision() {
     RelDataType decimalType = TYPE_FACTORY.createSqlType(SqlTypeName.DECIMAL, 38, 10);
     assertEquals(38, decimalType.getPrecision());


### PR DESCRIPTION
`SubstraitTypeSystem` overrides `getMaxPrecision` for the temporal types and `DECIMAL`; `CHAR`, `VARCHAR` and `BINARY` fell through to `RelDataTypeSystemImpl`, whose default caps them at 65536. The type factory then narrowed anything wider without raising an error, so a plan declaring `varchar<2147483647>` came back as `VARCHAR(65536)` and a consumer building a Calcite tree from it had no way to notice. The boundary is exact: 65536 round-trips, 65537 does not.

The cap reaches the conversion from SQL too, which the issue does not mention: Calcite narrows a declared width there the same silent way, so `SELECT CAST(a AS VARCHAR(100000))` came out of the conversion as a `varchar<65536>`. It now comes out as `varchar<100000>`. What SQL is accepted does not change -- Calcite never rejected the wider declaration, it just did not keep it.

Those three are the types whose length crosses the boundary — holding `fixedchar`, `varchar` and `fixedbinary` — and Substrait declares each length as a 32-bit integer, so they now report `Integer.MAX_VALUE`. `VARBINARY` is raised with them for a different reason: Substrait's `binary` carries no length of its own, but Calcite unifies a union of fixed-width binaries of different widths into a `VARBINARY` of the widest, so leaving it at the default reimposed the cap one step later — `leastRestrictive(BINARY(100000), BINARY(5))` returned `VARBINARY(65536)`, narrower than one of its own inputs. That shape was unreachable before this change, since no `BINARY` wider than 65536 could exist. Raising it opens no new failure at the extreme: a `VARBINARY` is not padded, so `cast(x'01' AS VARBINARY(2147483647))` projects fine, where the fixed-width `BINARY(2147483647)` runs out of memory exactly as `CHAR` does. The issue was filed for the character types; `fixedbinary` turned out to have the same defect at the same boundary.

One consequence, and where the ceiling belongs. `CHAR` and `BINARY` are fixed-width, so Calcite pads a literal cast to them out to the declared length, and the padding is now allowed to reach the declared width. At the extreme, `RelBuilder.project(cast('a' AS CHAR(2147483647)))` throws `OutOfMemoryError: Required length exceeds implementation limit`, where the old cap silently made it `CHAR(65536)` and it converted; `CHAR(100000)` is fine, and the varying types are unaffected at any width. No literal need appear in the plan for this either: `RexBuilder.zeroValue` allocates `new byte[precision]` for a `BINARY`, so `makeZeroLiteral(BINARY(2147483647))` throws the same way and a planner rule reaches it from a column type alone, where the old cap made it a 65536-byte array. A `VARBINARY`'s zero value is `ByteString.EMPTY`, so raising that type costs nothing here. `Integer.MAX_VALUE` stays here because it is the spec's own bound on a length -- a narrower one is a dialect's answer, which `SupportedType.maxLength()` already carries for `FIXED_CHAR`, `VARCHAR` and `FIXED_BINARY`, and reading it is #1124. A cap on this type system would not bound all of it in any case: `UserTypeMapper.toSubstrait` returns a Substrait type without going through the type factory at all. The padding isthmus does itself, on the `LogicalValues` path where Calcite does none, is bounded in #1171.

One more thing the raise changes, and it reaches plans carrying no wide type at all: `getMaxPrecision(VARCHAR)` is Calcite's overflow threshold for concatenation as well, in `ReturnTypes.DYADIC_STRING_SUM_PRECISION`. A sum of widths past it falls back to an unparameterised type, so `a || b` over two `varchar<40000>` columns converts to `varchar<80000>` where it converted to `string`; `CONCAT` does the same. Neither operand is anywhere near the old cap.

A `RelDataTypeFactory` narrows a width past its own maximum without saying so, and this conversion takes whatever factory it is handed, so raising the maximum fixes the narrowing only for the factory isthmus builds. A declared length the factory cannot hold is now reported instead of returned quietly, and a negative one is refused before the factory is asked at all. Asking cannot tell the two apart: with assertions off — the normal production JVM — the factory stores the negative and reports it back, so `varChar(-5)` certified itself as `VARCHAR(-5)`, while under `-ea` Calcite raised a bare `AssertionError` in place of the message. A length of -1 is Calcite's unspecified precision besides, so `varChar(-1)` passed and became a Substrait `string` where `fixedChar(-1)` was reported against a bound its length is below. A zero length is left to the factory, for the reason #1171 leaves it alone: ordinary SQL produces a `CHAR(0)` today, and substrait-io/substrait#1199 has the floor open. A decimal went the same silent way and now reports too: `decimal<38,10>` through a factory on Calcite's default type system came back `DECIMAL(19,10)` and read back as a precision the plan never declared. Its two ends go with it, both found checking the guard's boundaries rather than in review: `decimal<-1,0>` converted to a bare `DECIMAL` and read back as the maximum through any factory, `-1` being Calcite's unspecified precision here as well, and a scale above the precision was built as asked -- `decimal<19,25>` came out as `DECIMAL(19,25)`. That one is bounded by the spec rather than by the factory: scale sits in `0 <= S <= P`, and no maximum catches it, since both type systems here set `maxScale` equal to `maxPrecision`, so a scale within the precision is within the maximum too. Calcite reports a zero precision and a negative scale itself, so those are left to it. The precision's own ceiling is the spec's too, not the factory's: a type system allowing more than 38 -- a `getMaxPrecision(DECIMAL)` of 76 -- let `decimal<45,2>` convert to `DECIMAL(45,2)`, which `toSubstrait` then refused with "unsupported decimal precision 45", so the type converted in with no way back. Both ends of that clause read one constant now.

The conversion test asserts the resulting precision directly rather than through `testType`, whose expected type is built with the same type factory and would be narrowed alongside the value under test.

Closes #1167.

BREAKING CHANGE: `TypeConverter.toCalcite` throws `IllegalArgumentException` where it previously returned a narrowed type — for a declared length the given type factory cannot hold, and for a negative length, which a factory running without assertions accepted as a type of that width. It also throws for a decimal precision the given factory cannot hold and for a negative one, where it returned a narrowed type, for a scale above the precision, which it built as asked, and for a precision above the 38 the spec allows, which only a type factory more permissive than the spec could reach. Converted output types change with the raised bound: `SELECT CAST(a AS VARCHAR(100000))` converts to `varchar<100000>` where it converted to `varchar<65536>`, `a || b` over two `varchar<40000>` columns converts to `varchar<80000>` where it converted to `string`, and the least restrictive type of `BINARY(100000)` and `BINARY(5)` is `VARBINARY(100000)` where it was `VARBINARY(65536)`.



