### PR TITLE
fix(isthmus): refuse a created object's schema that names two columns the same

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSchemas.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSchemas.java
@@ -2,6 +2,7 @@ package io.substrait.isthmus.calcite.rel;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -45,24 +46,39 @@ final class DdlSchemas {
   }
 
   /**
-   * Checks that no two fields of a struct are named the same, at every level of it: Calcite reads a
-   * row type as a scope, and a repeated name there is one a reference cannot reach.
+   * Checks that no two fields of a struct are named the same, at every level of the schema: Calcite
+   * reads a row type as a scope, and a repeated name there is one a reference cannot reach. A
+   * struct reached through a collection is a level like any other -- that is the view the flattened
+   * name list a {@code NamedStruct} carries takes, and the one the conversion of a schema to a row
+   * type takes with it.
    *
    * @param type the type to check
    * @param what the object being created, for the failure message
    * @throws IllegalArgumentException if two fields of one struct share a name
    */
   private static void requireDistinctNames(RelDataType type, String what) {
-    if (!type.isStruct()) {
-      return;
-    }
-    List<String> names = type.getFieldNames();
-    if (new HashSet<>(names).size() != names.size()) {
-      throw new IllegalArgumentException(
-          "The schema of the " + what + " to create names two fields the same: " + names);
-    }
-    for (RelDataTypeField field : type.getFieldList()) {
-      requireDistinctNames(field.getType(), what);
+    switch (type.getSqlTypeName()) {
+      case ROW:
+      case STRUCTURED:
+        List<String> names = type.getFieldNames();
+        if (new HashSet<>(names).size() != names.size()) {
+          throw new IllegalArgumentException(
+              "The schema of the " + what + " to create names two fields the same: " + names);
+        }
+        for (RelDataTypeField field : type.getFieldList()) {
+          requireDistinctNames(field.getType(), what);
+        }
+        return;
+      case ARRAY:
+      case MULTISET:
+        requireDistinctNames(Objects.requireNonNull(type.getComponentType()), what);
+        return;
+      case MAP:
+        requireDistinctNames(Objects.requireNonNull(type.getKeyType()), what);
+        requireDistinctNames(Objects.requireNonNull(type.getValueType()), what);
+        return;
+      default:
+        return;
     }
   }
 

--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSchemas.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/rel/DdlSchemas.java
@@ -1,5 +1,7 @@
 package io.substrait.isthmus.calcite.rel;
 
+import java.util.HashSet;
+import java.util.List;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
@@ -11,9 +13,10 @@ final class DdlSchemas {
 
   /**
    * Returns the given schema, having checked that the given input can fill it: a schema is a struct
-   * of columns, and its leaf fields are the ones the input produces. The names and the types are
-   * the statement's to declare -- a CTAS may name a column something the input does not and give it
-   * a type the input is cast to -- so only their number is checked here.
+   * of distinctly named columns, and its leaf fields are the ones the input produces. Which names
+   * and which types is the statement's to declare -- a CTAS may name a column something the input
+   * does not and give it a type the input is cast to -- so beyond telling its columns apart, only
+   * their number is checked here.
    *
    * @param schema the declared schema of the object to create
    * @param input the relation filling it
@@ -37,7 +40,30 @@ final class DdlSchemas {
               + " leaf fields, but the input filling it produces "
               + produced);
     }
+    requireDistinctNames(schema, what);
     return schema;
+  }
+
+  /**
+   * Checks that no two fields of a struct are named the same, at every level of it: Calcite reads a
+   * row type as a scope, and a repeated name there is one a reference cannot reach.
+   *
+   * @param type the type to check
+   * @param what the object being created, for the failure message
+   * @throws IllegalArgumentException if two fields of one struct share a name
+   */
+  private static void requireDistinctNames(RelDataType type, String what) {
+    if (!type.isStruct()) {
+      return;
+    }
+    List<String> names = type.getFieldNames();
+    if (new HashSet<>(names).size() != names.size()) {
+      throw new IllegalArgumentException(
+          "The schema of the " + what + " to create names two fields the same: " + names);
+    }
+    for (RelDataTypeField field : type.getFieldList()) {
+      requireDistinctNames(field.getType(), what);
+    }
   }
 
   private static int leafFieldCount(RelDataType type) {

--- a/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
@@ -145,6 +145,17 @@ class DdlRoundtripTest extends PlanTestBase {
   }
 
   /**
+   * A statement naming two columns the same declares a schema no object can have, and Calcite
+   * builds the row type it is given without uniquifying it, so the conversion refuses instead.
+   */
+  @Test
+  void aStatementThatNamesTwoColumnsTheSameIsRefused() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> schemaOf("create table d (a, a) as select intcol, intcol from src1"));
+  }
+
+  /**
    * A DDL node produces the object it creates, not the query filling it, so the root over it is
    * named by the declared schema. The two disagree here: the query names its columns EXPR$0 and
    * EXPR$1.

--- a/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
@@ -68,6 +68,27 @@ class DdlRelCopyTest extends PlanTestBase {
   }
 
   /**
+   * Two columns of one object cannot share a name: Calcite reads a row type as a scope, and
+   * `createStructType` does not uniquify what it is given.
+   */
+  @Test
+  void aSchemaThatNamesTwoColumnsTheSameIsRejected() {
+    RelDataType repeated =
+        typeFactory.createStructType(
+            List.of(
+                typeFactory.createSqlType(SqlTypeName.BIGINT),
+                typeFactory.createSqlType(SqlTypeName.BIGINT)),
+            List.of("same", "same"));
+    RelNode twoColumns = builder.values(new String[] {"a", "b"}, 1, 2).build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new CreateTable(List.of("FOO"), repeated, twoColumns));
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateView(List.of("FOO"), repeated, twoColumns));
+  }
+
+  /**
    * The declared schema names the object's columns and the input fills them, so it has to be a
    * struct of as many leaf fields as the input produces. The names and the types are the
    * statement's own -- a CTAS may declare both -- so neither is checked.

--- a/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/calcite/rel/DdlRelCopyTest.java
@@ -89,6 +89,34 @@ class DdlRelCopyTest extends PlanTestBase {
   }
 
   /**
+   * A struct reached through a collection is a level of the schema like any other: the flattened
+   * name list a schema carries names its fields, and the row type the conversion builds holds them
+   * in a scope of their own.
+   */
+  @Test
+  void aSchemaThatRepeatsANameInsideACollectionIsRejected() {
+    RelDataType bigint = typeFactory.createSqlType(SqlTypeName.BIGINT);
+    RelDataType repeated =
+        typeFactory.createStructType(List.of(bigint, bigint), List.of("same", "same"));
+    RelDataType inArray =
+        typeFactory.createStructType(
+            List.of(typeFactory.createArrayType(repeated, -1)), List.of("c"));
+    RelDataType inMap =
+        typeFactory.createStructType(
+            List.of(typeFactory.createMapType(bigint, repeated)), List.of("c"));
+    RelNode oneColumn = builder.values(new String[] {"a"}, 1).build();
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateTable(List.of("FOO"), inArray, oneColumn));
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateTable(List.of("FOO"), inMap, oneColumn));
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateView(List.of("FOO"), inArray, oneColumn));
+    assertThrows(
+        IllegalArgumentException.class, () -> new CreateView(List.of("FOO"), inMap, oneColumn));
+  }
+
+  /**
    * The declared schema names the object's columns and the input fills them, so it has to be a
    * struct of as many leaf fields as the input produces. The names and the types are the
    * statement's own -- a CTAS may declare both -- so neither is checked.


### PR DESCRIPTION
`RelDataTypeFactory.createStructType` does not uniquify the names it is given, so `create table d (a, a) as select intcol, intcol from src1` built a row type holding two fields named `A`, and the schema recorded for the table read `[A, A]`. A plan whose `tableSchema` repeats a name went the same way. Calcite reads a row type as a scope and checks distinctness only inside `Project.isValid`, behind an `assert`, so the duplicate survives wherever assertions are off.

The check sits with the other checks on a declared schema rather than in the SQL path, so it covers a schema read from a plan as well as one a statement declares, and it recurses: every struct level is a scope of its own, so a struct column repeating a field name is refused too.

Closes #1187
