### PR TITLE
build: update vulnerability scan

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6.3.0
       - name: Scan
-        run: make component=${{ matrix.project }} scan
+        run: make scan-${{ matrix.project }}
   java:
     name: Build and Test Java
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ out/**
 .pmdCache
 gradle.lockfile
 settings-gradle.lockfile
+osv-scanner
 
 # VS Code ignores
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,38 @@
-OSV_SCANNER_IMAGE := ghcr.io/google/osv-scanner:v2.3.5
+COMPONENTS := core isthmus isthmus-cli
+SCAN_COMPONENTS := $(addprefix scan-,$(COMPONENTS))
+
+osv_scanner := ./osv-scanner
+kernel_name := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
+machine_hardware := $(shell uname -m)
+ifeq ($(machine_hardware), aarch64)
+	machine_hardware := arm64
+endif
+ifeq ($(machine_hardware), x86_64)
+	machine_hardware := amd64
+endif
 
 .PHONY: scan
-scan:
-ifdef component
-	./gradlew --quiet ':$(component):dependencies' --write-locks --configuration runtimeClasspath
-	docker run --rm \
-		--volume './$(component)/gradle.lockfile:/gradle.lockfile' \
-		--volume './osv-scanner.toml:/osv-scanner.toml' \
-		$(OSV_SCANNER_IMAGE) scan source --lockfile /gradle.lockfile --config /osv-scanner.toml
-else
-	$(MAKE) component=core scan
-	$(MAKE) component=isthmus scan
-	$(MAKE) component=isthmus-cli scan
-endif
+scan: $(SCAN_COMPONENTS)
+
+.PHONY: $(SCAN_COMPONENTS)
+$(SCAN_COMPONENTS): scan-%: $(osv_scanner) %/gradle.lockfile
+	$(osv_scanner) scan source --lockfile $*/gradle.lockfile --config osv-scanner.toml
+
+$(osv_scanner):
+	curl --silent --show-error --location --output $(osv_scanner) https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_$(kernel_name)_$(machine_hardware)
+	chmod u+x $(osv_scanner)
+
+.PHONY: install-osv-scanner
+install-osv-scanner: uninstall-osv-scanner $(osv_scanner)
+
+.PHONY: uninstall-osv-scanner
+uninstall-osv-scanner:
+	rm -f $(osv_scanner)
+
+$(addsuffix /gradle.lockfile,$(COMPONENTS)): %/gradle.lockfile:
+	./gradlew --quiet ':$*:dependencies' --write-locks --configuration runtimeClasspath
 
 .PHONY: clean
 clean:
-	find . -depth 2 -type f -name gradle.lockfile -delete -print
+	find . -maxdepth 2 -type f -name gradle.lockfile -delete -print


### PR DESCRIPTION
- Use latest version of OSV-Scanner rather than a fixed version.
- Refactor Makefile to avoid recursive calls to make.
- Download OSV-Scanner binary to remove dependency on Docker.