### PR TITLE
fix(isthmus): keep the schema a CTAS or a created view declares

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -788,7 +788,7 @@ public class SubstraitRelNodeConverter
 
     Rel viewDefinition = namedDdl.getViewDefinition().get();
     RelNode relNode = viewDefinition.accept(this, context);
-    return new CreateView(namedDdl.getNames(), relNode);
+    return new CreateView(namedDdl.getNames(), toRowType(namedDdl.getTableSchema()), relNode);
   }
 
   @Override
@@ -1010,6 +1010,16 @@ public class SubstraitRelNodeConverter
     return RexUtil.removeNullabilityCast(typeFactory, rexNode);
   }
 
+  /**
+   * Converts the schema a DDL relation declares into the row type that describes it.
+   *
+   * @param schema the declared schema, whose names are one per field at every level of the struct
+   * @return the row type of the object the statement creates
+   */
+  private RelDataType toRowType(NamedStruct schema) {
+    return typeConverter.toCalcite(typeFactory, schema.struct(), schema.names());
+  }
+
   private RelNode handleCreateTableAs(NamedWrite namedWrite, Context context) {
     if (namedWrite.getCreateMode() != AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS
         || namedWrite.getOutputMode() != AbstractWriteRel.OutputMode.NO_OUTPUT) {
@@ -1024,7 +1034,7 @@ public class SubstraitRelNodeConverter
 
     Rel input = namedWrite.getInput();
     RelNode relNode = input.accept(this, context);
-    return new CreateTable(namedWrite.getNames(), relNode);
+    return new CreateTable(namedWrite.getNames(), toRowType(namedWrite.getTableSchema()), relNode);
   }
 
   @Override

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -786,6 +786,12 @@ public class SubstraitRelNodeConverter
       throw new IllegalArgumentException("NamedDdl view definition must be set");
     }
 
+    if (!namedDdl.getTableDefaults().fields().isEmpty()) {
+      throw new UnsupportedOperationException(
+          "Default values on a NamedDdl are not supported: a Calcite CreateView has nowhere to put "
+              + "them, and the spec has table_defaults report a full list of them");
+    }
+
     Rel viewDefinition = namedDdl.getViewDefinition().get();
     RelNode relNode = viewDefinition.accept(this, context);
     return new CreateView(namedDdl.getNames(), toRowType(namedDdl.getTableSchema()), relNode);

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelVisitor.java
@@ -889,11 +889,6 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
         .collect(Collectors.toList());
   }
 
-  private NamedStruct getSchema(final RelNode queryRelRoot) {
-    final RelDataType rowType = queryRelRoot.getRowType();
-    return typeConverter.toNamedStruct(rowType);
-  }
-
   /**
    * Handles Calcite {@link CreateTable} as Substrait CTAS. (Create Table As Select)
    *
@@ -903,7 +898,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
   public Rel handleCreateTable(CreateTable createTable) {
     RelNode input = createTable.getInput();
     Rel inputRel = apply(input);
-    NamedStruct schema = getSchema(input);
+    NamedStruct schema = typeConverter.toNamedStruct(createTable.getTableSchema());
     return NamedWrite.builder()
         .input(inputRel)
         .tableSchema(schema)
@@ -928,7 +923,7 @@ public class SubstraitRelVisitor extends RelNodeVisitor<Rel, RuntimeException> {
 
     return NamedDdl.builder()
         .viewDefinition(inputRel)
-        .tableSchema(getSchema(input))
+        .tableSchema(typeConverter.toNamedStruct(createView.getViewSchema()))
         .tableDefaults(defaults)
         .operation(AbstractDdlRel.DdlOp.CREATE)
         .object(AbstractDdlRel.DdlObject.VIEW)

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
@@ -22,7 +22,7 @@ public class CreateTable extends SingleRel {
       RelNode input) {
     super(cluster, traitSet, input);
     this.tableName = tableName;
-    this.tableSchema = tableSchema;
+    this.tableSchema = DdlSchemas.requireFilledBy(tableSchema, input, "table");
   }
 
   /**
@@ -48,6 +48,17 @@ public class CreateTable extends SingleRel {
   }
 
   /**
+   * Returns the schema of the table this node creates, which is what it produces: the input fills
+   * it, and its own columns are the ones the statement declares.
+   *
+   * @return the schema of the table this node creates
+   */
+  @Override
+  protected RelDataType deriveRowType() {
+    return tableSchema;
+  }
+
+  /**
    * Explains the node terms for plan output.
    *
    * @param pw plan writer
@@ -57,7 +68,7 @@ public class CreateTable extends SingleRel {
   public RelWriter explainTerms(RelWriter pw) {
     return super.explainTerms(pw)
         .item("tableName", getTableName())
-        .item("tableSchema", getTableSchema());
+        .item("tableSchema", getTableSchema().getFullTypeString());
   }
 
   /**
@@ -87,8 +98,9 @@ public class CreateTable extends SingleRel {
   }
 
   /**
-   * Returns the schema of the table to create. A CTAS declares it, and it is not the row type of
-   * the input: the two hold the same columns, but the names are the ones the statement gives them.
+   * Returns the schema of the table to create: the one the statement declares where this node was
+   * built with it, and the row type of the input otherwise. A declared schema holds the same
+   * columns as the input, under the names -- and the types -- the statement gives them.
    *
    * @return the schema of the table this node creates
    */

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateTable.java
@@ -6,26 +6,45 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.type.RelDataType;
 
 /** Represents a CREATE TABLE DDL operation in Calcite's relational algebra. */
 public class CreateTable extends SingleRel {
 
   private final List<String> tableName;
+  private final RelDataType tableSchema;
 
   private CreateTable(
-      RelOptCluster cluster, RelTraitSet traitSet, List<String> tableName, RelNode input) {
+      RelOptCluster cluster,
+      RelTraitSet traitSet,
+      List<String> tableName,
+      RelDataType tableSchema,
+      RelNode input) {
     super(cluster, traitSet, input);
     this.tableName = tableName;
+    this.tableSchema = tableSchema;
+  }
+
+  /**
+   * CreateTable Constructor, taking the row type of the input as the schema of the table to create.
+   *
+   * @param tableName tablename components
+   * @param input RelNode input
+   */
+  public CreateTable(List<String> tableName, RelNode input) {
+    this(input.getCluster(), input.getTraitSet(), tableName, input.getRowType(), input);
   }
 
   /**
    * CreateTable Constructor.
    *
    * @param tableName tablename components
+   * @param tableSchema the schema of the table to create, which the input fills but need not name
+   *     the same way
    * @param input RelNode input
    */
-  public CreateTable(List<String> tableName, RelNode input) {
-    this(input.getCluster(), input.getTraitSet(), tableName, input);
+  public CreateTable(List<String> tableName, RelDataType tableSchema, RelNode input) {
+    this(input.getCluster(), input.getTraitSet(), tableName, tableSchema, input);
   }
 
   /**
@@ -36,7 +55,9 @@ public class CreateTable extends SingleRel {
    */
   @Override
   public RelWriter explainTerms(RelWriter pw) {
-    return super.explainTerms(pw).item("tableName", getTableName());
+    return super.explainTerms(pw)
+        .item("tableName", getTableName())
+        .item("tableSchema", getTableSchema());
   }
 
   /**
@@ -53,7 +74,7 @@ public class CreateTable extends SingleRel {
       throw new IllegalArgumentException(
           "CreateTable requires exactly one input, but got " + inputs.size());
     }
-    return new CreateTable(getCluster(), traitSet, tableName, inputs.get(0));
+    return new CreateTable(getCluster(), traitSet, tableName, tableSchema, inputs.get(0));
   }
 
   /**
@@ -63,5 +84,15 @@ public class CreateTable extends SingleRel {
    */
   public List<String> getTableName() {
     return tableName;
+  }
+
+  /**
+   * Returns the schema of the table to create. A CTAS declares it, and it is not the row type of
+   * the input: the two hold the same columns, but the names are the ones the statement gives them.
+   *
+   * @return the schema of the table this node creates
+   */
+  public RelDataType getTableSchema() {
+    return tableSchema;
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
@@ -21,7 +21,7 @@ public class CreateView extends SingleRel {
       RelNode input) {
     super(cluster, traitSet, input);
     this.viewName = viewName;
-    this.viewSchema = viewSchema;
+    this.viewSchema = DdlSchemas.requireFilledBy(viewSchema, input, "view");
   }
 
   /**
@@ -47,6 +47,17 @@ public class CreateView extends SingleRel {
   }
 
   /**
+   * Returns the schema of the view this node creates, which is what it produces: the input fills
+   * it, and its own columns are the ones the statement declares.
+   *
+   * @return the schema of the view this node creates
+   */
+  @Override
+  protected RelDataType deriveRowType() {
+    return viewSchema;
+  }
+
+  /**
    * Explains the node terms for plan output.
    *
    * @param pw plan writer
@@ -56,7 +67,7 @@ public class CreateView extends SingleRel {
   public RelWriter explainTerms(RelWriter pw) {
     return super.explainTerms(pw)
         .item("viewName", getViewName())
-        .item("viewSchema", getViewSchema());
+        .item("viewSchema", getViewSchema().getFullTypeString());
   }
 
   /**
@@ -86,9 +97,9 @@ public class CreateView extends SingleRel {
   }
 
   /**
-   * Returns the schema of the view to create. A view definition declares it, and it is not the row
-   * type of the definition: the two hold the same columns, but the names are the ones the statement
-   * gives them.
+   * Returns the schema of the view to create: the one the statement declares where this node was
+   * built with it, and the row type of the definition otherwise. A declared schema holds the same
+   * columns as the definition, under the names -- and the types -- the statement gives them.
    *
    * @return the schema of the view this node creates
    */

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/CreateView.java
@@ -6,25 +6,44 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.SingleRel;
+import org.apache.calcite.rel.type.RelDataType;
 
 /** Represents a CREATE VIEW DDL operation in Calcite's relational algebra. */
 public class CreateView extends SingleRel {
   private final List<String> viewName;
+  private final RelDataType viewSchema;
 
   private CreateView(
-      RelOptCluster cluster, RelTraitSet traitSet, List<String> viewName, RelNode input) {
+      RelOptCluster cluster,
+      RelTraitSet traitSet,
+      List<String> viewName,
+      RelDataType viewSchema,
+      RelNode input) {
     super(cluster, traitSet, input);
     this.viewName = viewName;
+    this.viewSchema = viewSchema;
+  }
+
+  /**
+   * CreateView Constructor, taking the row type of the input as the schema of the view to create.
+   *
+   * @param viewName view name components
+   * @param input RelNode input
+   */
+  public CreateView(List<String> viewName, RelNode input) {
+    this(input.getCluster(), input.getTraitSet(), viewName, input.getRowType(), input);
   }
 
   /**
    * CreateView Constructor.
    *
    * @param viewName view name components
+   * @param viewSchema the schema of the view to create, which the definition fills but need not
+   *     name the same way
    * @param input RelNode input
    */
-  public CreateView(List<String> viewName, RelNode input) {
-    this(input.getCluster(), input.getTraitSet(), viewName, input);
+  public CreateView(List<String> viewName, RelDataType viewSchema, RelNode input) {
+    this(input.getCluster(), input.getTraitSet(), viewName, viewSchema, input);
   }
 
   /**
@@ -35,7 +54,9 @@ public class CreateView extends SingleRel {
    */
   @Override
   public RelWriter explainTerms(RelWriter pw) {
-    return super.explainTerms(pw).item("viewName", getViewName());
+    return super.explainTerms(pw)
+        .item("viewName", getViewName())
+        .item("viewSchema", getViewSchema());
   }
 
   /**
@@ -52,7 +73,7 @@ public class CreateView extends SingleRel {
       throw new IllegalArgumentException(
           "CreateView requires exactly one input, but got " + inputs.size());
     }
-    return new CreateView(getCluster(), traitSet, viewName, inputs.get(0));
+    return new CreateView(getCluster(), traitSet, viewName, viewSchema, inputs.get(0));
   }
 
   /**
@@ -62,5 +83,16 @@ public class CreateView extends SingleRel {
    */
   public List<String> getViewName() {
     return viewName;
+  }
+
+  /**
+   * Returns the schema of the view to create. A view definition declares it, and it is not the row
+   * type of the definition: the two hold the same columns, but the names are the ones the statement
+   * gives them.
+   *
+   * @return the schema of the view this node creates
+   */
+  public RelDataType getViewSchema() {
+    return viewSchema;
   }
 }

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSchemas.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSchemas.java
@@ -1,0 +1,53 @@
+package io.substrait.isthmus.calcite.rel;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+
+/** The schema checks the DDL relations share. */
+final class DdlSchemas {
+
+  private DdlSchemas() {}
+
+  /**
+   * Returns the given schema, having checked that the given input can fill it: a schema is a struct
+   * of columns, and its leaf fields are the ones the input produces. The names and the types are
+   * the statement's to declare -- a CTAS may name a column something the input does not and give it
+   * a type the input is cast to -- so only their number is checked here.
+   *
+   * @param schema the declared schema of the object to create
+   * @param input the relation filling it
+   * @param what the object being created, for the failure message
+   * @return the schema
+   * @throws IllegalArgumentException if the schema is not a struct or the two do not align
+   */
+  static RelDataType requireFilledBy(RelDataType schema, RelNode input, String what) {
+    if (!schema.isStruct()) {
+      throw new IllegalArgumentException(
+          "The schema of the " + what + " to create must be a struct, but got " + schema);
+    }
+    int declared = leafFieldCount(schema);
+    int produced = leafFieldCount(input.getRowType());
+    if (declared != produced) {
+      throw new IllegalArgumentException(
+          "The schema of the "
+              + what
+              + " to create has "
+              + declared
+              + " leaf fields, but the input filling it produces "
+              + produced);
+    }
+    return schema;
+  }
+
+  private static int leafFieldCount(RelDataType type) {
+    if (!type.isStruct()) {
+      return 1;
+    }
+    int count = 0;
+    for (RelDataTypeField field : type.getFieldList()) {
+      count += leafFieldCount(field.getType());
+    }
+    return count;
+  }
+}

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSqlToRelConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSqlToRelConverter.java
@@ -1,12 +1,20 @@
 package io.substrait.isthmus.calcite.rel;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.ddl.SqlColumnDeclaration;
 import org.apache.calcite.sql.ddl.SqlCreateTable;
 import org.apache.calcite.sql.ddl.SqlCreateView;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
@@ -91,7 +99,12 @@ public class DdlSqlToRelConverter extends SqlBasicVisitor<RelRoot> {
       throw new IllegalArgumentException("Only create table as select statements are supported");
     }
     final RelNode input = converter.convertQuery(sqlCreateTable.query, true, true).rel;
-    return RelRoot.of(new CreateTable(sqlCreateTable.name.names, input), sqlCreateTable.getKind());
+    final RelDataType schema = declaredSchema(sqlCreateTable.columnList, input);
+    return RelRoot.of(
+        schema == null
+            ? new CreateTable(sqlCreateTable.name.names, input)
+            : new CreateTable(sqlCreateTable.name.names, schema, input),
+        sqlCreateTable.getKind());
   }
 
   /**
@@ -103,6 +116,63 @@ public class DdlSqlToRelConverter extends SqlBasicVisitor<RelRoot> {
    */
   protected RelRoot handleCreateView(final SqlCreateView sqlCreateView) {
     final RelNode input = converter.convertQuery(sqlCreateView.query, true, true).rel;
-    return RelRoot.of(new CreateView(sqlCreateView.name.names, input), sqlCreateView.getKind());
+    final RelDataType schema = declaredSchema(sqlCreateView.columnList, input);
+    return RelRoot.of(
+        schema == null
+            ? new CreateView(sqlCreateView.name.names, input)
+            : new CreateView(sqlCreateView.name.names, schema, input),
+        sqlCreateView.getKind());
+  }
+
+  /**
+   * Returns the schema a {@code CREATE} statement declares for the object it creates, or null where
+   * it declares none and the query's own row type is the schema.
+   *
+   * <p>A column is named by the statement and takes the type the statement gives it; a column named
+   * without a type takes the one the query produces for it. Anything else in the list -- a
+   * constraint -- describes the table rather than its columns and is left to whatever creates it.
+   *
+   * @param columnList the column list of the statement, which may be null
+   * @param input the relation filling the object
+   * @return the declared schema, or null where the statement declares none
+   * @throws IllegalArgumentException if the statement declares more columns than the query produces
+   */
+  protected RelDataType declaredSchema(final SqlNodeList columnList, final RelNode input) {
+    if (columnList == null) {
+      return null;
+    }
+    final List<RelDataTypeField> produced = input.getRowType().getFieldList();
+    final List<String> names = new ArrayList<>();
+    final List<RelDataType> types = new ArrayList<>();
+    for (final SqlNode element : columnList) {
+      final SqlIdentifier name;
+      RelDataType type = null;
+      if (element instanceof SqlColumnDeclaration) {
+        final SqlColumnDeclaration column = (SqlColumnDeclaration) element;
+        name = column.name;
+        type =
+            converter
+                .getCluster()
+                .getTypeFactory()
+                .createTypeWithNullability(
+                    column.dataType.deriveType(converter.validator),
+                    column.strategy != ColumnStrategy.NOT_NULLABLE);
+      } else if (element instanceof SqlIdentifier) {
+        name = (SqlIdentifier) element;
+      } else {
+        continue;
+      }
+      if (names.size() >= produced.size()) {
+        throw new IllegalArgumentException(
+            "The statement declares more columns than the query produces: "
+                + name
+                + " has nothing to fill it");
+      }
+      types.add(type == null ? produced.get(names.size()).getType() : type);
+      names.add(name.getSimple());
+    }
+    return names.isEmpty()
+        ? null
+        : converter.getCluster().getTypeFactory().createStructType(types, names);
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
@@ -1,7 +1,20 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import io.substrait.relation.AbstractDdlRel;
+import io.substrait.relation.AbstractWriteRel;
+import io.substrait.relation.NamedDdl;
+import io.substrait.relation.NamedWrite;
+import io.substrait.relation.Project;
+import io.substrait.relation.Rel;
+import io.substrait.type.NamedStruct;
+import io.substrait.type.TypeCreator;
+import java.util.List;
 import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
@@ -25,5 +38,71 @@ class DdlRoundtripTest extends PlanTestBase {
   void testCreateView() throws Exception {
     String sql = "create view dst1 as select * from src1";
     assertFullRoundTrip(sql, catalogReader);
+  }
+
+  /**
+   * The names a CTAS declares are the ones the table gets, and they are not the names of the
+   * columns filling it: a projection names its own columns whatever Calcite derives, here $f2 and
+   * $f3.
+   */
+  @Test
+  void createTableKeepsTheSchemaItDeclares() {
+    NamedWrite ctas =
+        NamedWrite.builder()
+            .input(computedColumns())
+            .names(List.of("dst1"))
+            .tableSchema(declaredSchema())
+            .operation(AbstractWriteRel.WriteOp.CTAS)
+            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
+            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
+            .build();
+
+    RelNode calcite = new SubstraitToCalcite(converterProvider, catalogReader).convert(ctas);
+    Rel converted = SubstraitRelVisitor.convert(copied(calcite), converterProvider);
+
+    assertEquals(declaredSchema(), ((NamedWrite) converted).getTableSchema());
+  }
+
+  /** The same for a view: its definition fills the columns, the statement names them. */
+  @Test
+  void createViewKeepsTheSchemaItDeclares() {
+    NamedDdl createView =
+        NamedDdl.builder()
+            .viewDefinition(computedColumns())
+            .names(List.of("dst1"))
+            .tableSchema(declaredSchema())
+            .tableDefaults(ExpressionCreator.struct(false))
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .build();
+
+    RelNode calcite = new SubstraitToCalcite(converterProvider, catalogReader).convert(createView);
+    Rel converted = SubstraitRelVisitor.convert(copied(calcite), converterProvider);
+
+    assertEquals(declaredSchema(), ((NamedDdl) converted).getTableSchema());
+  }
+
+  /**
+   * Copies the node the way a planner rewriting its input does, so that the schema has to be
+   * carried rather than derived when the conversion reads it back.
+   */
+  private RelNode copied(RelNode node) {
+    return node.copy(node.getTraitSet(), node.getInputs());
+  }
+
+  private NamedStruct declaredSchema() {
+    return NamedStruct.of(List.of("total", "doubled"), TypeCreator.REQUIRED.struct(N.I32, N.I32));
+  }
+
+  private Rel computedColumns() {
+    Rel scan =
+        sb.namedScan(List.of("SRC1"), List.of("INTCOL", "CHARCOL"), List.of(N.I32, N.varChar(10)));
+    return Project.builder()
+        .input(scan)
+        .remap(Rel.Remap.offset(2, 2))
+        .addExpressions(
+            sb.add(sb.fieldReference(scan, 0), sb.i32(1)),
+            sb.add(sb.fieldReference(scan, 0), sb.i32(2)))
+        .build();
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
@@ -1,9 +1,12 @@
 package io.substrait.isthmus;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
+import io.substrait.isthmus.sql.SubstraitSqlToCalcite;
+import io.substrait.plan.Plan;
 import io.substrait.relation.AbstractDdlRel;
 import io.substrait.relation.AbstractWriteRel;
 import io.substrait.relation.NamedDdl;
@@ -14,7 +17,7 @@ import io.substrait.type.NamedStruct;
 import io.substrait.type.TypeCreator;
 import java.util.List;
 import org.apache.calcite.prepare.Prepare;
-import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.jupiter.api.Test;
 
@@ -41,9 +44,9 @@ class DdlRoundtripTest extends PlanTestBase {
   }
 
   /**
-   * The names a CTAS declares are the ones the table gets, and they are not the names of the
-   * columns filling it: a projection names its own columns whatever Calcite derives, here $f2 and
-   * $f3.
+   * The schema a CTAS declares is the one the table gets, and it is not the row type of the columns
+   * filling it: a projection names its own columns whatever Calcite derives, here $f2 and $f3, and
+   * the declared types here are ones the input does not produce either.
    */
   @Test
   void createTableKeepsTheSchemaItDeclares() {
@@ -57,13 +60,10 @@ class DdlRoundtripTest extends PlanTestBase {
             .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
             .build();
 
-    RelNode calcite = new SubstraitToCalcite(converterProvider, catalogReader).convert(ctas);
-    Rel converted = SubstraitRelVisitor.convert(copied(calcite), converterProvider);
-
-    assertEquals(declaredSchema(), ((NamedWrite) converted).getTableSchema());
+    assertFullRoundTrip(ctas);
   }
 
-  /** The same for a view: its definition fills the columns, the statement names them. */
+  /** The same for a view: its definition fills the columns, the statement declares them. */
   @Test
   void createViewKeepsTheSchemaItDeclares() {
     NamedDdl createView =
@@ -76,22 +76,105 @@ class DdlRoundtripTest extends PlanTestBase {
             .object(AbstractDdlRel.DdlObject.VIEW)
             .build();
 
-    RelNode calcite = new SubstraitToCalcite(converterProvider, catalogReader).convert(createView);
-    Rel converted = SubstraitRelVisitor.convert(copied(calcite), converterProvider);
+    // Not assertFullRoundTrip: converting a NamedDdl without a catalog collects the schema by
+    // walking the plan with RelCopyOnWriteVisitor, whose visit(NamedDdl) throws.
+    Rel converted =
+        SubstraitRelVisitor.convert(
+            new SubstraitToCalcite(converterProvider, catalogReader).convert(createView),
+            converterProvider);
 
     assertEquals(declaredSchema(), ((NamedDdl) converted).getTableSchema());
   }
 
   /**
-   * Copies the node the way a planner rewriting its input does, so that the schema has to be
-   * carried rather than derived when the conversion reads it back.
+   * A Calcite CreateView has nowhere to put the default values a DDL relation reports, and the spec
+   * has that field report a full list of them, so a plan carrying any is refused rather than
+   * converted into one that has lost them.
    */
-  private RelNode copied(RelNode node) {
-    return node.copy(node.getTraitSet(), node.getInputs());
+  @Test
+  void aViewWithDefaultValuesIsRefused() {
+    NamedDdl withDefaults =
+        NamedDdl.builder()
+            .viewDefinition(computedColumns())
+            .names(List.of("dst1"))
+            .tableSchema(declaredSchema())
+            .tableDefaults(
+                ExpressionCreator.struct(
+                    false, ExpressionCreator.i32(false, 0), ExpressionCreator.i32(false, 0)))
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .build();
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> new SubstraitToCalcite(converterProvider, catalogReader).convert(withDefaults));
+  }
+
+  @Test
+  void createTableTakesTheColumnsTheStatementNames() throws SqlParseException {
+    assertEquals(
+        List.of("TOTAL", "DOUBLED"),
+        schemaOf("create table dst1 (total, doubled) as select intcol + 1, intcol + 2 from src1")
+            .names());
+  }
+
+  @Test
+  void createTableTakesTheColumnTypesTheStatementDeclares() throws SqlParseException {
+    NamedStruct schema =
+        schemaOf(
+            "create table dst1 (total bigint, doubled bigint not null)"
+                + " as select intcol + 1, intcol + 2 from src1");
+
+    assertEquals(List.of("TOTAL", "DOUBLED"), schema.names());
+    assertEquals(TypeCreator.REQUIRED.struct(N.I64, R.I64), schema.struct());
+  }
+
+  @Test
+  void createViewTakesTheColumnsTheStatementNames() throws SqlParseException {
+    assertEquals(
+        List.of("TOTAL", "DOUBLED"),
+        schemaOf("create view dst1 (total, doubled) as select intcol + 1, intcol + 2 from src1")
+            .names());
+  }
+
+  @Test
+  void aStatementWithoutAColumnListKeepsTheNamesTheQueryProduces() throws SqlParseException {
+    assertEquals(
+        List.of("TOTAL"),
+        schemaOf("create table dst1 as select intcol + 1 as total from src1").names());
+  }
+
+  /**
+   * A DDL node produces the object it creates, not the query filling it, so the root over it is
+   * named by the declared schema. The two disagree here: the query names its columns EXPR$0 and
+   * EXPR$1.
+   */
+  @Test
+  void theRootOverACreateStatementIsNamedByTheDeclaredSchema() throws SqlParseException {
+    RelRoot root =
+        SubstraitSqlToCalcite.convertQueries(
+                "create table dst1 (total, doubled) as select intcol + 1, intcol + 2 from src1",
+                catalogReader,
+                converterProvider)
+            .get(0);
+
+    Plan.Root converted = SubstraitRelVisitor.convert(root, converterProvider);
+
+    assertEquals(List.of("TOTAL", "DOUBLED"), converted.getNames());
+  }
+
+  /** The schema of the object a single DDL statement creates, as Substrait records it. */
+  private NamedStruct schemaOf(String sql) throws SqlParseException {
+    RelRoot root =
+        SubstraitSqlToCalcite.convertQueries(sql, catalogReader, converterProvider).get(0);
+    Rel converted = SubstraitRelVisitor.convert(root.rel, converterProvider);
+    return converted instanceof NamedWrite
+        ? ((NamedWrite) converted).getTableSchema()
+        : ((NamedDdl) converted).getTableSchema();
   }
 
   private NamedStruct declaredSchema() {
-    return NamedStruct.of(List.of("total", "doubled"), TypeCreator.REQUIRED.struct(N.I32, N.I32));
+    return NamedStruct.of(List.of("total", "doubled"), TypeCreator.REQUIRED.struct(R.I64, N.I32));
   }
 
   private Rel computedColumns() {

--- a/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
@@ -6,12 +6,23 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.substrait.isthmus.PlanTestBase;
 import java.util.List;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.jupiter.api.Test;
 
-/** The DDL relations are single-input, and their {@code copy()} rejects any other input count. */
+/**
+ * The DDL relations are single-input, their {@code copy()} rejects any other input count, and the
+ * schema they declare is carried rather than derived.
+ */
 class DdlRelCopyTest extends PlanTestBase {
 
   private final RelNode input = builder.values(new String[] {"a"}, 1).build();
+  private final RelNode otherInput = builder.values(new String[] {"b"}, 2).build();
+
+  private RelDataType declaredSchema() {
+    return typeFactory.createStructType(
+        List.of(typeFactory.createSqlType(SqlTypeName.BIGINT)), List.of("declared"));
+  }
 
   @Test
   void createTableCopiesItsSingleInput() {
@@ -36,5 +47,48 @@ class DdlRelCopyTest extends PlanTestBase {
     assertThrows(
         IllegalArgumentException.class,
         () -> createView.copy(createView.getTraitSet(), List.of(input, input)));
+  }
+
+  /**
+   * A planner rewrites what fills the object, which is what {@code copy} is for. The schema the
+   * statement declared is not derived from that input, so rewriting it leaves the schema alone.
+   */
+  @Test
+  void aDeclaredSchemaSurvivesACopyOntoAnotherInput() {
+    CreateTable createTable = new CreateTable(List.of("FOO"), declaredSchema(), input);
+    CreateView createView = new CreateView(List.of("FOO"), declaredSchema(), input);
+
+    RelNode copiedTable = createTable.copy(createTable.getTraitSet(), List.of(otherInput));
+    RelNode copiedView = createView.copy(createView.getTraitSet(), List.of(otherInput));
+
+    assertEquals(otherInput, copiedTable.getInput(0));
+    assertEquals(declaredSchema(), ((CreateTable) copiedTable).getTableSchema());
+    assertEquals(otherInput, copiedView.getInput(0));
+    assertEquals(declaredSchema(), ((CreateView) copiedView).getViewSchema());
+  }
+
+  /**
+   * The declared schema names the object's columns and the input fills them, so it has to be a
+   * struct of as many leaf fields as the input produces. The names and the types are the
+   * statement's own -- a CTAS may declare both -- so neither is checked.
+   */
+  @Test
+  void aSchemaTheInputCannotFillIsRejected() {
+    RelDataType notAStruct = typeFactory.createSqlType(SqlTypeName.BIGINT);
+    RelDataType twoColumns =
+        typeFactory.createStructType(
+            List.of(
+                typeFactory.createSqlType(SqlTypeName.BIGINT),
+                typeFactory.createSqlType(SqlTypeName.BIGINT)),
+            List.of("one", "two"));
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateTable(List.of("FOO"), notAStruct, input));
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateTable(List.of("FOO"), twoColumns, input));
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateView(List.of("FOO"), notAStruct, input));
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateView(List.of("FOO"), twoColumns, input));
   }
 }


### PR DESCRIPTION
`CreateTable` and `CreateView` now carry the schema of the object they create: the conversion fills it from the relation's `tableSchema` on the way in and reads it back on the way out, where it used to rebuild it from the input's row type. A CTAS declaring `[total, doubled]` over a projection of two computed columns came back as `[$f2, $f3]`.

The SQL path declares one too. `create table dst1 (total, doubled) as select intcol + 1, intcol + 2 from src1` recorded `[EXPR$0, EXPR$1]`, and a column list may give types as well as names, so `DdlSqlToRelConverter` now reads it: a column named without a type takes the one the query produces, a column declared with one takes what it declares, and anything else in the list -- a constraint -- is left alone. A statement without a column list keeps the query's own row type, which is what it means there.

A DDL node's row type is now the schema of the object it creates rather than its input's. That is what `AbstractDdlRel.deriveRecordType()` reports on the Substrait side, so the two agree and the root over such a node is named by the declared schema instead of by the query filling it. What `RelRoot.names` should name over a DDL root is not settled by the spec -- substrait-io/substrait#1189 has that boundary open.

A schema the input cannot fill is rejected where the node is built: it has to be a struct, and its leaf fields have to be the ones the input produces. Names and types are the statement's own -- `create table t (a bigint) as select intcol from src1` is a legal CTAS -- so neither is compared. `WriteRel.table_schema` requires that alignment and `DdlRel` is silent about it; substrait-io/substrait#1190 asks for the same wording there.

Default values on a `NamedDdl` are refused rather than dropped, the way `visit(NamedUpdate)` refuses an emit mapping it cannot apply: a Calcite `CreateView` has nowhere to put them, and the spec has `table_defaults` report a full list of them.

The two-argument constructors keep taking the input's row type as the schema, which is what it means for a node the SQL path builds without a column list. The schema is carried through `copy()` and named in the explain terms, so rewriting what fills the object leaves its schema alone and two nodes that differ only in it do not share a digest.

Closes #1180
