### PR TITLE
build: bump editorconfig-checker action to v3.0.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: editorconfig-checker/action-editorconfig-checker@v2.2.0
+      - uses: editorconfig-checker/action-editorconfig-checker@v3.0.0
       - run: editorconfig-checker
   yamllint:
     name: Lint YAML


### PR DESCRIPTION
editorconfig-checker v4.0.0 renamed its binary and its release assets from `ec-*` to `editorconfig-checker-*`. Because the action resolves `version: latest`, every PR run since that release fails before running any check:

```
Find 'latest' release
Error: The binary 'ec-linux-amd64*' not found
```

Action v3.0.0 looks for the new asset names (keeping an `ec-*` fallback for older checker versions) and puts the binary on PATH as `editorconfig-checker`, which the existing run step already invokes.

The checker's other v4 breaking changes don't affect this repo: it has no `.ecrc` (the config name that v4 stopped discovering) and no `SpacesAftertabs` key, and v4.0.0 reports no violations here.

Upstream: https://github.com/editorconfig-checker/action-editorconfig-checker/issues/280