### PR TITLE
fix(core)!: require exactly one ordering expression for RANGE window bounds

### DIFF
--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -2013,6 +2013,46 @@ public class SubstraitBuilder {
       WindowBound lowerBound,
       WindowBound upperBound,
       Expression... args) {
+    return windowFn(
+        urn,
+        key,
+        outputType,
+        aggregationPhase,
+        invocation,
+        Collections.emptyList(),
+        boundsType,
+        lowerBound,
+        upperBound,
+        args);
+  }
+
+  /**
+   * Creates a window function invocation with specified arguments, window bounds, and ordering.
+   *
+   * @param urn the URN of the extension containing the function
+   * @param key the function key (name and signature)
+   * @param outputType the output type of the function
+   * @param aggregationPhase the aggregation phase
+   * @param invocation the aggregation invocation mode
+   * @param sort the ordering expressions for the window, required by a RANGE bound with a Preceding
+   *     or Following side
+   * @param boundsType the type of window bounds
+   * @param lowerBound the lower bound of the window
+   * @param upperBound the upper bound of the window
+   * @param args the arguments to pass to the function
+   * @return a new {@link Expression.WindowFunctionInvocation}
+   */
+  public Expression.WindowFunctionInvocation windowFn(
+      String urn,
+      String key,
+      Type outputType,
+      Expression.AggregationPhase aggregationPhase,
+      Expression.AggregationInvocation invocation,
+      List<Expression.SortField> sort,
+      Expression.WindowBoundsType boundsType,
+      WindowBound lowerBound,
+      WindowBound upperBound,
+      Expression... args) {
     SimpleExtension.WindowFunctionVariant declaration =
         extensions.getWindowFunction(SimpleExtension.FunctionAnchor.of(urn, key));
     return Expression.WindowFunctionInvocation.builder()
@@ -2020,6 +2060,7 @@ public class SubstraitBuilder {
         .outputType(outputType)
         .aggregationPhase(aggregationPhase)
         .invocation(invocation)
+        .sort(sort)
         .boundsType(boundsType)
         .lowerBound(lowerBound)
         .upperBound(upperBound)

--- a/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
+++ b/core/src/main/java/io/substrait/dsl/SubstraitBuilder.java
@@ -1990,7 +1990,9 @@ public class SubstraitBuilder {
   }
 
   /**
-   * Creates a window function invocation with specified arguments and window bounds.
+   * Creates a window function invocation with specified arguments and window bounds. Supplies no
+   * ordering expressions, so a RANGE bound with a Preceding or Following side is rejected outright;
+   * use the {@code sort}-carrying overload for that.
    *
    * @param urn the URN of the extension containing the function
    * @param key the function key (name and signature)

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -1640,7 +1640,8 @@ public interface Expression extends FunctionArg {
     protected void check() {
       VariadicParameterConsistencyValidator.validate(declaration(), arguments());
       WindowBound.checkBoundsType(boundsType(), lowerBound(), upperBound());
-      WindowBound.checkRangeOrdering(boundsType(), lowerBound(), upperBound(), sort());
+      WindowBound.checkRangeOrdering(
+          boundsType(), lowerBound(), upperBound(), sort(), declaration().key());
     }
 
     /**

--- a/core/src/main/java/io/substrait/expression/Expression.java
+++ b/core/src/main/java/io/substrait/expression/Expression.java
@@ -1629,8 +1629,9 @@ public interface Expression extends FunctionArg {
     public abstract AggregationInvocation invocation();
 
     /**
-     * Validates that variadic arguments satisfy the parameter consistency requirement, and that
-     * {@code bounds_type} is set whenever a window bound requires it.
+     * Validates that variadic arguments satisfy the parameter consistency requirement, that {@code
+     * bounds_type} is set whenever a window bound requires it, and that a RANGE bound with a
+     * Preceding or Following side has exactly one, non-CLUSTERED ordering expression.
      *
      * <p>When CONSISTENT, all variadic arguments must have the same type (ignoring nullability).
      * When INCONSISTENT, arguments can have different types.
@@ -1639,6 +1640,7 @@ public interface Expression extends FunctionArg {
     protected void check() {
       VariadicParameterConsistencyValidator.validate(declaration(), arguments());
       WindowBound.checkBoundsType(boundsType(), lowerBound(), upperBound());
+      WindowBound.checkRangeOrdering(boundsType(), lowerBound(), upperBound(), sort());
     }
 
     /**

--- a/core/src/main/java/io/substrait/expression/WindowBound.java
+++ b/core/src/main/java/io/substrait/expression/WindowBound.java
@@ -1,5 +1,6 @@
 package io.substrait.expression;
 
+import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -59,6 +60,46 @@ public interface WindowBound {
       throw new IllegalArgumentException(
           "bounds_type is required when either window bound is CurrentRow, Preceding, or"
               + " Following, but was BOUNDS_TYPE_UNSPECIFIED");
+    }
+  }
+
+  /**
+   * Validates a RANGE window's ordering against its bounds, per the spec's rule that a RANGE frame
+   * with a {@link Preceding} or {@link Following} bound must have exactly one ordering expression,
+   * which must not use {@code SORT_DIRECTION_CLUSTERED}.
+   *
+   * @param boundsType the window's bounds type
+   * @param lowerBound the window's lower bound
+   * @param upperBound the window's upper bound
+   * @param sorts the window's ordering expressions
+   * @throws IllegalArgumentException if {@code boundsType} is {@code RANGE}, either bound is {@link
+   *     Preceding} or {@link Following}, and {@code sorts} does not contain exactly one ordering
+   *     expression, or that expression uses {@code SORT_DIRECTION_CLUSTERED}
+   */
+  static void checkRangeOrdering(
+      Expression.WindowBoundsType boundsType,
+      WindowBound lowerBound,
+      WindowBound upperBound,
+      List<Expression.SortField> sorts) {
+    boolean needsSingleOrdering =
+        boundsType == Expression.WindowBoundsType.RANGE
+            && (lowerBound instanceof Preceding
+                || lowerBound instanceof Following
+                || upperBound instanceof Preceding
+                || upperBound instanceof Following);
+    if (!needsSingleOrdering) {
+      return;
+    }
+    if (sorts.size() != 1) {
+      throw new IllegalArgumentException(
+          "a RANGE bound with a Preceding or Following side requires exactly one ordering"
+              + " expression, but found "
+              + sorts.size());
+    }
+    if (sorts.get(0).direction() == Expression.SortDirection.CLUSTERED) {
+      throw new IllegalArgumentException(
+          "a RANGE bound with a Preceding or Following side cannot use"
+              + " SORT_DIRECTION_CLUSTERED for its ordering expression");
     }
   }
 

--- a/core/src/main/java/io/substrait/expression/WindowBound.java
+++ b/core/src/main/java/io/substrait/expression/WindowBound.java
@@ -72,15 +72,17 @@ public interface WindowBound {
    * @param lowerBound the window's lower bound
    * @param upperBound the window's upper bound
    * @param sorts the window's ordering expressions
-   * @throws IllegalArgumentException if {@code boundsType} is {@code RANGE}, either bound is {@link
-   *     Preceding} or {@link Following}, and {@code sorts} does not contain exactly one ordering
-   *     expression, or that expression uses {@code SORT_DIRECTION_CLUSTERED}
+   * @param function identifies the window function being validated, for the exception message
+   * @throws IllegalArgumentException if {@code boundsType} is {@code RANGE} and either bound is
+   *     {@link Preceding} or {@link Following}, and {@code sorts} does not hold exactly one
+   *     ordering expression whose direction is not {@code SORT_DIRECTION_CLUSTERED}
    */
   static void checkRangeOrdering(
       Expression.WindowBoundsType boundsType,
       WindowBound lowerBound,
       WindowBound upperBound,
-      List<Expression.SortField> sorts) {
+      List<Expression.SortField> sorts,
+      String function) {
     boolean needsSingleOrdering =
         boundsType == Expression.WindowBoundsType.RANGE
             && (lowerBound instanceof Preceding
@@ -92,13 +94,15 @@ public interface WindowBound {
     }
     if (sorts.size() != 1) {
       throw new IllegalArgumentException(
-          "a RANGE bound with a Preceding or Following side requires exactly one ordering"
+          function
+              + ": a RANGE bound with a Preceding or Following side requires exactly one ordering"
               + " expression, but found "
               + sorts.size());
     }
     if (sorts.get(0).direction() == Expression.SortDirection.CLUSTERED) {
       throw new IllegalArgumentException(
-          "a RANGE bound with a Preceding or Following side cannot use"
+          function
+              + ": a RANGE bound with a Preceding or Following side cannot use"
               + " SORT_DIRECTION_CLUSTERED for its ordering expression");
     }
   }

--- a/core/src/main/java/io/substrait/expression/WindowBound.java
+++ b/core/src/main/java/io/substrait/expression/WindowBound.java
@@ -168,9 +168,8 @@ public interface WindowBound {
     public abstract Expression offset();
 
     /**
-     * Creates a {@link Preceding} bound from a literal row offset. For {@code BOUNDS_TYPE_ROWS}
-     * only: a RANGE bound's offset must be type-compatible with the ordering expression, so use
-     * {@link #of(Expression)} there.
+     * Creates a {@link Preceding} bound from a literal {@code i64} row offset. Valid for ROWS, or
+     * for RANGE over an {@code i64} ordering expression; use {@link #of(Expression)} otherwise.
      *
      * @param offset the row offset preceding the current row
      * @return the preceding bound
@@ -206,9 +205,8 @@ public interface WindowBound {
     public abstract Expression offset();
 
     /**
-     * Creates a {@link Following} bound from a literal row offset. For {@code BOUNDS_TYPE_ROWS}
-     * only: a RANGE bound's offset must be type-compatible with the ordering expression, so use
-     * {@link #of(Expression)} there.
+     * Creates a {@link Following} bound from a literal {@code i64} row offset. Valid for ROWS, or
+     * for RANGE over an {@code i64} ordering expression; use {@link #of(Expression)} otherwise.
      *
      * @param offset the row offset following the current row
      * @return the following bound

--- a/core/src/main/java/io/substrait/relation/ConsistentPartitionWindow.java
+++ b/core/src/main/java/io/substrait/relation/ConsistentPartitionWindow.java
@@ -49,12 +49,15 @@ public abstract class ConsistentPartitionWindow extends SingleInputRel implement
    */
   @Value.Check
   protected void check() {
-    for (WindowRelFunctionInvocation windowFunction : getWindowFunctions()) {
+    List<WindowRelFunctionInvocation> windowFunctions = getWindowFunctions();
+    for (int i = 0; i < windowFunctions.size(); i++) {
+      WindowRelFunctionInvocation windowFunction = windowFunctions.get(i);
       WindowBound.checkRangeOrdering(
           windowFunction.boundsType(),
           windowFunction.lowerBound(),
           windowFunction.upperBound(),
-          getSorts());
+          getSorts(),
+          "window function " + i + " (" + windowFunction.declaration().key() + ")");
     }
   }
 

--- a/core/src/main/java/io/substrait/relation/ConsistentPartitionWindow.java
+++ b/core/src/main/java/io/substrait/relation/ConsistentPartitionWindow.java
@@ -44,6 +44,21 @@ public abstract class ConsistentPartitionWindow extends SingleInputRel implement
   public abstract List<SortField> getSorts();
 
   /**
+   * Validates that a RANGE bound with a Preceding or Following side has exactly one, non-CLUSTERED
+   * ordering expression, for every window function invocation.
+   */
+  @Value.Check
+  protected void check() {
+    for (WindowRelFunctionInvocation windowFunction : getWindowFunctions()) {
+      WindowBound.checkRangeOrdering(
+          windowFunction.boundsType(),
+          windowFunction.lowerBound(),
+          windowFunction.upperBound(),
+          getSorts());
+    }
+  }
+
+  /**
    * Derives the output record type by appending window outputs to the input type.
    *
    * @return the resulting struct type

--- a/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
+++ b/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
@@ -8,6 +8,7 @@ import io.substrait.TestBase;
 import io.substrait.expression.AggregateFunctionInvocation;
 import io.substrait.expression.Expression;
 import io.substrait.expression.FieldReference;
+import io.substrait.expression.WindowBound;
 import io.substrait.extension.DefaultExtensionCatalog;
 import io.substrait.extension.SimpleExtension;
 import io.substrait.plan.Plan;
@@ -226,6 +227,28 @@ class SubstraitBuilderTest extends TestBase {
       assertNotNull(builder.or(b1, b2));
       assertNotNull(builder.not(b1));
       assertNotNull(builder.isNull(b1));
+    }
+
+    @Test
+    void testWindowFunctionWithOrdering() {
+      // The single shape the sorts-carrying overload exists for: a RANGE bound with a Preceding
+      // side, which requires exactly one ordering expression.
+      final NamedScan scan = createSimpleScan();
+      final Expression.WindowFunctionInvocation windowFn =
+          builder.windowFn(
+              DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
+              "lead:any",
+              Type.I32.builder().nullable(false).build(),
+              Expression.AggregationPhase.INITIAL_TO_RESULT,
+              Expression.AggregationInvocation.ALL,
+              builder.sortFields(scan, 0),
+              Expression.WindowBoundsType.RANGE,
+              WindowBound.Preceding.of(builder.i32(5)),
+              WindowBound.CURRENT_ROW,
+              builder.fieldReference(scan, 0));
+
+      assertNotNull(windowFn);
+      assertEquals(1, windowFn.sort().size());
     }
   }
 

--- a/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
+++ b/core/src/test/java/io/substrait/dsl/SubstraitBuilderTest.java
@@ -3,6 +3,7 @@ package io.substrait.dsl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.substrait.TestBase;
 import io.substrait.expression.AggregateFunctionInvocation;
@@ -249,6 +250,21 @@ class SubstraitBuilderTest extends TestBase {
 
       assertNotNull(windowFn);
       assertEquals(1, windowFn.sort().size());
+
+      // The no-sorts overload cannot express this shape at all.
+      assertThrows(
+          IllegalArgumentException.class,
+          () ->
+              builder.windowFn(
+                  DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC,
+                  "lead:any",
+                  Type.I32.builder().nullable(false).build(),
+                  Expression.AggregationPhase.INITIAL_TO_RESULT,
+                  Expression.AggregationInvocation.ALL,
+                  Expression.WindowBoundsType.RANGE,
+                  WindowBound.Preceding.of(builder.i32(5)),
+                  WindowBound.CURRENT_ROW,
+                  builder.fieldReference(scan, 0)));
     }
   }
 

--- a/core/src/test/java/io/substrait/relation/ExpressionCopyOnWriteVisitorTest.java
+++ b/core/src/test/java/io/substrait/relation/ExpressionCopyOnWriteVisitorTest.java
@@ -98,7 +98,12 @@ class ExpressionCopyOnWriteVisitorTest extends TestBase {
             .declaration(declaration)
             .arguments(Collections.emptyList())
             .partitionBy(Collections.emptyList())
-            .sort(Collections.emptyList())
+            .sort(
+                Collections.singletonList(
+                    Expression.SortField.builder()
+                        .expr(sb.i32(1))
+                        .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                        .build()))
             .outputType(R.I64)
             .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
             .invocation(Expression.AggregationInvocation.ALL)
@@ -114,6 +119,12 @@ class ExpressionCopyOnWriteVisitorTest extends TestBase {
         Optional.of(
             Expression.WindowFunctionInvocation.builder()
                 .from(wfi)
+                .sort(
+                    Collections.singletonList(
+                        Expression.SortField.builder()
+                            .expr(sb.i32(-1))
+                            .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                            .build()))
                 .lowerBound(WindowBound.Preceding.of(sb.i32(-5)))
                 .upperBound(WindowBound.Following.of(sb.i32(-7)))
                 .build()),

--- a/core/src/test/java/io/substrait/relation/OuterReferenceConverterTest.java
+++ b/core/src/test/java/io/substrait/relation/OuterReferenceConverterTest.java
@@ -308,7 +308,13 @@ class OuterReferenceConverterTest extends TestBase {
                                         .declaration(declaration)
                                         .arguments(List.of(sb.fieldReference(input2, 0)))
                                         .partitionBy(Collections.emptyList())
-                                        .sort(Collections.emptyList())
+                                        .sort(
+                                            List.of(
+                                                Expression.SortField.builder()
+                                                    .expr(sb.fieldReference(input2, 0))
+                                                    .direction(
+                                                        Expression.SortDirection.ASC_NULLS_FIRST)
+                                                    .build()))
                                         .outputType(TypeCreator.NULLABLE.I64)
                                         .aggregationPhase(
                                             Expression.AggregationPhase.INITIAL_TO_RESULT)

--- a/core/src/test/java/io/substrait/relation/RelCopyOnWriteVisitorTest.java
+++ b/core/src/test/java/io/substrait/relation/RelCopyOnWriteVisitorTest.java
@@ -72,7 +72,7 @@ class RelCopyOnWriteVisitorTest extends TestBase {
 
   @Test
   void consistentPartitionWindowBoundOffsetsAreRewritten() {
-    Rel input = sb.namedScan(Arrays.asList("test"), Arrays.asList("a"), Arrays.asList(R.I64));
+    Rel input = sb.namedScan(Arrays.asList("test"), Arrays.asList("a"), Arrays.asList(R.I32));
     ConsistentPartitionWindow window =
         windowOver(input, WindowBound.Preceding.of(sb.i32(5)), WindowBound.Following.of(sb.i32(7)));
 

--- a/core/src/test/java/io/substrait/relation/RelCopyOnWriteVisitorTest.java
+++ b/core/src/test/java/io/substrait/relation/RelCopyOnWriteVisitorTest.java
@@ -61,6 +61,12 @@ class RelCopyOnWriteVisitorTest extends TestBase {
                     .upperBound(upper)
                     .boundsType(Expression.WindowBoundsType.RANGE)
                     .build()))
+        .sorts(
+            Arrays.asList(
+                Expression.SortField.builder()
+                    .expr(sb.fieldReference(input, 0))
+                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                    .build()))
         .build();
   }
 

--- a/core/src/test/java/io/substrait/relation/RelCopyOnWriteVisitorTest.java
+++ b/core/src/test/java/io/substrait/relation/RelCopyOnWriteVisitorTest.java
@@ -61,12 +61,7 @@ class RelCopyOnWriteVisitorTest extends TestBase {
                     .upperBound(upper)
                     .boundsType(Expression.WindowBoundsType.RANGE)
                     .build()))
-        .sorts(
-            Arrays.asList(
-                Expression.SortField.builder()
-                    .expr(sb.fieldReference(input, 0))
-                    .direction(Expression.SortDirection.ASC_NULLS_FIRST)
-                    .build()))
+        .sorts(sb.sortFields(input, 0))
         .build();
   }
 

--- a/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
@@ -315,16 +315,7 @@ class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
                         .upperBound(WindowBound.CURRENT_ROW)
                         .boundsType(Expression.WindowBoundsType.RANGE)
                         .build()))
-            .sorts(
-                Arrays.asList(
-                    Expression.SortField.builder()
-                        .expr(sb.fieldReference(input, 0))
-                        .direction(Expression.SortDirection.ASC_NULLS_FIRST)
-                        .build(),
-                    Expression.SortField.builder()
-                        .expr(sb.fieldReference(input, 1))
-                        .direction(Expression.SortDirection.ASC_NULLS_FIRST)
-                        .build()));
+            .sorts(sb.sortFields(input, 0, 1));
 
     assertThrows(IllegalArgumentException.class, relBuilder::build);
   }

--- a/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
@@ -355,6 +355,35 @@ class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
   }
 
   @Test
+  void rangePrecedingWithTwoOrderingExpressionsOnAnInvocationIsRejected() {
+    SimpleExtension.WindowFunctionVariant declaration =
+        extensions.getWindowFunction(
+            SimpleExtension.FunctionAnchor.of(
+                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
+    Expression.SortField sort =
+        Expression.SortField.builder()
+            .expr(sb.i64(1))
+            .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+            .build();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            Expression.WindowFunctionInvocation.builder()
+                .declaration(declaration)
+                .arguments(Collections.emptyList())
+                .partitionBy(Collections.emptyList())
+                .sort(Arrays.asList(sort, sort))
+                .outputType(R.I64)
+                .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                .invocation(Expression.AggregationInvocation.ALL)
+                .lowerBound(WindowBound.Preceding.of(5))
+                .upperBound(WindowBound.CURRENT_ROW)
+                .boundsType(Expression.WindowBoundsType.RANGE)
+                .build());
+  }
+
+  @Test
   void boundsTypeUnspecifiedWithUnboundedBoundsIsAccepted() {
     SimpleExtension.WindowFunctionVariant windowFunctionDeclaration =
         extensions.getWindowFunction(

--- a/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
+++ b/core/src/test/java/io/substrait/type/proto/ConsistentPartitionWindowRelRoundtripTest.java
@@ -202,12 +202,19 @@ class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
                 DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
     // Unlike the relation-level fixture above, this bare expression has no enclosing relation to
     // resolve field references against, so the offset is a scalar function call over literals.
+    // A RANGE bound with a Preceding side requires exactly one ordering expression, carried here
+    // directly on the invocation since there is no enclosing relation to hold it.
     Expression.WindowFunctionInvocation wfi =
         Expression.WindowFunctionInvocation.builder()
             .declaration(windowFunctionDeclaration)
             .arguments(Collections.emptyList())
             .partitionBy(Collections.emptyList())
-            .sort(Collections.emptyList())
+            .sort(
+                Collections.singletonList(
+                    Expression.SortField.builder()
+                        .expr(sb.i64(1))
+                        .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                        .build()))
             .outputType(R.I64)
             .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
             .invocation(Expression.AggregationInvocation.ALL)
@@ -252,6 +259,108 @@ class ConsistentPartitionWindowRelRoundtripTest extends TestBase {
             .boundsType(Expression.WindowBoundsType.UNSPECIFIED);
 
     assertThrows(IllegalArgumentException.class, invocationBuilder::build);
+  }
+
+  @Test
+  void rangePrecedingWithoutASingleOrderingExpressionIsRejected() {
+    SimpleExtension.WindowFunctionVariant windowFunctionDeclaration =
+        extensions.getWindowFunction(
+            SimpleExtension.FunctionAnchor.of(
+                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
+    Rel input = sb.namedScan(Arrays.asList("test"), Arrays.asList("a"), Arrays.asList(R.I64));
+    // A RANGE bound with a Preceding side requires exactly one ordering expression on the
+    // enclosing relation; this fixture has none. The check runs in a @Value.Check, so it fires at
+    // construction time rather than only when a plan is later read back from proto.
+    ImmutableConsistentPartitionWindow.Builder relBuilder =
+        ConsistentPartitionWindow.builder()
+            .input(input)
+            .windowFunctions(
+                Arrays.asList(
+                    ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
+                        .declaration(windowFunctionDeclaration)
+                        .arguments(Arrays.asList(sb.fieldReference(input, 0)))
+                        .outputType(R.I64)
+                        .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                        .invocation(Expression.AggregationInvocation.ALL)
+                        .lowerBound(WindowBound.Preceding.of(5))
+                        .upperBound(WindowBound.CURRENT_ROW)
+                        .boundsType(Expression.WindowBoundsType.RANGE)
+                        .build()));
+
+    assertThrows(IllegalArgumentException.class, relBuilder::build);
+  }
+
+  @Test
+  void rangePrecedingWithTwoOrderingExpressionsIsRejected() {
+    SimpleExtension.WindowFunctionVariant windowFunctionDeclaration =
+        extensions.getWindowFunction(
+            SimpleExtension.FunctionAnchor.of(
+                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
+    Rel input =
+        sb.namedScan(Arrays.asList("test"), Arrays.asList("a", "b"), Arrays.asList(R.I64, R.I64));
+    // A RANGE bound with a Preceding side requires exactly one ordering expression; this fixture
+    // has two.
+    ImmutableConsistentPartitionWindow.Builder relBuilder =
+        ConsistentPartitionWindow.builder()
+            .input(input)
+            .windowFunctions(
+                Arrays.asList(
+                    ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
+                        .declaration(windowFunctionDeclaration)
+                        .arguments(Arrays.asList(sb.fieldReference(input, 0)))
+                        .outputType(R.I64)
+                        .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                        .invocation(Expression.AggregationInvocation.ALL)
+                        .lowerBound(WindowBound.Preceding.of(5))
+                        .upperBound(WindowBound.CURRENT_ROW)
+                        .boundsType(Expression.WindowBoundsType.RANGE)
+                        .build()))
+            .sorts(
+                Arrays.asList(
+                    Expression.SortField.builder()
+                        .expr(sb.fieldReference(input, 0))
+                        .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                        .build(),
+                    Expression.SortField.builder()
+                        .expr(sb.fieldReference(input, 1))
+                        .direction(Expression.SortDirection.ASC_NULLS_FIRST)
+                        .build()));
+
+    assertThrows(IllegalArgumentException.class, relBuilder::build);
+  }
+
+  @Test
+  void rangePrecedingWithClusteredOrderingIsRejected() {
+    SimpleExtension.WindowFunctionVariant windowFunctionDeclaration =
+        extensions.getWindowFunction(
+            SimpleExtension.FunctionAnchor.of(
+                DefaultExtensionCatalog.FUNCTIONS_ARITHMETIC, "lead:any"));
+    Rel input = sb.namedScan(Arrays.asList("test"), Arrays.asList("a"), Arrays.asList(R.I64));
+    // A RANGE bound with a Preceding side cannot use SORT_DIRECTION_CLUSTERED for its ordering
+    // expression.
+    ImmutableConsistentPartitionWindow.Builder relBuilder =
+        ConsistentPartitionWindow.builder()
+            .input(input)
+            .windowFunctions(
+                Arrays.asList(
+                    ConsistentPartitionWindow.WindowRelFunctionInvocation.builder()
+                        .declaration(windowFunctionDeclaration)
+                        .arguments(Arrays.asList(sb.fieldReference(input, 0)))
+                        .outputType(R.I64)
+                        .aggregationPhase(Expression.AggregationPhase.INITIAL_TO_RESULT)
+                        .invocation(Expression.AggregationInvocation.ALL)
+                        .lowerBound(WindowBound.Preceding.of(5))
+                        .upperBound(WindowBound.CURRENT_ROW)
+                        .boundsType(Expression.WindowBoundsType.RANGE)
+                        .build()))
+            .sorts(
+                Arrays.asList(
+                    Expression.SortField.builder()
+                        .expr(sb.fieldReference(input, 0))
+                        .direction(Expression.SortDirection.CLUSTERED)
+                        .build()));
+
+    assertThrows(IllegalArgumentException.class, relBuilder::build);
   }
 
   @Test


### PR DESCRIPTION
- Spec v0.102.0 states this rule at site/docs/expressions/window_functions.md:34, and in algebra.proto at WindowRelFunction.bounds_type (:457) and Expression.WindowFunction.sorts (:1401)        
- Requires exactly one, non-CLUSTERED ordering expression for a RANGE bound with a Preceding/Following side
- Fixed 4 pre-existing test fixtures that were building this invalid shape      
- Adds a sorts-carrying overload to SubstraitBuilder.windowFn, since the existing one left every RANGE frame built through the DSL with no way to supply the ordering this check now requires     
  
BREAKING CHANGE: a ConsistentPartitionWindow or WindowFunctionInvocation with a RANGE bound's Preceding or Following side now requires exactly one, non-CLUSTERED ordering expression. A plan that
previously built or parsed with zero, multiple, or a CLUSTERED ordering expression in that position now throws IllegalArgumentException.