### PR TITLE
build: bump editorconfig-checker action to v2.2.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: editorconfig-checker/action-editorconfig-checker@v2
+      - uses: editorconfig-checker/action-editorconfig-checker@v2.2.0
       - run: editorconfig-checker
   yamllint:
     name: Lint YAML


### PR DESCRIPTION
The v2 tag for editorconfig-checker/action-editorconfig-checker is not maintained with the latest v2.x release state. The code in this version was last updated in 2023. This results in build warnings due to the back-level Node version used:

Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24:
editorconfig-checker/action-editorconfig-checker@v2.

This change updates to the latest release version, which uses Node 24.

<!--
The PR title and this description become the squash-merge commit message, so this
text is changelog input rather than a review scratchpad. The title must be a valid
Conventional Commit (`type(scope): summary`, or `type(scope)!: summary` when the
change is breaking). Write the rationale below, then delete this comment.

What to include, and where a BREAKING CHANGE footer goes:
https://github.com/substrait-io/substrait-java/blob/main/CONTRIBUTING.md#pull-requests
-->
