### PR TITLE
feat(isthmus): convert REVERSE and INITCAP from Calcite

### DIFF
--- a/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/calcite/SubstraitOperatorTable.java
@@ -56,7 +56,11 @@ public class SubstraitOperatorTable implements SqlOperatorTable {
   // feed OVERRIDE_KINDS: they share generic kinds such as OTHER_FUNCTION with many standard
   // operators, which we must not shadow.
   private static final SqlOperatorTable SUBSTRAIT_SCALAR_OPERATOR_TABLE =
-      SqlOperatorTables.of(List.of(CurrentTimezoneFunction.INSTANCE, FunctionMappings.RIGHTSHIFT));
+      SqlOperatorTables.of(
+          List.of(
+              CurrentTimezoneFunction.INSTANCE,
+              FunctionMappings.RIGHTSHIFT,
+              FunctionMappings.REVERSE));
 
   // Utilisation of extended library operators available from calcite 1.35+, i.e hyperbolic
   // functions

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -76,6 +76,10 @@ public class FunctionMappings {
    * Substrait declaration says {@code fixedchar<L1>}. Its name also collides with the Spark library
    * operator Calcite likewise calls {@code REVERSE}, which leaves neither candidate reachable once
    * both libraries are enabled. Isthmus defines its own to keep the declared return and the name.
+   *
+   * <p>Calcite's Enumerable convention cannot execute this operator because it has no {@code
+   * RexImpTable} implementor, unlike the library operator it replaces. It is used to preserve
+   * conversion semantics and operator identity.
    */
   public static final SqlFunction REVERSE =
       SqlBasicFunction.create(

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -71,6 +71,17 @@ public class FunctionMappings {
           OperandTypes.family(SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER));
 
   /**
+   * The {@code REVERSE(string)} function. Calcite's own is {@link SqlLibraryOperators#REVERSE},
+   * whose {@code ARG0_NULLABLE_VARYING} return widens a {@code CHAR} to {@code VARCHAR}, where the
+   * Substrait declaration says {@code fixedchar<L1>}. Its name also collides with the Spark library
+   * operator Calcite likewise calls {@code REVERSE}, which leaves neither candidate reachable once
+   * both libraries are enabled. Isthmus defines its own to keep the declared return and the name.
+   */
+  public static final SqlFunction REVERSE =
+      SqlBasicFunction.create(
+          "REVERSE", ReturnTypes.ARG0_NULLABLE, OperandTypes.CHARACTER, SqlFunctionCategory.STRING);
+
+  /**
    * The Substrait datetime subtraction function.
    *
    * <p>Calcite's datetime subtraction operators either infer their return type from a third
@@ -133,7 +144,7 @@ public class FunctionMappings {
               s(SqlStdOperatorTable.LOWER, "lower"),
               s(SqlStdOperatorTable.UPPER, "upper"),
               s(SqlStdOperatorTable.INITCAP, "initcap"),
-              s(SqlLibraryOperators.REVERSE, "reverse"),
+              s(REVERSE, "reverse"),
               s(SqlStdOperatorTable.BETWEEN),
               s(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM, "is_not_distinct_from"),
               s(SqlStdOperatorTable.COALESCE, "coalesce"),

--- a/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
+++ b/isthmus/src/main/java/io/substrait/isthmus/expression/FunctionMappings.java
@@ -132,6 +132,8 @@ public class FunctionMappings {
               s(SqlStdOperatorTable.CHAR_LENGTH, "char_length"),
               s(SqlStdOperatorTable.LOWER, "lower"),
               s(SqlStdOperatorTable.UPPER, "upper"),
+              s(SqlStdOperatorTable.INITCAP, "initcap"),
+              s(SqlLibraryOperators.REVERSE, "reverse"),
               s(SqlStdOperatorTable.BETWEEN),
               s(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM, "is_not_distinct_from"),
               s(SqlStdOperatorTable.COALESCE, "coalesce"),

--- a/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
@@ -54,6 +54,20 @@ final class StringFunctionTest extends PlanTestBase {
 
   @ParameterizedTest
   @ValueSource(strings = {"c16", "vc32"})
+  void initcap(String column) throws Exception {
+    String query = String.format("SELECT initcap(%s) FROM strings", column);
+    assertFullRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
+  void reverse(String column) throws Exception {
+    String query = String.format("SELECT reverse(%s) FROM strings", column);
+    assertFullRoundTrip(query, CREATES);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"c16", "vc32"})
   void replace(String column) throws Exception {
     String query =
         String.format("SELECT replace(%s, replace_from, replace_to) FROM replace_strings", column);

--- a/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
+++ b/isthmus/src/test/java/io/substrait/isthmus/StringFunctionTest.java
@@ -8,6 +8,7 @@ import io.substrait.expression.Expression.FixedCharLiteral;
 import io.substrait.isthmus.sql.SubstraitCreateStatementParser;
 import io.substrait.plan.Plan;
 import io.substrait.relation.Project;
+import io.substrait.type.TypeCreator;
 import java.util.List;
 import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.sql.parser.SqlParseException;
@@ -53,17 +54,56 @@ final class StringFunctionTest extends PlanTestBase {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"c16", "vc32"})
+  @ValueSource(strings = {"c16", "vc32", "vc"})
   void initcap(String column) throws Exception {
     String query = String.format("SELECT initcap(%s) FROM strings", column);
     assertFullRoundTrip(query, CREATES);
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"c16", "vc32"})
+  @ValueSource(strings = {"c16", "vc32", "vc"})
   void reverse(String column) throws Exception {
     String query = String.format("SELECT reverse(%s) FROM strings", column);
     assertFullRoundTrip(query, CREATES);
+  }
+
+  /**
+   * Isthmus binds its own {@code REVERSE} rather than Calcite's, whose {@code
+   * ARG0_NULLABLE_VARYING} return widens a {@code CHAR} to {@code VARCHAR}. A round trip cannot see
+   * that: both directions carry the recorded {@code output_type} verbatim, so a call declaring
+   * {@code varchar<16>} for a {@code fixedchar<16>} operand round-trips green.
+   */
+  @Test
+  void reverseKeepsTheDeclaredReturnOfAFixedCharOperand() throws Exception {
+    CalciteCatalogReader catalog =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(CREATES);
+
+    Plan plan = new SqlToSubstrait().convert("SELECT reverse(c16) FROM strings", catalog);
+
+    Project project = (Project) plan.getRoots().get(0).getInput();
+    Expression.ScalarFunctionInvocation reverse =
+        (Expression.ScalarFunctionInvocation) project.getExpressions().get(0);
+    assertEquals("reverse:fchar", reverse.declaration().key());
+    assertEquals(TypeCreator.NULLABLE.fixedChar(16), reverse.outputType());
+  }
+
+  /**
+   * Calcite names the Spark library's operator {@code REVERSE} as well, so with both libraries
+   * enabled a lookup by that name returns two candidates and keeps neither. Isthmus' own operator
+   * is consulted first, which is what makes these reachable.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "SELECT c16 FROM strings ORDER BY reverse(c16)",
+        "SELECT reverse(c16) FROM strings ORDER BY 1",
+        "SELECT reverse(c16) AS r FROM strings ORDER BY r"
+      })
+  void reverseIsReachableInAnOrderBy(String query) throws Exception {
+    CalciteCatalogReader catalog =
+        SubstraitCreateStatementParser.processCreateStatementsToCatalog(CREATES);
+
+    assertDoesNotThrow(() -> new SqlToSubstrait().convert(query, catalog));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
`REVERSE` and `INITCAP` had no `FunctionMappings` entry, and `FunctionConverter` builds its signature map from that list alone, so neither had a `FunctionFinder` and no call to either converted. `functions_string.yaml` declares both, so the mapping was the whole gap; without it a call fails with `Unable to convert call REVERSE(char<16>?)`.

`INITCAP` binds Calcite's operator. `REVERSE` binds a local `SqlFunction` with `ARG0_NULLABLE`, registered in `SUBSTRAIT_SCALAR_OPERATOR_TABLE` where a lookup reaches it before the libraries, because Calcite's is wrong twice over. `SqlLibraryOperators.REVERSE` infers its return with `ARG0_NULLABLE_VARYING`, which widens a `CHAR`: `reverse(c16)` bound the `fixedchar` variant and then recorded `varchar<16>` as its output type, where the declared `fixedchar<L1>` makes it `fixedchar<16>`. And Calcite gives the Spark library's operator the same name, so with both libraries enabled the validator finds two candidates and discards both, which is why an `ORDER BY` over the call failed to validate. The same collision catches `least` and `greatest`, filed as #1274.

Neither fault is visible to a round trip, which carries the recorded `output_type` verbatim in both directions, so the two new tests assert the invocation's output type and the three `ORDER BY` forms directly.

Closes #1222
