### PR TITLE
build: surface scan failures in build summary

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,17 +52,11 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6.3.0
-      - name: Generate lockfile
-        run: make ${{ matrix.project }}/gradle.lockfile
       - name: Scan
         id: scan
-        run: |
-          make install-osv-scanner
-          ./osv-scanner scan source \
-            --config=osv-scanner.toml \
-            --lockfile=${{ matrix.project }}/gradle.lockfile \
-            --format=markdown \
-            --output-file=osv-scanner.md
+        run: make scan-${{ matrix.project }}
+        env:
+          OSV_SCANNER_ARGS: --format=markdown --output-file=osv-scanner.md
       - name: Report failure
         if: ${{ failure() && steps.scan.conclusion == 'failure' }}
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,8 +52,23 @@ jobs:
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6.3.0
+      - name: Generate lockfile
+        run: make ${{ matrix.project }}/gradle.lockfile
       - name: Scan
-        run: make scan-${{ matrix.project }}
+        id: scan
+        run: |
+          docker run --rm \
+            --volume './:/src' \
+            ghcr.io/google/osv-scanner:latest \
+            scan source \
+            --config=/src/osv-scanner.toml \
+            --lockfile /src/${{ matrix.project }}/gradle.lockfile \
+            --format=markdown \
+            --output-file=/src/osv-scanner.md
+      - name: Report failure
+        if: ${{ failure() && steps.scan.conclusion == 'failure' }}
+        run: |
+          cat osv-scanner.md >> ${GITHUB_STEP_SUMMARY}
   java:
     name: Build and Test Java
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,14 +57,12 @@ jobs:
       - name: Scan
         id: scan
         run: |
-          docker run --rm \
-            --volume './:/src' \
-            ghcr.io/google/osv-scanner:latest \
-            scan source \
-            --config=/src/osv-scanner.toml \
-            --lockfile /src/${{ matrix.project }}/gradle.lockfile \
+          make install-osv-scanner
+          ./osv-scanner scan source \
+            --config=osv-scanner.toml \
+            --lockfile=${{ matrix.project }}/gradle.lockfile \
             --format=markdown \
-            --output-file=/src/osv-scanner.md
+            --output-file=osv-scanner.md
       - name: Report failure
         if: ${{ failure() && steps.scan.conclusion == 'failure' }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 COMPONENTS := core isthmus isthmus-cli
 SCAN_COMPONENTS := $(addprefix scan-,$(COMPONENTS))
+OSV_SCANNER_ARGS ?=
 
 osv_scanner := ./osv-scanner
 kernel_name := $(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -17,7 +18,7 @@ scan: $(SCAN_COMPONENTS)
 
 .PHONY: $(SCAN_COMPONENTS)
 $(SCAN_COMPONENTS): scan-%: $(osv_scanner) %/gradle.lockfile
-	$(osv_scanner) scan source --lockfile $*/gradle.lockfile --config osv-scanner.toml
+	$(osv_scanner) scan source --lockfile $*/gradle.lockfile --config osv-scanner.toml $(OSV_SCANNER_ARGS)
 
 $(osv_scanner):
 	curl --silent --show-error --location --output $(osv_scanner) https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_$(kernel_name)_$(machine_hardware)


### PR DESCRIPTION
Currently a scan failures requires inspection of the build log for the failing scan job. This change outputs the failure to the step summary so it is visible directly in the build summary page.

<!--
The PR title and this description become the squash-merge commit message, so this
text is changelog input rather than a review scratchpad. The title must be a valid
Conventional Commit (`type(scope): summary`, or `type(scope)!: summary` when the
change is breaking). Write the rationale below, then delete this comment.

What to include, and where a BREAKING CHANGE footer goes:
https://github.com/substrait-io/substrait-java/blob/main/CONTRIBUTING.md#pull-requests
-->
