### PR TITLE
fix(isthmus): report an unsupported type whatever its fields are called

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/TypeConverter.java
@@ -217,7 +217,7 @@ public class TypeConverter {
         return creator.list(toSubstrait(type.getComponentType(), names));
       default:
         throw new UnsupportedOperationException(
-            String.format("Unable to convert the type " + type.toString()));
+            String.format("Unable to convert the type %s", type));
     }
   }
 

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -365,4 +365,22 @@ class CalciteTypeTest extends CalciteObjs {
     assertEquals(expression, converter.toSubstrait(calciteType));
     assertEquals(calciteType, converter.toCalcite(type, expression, dfsFieldNames));
   }
+
+  /**
+   * The unsupported-type arm reports the type it was handed, and a type renders whatever a field
+   * name says. Passing that message to {@code String.format} as its format string made the
+   * exception class depend on the name: a {@code %s} in it arrived as a conversion specifier.
+   */
+  @Test
+  void anUnsupportedTypeIsReportedWhateverItsFieldsAreCalled() {
+    RelDataType struct =
+        type.createStructType(
+            Arrays.asList(type.createSqlType(SqlTypeName.INTEGER)), Arrays.asList("%s"));
+
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> TypeConverter.DEFAULT.toSubstrait(type.createMultisetType(struct, -1)));
+    assertTrue(e.getMessage().contains("%s"), e.getMessage());
+  }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -368,19 +368,26 @@ class CalciteTypeTest extends CalciteObjs {
 
   /**
    * The unsupported-type arm reports the type it was handed, and a type renders whatever a field
-   * name says. Passing that message to {@code String.format} as its format string made the
-   * exception class depend on the name: a {@code %s} in it arrived as a conversion specifier.
+   * name says. Passing that message to {@code String.format} as its format string made the name
+   * decide the outcome: {@code %s} and {@code %d} arrived as conversion specifiers and changed the
+   * exception class, while {@code %n} and {@code %%} changed the message instead and threw nothing.
+   *
+   * <p>Both fixture choices are forced. {@code MULTISET} is the only {@link SqlTypeName} reaching
+   * that arm whose rendering carries a field name -- {@code ROW}, {@code ARRAY} and {@code MAP}
+   * recurse past it and every other name renders a fixed string -- and {@code -1} is the only
+   * maximum cardinality {@code createMultisetType} accepts.
    */
-  @Test
-  void anUnsupportedTypeIsReportedWhateverItsFieldsAreCalled() {
+  @ParameterizedTest
+  @ValueSource(strings = {"%s", "%d", "100%", "%n", "%%"})
+  void anUnsupportedTypeIsReportedWhateverItsFieldsAreCalled(String fieldName) {
     RelDataType struct =
         type.createStructType(
-            Arrays.asList(type.createSqlType(SqlTypeName.INTEGER)), Arrays.asList("%s"));
+            Arrays.asList(type.createSqlType(SqlTypeName.INTEGER)), Arrays.asList(fieldName));
+    RelDataType multiset = type.createMultisetType(struct, -1);
 
     UnsupportedOperationException e =
         assertThrows(
-            UnsupportedOperationException.class,
-            () -> TypeConverter.DEFAULT.toSubstrait(type.createMultisetType(struct, -1)));
-    assertTrue(e.getMessage().contains("%s"), e.getMessage());
+            UnsupportedOperationException.class, () -> TypeConverter.DEFAULT.toSubstrait(multiset));
+    assertEquals("Unable to convert the type " + multiset, e.getMessage());
   }
 }

--- a/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/CalciteTypeTest.java
@@ -327,6 +327,31 @@ class CalciteTypeTest extends CalciteObjs {
     testType(typeConverter, type, uTypeFactory.createCalcite(nullable), null);
   }
 
+  /**
+   * The unsupported-type arm reports the type it was handed, and a type renders whatever a field
+   * name says. Passing that message to {@code String.format} as its format string made the name
+   * decide the outcome: {@code %s} and {@code %d} arrived as conversion specifiers and changed the
+   * exception class, while {@code %n} and {@code %%} changed the message instead and threw nothing.
+   *
+   * <p>Both fixture choices are forced. {@code MULTISET} is the only {@link SqlTypeName} reaching
+   * that arm whose rendering carries a field name -- {@code ROW}, {@code ARRAY} and {@code MAP}
+   * recurse past it and every other name renders a fixed string -- and {@code -1} is the only
+   * maximum cardinality {@code createMultisetType} accepts.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"%s", "%d", "100%", "%n", "%%"})
+  void anUnsupportedTypeIsReportedWhateverItsFieldsAreCalled(String fieldName) {
+    RelDataType struct =
+        type.createStructType(
+            Arrays.asList(type.createSqlType(SqlTypeName.INTEGER)), Arrays.asList(fieldName));
+    RelDataType multiset = type.createMultisetType(struct, -1);
+
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class, () -> TypeConverter.DEFAULT.toSubstrait(multiset));
+    assertEquals("Unable to convert the type " + multiset, e.getMessage());
+  }
+
   private void testType(TypeExpression expression, SqlTypeName typeName, boolean nullable) {
     testType(expression, type.createTypeWithNullability(type.createSqlType(typeName), nullable));
   }
@@ -364,30 +389,5 @@ class CalciteTypeTest extends CalciteObjs {
       List<String> dfsFieldNames) {
     assertEquals(expression, converter.toSubstrait(calciteType));
     assertEquals(calciteType, converter.toCalcite(type, expression, dfsFieldNames));
-  }
-
-  /**
-   * The unsupported-type arm reports the type it was handed, and a type renders whatever a field
-   * name says. Passing that message to {@code String.format} as its format string made the name
-   * decide the outcome: {@code %s} and {@code %d} arrived as conversion specifiers and changed the
-   * exception class, while {@code %n} and {@code %%} changed the message instead and threw nothing.
-   *
-   * <p>Both fixture choices are forced. {@code MULTISET} is the only {@link SqlTypeName} reaching
-   * that arm whose rendering carries a field name -- {@code ROW}, {@code ARRAY} and {@code MAP}
-   * recurse past it and every other name renders a fixed string -- and {@code -1} is the only
-   * maximum cardinality {@code createMultisetType} accepts.
-   */
-  @ParameterizedTest
-  @ValueSource(strings = {"%s", "%d", "100%", "%n", "%%"})
-  void anUnsupportedTypeIsReportedWhateverItsFieldsAreCalled(String fieldName) {
-    RelDataType struct =
-        type.createStructType(
-            Arrays.asList(type.createSqlType(SqlTypeName.INTEGER)), Arrays.asList(fieldName));
-    RelDataType multiset = type.createMultisetType(struct, -1);
-
-    UnsupportedOperationException e =
-        assertThrows(
-            UnsupportedOperationException.class, () -> TypeConverter.DEFAULT.toSubstrait(multiset));
-    assertEquals("Unable to convert the type " + multiset, e.getMessage());
   }
 }


### PR DESCRIPTION
`TypeConverter`'s unsupported-type arm built its message by concatenation and handed the result to `String.format` as the format string, so the exception class depended on how the type rendered: a `%` in a field name arrived as a conversion specifier, and a caller catching `UnsupportedOperationException` saw a `MissingFormatArgumentException` escape instead. `toSubstrait(RelDataType)` is public, so a struct field named `%s` inside a multiset reaches it with stock Calcite types. The message is unchanged, and #1244 reports this as the last concatenated format string in the main sources.

The test asserts that message rather than the exception class alone, because two of the five field names it covers never changed the class: `%n` and `%%` rewrote the message and left an `UnsupportedOperationException` behind, while `100%` threw an `UnknownFormatConversionException`.

Closes #1244
