### PR TITLE
fix(isthmus)!: apply the emit mapping a virtual table carries

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -789,6 +789,12 @@ public class SubstraitRelNodeConverter
               namedDdl.getObject()));
     }
 
+    if (namedDdl.getRemap().isPresent()) {
+      throw new UnsupportedOperationException(
+          "Emit mapping on a NamedDdl is not supported: a CreateView produces the view it creates, "
+              + "not columns to select from");
+    }
+
     if (namedDdl.getViewDefinition().isEmpty()) {
       throw new IllegalArgumentException("NamedDdl view definition must be set");
     }
@@ -855,7 +861,9 @@ public class SubstraitRelNodeConverter
         }
         tuplesBuilder.add(tupleBuilder.build());
       }
-      return LogicalValues.create(relBuilder.getCluster(), rowType, tuplesBuilder.build());
+      return applyRelCommon(
+          LogicalValues.create(relBuilder.getCluster(), rowType, tuplesBuilder.build()),
+          virtualTableScan);
     } else {
       // A row that does not fit a LogicalValues tuple is computed instead: we create a
       // LogicalProject for each row to compute its values, and combine them together using a
@@ -892,8 +900,10 @@ public class SubstraitRelNodeConverter
       for (int i = 0; i < rowType.getFieldCount(); i++) {
         topProjectExprs.add(rexBuilder.makeInputRef(union, i));
       }
-      return LogicalProject.create(
-          union, Collections.emptyList(), topProjectExprs, rowType, Collections.emptySet());
+      return applyRelCommon(
+          LogicalProject.create(
+              union, Collections.emptyList(), topProjectExprs, rowType, Collections.emptySet()),
+          virtualTableScan);
     }
   }
 
@@ -1052,6 +1062,12 @@ public class SubstraitRelNodeConverter
 
   @Override
   public RelNode visit(NamedWrite write, Context context) {
+    if (write.getRemap().isPresent()) {
+      throw new UnsupportedOperationException(
+          "Emit mapping on a NamedWrite is not supported: a TableModify's row type is a single "
+              + "ROWCOUNT column and a CreateTable produces the table it creates, neither of them "
+              + "columns to select from");
+    }
     RelNode input = write.getInput().accept(this, context);
     final RelOptSchema relOptSchema = requireRelOptSchema();
     final RelOptTable targetTable = relOptSchema.getTableForMember(write.getNames());

--- a/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/SubstraitRelNodeConverter.java
@@ -81,7 +81,6 @@ import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
@@ -789,14 +788,14 @@ public class SubstraitRelNodeConverter
               namedDdl.getObject()));
     }
 
-    if (namedDdl.getRemap().isPresent()) {
-      throw new UnsupportedOperationException(
-          "Emit mapping on a NamedDdl is not supported: a CreateView produces the view it creates, "
-              + "not columns to select from");
-    }
-
     if (namedDdl.getViewDefinition().isEmpty()) {
       throw new IllegalArgumentException("NamedDdl view definition must be set");
+    }
+
+    if (namedDdl.getRemap().isPresent()) {
+      throw new UnsupportedOperationException(
+          "Emit mapping on a NamedDdl is not supported: isthmus has no place for a projection "
+              + "between a CreateView's definition and the view it creates");
     }
 
     if (!namedDdl.getTableDefaults().fields().isEmpty()) {
@@ -812,6 +811,11 @@ public class SubstraitRelNodeConverter
 
   @Override
   public RelNode visit(VirtualTableScan virtualTableScan, Context context) {
+    if (virtualTableScan.getProjection().isPresent()) {
+      throw new UnsupportedOperationException(
+          "Projection on a VirtualTableScan is not supported: its columns would have to be "
+              + "masked before an emit mapping selects from them");
+    }
     // A schema's names are one per field at every level of the struct, in depth-first order, so
     // they have to be handed to the conversion rather than paired with the row type afterwards:
     // with a nested struct anywhere in the schema the two lists do not even have the same length.
@@ -900,10 +904,10 @@ public class SubstraitRelNodeConverter
       for (int i = 0; i < rowType.getFieldCount(); i++) {
         topProjectExprs.add(rexBuilder.makeInputRef(union, i));
       }
-      return applyRelCommon(
+      RelNode topProject =
           LogicalProject.create(
-              union, Collections.emptyList(), topProjectExprs, rowType, Collections.emptySet()),
-          virtualTableScan);
+              union, Collections.emptyList(), topProjectExprs, rowType, Collections.emptySet());
+      return applyRelCommon(topProject, virtualTableScan, topProject);
     }
   }
 
@@ -1064,9 +1068,9 @@ public class SubstraitRelNodeConverter
   public RelNode visit(NamedWrite write, Context context) {
     if (write.getRemap().isPresent()) {
       throw new UnsupportedOperationException(
-          "Emit mapping on a NamedWrite is not supported: a TableModify's row type is a single "
-              + "ROWCOUNT column and a CreateTable produces the table it creates, neither of them "
-              + "columns to select from");
+          "Emit mapping on a NamedWrite is not supported: isthmus converts a write to a "
+              + "TableModify whose row type is a single ROWCOUNT column, dropping the write's "
+              + "output_mode, so the mapping has no columns to select from");
     }
     RelNode input = write.getInput().accept(this, context);
     final RelOptSchema relOptSchema = requireRelOptSchema();
@@ -1305,14 +1309,11 @@ public class SubstraitRelNodeConverter
 
   private RelNode applyRemap(RelNode relNode, Rel.Remap remap) {
     RelDataType rowType = relNode.getRowType();
-    List<String> fieldNames = rowType.getFieldNames();
+    // By index rather than by name: a virtual table's row type comes straight from its schema,
+    // which Calcite never uniquifies, so a name can stand for more than one field.
     List<RexNode> rexList =
         remap.indices().stream()
-            .map(
-                index -> {
-                  RelDataTypeField t = rowType.getField(fieldNames.get(index), true, false);
-                  return new RexInputRef(index, t.getValue());
-                })
+            .map(index -> new RexInputRef(index, rowType.getFieldList().get(index).getType()))
             .collect(java.util.stream.Collectors.toList());
     return relBuilder.push(relNode).project(rexList).build();
   }

--- a/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
@@ -1,7 +1,9 @@
 package io.substrait.isthmus;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.substrait.expression.ExpressionCreator;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
@@ -175,10 +177,10 @@ class DdlRoundtripTest extends PlanTestBase {
   }
 
   /**
-   * A write and a DDL relation produce the object they act on rather than columns to select from --
-   * a TableModify's row type is a single ROWCOUNT column, a CreateTable and a CreateView the object
-   * they create -- so an emit mapping over one has nothing to apply to and is refused rather than
-   * dropped.
+   * Neither a write nor a DDL relation gives an emit mapping columns to select from: isthmus
+   * converts a write to a TableModify whose row type is a single ROWCOUNT column, and has nowhere
+   * to put a projection between a CreateView's definition and the view it creates. A mapping over
+   * either is refused rather than dropped.
    */
   @Test
   void anEmitMappingOnAWriteOrADdlIsRefused() {
@@ -204,8 +206,18 @@ class DdlRoundtripTest extends PlanTestBase {
             .build();
     SubstraitToCalcite converter = new SubstraitToCalcite(converterProvider, catalogReader);
 
-    assertThrows(UnsupportedOperationException.class, () -> converter.convert(ctas));
-    assertThrows(UnsupportedOperationException.class, () -> converter.convert(createView));
+    assertAll(
+        () ->
+            assertTrue(
+                assertThrows(UnsupportedOperationException.class, () -> converter.convert(ctas))
+                    .getMessage()
+                    .contains("Emit mapping on a NamedWrite is not supported")),
+        () ->
+            assertTrue(
+                assertThrows(
+                        UnsupportedOperationException.class, () -> converter.convert(createView))
+                    .getMessage()
+                    .contains("Emit mapping on a NamedDdl is not supported")));
   }
 
   /** The schema of the object a single DDL statement creates, as Substrait records it. */

--- a/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/DdlRoundtripTest.java
@@ -174,6 +174,40 @@ class DdlRoundtripTest extends PlanTestBase {
     assertEquals(List.of("TOTAL", "DOUBLED"), converted.getNames());
   }
 
+  /**
+   * A write and a DDL relation produce the object they act on rather than columns to select from --
+   * a TableModify's row type is a single ROWCOUNT column, a CreateTable and a CreateView the object
+   * they create -- so an emit mapping over one has nothing to apply to and is refused rather than
+   * dropped.
+   */
+  @Test
+  void anEmitMappingOnAWriteOrADdlIsRefused() {
+    NamedWrite ctas =
+        NamedWrite.builder()
+            .input(computedColumns())
+            .names(List.of("dst1"))
+            .tableSchema(declaredSchema())
+            .operation(AbstractWriteRel.WriteOp.CTAS)
+            .createMode(AbstractWriteRel.CreateMode.REPLACE_IF_EXISTS)
+            .outputMode(AbstractWriteRel.OutputMode.NO_OUTPUT)
+            .remap(Rel.Remap.of(List.of(0)))
+            .build();
+    NamedDdl createView =
+        NamedDdl.builder()
+            .viewDefinition(computedColumns())
+            .names(List.of("dst1"))
+            .tableSchema(declaredSchema())
+            .tableDefaults(ExpressionCreator.struct(false))
+            .operation(AbstractDdlRel.DdlOp.CREATE)
+            .object(AbstractDdlRel.DdlObject.VIEW)
+            .remap(Rel.Remap.of(List.of(0)))
+            .build();
+    SubstraitToCalcite converter = new SubstraitToCalcite(converterProvider, catalogReader);
+
+    assertThrows(UnsupportedOperationException.class, () -> converter.convert(ctas));
+    assertThrows(UnsupportedOperationException.class, () -> converter.convert(createView));
+  }
+
   /** The schema of the object a single DDL statement creates, as Substrait records it. */
   private NamedStruct schemaOf(String sql) throws SqlParseException {
     RelRoot root =

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -447,7 +447,9 @@ class VirtualTableScanTest extends PlanTestBase {
 
   /**
    * The emit mapping of a virtual table selects its columns like any other relation's: the scan
-   * produced the whole table and dropped what the mapping leaves out.
+   * produces the whole table and a projection drops what the mapping leaves out. That projection is
+   * what converts back, so such a scan returns as a projection over one -- the same shape every
+   * relation with a mapping comes back as.
    */
   @Test
   void anEmitMappingSelectsTheColumnsItNames() {
@@ -464,6 +466,25 @@ class VirtualTableScanTest extends PlanTestBase {
     assertEquals(
         List.of(R.STRING),
         SubstraitRelVisitor.convert(relNode, extensions).getRecordType().fields());
+  }
+
+  /**
+   * Without a mapping there is no projection to name, and a virtual table's own schema already
+   * names its columns, so the hint is left where it is rather than rebuilding the table around it.
+   */
+  @Test
+  void outputNamesWithoutAMappingAreLeftAlone() {
+    NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
+    VirtualTableScan table =
+        VirtualTableScan.builder()
+            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .hint(Hint.builder().addOutputNames("x", "y").build())
+            .build();
+
+    RelNode relNode = substraitToCalcite.convert(table);
+
+    assertInstanceOf(LogicalValues.class, relNode);
+    assertEquals(List.of("col1", "col2"), relNode.getRowType().getFieldNames());
   }
 
   /** The names of its hint reach the projection the mapping adds, as they do elsewhere. */

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
+import io.substrait.hint.Hint;
+import io.substrait.relation.Rel;
 import io.substrait.relation.VirtualTableScan;
 import io.substrait.type.NamedStruct;
 import java.io.PrintWriter;
@@ -441,6 +443,41 @@ class VirtualTableScanTest extends PlanTestBase {
             + "    LogicalProject(exprs=[[ROW(ROW(1))]])\n"
             + "      LogicalValues(type=[RecordType()], tuples=[[{  }]])\n",
         explain(relNode));
+  }
+
+  /**
+   * The emit mapping of a virtual table selects its columns like any other relation's: the scan
+   * produced the whole table and dropped what the mapping leaves out.
+   */
+  @Test
+  void anEmitMappingSelectsTheColumnsItNames() {
+    NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
+    VirtualTableScan table =
+        VirtualTableScan.builder()
+            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .remap(Rel.Remap.of(List.of(1)))
+            .build();
+
+    RelNode relNode = substraitToCalcite.convert(table);
+
+    assertEquals(List.of("col2"), relNode.getRowType().getFieldNames());
+    assertEquals(
+        List.of(R.STRING),
+        SubstraitRelVisitor.convert(relNode, extensions).getRecordType().fields());
+  }
+
+  /** The names of its hint reach the projection the mapping adds, as they do elsewhere. */
+  @Test
+  void outputNamesReachTheProjectionTheMappingAdds() {
+    NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
+    VirtualTableScan table =
+        VirtualTableScan.builder()
+            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .remap(Rel.Remap.of(List.of(1)))
+            .hint(Hint.builder().addOutputNames("label").build())
+            .build();
+
+    assertEquals(List.of("label"), substraitToCalcite.convert(table).getRowType().getFieldNames());
   }
 
   @SafeVarargs

--- a/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/VirtualTableScanTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.ImmutableList;
 import io.substrait.expression.Expression;
 import io.substrait.expression.ExpressionCreator;
+import io.substrait.expression.MaskExpression;
 import io.substrait.hint.Hint;
 import io.substrait.relation.Rel;
 import io.substrait.relation.VirtualTableScan;
@@ -484,6 +485,76 @@ class VirtualTableScanTest extends PlanTestBase {
     RelNode relNode = substraitToCalcite.convert(table);
 
     assertInstanceOf(LogicalValues.class, relNode);
+    assertEquals(List.of("col1", "col2"), relNode.getRowType().getFieldNames());
+  }
+
+  /**
+   * A projection masks a read relation's columns before anything else selects from them -- {@link
+   * io.substrait.relation.AbstractReadRel#deriveRecordType()} applies it to the initial schema --
+   * so an emit mapping's indices count the columns it leaves. Isthmus builds the row type from the
+   * unmasked schema and reads the projection nowhere, so a scan carrying one is refused rather than
+   * converted against the wrong columns.
+   */
+  @Test
+  void aProjectionOnAVirtualTableIsRefused() {
+    NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.STRING));
+    VirtualTableScan table =
+        VirtualTableScan.builder()
+            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .projection(
+                MaskExpression.builder()
+                    .select(
+                        MaskExpression.StructSelect.builder()
+                            .addStructItems(MaskExpression.StructItem.of(1))
+                            .build())
+                    .build())
+            .build();
+
+    assertTrue(
+        assertThrows(UnsupportedOperationException.class, () -> substraitToCalcite.convert(table))
+            .getMessage()
+            .contains("Projection on a VirtualTableScan is not supported"));
+  }
+
+  /**
+   * A virtual table's row type carries the names its schema gives it, which nothing uniquifies, so
+   * the mapping has to select its columns by index: resolving a field by name would give the
+   * projection the type of the first column sharing it.
+   */
+  @Test
+  void anEmitMappingSelectsByIndexWhereTwoColumnsShareAName() {
+    NamedStruct schema = NamedStruct.of(List.of("c", "c"), R.struct(R.I32, R.STRING));
+    VirtualTableScan table =
+        VirtualTableScan.builder()
+            .from(createVirtualTableScan(schema, List.of(sb.i32(2), sb.str("a"))))
+            .remap(Rel.Remap.of(List.of(1)))
+            .build();
+
+    RelNode relNode = substraitToCalcite.convert(table);
+
+    assertEquals(
+        List.of(R.STRING),
+        SubstraitRelVisitor.convert(relNode, extensions).getRecordType().fields());
+  }
+
+  /**
+   * The same as {@link #outputNamesWithoutAMappingAreLeftAlone()} for a table whose rows are
+   * computed. That one comes back under a projection of its own, which is not one a mapping added
+   * and so not one the names are for.
+   */
+  @Test
+  void outputNamesWithoutAMappingAreLeftAloneOnAComputedTable() {
+    NamedStruct schema = NamedStruct.of(List.of("col1", "col2"), R.struct(R.I32, R.FP64));
+    VirtualTableScan table =
+        VirtualTableScan.builder()
+            .from(
+                createVirtualTableScan(
+                    schema, List.of(sb.i32(2), sb.add(sb.fp64(4.4), sb.fp64(4.5)))))
+            .hint(Hint.builder().addOutputNames("x", "y").build())
+            .build();
+
+    RelNode relNode = substraitToCalcite.convert(table);
+
     assertEquals(List.of("col1", "col2"), relNode.getRowType().getFieldNames());
   }
 


### PR DESCRIPTION
`visit(VirtualTableScan)` routed neither half of the relation's `RelCommon`: a scan whose emit mapping drops a column converted carrying all of them, under a row type that reported one, and the names of its hint were dropped with it. It goes through `applyRelCommon` now, like every relation whose conversion applies a mapping.

A `NamedWrite` and a `NamedDdl` cannot apply one, for reasons that are isthmus' rather than the relation's. A write's record type is its input's, but isthmus converts it to a `TableModify` whose row type is a single ROWCOUNT column, dropping the write's `output_mode` along the way, so the mapping has nothing left to select from; and there is no place for a projection between a `CreateView`'s definition and the view it creates. `visit(NamedUpdate)` already refuses one, and these two now do the same instead of dropping it.

A scan carrying a `projection` is refused as well. `AbstractReadRel.deriveRecordType()` masks the initial schema with it before anything else, so an emit mapping's indices count the columns the mask leaves -- while isthmus builds the row type from the unmasked schema and reads the projection nowhere. `ProtoRelConverter` fills the field from the proto, so such a relation reaches the conversion.

The mapping selects its columns by index rather than by name. A virtual table's row type carries the names of its schema, which Calcite never uniquifies, so resolving a field by name gave the projection the type of the first column sharing it: an `AssertionError` under `-ea`, a silently mistyped plan without one.

A mapping is materialised as a projection, so a scan carrying one comes back from Calcite as a projection over a virtual table rather than as the scan it went in as -- the shape every relation with a mapping returns as. Without a mapping there is no projection for the hint's names to land on, and the table keeps the names its schema gives it.

Closes #1160

BREAKING CHANGE: a NamedWrite or a NamedDdl carrying an emit mapping, and a VirtualTableScan carrying a projection, no longer convert to Calcite. They used to convert with the mapping or the projection dropped, which produced a plan that did not describe the relation it came from.
